### PR TITLE
More details for organizing committee of an activity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "ext-exif": "^0.0.0",
         "ext-imagick": "^3.1",
         "twbs/bootstrap-sass": "^3.3",
-        "maglnet/magl-markdown":"^1.4"
+        "maglnet/magl-markdown":"^1.4",
+        "dino/dompdf-module": "0.2.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "52dc400699b795e67c7ee539ebd737f1",
-    "content-hash": "90fa3da4db21322d48daf35dcc3bbe3e",
+    "hash": "d7e9cb47f43a960610c1bb736e369759",
+    "content-hash": "bb701756fa53e9394ed279c2d32881b9",
     "packages": [
         {
             "name": "GEWIS/gewisweb-migrate",
@@ -13,7 +13,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/GEWIS/gewisweb-migrate",
-                "reference": "a862e2990af4317a5c3bdf65b5676ce5a2fb2333"
+                "reference": "154d5cc5bb342e6a2eef234ec017be224be1f0e4"
             },
             "require": {
                 "php": ">=5.3.3"
@@ -35,7 +35,49 @@
             "keywords": [
                 "gewis"
             ],
-            "time": "2015-12-28 14:28:57"
+            "time": "2016-01-24 20:55:29"
+        },
+        {
+            "name": "dino/dompdf-module",
+            "version": "v0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/raykolbe/DOMPDFModule.git",
+                "reference": "e234ac3c7c2af3ccd916a4079e529c1820eff60b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/raykolbe/DOMPDFModule/zipball/e234ac3c7c2af3ccd916a4079e529c1820eff60b",
+                "reference": "e234ac3c7c2af3ccd916a4079e529c1820eff60b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "DOMPDFModule": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raymond Kolbe",
+                    "email": "raymond.kolbe@maine.edu"
+                }
+            ],
+            "description": "A Zend Framework 2 module for incorporating DOMPDF support.",
+            "homepage": "http://raymondkolbe.com",
+            "keywords": [
+                "dompdf",
+                "pdf",
+                "zf2"
+            ],
+            "time": "2013-04-25 10:31:36"
         },
         {
             "name": "doctrine/annotations",
@@ -960,16 +1002,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "0.12.0",
+            "version": "0.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "3eb64850ee688623db494398a5284a7a4cdf7b47"
+                "reference": "a4e93bc4fd1a8ff8f534040c4a07371ea5f4b484"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/3eb64850ee688623db494398a5284a7a4cdf7b47",
-                "reference": "3eb64850ee688623db494398a5284a7a4cdf7b47",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/a4e93bc4fd1a8ff8f534040c4a07371ea5f4b484",
+                "reference": "a4e93bc4fd1a8ff8f534040c4a07371ea5f4b484",
                 "shasum": ""
             },
             "require": {
@@ -981,13 +1023,15 @@
             },
             "require-dev": {
                 "erusev/parsedown": "~1.0",
-                "jgm/commonmark": "0.22",
-                "jgm/smartpunct": "0.22",
+                "jgm/commonmark": "0.24",
                 "michelf/php-markdown": "~1.4",
                 "mikehaertl/php-shellcommand": "~1.1.0",
                 "phpunit/phpunit": "~4.3|~5.0",
                 "scrutinizer/ocular": "^1.1",
                 "symfony/finder": "~2.3"
+            },
+            "suggest": {
+                "league/commonmark-extras": "Library of useful extensions including smart punctuation"
             },
             "bin": [
                 "bin/commonmark"
@@ -995,7 +1039,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.13-dev"
+                    "dev-master": "0.14-dev"
                 }
             },
             "autoload": {
@@ -1003,7 +1047,7 @@
                     "League\\CommonMark\\": "src/"
                 }
             },
