### PR TITLE
Add the ability to store sessions directly in memcached

### DIFF
--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -87,6 +87,14 @@ return [
     'sslcapath' => '/etc/ssl/certs',
 
     /**
+     * Session configuration
+     */
+    'session_config' => [
+        'use_cookies' => true,
+        'hash_function' => 'sha1'
+    ],
+
+    /**
      * Photo's upload directory configuration
      */
     'photo' => [

--- a/config/autoload/memcached.local.php.dist
+++ b/config/autoload/memcached.local.php.dist
@@ -1,0 +1,33 @@
+<?php
+return [
+    'session_storage' => [
+        'type' => 'Zend\Session\Storage\SessionArrayStorage'
+    ],
+    'session_name' => 'gewiswebsessid',
+    'session_manager' => [
+
+        'validators' => array(
+            'Zend\Session\Validator\RemoteAddr',
+            'Zend\Session\Validator\HttpUserAgent',
+        ),
+    ],
+    'memcached_session' => [
+
+        'enabled' => true,
+
+        // Optionally we can add more servers here for redundancy
+        'servers' => [
+            '127.0.0.1:11211',
+        ],
+        'lib_options' => [
+            \Memcached::OPT_CONNECT_TIMEOUT => 10,
+            \Memcached::OPT_REMOVE_FAILED_SERVERS => true,
+            // set it to consistent hashing. If one memcached node is dead, its keys (and only its keys) will be evenly distributed to other nodes.
+            // This is where the magic is done. This is really different from removing one server in your ->addServers() call.
+            \Memcached::OPT_DISTRIBUTION => \Memcached::DISTRIBUTION_CONSISTENT,
+            \Memcached::OPT_SERVER_FAILURE_LIMIT => 5,
+            \Memcached::OPT_REMOVE_FAILED_SERVERS => true,
+            \Memcached::OPT_RETRY_TIMEOUT => 1,
+        ]
+    ]
+];

--- a/module/Application/src/Application/Service/MemcachedStorageFactory.php
+++ b/module/Application/src/Application/Service/MemcachedStorageFactory.php
@@ -1,0 +1,33 @@
+<?php
+namespace Application\Service;
+
+use Zend\Cache\Storage\Adapter\MemcachedOptions;
+use Zend\Cache\Storage\Adapter\MemcachedResourceManager;
+use Zend\Cache\StorageFactory;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Session\SaveHandler\Cache;
+
+class MemcachedStorageFactory implements FactoryInterface
+{
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return mixed
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $memcachedResourceManager = new MemcachedResourceManager();
+        $memcachedResourceManager->addServers('default', $serviceLocator->get('Config')['memcached_session']['servers']);
+        $memcachedResourceManager->setLibOptions('default', $serviceLocator->get('Config')['memcached_session']['lib_options']);
+
+        $memcachedOptions = new MemcachedOptions();
+        $memcachedOptions->setResourceManager($memcachedResourceManager);
+
+        $adapter = StorageFactory::adapterFactory('memcached', $memcachedOptions);
+
+        return new Cache($adapter);
+    }
+
+}


### PR DESCRIPTION
This replaces the default zf2 session storage (using php sessions)  by memcached session storage. This should prevent conflicts with other php applications running on the same server. What's left to figure out is how session cleaning should work. Also the sws compatibility layer will need a few changes.