### PR TITLE
ACL configuration

### DIFF
--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -28,6 +28,12 @@ return [
      */
     'bcrypt_cost' => 13,
 
+    /**
+     * IP address start for the TU/e. All IP addresses starting with this will
+     * be allowed more base rights, like viewing exams
+     */
+    'tue_range' => '131.155.',
+
     'storage' => [
         'storage_dir' => 'public/data',
         'public_dir' => 'data',

--- a/module/Decision/src/Decision/Model/Member.php
+++ b/module/Decision/src/Decision/Model/Member.php
@@ -530,6 +530,16 @@ class Member
     }
 
     /**
+     * Get the board installations.
+     *
+     * @return ArrayCollection
+     */
+    public function getBoardInstallations()
+    {
+        return $this->boardInstallations;
+    }
+
+    /**
      * Convert to array.
      *
      * @return array

--- a/module/Education/Module.php
+++ b/module/Education/Module.php
@@ -151,9 +151,9 @@ class Module
                     $acl->addResource('exam');
 
                     // users (logged in GEWIS members) are allowed to view exams
-                    // TODO: besides users, also people on the TU/e network
-                    // are allowed to view exams
-                    $acl->allow('user', 'exam', 'view');
+                    // besides users, also people on the TU/e network are
+                    // allowed to view exams (users inherit from tueguest)
+                    $acl->allow('tueguest', 'exam', 'view');
 
                     return $acl;
                 },

--- a/module/User/Module.php
+++ b/module/User/Module.php
@@ -202,7 +202,7 @@ class Module
                      */
                     $acl->addRole(new Role('guest'));
                     $acl->addRole(new Role('tueguest'), 'guest');
-                    $acl->addRole(new Role('user'), 'guest');
+                    $acl->addRole(new Role('user'), 'tueguest');
                     $acl->addrole(new Role('apiuser'), 'guest');
                     $acl->addRole(new Role('admin'));
 

--- a/module/User/Module.php
+++ b/module/User/Module.php
@@ -168,6 +168,10 @@ class Module
                     );
                 },
 