-            "notification-url": "http://packagist.org/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -1022,7 +1066,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2015-11-04 14:24:41"
+            "time": "2016-01-14 04:29:54"
         },
         {
             "name": "maglnet/magl-markdown",
@@ -1202,16 +1246,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.0.1",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25"
+                "reference": "1289d16209491b584839022f29257ad859b8532d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/49ff736bd5d41f45240cec77b44967d76e0c3d25",
-                "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
+                "reference": "1289d16209491b584839022f29257ad859b8532d",
                 "shasum": ""
             },
             "require": {
@@ -1223,7 +1267,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -1257,7 +1301,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2015-11-20 09:19:13"
+            "time": "2016-01-20 09:13:37"
         },
         {
             "name": "twbs/bootstrap-sass",

--- a/config/application.config.production.php
+++ b/config/application.config.production.php
@@ -13,7 +13,8 @@ return [
         'Photo',
         'Education',
         'Migration',
-        'MaglMarkdown'
+        'MaglMarkdown',
+        'DOMPDFModule',
     ],
     // These are various options for the listeners attached to the ModuleManager
     'module_listener_options' => [

--- a/module/Activity/Module.php
+++ b/module/Activity/Module.php
@@ -1,8 +1,7 @@
 <?php
 namespace Activity;
 
-
-use User\Service\User;
+use User\Permissions\Assertion\IsOrganMember;;
 
 class Module
 {
@@ -115,6 +114,7 @@ class Module
 
                     $acl->allow('user', 'activity', 'create');
                     $acl->allow('user', 'activitySignup', ['signup', 'signoff', 'checkUserSignedUp']);
+                    $acl->allow('user', 'activity', 'viewDetails', new IsOrganMember());
 
                     $acl->allow('sosuser', 'activitySignup', ['signup', 'signoff', 'checkUserSignedUp']);
 

--- a/module/Activity/config/module.config.php
+++ b/module/Activity/config/module.config.php
@@ -71,6 +71,30 @@ return [
                 ],
                 'priority' => 100
             ],
+            'organizer_activity' => [
+                'type' => 'Literal',
+                'options' => [
+                    'route' => '/activity/organizer/',
+                    'defaults' => [
+                        '__NAMESPACE__' => 'Activity\Controller',
+                        'controller' => 'organizer',
+                    ],
+                ],
+                'may_terminate' => true,
+                'child_routes' => [
+                    'email' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => ':id/email',
+                            'defaults' => [
+                                'controller' => 'organizer',
+                                'action' => 'email',
+                            ]
+                        ]
+                    ]
+                ]
+
+            ],
             'admin_activity' => [
                 'type' => 'Literal',
                 'options' => [
@@ -210,7 +234,8 @@ return [
         'invokables' => [
             'Activity\Controller\Activity' => 'Activity\Controller\ActivityController',
             'Activity\Controller\Admin' => 'Activity\Controller\AdminController',
-            'Activity\Controller\Api' => 'Activity\Controller\ApiController'
+            'Activity\Controller\Api' => 'Activity\Controller\ApiController',
+            'Activity\Controller\Organizer' => 'Activity\Controller\OrganizerController',
         ],
         'factories' => [
             'Activity\Controller\Activity' => function ($sm) {

--- a/module/Activity/config/module.config.php
+++ b/module/Activity/config/module.config.php
@@ -91,6 +91,16 @@ return [
                                 'action' => 'email',
                             ]
                         ]
+                    ],
+                    'export' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => ':id/export',
+                            'defaults' => [
+                                'controller' => 'organizer',
+                                'action' => 'export',
+                            ]
+                        ]
                     ]
                 ]
 

--- a/module/Activity/config/module.config.php
+++ b/module/Activity/config/module.config.php
@@ -101,6 +101,16 @@ return [
                                 'action' => 'export',
                             ]
                         ]
+                    ],
+                    'exportpdf' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => ':id/export/pdf',
+                            'defaults' => [
+                                'controller' => 'organizer',
+                                'action' => 'exportpdf',
+                            ]
+                        ]
                     ]
                 ]
 

--- a/module/Activity/src/Activity/Controller/OrganizerController.php
+++ b/module/Activity/src/Activity/Controller/OrganizerController.php
@@ -24,7 +24,7 @@ class OrganizerController extends AbstractActionController
         $activityService = $this->getServiceLocator()->get('activity_service_activity');
 
         /** @var $activity Activity*/
