### PR TITLE
Require login to view photos

### DIFF
--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -134,17 +134,19 @@ $lang = $this->plugin('translate')->getTranslator()->getLocale();
                             <li><a href="<?= $this->url('activity/create') ?>"> <?= $this->translate('Create an activity') ?></a></li>
                         <?php endif; ?>
                         <?php if ($this->acl('activity_acl')->isAllowed('activity', 'create')): ?>
-                            <li><a href="<?= $this->url('activity_calendar') ?>"> <?= $this->translate('Option 
+                            <li><a href="<?= $this->url('activity_calendar') ?>"> <?= $this->translate('Option
                             calendar') ?></a></li>
                         <?php endif; ?>
                     </ul>
                 </li>
+                <?php if ($this->acl('photo_acl')->isAllowed('album','view')): ?>
                 <li class="dropdown dropdown-hover <?= $this->moduleIsActive(['photo']) ? 'active' : '' ?>"><a href="<?= $this->url('photo') ?>"><?= $this->translate('Photos') ?></a>
                     <ul class="dropdown-menu">
                         <li><a href="<?= $this->url('photo/weekly') ?>"><?= $this->translate('Photo of the week') ?></a></li>
 
                     </ul>
                 </li>
+                <?php endif;?>
             </ul>
             <?php if (null != $this->identity()): ?>
             <ul class="nav navbar-nav navbar-right">

--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -139,14 +139,14 @@ $lang = $this->plugin('translate')->getTranslator()->getLocale();
                         <?php endif; ?>
                     </ul>
                 </li>
-                <?php if ($this->acl('photo_acl')->isAllowed('album','view')): ?>
                 <li class="dropdown dropdown-hover <?= $this->moduleIsActive(['photo']) ? 'active' : '' ?>"><a href="<?= $this->url('photo') ?>"><?= $this->translate('Photos') ?></a>
+                <?php if ($this->acl('photo_acl')->isAllowed('photo','view')): ?>
                     <ul class="dropdown-menu">
                         <li><a href="<?= $this->url('photo/weekly') ?>"><?= $this->translate('Photo of the week') ?></a></li>
 
                     </ul>
-                </li>
                 <?php endif;?>
+                </li>
             </ul>
             <?php if (null != $this->identity()): ?>
             <ul class="nav navbar-nav navbar-right">

--- a/module/Photo/Module.php
+++ b/module/Photo/Module.php
@@ -121,9 +121,9 @@ class Module
                     $acl->addResource('album');
                     $acl->addResource('tag');
 
-                    // Guests are allowed to view photos and albums
-                    $acl->allow('guest', 'photo', 'view');
-                    $acl->allow('guest', 'album', 'view');
+                    // Only users are allowed to view photos and albums
+                    $acl->allow('user', 'photo', 'view');
+                    $acl->allow('user', 'album', 'view');
 
                     // Users are allowed to view, remove and add tags
                     $acl->allow('user', 'tag', ['view', 'add', 'remove']);

--- a/module/Photo/src/Photo/Service/Photo.php
+++ b/module/Photo/src/Photo/Service/Photo.php
@@ -244,12 +244,12 @@ class Photo extends AbstractAclService
     }
     /**
      * Generates the PhotoOfTheWeek and adds it to the list
-     * if at least one photo has been viewed in the specified time. 
-     * The parameters determine the week to check the photos of.  
-     * 
+     * if at least one photo has been viewed in the specified time.
+     * The parameters determine the week to check the photos of.
+     *
      * @param \DateTime $begindate
      * @param \DateTime $enddate
-     * 
+     *
      * @return \Photo\Model\Photo|null
      */
     public function generatePhotoOfTheWeek($begindate = null, $enddate = null)
@@ -270,10 +270,10 @@ class Photo extends AbstractAclService
         $mapper->flush();
         return $weeklyPhoto;
     }
-    
+
     /**
      * Determine which photo is the photo of the week
-     * 
+     *
      * @param \DateTime $begindate
      * @param \DateTime $enddate
      * @return \Photo\Model\Photo|null
@@ -304,12 +304,17 @@ class Photo extends AbstractAclService
      */
     public function getPhotosOfTheWeek()
     {
+        if (!$this->isAllowed('view')) {
+            throw new \User\Permissions\NotAllowedException(
+                $this->getTranslator()->translate('Not allowed to view previous photos of the week')
+            );
+        }
         return $this->getWeeklyPhotoMapper()->getPhotosOfTheWeek();
     }
 
     /**
      * Determine the preference rating of the photo.
-     * 
+     *
      * @param \Photo\Model\Photo $photo
      * @param integer $occurences
      * @return float
@@ -503,7 +508,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('photo_mapper_tag');
     }
-    
+
     public function getHitMapper()
     {
         return $this->sm->get('photo_mapper_hit');
@@ -511,7 +516,7 @@ class Photo extends AbstractAclService
 
     /**
      * Get the weekly photo mapper.
-     * 
+     *
      * @return \Photo\Mapper\WeeklyPhoto
      */
     public function getWeeklyPhotoMapper()


### PR DESCRIPTION
Requires a login to view all* photos (even thumbnails).

Additionally,
-Hides the 'Photos of the week' dropdown from the nav-bar when logged out.
-Restricts viewing the 'photos of the week' such that only the most recent one can be viewed.

*The frontpage banner and the most recent 'photo of the week' are exceptions.