### PR TITLE
Photo: No longer throws exceptions on (partially) missing EXIF data

### DIFF
--- a/module/Photo/src/Photo/Model/Photo.php
+++ b/module/Photo/src/Photo/Model/Photo.php
@@ -34,56 +34,56 @@ class Photo implements ResourceInterface
     /**
      * Artist/author
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", nullable=true)
      */
     protected $artist;
 
     /**
      * The type of camera used
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", nullable=true))
      */
     protected $camera;
 
     /**
      * Whether a flash has been used
      *
-     * @ORM\Column(type="boolean")
+     * @ORM\Column(type="boolean", nullable=true))
      */
     protected $flash;
 
     /**
      * The focal length of the lens, in mm.
      *
-     * @ORM\Column(type="float")
+     * @ORM\Column(type="float", nullable=true))
      */
     protected $focalLength;
 
     /**
      * The exposure time, in seconds.
      *
-     * @ORM\Column(type="float")
+     * @ORM\Column(type="float", nullable=true))
      */
     protected $exposureTime;
 
     /**
      * The shutter speed.
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", nullable=true))
      */
     protected $shutterSpeed;
 
     /**
      * The lens aperture.
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", nullable=true))
      */
     protected $aperture;
 
     /**
      * Indicates the ISO Speed and ISO Latitude of the camera
      *
-     * @ORM\Column(type="smallint")
+     * @ORM\Column(type="smallint", nullable=true))
      */
     protected $iso;
 

--- a/module/Photo/src/Photo/Service/Metadata.php
+++ b/module/Photo/src/Photo/Service/Metadata.php
@@ -22,22 +22,22 @@ class Metadata extends AbstractService
     public function populateMetadata($photo, $path)
     {
         $exif = read_exif_data($path, 'EXIF');
-        if (isset($exif['Artist'])) {
-            $photo->setArtist($exif['Artist']);
-        } else {
-            $photo->setArtist("Unknown"); //Needs to be t9n'd in the view
-        }
-        //I assume the exif data isn't deliberately stripped, so most values 
-        //are assumed to exist.
-        $photo->setCamera($exif['Model']);
-        $photo->setDateTime(date_create($exif['DateTimeOriginal']));
-        $photo->setFlash($exif['Flash'] != 0);
-        $photo->setFocalLength($this->frac2dec($exif['FocalLength']));
-        $photo->setExposureTime($this->frac2dec($exif['ExposureTime']));
-        $photo->setShutterSpeed($this->exifGetShutter($exif));
-        $photo->setAperture($this->exifGetFstop($exif));
-        $photo->setIso($exif['ISOSpeedRatings']);
 
+        if($exif) {
+            $photo->setArtist($exif['Artist']);
+            $photo->setCamera($exif['Model']);
+            $photo->setDateTime(new \DateTime($exif['DateTimeOriginal']));
+            $photo->setFlash($exif['Flash'] != 0);
+            $photo->setFocalLength($this->frac2dec($exif['FocalLength']));
+            $photo->setExposureTime($this->frac2dec($exif['ExposureTime']));
+            $photo->setShutterSpeed($this->exifGetShutter($exif));
+            $photo->setAperture($this->exifGetFstop($exif));
+            $photo->setIso($exif['ISOSpeedRatings']);
+        } else {
+            // We must have a date/time for a photo
+            // Since no date is known, we use the current one
+            $photo->setDateTime(new \DateTime());
+        }
         return $photo;
     }
 

--- a/module/Photo/src/Photo/Service/Metadata.php
+++ b/module/Photo/src/Photo/Service/Metadata.php
@@ -69,7 +69,7 @@ class Metadata extends AbstractService
      *
      * @param string $shutterSpeed the shutter speed as listed in the photo's exif data.
      *