-        $activity = $activityService->getActivity($id);
+        $activity = $activityService->getActivityWithDetails($id);
 
         if (is_null($activity)) {
             return $this->notFoundAction();

--- a/module/Activity/src/Activity/Controller/OrganizerController.php
+++ b/module/Activity/src/Activity/Controller/OrganizerController.php
@@ -23,17 +23,19 @@ class OrganizerController extends AbstractActionController
     {
         $id = (int) $this->params('id');
         $activityService = $this->getServiceLocator()->get('activity_service_activity');
+        $translatorService = $this->getServiceLocator()->get('activity_service_activityTranslator');
+        $langSession = new SessionContainer('lang');
 
         /** @var $activity Activity*/
         $activity = $activityService->getActivityWithDetails($id);
-
+        $translatedActivity = $translatorService->getTranslatedActivity($activity, $langSession->lang);
 
         if (is_null($activity)) {
             return $this->notFoundAction();
         }
 
         return [
-            'activity' => $activity,
+            'activity' => $translatedActivity,
         ];
     }
 

--- a/module/Activity/src/Activity/Controller/OrganizerController.php
+++ b/module/Activity/src/Activity/Controller/OrganizerController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Activity\Controller;
+
+use Activity\Model\Activity;
+use Activity\Service\Signup;
+use Zend\Mvc\Controller\AbstractActionController;
+use Zend\Session\Container as SessionContainer;
+use Activity\Form\ModifyRequest as RequestForm;
+use Zend\View\Model\ViewModel;
+
+/**
+ * Controller that gives some additional details for activities, such as a list of email adresses
+ * or an export function specially tailored for the organizer.
+ */
+class OrganizerController extends AbstractActionController
+{
+    /**
+     * Show the email adresses belonging to an Activity
+     */
+    public function emailAction()
+    {
+        die('yay');
+    }
+}

--- a/module/Activity/src/Activity/Controller/OrganizerController.php
+++ b/module/Activity/src/Activity/Controller/OrganizerController.php
@@ -26,12 +26,40 @@ class OrganizerController extends AbstractActionController
         /** @var $activity Activity*/
         $activity = $activityService->getActivityWithDetails($id);
 
+
         if (is_null($activity)) {
             return $this->notFoundAction();
         }
 
         return [
             'activity' => $activity,
+        ];
+    }
+
+    /**
+     * Return the data for exporting activities
+     *
+     * @return array
+     */
+    public function exportAction()
+    {
+        $id = (int) $this->params('id');
+        $activityService = $this->getServiceLocator()->get('activity_service_activity');
+        $translatorService = $this->getServiceLocator()->get('activity_service_activityTranslator');
+        $langSession = new SessionContainer('lang');
+
+
+        /** @var $activity Activity*/
+        $activity = $activityService->getActivityWithDetails($id);
+        $translatedActivity = $translatorService->getTranslatedActivity($activity, $langSession->lang);
+
+        if (is_null($activity)) {
+            return $this->notFoundAction();
+        }
+
+        return [
+            'activity' => $translatedActivity,
+            'signupData' => $translatorService->getTranslatedSignedUpData($activity, $langSession->lang),
         ];
     }
 }

--- a/module/Activity/src/Activity/Controller/OrganizerController.php
+++ b/module/Activity/src/Activity/Controller/OrganizerController.php
@@ -20,6 +20,18 @@ class OrganizerController extends AbstractActionController
      */
     public function emailAction()
     {
-        die('yay');
+        $id = (int) $this->params('id');
+        $activityService = $this->getServiceLocator()->get('activity_service_activity');
+
+        /** @var $activity Activity*/
+        $activity = $activityService->getActivity($id);
+
+        if (is_null($activity)) {
+            return $this->notFoundAction();
+        }
+
+        return [
+            'activity' => $activity,
+        ];
     }
 }

--- a/module/Activity/src/Activity/Controller/OrganizerController.php
+++ b/module/Activity/src/Activity/Controller/OrganizerController.php
@@ -8,6 +8,7 @@ use Zend\Mvc\Controller\AbstractActionController;
 use Zend\Session\Container as SessionContainer;
 use Activity\Form\ModifyRequest as RequestForm;
 use Zend\View\Model\ViewModel;
