### PR TITLE
Add API method for getting member by lidnr

### DIFF
--- a/module/Decision/Module.php
+++ b/module/Decision/Module.php
@@ -135,6 +135,7 @@ class Module
 
                     // users are allowed to view and search members
                     $acl->allow('user', 'member', ['view', 'view_self', 'search', 'birthdays']);
+                    $acl->allow('apiuser', 'member', ['view']);
 
                     $acl->allow('user', 'decision', ['search', 'view_meeting', 'list_meetings']);
 

--- a/module/Decision/config/module.config.php
+++ b/module/Decision/config/module.config.php
@@ -239,6 +239,30 @@ return [
                 ],
                 'priority' => 100
             ],
+            'member_api' => [
+                'type' => 'Literal',
+                'options' => [
+                    'route' => '/api/member',
+                    'defaults' => [
+                        '__NAMESPACE__' => 'Decision\Controller',
+                        'controller' => 'MemberApi',
+                        'action' => 'index',
+                    ],
+                ],
+                'may_terminate' => true,
+                'child_routes' => [
+                    'lidnr' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/lidnr/:lidnr',
+                            'defaults' => [
+                                'action' => 'lidnr',
+                            ],
+                        ],
+                    ],
+                ],
+                'priority' => 100,
+            ],
             'admin_organ' => [
                 'type' => 'Literal',
                 'options' => [
@@ -283,7 +307,8 @@ return [
             'Decision\Controller\Organ' => 'Decision\Controller\OrganController',
             'Decision\Controller\Admin' => 'Decision\Controller\AdminController',
             'Decision\Controller\OrganAdmin' => 'Decision\Controller\OrganAdminController',
-            'Decision\Controller\Member' => 'Decision\Controller\MemberController'
+            'Decision\Controller\Member' => 'Decision\Controller\MemberController',
+            'Decision\Controller\MemberApi' => 'Decision\Controller\MemberApiController',
         ]
     ],
     'view_manager' => [

--- a/module/Decision/src/Decision/Controller/MemberApiController.php
+++ b/module/Decision/src/Decision/Controller/MemberApiController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Decision\Controller;
+
+use Zend\Mvc\Controller\AbstractActionController;
+use Zend\View\Model\JsonModel;
+
+class MemberApiController extends AbstractActionController
+{
+
+    public function lidnrAction()
+    {
+        $lidnr = $this->params()->fromRoute('lidnr');
+
+        $member = $this->getMemberService()->findMemberByLidNr($lidnr);
+
+        if ($member) {
+            return new JsonModel($member->toArray());
+        }
+
+        return new JsonModel([]);
+    }
+
+    /**
+     * Get the member service.
+     *
+     * @return \Decision\Service\Member
+     */
+    public function getMemberService()
+    {
+        return $this->getServiceLocator()->get('decision_service_member');
+    }
+}

--- a/module/Decision/src/Decision/Controller/MemberApiController.php
+++ b/module/Decision/src/Decision/Controller/MemberApiController.php
@@ -15,7 +15,7 @@ class MemberApiController extends AbstractActionController
         $member = $this->getMemberService()->findMemberByLidNr($lidnr);
 
         if ($member) {
-            return new JsonModel($member->toArray());
+            return new JsonModel($member->toApiArray());
         }
 
         return new JsonModel([]);

--- a/module/Decision/src/Decision/Model/Member.php
+++ b/module/Decision/src/Decision/Model/Member.php
@@ -576,6 +576,22 @@ class Member
         ];
     }
 
+    public function toApiArray()
+    {
+        return [
+            'lidnr' => $this->getLidnr(),
+            'email' => $this->getEmail(),
+            'fullName' => $this->getFullName(),
+            'initials' => $this->getInitials(),
+            'firstName' => $this->getFirstName(),
+            'middleName' => $this->getMiddleName(),
+            'lastName' => $this->getLastName(),
+            'birth' => $this->getBirth()->format(\DateTime::ISO8601),
+            'generation' => $this->getGeneration(),
+            'expiration' => $this->getExpiration()->format(\DateTime::ISO8601),
+        ];
+    }
+
     /**
      * Get all addresses.
      *

--- a/module/Decision/src/Decision/Service/Member.php
+++ b/module/Decision/src/Decision/Service/Member.php
@@ -76,6 +76,13 @@ class Member extends AbstractAclService
      */
     public function findMemberByLidNr($lidnr)
     {
+        if (!$this->isAllowed('view')) {
+            $translator = $this->getTranslator();
+            throw new \User\Permissions\NotAllowedException(
+                $translator->translate('You are not allowed to view members.')
+            );
+        }
+
         return $this->getMemberMapper()->findByLidnr($lidnr);
     }
 


### PR DESCRIPTION
This PR will allow API users to get information for a member using the following URL: `/api/member/lidnr/1234`.

---

N.B. This PR was a request for the GEPWNAGE LAN website so members can sign up using their lidnr.