### PR TITLE
Removed reserve order

### DIFF
--- a/module/Frontpage/src/Frontpage/Service/Frontpage.php
+++ b/module/Frontpage/src/Frontpage/Service/Frontpage.php
@@ -110,7 +110,7 @@ class Frontpage extends AbstractAclService
         $count = $this->getConfig()['activity_count'];
         $activities = $this->getActivityMapper()->getUpcomingActivities($count);
 
-        return array_reverse($activities);
+        return $activities;
 
     }
 


### PR DESCRIPTION
It's more logical to have the newest activities first and the oldest last.