### PR TITLE
Limit query results

### DIFF
--- a/module/Decision/src/Decision/Mapper/Decision.php
+++ b/module/Decision/src/Decision/Mapper/Decision.php
@@ -39,7 +39,8 @@ class Decision
         $qb->select('d, m')
             ->where('d.content LIKE :query')
             ->join('d.meeting', 'm')
-            ->orderBy('m.date', 'DESC');
+            ->orderBy('m.date', 'DESC')
+            ->setMaxResults(50);
 
         $qb->setParameter('query', "%$query%");
 

--- a/module/Decision/src/Decision/Mapper/Organ.php
+++ b/module/Decision/src/Decision/Mapper/Organ.php
@@ -115,7 +115,7 @@ class Organ
         $qb->select('o, om, m')
             ->leftJoin('o.members', 'om')
             ->leftJoin('om.member', 'm')
-            ->where('o.abbr LIKE :abbr');
+            ->where('o.abbr = :abbr');
 
         $qb->setParameter('abbr', $abbr);
 


### PR DESCRIPTION
Limit all user search queries (that have not been limited yet) to _some_ value. (this is only the decision query)
Also, remove an unneeded LIKE query.