### PR TITLE
Made names on committee pages clickable.

### DIFF
--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -96,10 +96,14 @@ function getOrganDescription($organInformation, $lang)
             <h1><?= $this->translate('Current members') ?></h1>
             <ul>
                 <?php foreach ($currentMembers as $membership): ?>
-                    <li><?= $membership['member']->getFullName() ?>
-                        <?php if (!empty($membership['functions'])): ?>
-                            (<?= implode(', ', $membership['functions']) ?>)
-                        <?php endif ?></li>
+                    <li>
+                        <a href="<?= $this->url('member/view', ['lidnr' => $membership['member']->getLidnr()]) ?>">
+                            <?= $membership['member']->getFullName() ?>
+                            <?php if (!empty($membership['functions'])): ?>
+                                (<?= implode(', ', $membership['functions']) ?>)
+                            <?php endif ?>
+                        </a>
+                    </li>
                 <?php endforeach ?>
             </ul>
             <?php else: ?>


### PR DESCRIPTION
Fixes #547 

It would be nice if committees on the member info page were also clickable, but I do not dare changing the MemberService.