+use DOMPDFModule\View\Model\PdfModel;
 
 /**
  * Controller that gives some additional details for activities, such as a list of email adresses
@@ -61,5 +62,12 @@ class OrganizerController extends AbstractActionController
             'activity' => $translatedActivity,
             'signupData' => $translatorService->getTranslatedSignedUpData($activity, $langSession->lang),
         ];
+    }
+
+    public function exportPdfAction()
+    {
+        $pdf = new PdfModel();
+        $pdf->setVariables($this->exportAction());
+        return $pdf;
     }
 }

--- a/module/Activity/src/Activity/Model/Activity.php
+++ b/module/Activity/src/Activity/Model/Activity.php
@@ -2,6 +2,7 @@
 
 namespace Activity\Model;
 
+use Decision\Model\Organ;
 use Doctrine\ORM\Mapping as ORM;
 use \DateTime;
 use User\Model\User;
@@ -11,7 +12,7 @@ use User\Model\User;
  *
  * @ORM\Entity
  */
-class Activity
+class Activity implements  \User\Permissions\Resource\OrganResourceInterface
 {
     /**
      * Status codes for the activity
@@ -505,5 +506,26 @@ class Activity
             'attendees' => $attendees,
             'fields' => $fields,
         ];
+    }
+
+    // Permission to link the resource to an organ
+    /**
+     * Get the organ of this resource.
+     *
+     * @return Organ
+     */
+    public function getResourceOrgan()
+    {
+        return $this->getOrgan();
+    }
+
+    /**
+     * Returns the string identifier of the Resource
+     *
+     * @return string
+     */
+    public function getResourceId()
+    {
+        return $this->getId();
     }
 }