+                'user_remoteaddress' => function ($sm) {
+                    $remote = new \Zend\Http\PhpEnvironment\RemoteAddress();
+                    return $remote->getIpAddress();
+                },
                 'user_role' => function ($sm) {
                     $authService = $sm->get('user_auth_service');
                     if ($authService->hasIdentity()) {
@@ -176,6 +180,10 @@ class Module
                     $apiService = $sm->get('user_service_apiuser');
                     if ($apiService->hasIdentity()) {
                         return 'apiuser';
+                    }
+                    $range = $sm->get('config')['tue_range'];
+                    if (strpos($sm->get('user_remoteaddress'), $range) === 0) {
+                        return 'tueguest';
                     }
                     return 'guest';
                 },
@@ -187,11 +195,13 @@ class Module
                      * Define all basic roles.
                      *
                      * - guest: everyone gets at least this access level
+                     * - tueguest: guest from the TU/e
                      * - user: GEWIS-member
                      * - apiuser: Automated tool given access by an admin
                      * - admin: Defined administrators
                      */
                     $acl->addRole(new Role('guest'));
+                    $acl->addRole(new Role('tueguest'), 'guest');
                     $acl->addRole(new Role('user'), 'guest');
                     $acl->addrole(new Role('apiuser'), 'guest');
                     $acl->addRole(new Role('admin'));

--- a/module/User/Module.php
+++ b/module/User/Module.php
@@ -221,6 +221,9 @@ class Module
                     // admins are allowed to do everything
                     $acl->allow('admin');
 
+                    // board members also are admins
+                    $acl->allow('user', null, null, new \User\Permissions\Assertion\IsBoardMember());
+
                     // configure the user ACL
                     $acl->addResource(new Resource('apiuser'));
 

--- a/module/User/src/User/Mapper/User.php
+++ b/module/User/src/User/Mapper/User.php
@@ -62,10 +62,12 @@ class User
     {
         // create query for user
         $qb = $this->em->createQueryBuilder();
-        $qb->select('u, r, m')
+        $qb->select('u, r, m, b, o')
             ->from('User\Model\User', 'u')
             ->leftJoin('u.roles', 'r')
-            ->join('u.member', 'm');
+            ->join('u.member', 'm')
+            ->leftJoin('m.boardInstallations', 'b')
+            ->leftJoin('m.organInstallations', 'o');
 
 
         // depending on login, add correct where clause

--- a/module/User/src/User/Mapper/User.php
+++ b/module/User/src/User/Mapper/User.php
@@ -62,12 +62,13 @@ class User
     {
         // create query for user
         $qb = $this->em->createQueryBuilder();
-        $qb->select('u, r, m, b, o')
+        $qb->select('u, r, m, b, oi')
             ->from('User\Model\User', 'u')
             ->leftJoin('u.roles', 'r')
             ->join('u.member', 'm')
             ->leftJoin('m.boardInstallations', 'b')
-            ->leftJoin('m.organInstallations', 'o');
+            ->leftJoin('m.organInstallations', 'oi')
+            ->leftJoin('oi.organ', 'o');
 
 
         // depending on login, add correct where clause

--- a/module/User/src/User/Permissions/Assertion/IsBoardMember.php
+++ b/module/User/src/User/Permissions/Assertion/IsBoardMember.php
@@ -11,6 +11,9 @@ use User\Model\User;
 
 use Decision\Model\BoardMember;
 
+/**
+ * Assertion to check if the user is a board member.
+ */
 class IsBoardMember implements AssertionInterface
 {
 

--- a/module/User/src/User/Permissions/Assertion/IsBoardMember.php
+++ b/module/User/src/User/Permissions/Assertion/IsBoardMember.php
@@ -60,5 +60,4 @@ class IsBoardMember implements AssertionInterface
         return $boardMember->getInstallDate() <= $now &&
             (null === $boardMember->getDischargeDate() || $boardMember->getDischargeDate >= $now);
     }
-
 }

--- a/module/User/src/User/Permissions/Assertion/IsBoardMember.php
+++ b/module/User/src/User/Permissions/Assertion/IsBoardMember.php
@@ -9,6 +9,8 @@ use Zend\Permissions\Acl\Assertion\AssertionInterface;
 
 use User\Model\User;
 
+use Decision\Model\BoardMember;
+
 class IsBoardMember implements AssertionInterface
 {
 
@@ -33,7 +35,27 @@ class IsBoardMember implements AssertionInterface
         }
         $member = $role->getMember();
 
-        // TODO: obtain this members board installations, and check if the user is a current board member
+        foreach ($member->getBoardInstallations() as $boardInstall) {
+            if ($this->isCurrentBoard($boardInstall)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if this is a current board member.
+     *
+     * @param BoardMember $boardMember
+     *
+     * @return bool
+     */
+    protected function isCurrentBoard(BoardMember $boardMember)
+    {
+        $now = new \DateTime();
+        return $boardMember->getInstallDate() <= $now &&
+            (null === $boardMember->getDischargeDate() || $boardMember->getDischargeDate >= $now);
     }
 
 }

--- a/module/User/src/User/Permissions/Assertion/IsBoardMember.php
+++ b/module/User/src/User/Permissions/Assertion/IsBoardMember.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace User\Permissions\Assertion;
+
+use Zend\Permissions\Acl\Acl;
+use Zend\Permissions\Acl\Role\RoleInterface;
+use Zend\Permissions\Acl\Resource\ResourceInterface;
+use Zend\Permissions\Acl\Assertion\AssertionInterface;
+
+use User\Model\User;
+
+class IsBoardMember implements AssertionInterface
+{
+
+
+    /**
+     * Returns true if and only if the assertion conditions are met
+     *
+     * This method is passed the ACL, Role, Resource, and privilege to which the authorization query applies. If the
+     * $role, $resource, or $privilege parameters are null, it means that the query applies to all Roles, Resources, or
+     * privileges, respectively.
+     *
+     * @param  Acl                        $acl
+     * @param  RoleInterface         $role
+     * @param  ResourceInterface $resource
+     * @param  string                         $privilege
+     * @return bool
+     */
+    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null)
+    {
+        if (!$role instanceof User) {
+            return false;
+        }
+        $member = $role->getMember();
+
+        // TODO: obtain this members board installations, and check if the user is a current board member
+    }
+
+}

--- a/module/User/src/User/Permissions/Assertion/IsOrganMember.php
+++ b/module/User/src/User/Permissions/Assertion/IsOrganMember.php
@@ -68,5 +68,4 @@ class IsOrganMember implements AssertionInterface
         return $organMember->getInstallDate() <= $now &&
             (null === $organMember->getDischargeDate() || $organMember->getDischargeDate >= $now);
     }
-
 }

