### PR TITLE
Fixes #409. Company names are now using the full width at the jobs list.

### DIFF
--- a/module/Company/view/company/company/job-list.phtml
+++ b/module/Company/view/company/company/job-list.phtml
@@ -41,7 +41,7 @@ $this->headTitle($this->translate('Jobs'));
     <div class="job-list">
 
         <div class="row">
-            <h1 class="col-md-5 col-sm-5 col-xs-5"><?= $this->translate('Jobs') ?>
+            <h1 class="col-md-8 col-sm-7 col-xs-12"><?= $this->translate('Jobs') ?>
                 <?php if (isset($this->company)): ?>
                     <small>
                         <?= $this->translate('at') ?>


### PR DESCRIPTION
Fixes #409 