--- a/module/Activity/src/Activity/Service/Activity.php
+++ b/module/Activity/src/Activity/Service/Activity.php
@@ -74,6 +74,23 @@ class Activity extends AbstractAclService implements ServiceManagerAwareInterfac
     }
 
     /**
+     * Get the activity with additional details
+     *
+     * @param $id
+     * @return ActivityModel
+     */
+    public function getActivityWithDetails($id)
+    {
+        if (! $this->isAllowed('viewDetails', 'activity')) {
+            $translator = $this->getTranslator();
+            throw new \User\Permissions\NotAllowedException(
+                $translator->translate('You are not allowed to view the activities')
+            );
+        }
+        return $this->getActivity($id   );
+    }
+
+    /**
      * Returns an array of all activities.
      *
      * @return array Array of activities

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -144,4 +144,9 @@ $this->headTitle($this->translate('Activities')); ?>
         echo $this->formSubmit($submit);
         echo $this->form()->closeTag();?>
     <?php endif; ?>
+
+    <?php if ($this->acl('activity_acl')->isAllowed('activity', 'create')): ?>
+        <a href="<?= $this->url('organizer_activity/email', ['id' => $activity->getId()])?>"><?= $this->Translate('View email Adresses') ?></a> |
+        <a href="<?= $this->url('organizer_activity/export', ['id' => $activity->getId()])?>"><?= $this->translate('Export subscriptions') ?></a>
+    <?php endif; ?>
 </div>

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -84,7 +84,7 @@ $this->headTitle($this->translate('Activities')); ?>
                         <th></th>
                         <th><?= $this->translate('Name') ?> </th>
                         <?php foreach($fields as $field):?>
-                        <th><?= $field->getName() ?></th>
+                            <th><?= $field->getName() ?></th>
                         <?php endforeach;?>
                     </tr>
                 </thead>

--- a/module/Activity/view/activity/organizer/email.phtml
+++ b/module/Activity/view/activity/organizer/email.phtml
@@ -31,12 +31,29 @@ $this->headTitle($this->translate('Activities')); ?>
             <th><?= $this->translate('Email') ?></th>
         </thead>
         <tbody>
-            <?php foreach ($activity->getSignUps() as $signUp): ?>
+            <?php
+                $mailAllString = '';
+                foreach ($activity->getSignUps() as $signUp):
+                    $email = $signUp->getUser()->getMember()->getEmail();
+                    $mailAllString .= ',' . $email;
+                ?>
                 <tr>
                     <td><?= $signUp->getUser()->getMember()->getFullName() ?></td>
-                    <td><?= $signUp->getUser()->getMember()->getEmail() ?></td>
+                    <td>
+                        <a href="mailto:<?= $email ?>">
+                            <?= $email ?>
+                        </a>
+                    </td>
                 </tr>
             <?php endforeach;?>
         </tbody>
+        <tfoot>
+            <td></td>
+            <td>
+                <a href="mailto:<?= $mailAllString ?>">
+                    <?= $this->translate('Mail everybody') ?>
+                </a>
+            </td>
+        </tfoot>
     </table>
 </div>

--- a/module/Activity/view/activity/organizer/email.phtml
+++ b/module/Activity/view/activity/organizer/email.phtml
@@ -1,0 +1,42 @@
+<?php $lang = $this->plugin('translate')->getTranslator()->getLocale();
+
+// set title
+$this->headTitle($activity->getName());
+$this->headTitle($this->translate('Activities')); ?>
+
+
+<?php if (!isset($breadcrumb)): // only show breadcrumbs if they were not yet shown ?>
+    <section class="section section-breadcrumb">
+        <div class="container">
+            <ol class="breadcrumb">
+                <li>
+                    <a href="<?= $this->url('activity') ?>">
+                        <?= $this->translate('Activities') ?>
+                    </a>
+                </li>
+                <li class="active">
+                    <?= $activity->getName() ?>
+                </li>
+            </ol>
+        </div>
+    </section>
+<?php endif; ?>
+
+<div class="container">
+    <h1><?= $this->translate('Subscription email adresses for activity ') . ' ' . $activity->getName() ?></h1>
+
+    <table class="table">
+        <thead>
+            <th><?= $this->translate('Name') ?></th>
+            <th><?= $this->translate('Email') ?></th>
+        </thead>
+        <tbody>
+            <?php foreach ($activity->getSignUps() as $signUp): ?>
+                <tr>
+                    <td><?= $signUp->getUser()->getMember()->getFullName() ?></td>
+                    <td><?= $signUp->getUser()->getMember()->getEmail() ?></td>
+                </tr>
+            <?php endforeach;?>
+        </tbody>
+    </table>
+</div>

--- a/module/Activity/view/activity/organizer/export.phtml
+++ b/module/Activity/view/activity/organizer/export.phtml
@@ -1,0 +1,49 @@
+<?php $lang = $this->plugin('translate')->getTranslator()->getLocale();
+
+// set title
+$this->headTitle($activity->getName());
+$this->headTitle($this->translate('Activities')); ?>
+
+
+<?php if (!isset($breadcrumb)): // only show breadcrumbs if they were not yet shown ?>
+    <section class="section section-breadcrumb">
+        <div class="container">
+            <ol class="breadcrumb">
+                <li>
+                    <a href="<?= $this->url('activity') ?>">
+                        <?= $this->translate('Activities') ?>
+                    </a>
+                </li>
+                <li class="active">
+                    <?= $activity->getName() ?>
+                </li>
+            </ol>
+        </div>
+    </section>
+<?php endif; ?>
+
+<div class="container">
+    <h1><?= $this->translate('Details for activity ') . ' ' . $activity->getName() ?></h1>
+
+    <table class="table">
+        <thead>
+            <th></th>
+            <th><?= $this->translate('Name') ?></th>
+            <?php foreach ($activity->getFields() as $field): ?>
+                <th><?= $field->getName() ?></th>
+            <?php endforeach; ?>
+        </thead>
+        <tbody>
+                <?php $i = 1; ?>
+                <?php foreach($signupData as $signup): ?>
+                    <tr>
+                        <td><?php echo $i; $i = $i + 1; ?></td>
+                        <td><?= $signup['member'] ?></td>
+                        <?php foreach($signup['values'] as $value):?>
+                            <td><?= $value ?></td>
+                        <?php endforeach;?>
+                    </tr>
+                <?php endforeach;?>
+        </tbody>
+    </table>
+</div>

--- a/module/Activity/view/activity/organizer/export.phtml
+++ b/module/Activity/view/activity/organizer/export.phtml
@@ -28,5 +28,5 @@ $this->headTitle($this->translate('Activities')); ?>
             'signupData' => $signupData
     ]);?>
 
-    <a href="<?php echo $this->url('organizer_activity/exportpdf', ['id' => $activity->getId()])?>"><?= $this->translate('Download as pdf');?></a>
+    <a href="<?= $this->url('organizer_activity/exportpdf', ['id' => $activity->getId()])?>"><?= $this->translate('Download as pdf');?></a>
 </div>

--- a/module/Activity/view/activity/organizer/export.phtml
+++ b/module/Activity/view/activity/organizer/export.phtml
@@ -23,27 +23,10 @@ $this->headTitle($this->translate('Activities')); ?>
 <?php endif; ?>
 
 <div class="container">
-    <h1><?= $this->translate('Details for activity ') . ' ' . $activity->getName() ?></h1>
+    <?= $this->partial('activity/organizer/exportTable.phtml', [
+            'activity' => $activity,
+            'signupData' => $signupData
+    ]);?>
 
-    <table class="table">
-        <thead>
-            <th></th>
-            <th><?= $this->translate('Name') ?></th>
-            <?php foreach ($activity->getFields() as $field): ?>
-                <th><?= $field->getName() ?></th>
-            <?php endforeach; ?>
-        </thead>
-        <tbody>
-                <?php $i = 1; ?>
-                <?php foreach($signupData as $signup): ?>
-                    <tr>
-                        <td><?php echo $i; $i = $i + 1; ?></td>
-                        <td><?= $signup['member'] ?></td>
-                        <?php foreach($signup['values'] as $value):?>
-                            <td><?= $value ?></td>
-                        <?php endforeach;?>
-                    </tr>
-                <?php endforeach;?>
-        </tbody>
-    </table>
+    <a href="<?php echo $this->url('organizer_activity/exportpdf', ['id' => $activity->getId()])?>"><?= $this->translate('Download as pdf');?></a>
 </div>

--- a/module/Activity/view/activity/organizer/exportTable.phtml
+++ b/module/Activity/view/activity/organizer/exportTable.phtml
@@ -1,0 +1,23 @@
+<table class="table">
+    <thead>
+        <tr>
+            <th></th>
+            <th><?= $this->translate('Name') ?></th>
+            <?php foreach ($activity->getFields() as $field): ?>
+                <th><?= $field->getName() ?></th>
+            <?php endforeach; ?>
+        </tr>
+    </thead>
+    <tbody>
+    <?php $i = 1; ?>
+    <?php foreach($signupData as $signup): ?>
+        <tr>
+            <td><?php echo $i; $i = $i + 1; ?></td>
+            <td><?= $signup['member'] ?></td>
+            <?php foreach($signup['values'] as $value):?>
+                <td><?= $value ?></td>
+            <?php endforeach;?>
+        </tr>
+    <?php endforeach;?>
+    </tbody>
+</table>

--- a/module/Activity/view/activity/organizer/exportpdf.phtml
+++ b/module/Activity/view/activity/organizer/exportpdf.phtml
@@ -1,0 +1,9 @@
+<html>
+    <body>
+        <h1><?= $this->translate('Details for activity ') . ' ' . $activity->getName() ?></h1>
+        <?= $this->partial('activity/organizer/exportTable.phtml', [
+                'activity' => $activity,
+                'signupData' => $signupData
+        ]);?>
+    </body>
+</html>


### PR DESCRIPTION
This pull requests adds two things:

- A link to view all email adresses (and the ability to mail all the subscribed people)
- An export to pdf function for an activity

See #237 and #238 

The only slight issue that I still have is that only an organizing committee can view this details, and not the organizer itself. This might be good (if the creator leaves the committee), or bad (if there is no activity behind it, you can not view the information of the activity you created). It can be fixed by adjusting the permissions. However, I am currently now aware of a way to give a permission if you have either created the activity, or are in the organizing activity.