--- a/module/User/src/User/Permissions/Assertion/IsOrganMember.php
+++ b/module/User/src/User/Permissions/Assertion/IsOrganMember.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace User\Permissions\Assertion;
+
+use Zend\Permissions\Acl\Acl;
+use Zend\Permissions\Acl\Role\RoleInterface;
+use Zend\Permissions\Acl\Resource\ResourceInterface;
+use Zend\Permissions\Acl\Assertion\AssertionInterface;
+
+use User\Model\User;
+use User\Permissions\Resource\OrganResourceInterface;
+
+use Decision\Model\OrganMember;
+use Decision\Model\Organ;
+
+/**
+ * Assertion to check if the user is a member of the organ tied to the resource.
+ */
+class IsOrganMember implements AssertionInterface
+{
+
+
+    /**
+     * Returns true if and only if the assertion conditions are met
+     *
+     * This method is passed the ACL, Role, Resource, and privilege to which the authorization query applies. If the
+     * $role, $resource, or $privilege parameters are null, it means that the query applies to all Roles, Resources, or
+     * privileges, respectively.
+     *
+     * @param  Acl                        $acl
+     * @param  RoleInterface         $role
+     * @param  ResourceInterface $resource
+     * @param  string                         $privilege
+     * @return bool
+     */
+    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null)
+    {
+        if (!$role instanceof User) {
+            return false;
+        }
+        if (!$resource instanceof OrganResourceInterface) {
+            return false;
+        }
+
+        $member = $role->getMember();
+        $organ = $resource->getResourceOrgan();
+
+        foreach ($member->getOrganInstallations() as $organInstall) {
+            if ($organInstall->getOrgan()->getId() === $organ->getId()
+                && $this->isCurrentMember($organInstall)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if this is a current organ member.
+     *
+     * @param OrganMember $organMember
+     *
+     * @return bool
+     */
+    protected function isCurrentMember(OrganMember $organMember)
+    {
+        $now = new \DateTime();
+        return $organMember->getInstallDate() <= $now &&
+            (null === $organMember->getDischargeDate() || $organMember->getDischargeDate >= $now);
+    }
+
+}

--- a/module/User/src/User/Permissions/Resource/OrganResourceInterface.php
+++ b/module/User/src/User/Permissions/Resource/OrganResourceInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace User\Permissions\Resource;
+
+use Zend\Permissions\Acl\Resource\ResourceInterface;
+
+use Decision\Model\Organ;
+
+interface OrganResourceInterface extends ResourceInterface
+{
+
+    /**
+     * Get the organ of this resource.
+     *
+     * @return Organ
+     */
+    public function getResourceOrgan();
+
+}

--- a/module/User/src/User/Permissions/Resource/OrganResourceInterface.php
+++ b/module/User/src/User/Permissions/Resource/OrganResourceInterface.php
@@ -15,5 +15,4 @@ interface OrganResourceInterface extends ResourceInterface
      * @return Organ
      */
     public function getResourceOrgan();
-
 }


### PR DESCRIPTION
Configures ACL to:

- [x] Allow users in TU/e range to view exams
- [x] Give board members the same rights as admins.
- [x] Make it possible to check if a user has access because of an organ relation.

This belongs with issues #252 and #253 