-     * @return string the shutter speed, represented as a rational string.
+     * @return string|null
      */
     private function exifGetShutter($shutterSpeed)
     {
@@ -93,7 +93,7 @@ class Metadata extends AbstractService
      *
      * @param string $apertureValue the aperture value as listed in the photo's exif data.
      *
-     * @return string the aperture, represented as a rational string.
+     * @return string|null
      */
     private function exifGetFstop($apertureValue)
     {

--- a/module/Photo/src/Photo/Service/Metadata.php
+++ b/module/Photo/src/Photo/Service/Metadata.php
@@ -30,8 +30,12 @@ class Metadata extends AbstractService
             $photo->setFlash($exif['Flash'] != 0);
             $photo->setFocalLength($this->frac2dec($exif['FocalLength']));
             $photo->setExposureTime($this->frac2dec($exif['ExposureTime']));
-            $photo->setShutterSpeed($this->exifGetShutter($exif['ShutterSpeedValue']));
-            $photo->setAperture($this->exifGetFstop($exif['ApertureValue']));
+            if(isset($exif['ShutterSpeedValue'])) {
+                $photo->setShutterSpeed($this->exifGetShutter($exif['ShutterSpeedValue']));
+            }
+            if(isset($exif['ShutterSpeedValue'])) {
+                $photo->setAperture($this->exifGetFstop($exif['ApertureValue']));
+            }
             $photo->setIso($exif['ISOSpeedRatings']);
         } else {
             // We must have a date/time for a photo
@@ -73,9 +77,6 @@ class Metadata extends AbstractService
      */
     private function exifGetShutter($shutterSpeed)
     {
-        if (!isset($shutterSpeed)) {
-            return null;
-        }
         $apex = $this->frac2dec($shutterSpeed);
         $shutter = pow(2, -$apex);
         if ($shutter == 0) {
@@ -97,9 +98,6 @@ class Metadata extends AbstractService
      */
     private function exifGetFstop($apertureValue)
     {
-        if (!isset($apertureValue)) {
-            return null;
-        }
         $apex = $this->frac2dec($apertureValue);
         $fstop = pow(2, $apex / 2);
         if ($fstop == 0) {

--- a/module/Photo/src/Photo/Service/Metadata.php
+++ b/module/Photo/src/Photo/Service/Metadata.php
@@ -30,8 +30,8 @@ class Metadata extends AbstractService
             $photo->setFlash($exif['Flash'] != 0);
             $photo->setFocalLength($this->frac2dec($exif['FocalLength']));
             $photo->setExposureTime($this->frac2dec($exif['ExposureTime']));
-            $photo->setShutterSpeed($this->exifGetShutter($exif));
-            $photo->setAperture($this->exifGetFstop($exif));
+            $photo->setShutterSpeed($this->exifGetShutter($exif['ShutterSpeedValue']));
+            $photo->setAperture($this->exifGetFstop($exif['ApertureValue']));
             $photo->setIso($exif['ISOSpeedRatings']);
         } else {
             // We must have a date/time for a photo
@@ -66,19 +66,20 @@ class Metadata extends AbstractService
 
     /**
      * Computes the shutter speed from the exif data.
-     * @param array $exif the exif data extracted from the photo.
+     *
+     * @param string $shutterSpeed the shutter speed as listed in the photo's exif data.
      *
      * @return string the shutter speed, represented as a rational string.
      */
-    private function exifGetShutter($exif)
+    private function exifGetShutter($shutterSpeed)
     {
-        if (!isset($exif['ShutterSpeedValue'])) {
-            return "unknown";
+        if (!isset($shutterSpeed)) {
+            return null;
         }
-        $apex = $this->frac2dec($exif['ShutterSpeedValue']);
+        $apex = $this->frac2dec($shutterSpeed);
         $shutter = pow(2, -$apex);
         if ($shutter == 0) {
-            return "unknown";
+            return null;
         }
         if ($shutter >= 1) {
             return round($shutter) . 's';
@@ -88,20 +89,21 @@ class Metadata extends AbstractService
     }
 
     /**
-     * Computes the aperture form the exif data.
-     * @param array $exif the exif data extracted from the photo.
+     * Computes the relative aperture from the exif data.
+     *
+     * @param string $apertureValue the aperture value as listed in the photo's exif data.
      *
      * @return string the aperture, represented as a rational string.
      */
-    private function exifGetFstop($exif)
+    private function exifGetFstop($apertureValue)
     {
-        if (!isset($exif['ApertureValue'])) {
-            return "unknown";
+        if (!isset($apertureValue)) {
+            return null;
         }
-        $apex = $this->frac2dec($exif['ApertureValue']);
+        $apex = $this->frac2dec($apertureValue);
         $fstop = pow(2, $apex / 2);
         if ($fstop == 0) {
-            return "unknown";
+            return null;
         }
 
         return 'f/' . sprintf("%01.1f", $fstop);

--- a/module/Photo/view/photo/photo/view.phtml
+++ b/module/Photo/view/photo/photo/view.phtml
@@ -17,11 +17,11 @@
                 <tbody>
                     <tr>
                         <td><?= $this->translate('Artist') ?></td>
-                        <td><?= $photo->getArtist() ?></td>
+                        <td><?= is_null($photo->getArtist()) ? $this->translate("Unknown") : $photo->getArtist() ?></td>
                     </tr>
                     <tr>
                         <td><?= $this->translate('Camera') ?></td>
-                        <td><?= $photo->getCamera() ?></td>
+                        <td><?= is_null($photo->getCamera()) ? $this->translate("Unknown") : $photo->getCamera() ?></td>
                     </tr>
                     <tr>
                         <td><?= $this->translate('Date/time') ?></td>
@@ -33,23 +33,23 @@
                     </tr>
                     <tr>
                         <td><?= $this->translate('Focal length') ?></td>
-                        <td><?= $photo->getFocalLength() ?></td>
+                        <td><?= is_null($photo->getFocalLength()) ? $this->translate("Unknown") : $photo->getFocalLength() ?></td>
                     </tr>
                     <tr>
                         <td><?= $this->translate('Exposure time') ?></td>
-                        <td><?= $photo->getExposureTime() ?></td>
+                        <td><?= is_null($photo->getExposureTime()) ? $this->translate("Unknown") : $photo->getExposureTime() ?></td>
                     </tr>
                     <tr>
                         <td><?= $this->translate('Shutter speed') ?></td>
-                        <td><?= $photo->getShutterSpeed() ?></td>
+                        <td><?= is_null($photo->getShutterSpeed()) ? $this->translate("Unknown") : $photo->getShutterSpeed() ?></td>
                     </tr>
                     <tr>
                         <td><?= $this->translate('Aperture') ?></td>
-                        <td><?= $photo->getAperture() ?></td>
+                        <td><?= is_null($photo->getAperture()) ? $this->translate("Unknown") : $photo->getAperture() ?></td>
                     </tr>
                     <tr>
                         <td><?= $this->translate('ISO') ?></td>
-                        <td><?= $photo->getIso() ?></td>
+                        <td><?= is_null($photo->getIso()) ? $this->translate("Unknown") : $photo->getIso() ?></td>
                     </tr>
                     </tbody>
             </table>


### PR DESCRIPTION
Not all photos have full EXIF data. Some even have no EXIF data at all. These changes allow importing such photos.