### PR TITLE
Don't use the email adres in the users table anymore for anything

### DIFF
--- a/module/User/src/User/Model/User.php
+++ b/module/User/src/User/Model/User.php
@@ -25,7 +25,7 @@ class User implements RoleInterface, ResourceInterface
 
     /**
      * The user's email address.
-     *
+     * Deprecated
      * @ORM\Column(type="string")
      */
     protected $email;
@@ -90,7 +90,7 @@ class User implements RoleInterface, ResourceInterface
      */
     public function getEmail()
     {
-        return $this->email;
+        return $this->member->getEmail();
     }
 
     /**


### PR DESCRIPTION
Whenever a member's email changes it is not updated in the users table. Furthermore there is no good reason at all to store the email address twice in the database.