### PR TITLE
Feature/activity hide subscriptions

### DIFF
--- a/module/Activity/Module.php
+++ b/module/Activity/Module.php
@@ -149,10 +149,10 @@ class Module
 
                     $acl->allow('guest', 'activity', 'view');
 
-                    $acl->allow('guest', 'activitySignup', ['view', 'externalSignup']);
+                    $acl->allow('guest', 'activitySignup', 'externalSignup');
 
                     $acl->allow('user', 'activity', 'create');
-                    $acl->allow('user', 'activitySignup', ['signup', 'signoff', 'checkUserSignedUp']);
+                    $acl->allow('user', 'activitySignup', ['view', 'signup', 'signoff', 'checkUserSignedUp']);
 
                     $acl->allow('admin', 'activity', ['update', 'viewDetails', 'adminSignup']);
                     $acl->allow('user', 'activity', ['update', 'viewDetails', 'adminSignup'], new IsCreator());

--- a/module/Activity/src/Activity/Controller/ActivityController.php
+++ b/module/Activity/src/Activity/Controller/ActivityController.php
@@ -64,7 +64,9 @@ class ActivityController extends AbstractActionController
             $activity->getStatus() === Activity::STATUS_APPROVED,
             'isAllowedToSubscribe' => $isAllowedToSubscribe,
             'isSignedUp' => $isSignedUp,
-            'signupData' => $translatorService->getTranslatedSignedUpData($activity, $langSession->lang),
+            'signupData' => $signupService->isAllowedToViewSubscriptions() ?
+                $translatorService->getTranslatedSignedUpData($activity, $langSession->lang) :
+                null,
             'form' => $form,
             'signoffForm' => new RequestForm('activitysignoff', 'Unsubscribe'),
             'fields' => $fields,

--- a/module/Activity/src/Activity/Controller/ActivityController.php
+++ b/module/Activity/src/Activity/Controller/ActivityController.php
@@ -70,6 +70,7 @@ class ActivityController extends AbstractActionController
             'form' => $form,
             'signoffForm' => new RequestForm('activitysignoff', 'Unsubscribe'),
             'fields' => $fields,
+            'memberSignups' => $signupService->getNumberOfSubscribedMembers($activity),
         ];
 
         //Retrieve and clear the request status from the session, if it exists.

--- a/module/Activity/src/Activity/Form/Activity.php
+++ b/module/Activity/src/Activity/Form/Activity.php
@@ -173,6 +173,15 @@ class Activity extends Form implements InputFilterProviderInterface
         ]);
 
         $this->add([
+            'name' => 'displaySubscribedNumber',
+            'type' => 'Zend\Form\Element\Checkbox',
+            'options' => [
+                'checked_value' => 1,
+                'unchecked_value' => 0,
+            ],
+        ]);
+
+        $this->add([
             'name' => 'fields',
             'type' => 'Zend\Form\Element\Collection',
             'options' => [

--- a/module/Activity/src/Activity/Mapper/Signup.php
+++ b/module/Activity/src/Activity/Mapper/Signup.php
@@ -103,7 +103,7 @@ class Signup
     {
         $qb = $this->em->createQueryBuilder();
         $qb->select('COUNT(s)')
-           ->from('Activity\Model\UserActivitySignup','s')
+           ->from('Activity\Model\UserActivitySignup', 's')
            ->join('s.activity', 'a')
            ->where('a.id = ?1')
            ->setParameter(1, $activityId);

--- a/module/Activity/src/Activity/Mapper/Signup.php
+++ b/module/Activity/src/Activity/Mapper/Signup.php
@@ -98,4 +98,17 @@ class Signup
 
         return $result;
     }
+
+    public function getNumberOfSignedUpMembers($activityId)
+    {
+        $qb = $this->em->createQueryBuilder();
+        $qb->select('COUNT(s)')
+           ->from('Activity\Model\UserActivitySignup','s')
+           ->join('s.activity', 'a')
+           ->where('a.id = ?1')
+           ->setParameter(1, $activityId);
+        $result = $qb->getQuery()->getResult();
+
+        return $result[0];
+    }
 }

--- a/module/Activity/src/Activity/Model/Activity.php
+++ b/module/Activity/src/Activity/Model/Activity.php
@@ -618,6 +618,7 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
             'canSignUp' => $this->getCanSignUp(),
             'isFood' => $this->getIsFood(),
             'isMyFuture' => $this->getIsMyFuture(),
+            'displaySubscribedNumber' => $this->getDisplaySubscribedNumber(),
             'attendees' => $attendees,
             'fields' => $fields,
         ];

--- a/module/Activity/src/Activity/Model/Activity.php
+++ b/module/Activity/src/Activity/Model/Activity.php
@@ -113,6 +113,14 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     protected $onlyGEWIS;
 
     /**
+     * Should the number of subscribed members be displayed
+     * when the user is NOT logged in?
+     *
+     * @ORM\Column(type="boolean")
+     */
+    protected $displaySubscribedNumber;
+
+    /**
      * Who did approve this activity.
      *
      * @ORM\ManyToOne(targetEntity="User\Model\User")
@@ -383,6 +391,22 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     public function setOnlyGEWIS($onlyGEWIS)
     {
         $this->onlyGEWIS = $onlyGEWIS;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getDisplaySubscribedNumber()
+    {
+        return $this->displaySubscribedNumber;
+    }
+
+    /**
+     * @param boolean $displaySubscribedNumber
+     */
+    public function setDisplaySubscribedNumber($displaySubscribedNumber)
+    {
+        $this->displaySubscribedNumber = $displaySubscribedNumber;
     }
 
     /**

--- a/module/Activity/src/Activity/Model/ActivityTranslation.php
+++ b/module/Activity/src/Activity/Model/ActivityTranslation.php
@@ -66,6 +66,12 @@ class ActivityTranslation
     protected $onlyGEWIS;
 
     /**
+     * Should the number of subscribed members be displayed
+     * when the user is NOT logged in?
+     */
+    protected $displaySubscribedNumber;
+
+    /**
      * Who did approve this activity.
      */
     protected $approver;
@@ -109,7 +115,7 @@ class ActivityTranslation
     {
         return $this->id;
     }
-    
+
     public function setId($id)
     {
         $this->id = $id;
@@ -242,6 +248,22 @@ class ActivityTranslation
     public function setOnlyGEWIS($onlyGEWIS)
     {
         $this->onlyGEWIS = $onlyGEWIS;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getDisplaySubscribedNumber()
+    {
+        return $this->displaySubscribedNumber;
+    }
+
+    /**
+     * @param boolean $displaySubscribedNumber
+     */
+    public function setDisplaySubscribedNumber($displaySubscribedNumber)
+    {
+        $this->displaySubscribedNumber = $displaySubscribedNumber;
     }
 
     /**
@@ -392,6 +414,7 @@ class ActivityTranslation
             'costs' => $this->getCosts(),
             'description' => $this->getDescription(),
             'attendees' => $attendees,
+            'displaySubscribedNumber' => $this->getDisplaySubscribedNumber(),
             'fields' => $fields,
         ];
     }

--- a/module/Activity/src/Activity/Service/Activity.php
+++ b/module/Activity/src/Activity/Service/Activity.php
@@ -262,6 +262,7 @@ class Activity extends AbstractAclService implements ServiceManagerAwareInterfac
         $activity->setIsFood($params['isFood']);
         $activity->setIsMyFuture($params['isMyFuture']);
         $activity->setOnlyGEWIS($params['onlyGEWIS']);
+        $activity->setDisplaySubscribedNumber($params['displaySubscribedNumber']);
 
         // Not user provided input
         $activity->setCreator($user);

--- a/module/Activity/src/Activity/Service/ActivityTranslator.php
+++ b/module/Activity/src/Activity/Service/ActivityTranslator.php
@@ -94,6 +94,7 @@ class ActivityTranslator extends AbstractService
         $activityTranslation->setEndTime($activity->getEndTime());
         $activityTranslation->setCanSignUp($activity->getCanSignUp());
         $activityTranslation->setIsFood($activity->getIsFood());
+        $activityTranslation->setDisplaySubscribedNumber($activity->getDisplaySubscribedNumber());
         $activityTranslation->setIsMyFuture($activity->getIsMyFuture());
         $activityTranslation->setOnlyGEWIS($activity->getOnlyGEWIS());
         $activityTranslation->setApprover($activity->getApprover());

--- a/module/Activity/src/Activity/Service/Signup.php
+++ b/module/Activity/src/Activity/Service/Signup.php
@@ -313,6 +313,12 @@ class Signup extends AbstractAclService
         $this->removeSignUp($signUp);
     }
 
+    public function getNumberOfSubscribedMembers(ActivityModel $activity)
+    {
+        return $this->getServiceManager()->get('activity_mapper_signup')
+                ->getNumberOfSignedUpMembers($activity->getId())[1];
+    }
+
     public function externalSignOff(ExternalActivitySignup $signup)
     {
         if (!($this->isAllowed('adminSignup', 'activity') ||

--- a/module/Activity/src/Activity/Service/Signup.php
+++ b/module/Activity/src/Activity/Service/Signup.php
@@ -352,6 +352,11 @@ class Signup extends AbstractAclService
         return $this->isAllowed('externalSignup', 'activitySignup');
     }
 
+    public function isAllowedToViewSubscriptions()
+    {
+        return $this->isAllowed('view', 'activitySignup');
+    }
+
     public function isAllowedToInternalSubscribe()
     {
         return $this->isAllowed('signup', 'activitySignup');

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -94,8 +94,8 @@ $this->headTitle($this->translate('Activities')); ?>
                         <tr>
                             <td align="center" colspan="<?= count($fields) + 2 ?>">
                                 <?php if ($activity->getDisplaySubscribedNumber()){
-                                    echo sprintf($this->translate('The number of subscribed member(s) is currently %d.'), $memberSignups);
-                                }?><br/>
+                                    echo sprintf($this->translate('The number of subscribed member(s) is currently %d.'), $memberSignups) . '<br/>';
+                                }?>
                                 <a href="<?= $this->url('user') ?>">
                                     <?= $this->translate('Login to view the subscribed members.') ?>
                                 </a>

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -92,9 +92,9 @@ $this->headTitle($this->translate('Activities')); ?>
                     <?php $i = 1; ?>
                     <?php if(!$this->acl('activity_acl')->isAllowed('activitySignup', 'view')): ?>
                         <tr>
-                            <td align="center" rowspan="1" colspan="<?= count($fields) + 2 ?>">
+                            <td align="center" colspan="<?= count($fields) + 2 ?>">
                                 <a href="<?= $this->url('user') ?>">
-                                    <?= $this->translate('Login to view the subscribed members') ?>
+                                    <?= $this->translate('Login to view the subscribed members.') ?>
                                 </a>
                             </td>
                         </tr>

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -89,41 +89,43 @@ $this->headTitle($this->translate('Activities')); ?>
                     </tr>
                 </thead>
                 <tbody>
-                <?php $i = 1; ?>
-                <?php foreach($activity->getSignUps() as $signup): ?>
-                    <tr>
-                        <td><?php echo $i; $i = $i + 1; ?></td>
-                        <td><?= $this->escapeHtml($signup->getFullName()) ?></td>
-                        <?php foreach ($fields as $field): ?>
-                            <?php foreach($signup->getFieldValues() as $fieldValue):?>
-                                <?php if ($fieldValue->getField()->getId() === $field->getId()): ?>
-                                <td>
-                                    <?php
-                                    switch ($field->getType()) {
-                                        case 0:
-                                            echo $this->escapeHtml($fieldValue->getValue());
-                                            break;
-                                        case 1:
-                                            echo $this->translate($fieldValue->getValue());
-                                            break;
-                                        case 2:
-                                            echo $fieldValue->getValue();
-                                            break;
-                                        case 3:
-                                            if ($lang === 'nl') {
-                                                echo $fieldValue->getOption()->getValue();
-                                            } else {
-                                                echo $fieldValue->getOption()->getValueEn();
+                    <?php $i = 1; ?>
+                    <?php foreach($activity->getSignUps() as $signup): ?>
+                        <?php if (($signup instanceof Activity\Model\ExternalActivitySignup) || $this->acl('activity_acl')->isAllowed('activitySignup', 'view')): ?>
+                            <tr>
+                                <td><?php echo $i; $i = $i + 1; ?></td>
+                                <td><?= $this->escapeHtml($signup->getFullName()) ?></td>
+                                <?php foreach ($fields as $field): ?>
+                                    <?php foreach($signup->getFieldValues() as $fieldValue):?>
+                                        <?php if ($fieldValue->getField()->getId() === $field->getId()): ?>
+                                        <td>
+                                            <?php
+                                            switch ($field->getType()) {
+                                                case 0:
+                                                    echo $this->escapeHtml($fieldValue->getValue());
+                                                    break;
+                                                case 1:
+                                                    echo $this->translate($fieldValue->getValue());
+                                                    break;
+                                                case 2:
+                                                    echo $fieldValue->getValue();
+                                                    break;
+                                                case 3:
+                                                    if ($lang === 'nl') {
+                                                        echo $fieldValue->getOption()->getValue();
+                                                    } else {
+                                                        echo $fieldValue->getOption()->getValueEn();
+                                                    }
+                                                    break;
                                             }
-                                            break;
-                                    }
-                                    ?>
-                                </td>
-                                <?php endif; ?>
-                            <?php endforeach;?>
-                        <?php endforeach; ?>
-                    </tr>
-                <?php endforeach;?>
+                                            ?>
+                                        </td>
+                                        <?php endif; ?>
+                                    <?php endforeach;?>
+                                <?php endforeach; ?>
+                            </tr>
+                        <?php endif; ?>
+                    <?php endforeach;?>
                 </tbody>
             </table>
         </div>

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -94,7 +94,7 @@ $this->headTitle($this->translate('Activities')); ?>
                         <tr>
                             <td align="center" colspan="<?= count($fields) + 2 ?>">
                                 <?php if ($activity->getDisplaySubscribedNumber()){
-                                    echo sprintf($this->translate('The number of subscribed member(s) is currently %d.'), $memberSignups) . '<br/>';
+                                    echo sprintf($this->translate('The number of subscribed members is currently %d.'), $memberSignups) . '<br/>';
                                 }?>
                                 <a href="<?= $this->url('user') ?>">
                                     <?= $this->translate('Login to view the subscribed members.') ?>

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -93,6 +93,9 @@ $this->headTitle($this->translate('Activities')); ?>
                     <?php if(!$this->acl('activity_acl')->isAllowed('activitySignup', 'view')): ?>
                         <tr>
                             <td align="center" colspan="<?= count($fields) + 2 ?>">
+                                <?php if ($activity->getDisplaySubscribedNumber()){
+                                    echo sprintf($this->translate('The number of subscribed member(s) is currently %d.'), $memberSignups);
+                                }?><br/>
                                 <a href="<?= $this->url('user') ?>">
                                     <?= $this->translate('Login to view the subscribed members.') ?>
                                 </a>
@@ -103,7 +106,7 @@ $this->headTitle($this->translate('Activities')); ?>
 
                         <?php if (($signup instanceof Activity\Model\ExternalActivitySignup) || $this->acl('activity_acl')->isAllowed('activitySignup', 'view')): ?>
                             <tr>
-                                <td><?= $this->acl('activity_acl')->isAllowed('activitySignup', 'view') ? $i : '' ?></td>
+                                <td><?= $this->acl('activity_acl')->isAllowed('activitySignup', 'view') || $activity->getDisplaySubscribedNumber() ? $i : '' ?></td>
                                 <td><?= $this->escapeHtml($signup->getFullName()) ?></td>
                                 <?php foreach ($fields as $field): ?>
                                     <?php foreach($signup->getFieldValues() as $fieldValue):?>

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -90,10 +90,20 @@ $this->headTitle($this->translate('Activities')); ?>
                 </thead>
                 <tbody>
                     <?php $i = 1; ?>
+                    <?php if(!$this->acl('activity_acl')->isAllowed('activitySignup', 'view')): ?>
+                        <tr>
+                            <td align="center" rowspan="1" colspan="<?= count($fields) + 2 ?>">
+                                <a href="<?= $this->url('user') ?>">
+                                    <?= $this->translate('Login to view the subscribed members') ?>
+                                </a>
+                            </td>
+                        </tr>
+                    <?php endif; ?>
                     <?php foreach($activity->getSignUps() as $signup): ?>
+
                         <?php if (($signup instanceof Activity\Model\ExternalActivitySignup) || $this->acl('activity_acl')->isAllowed('activitySignup', 'view')): ?>
                             <tr>
-                                <td><?php echo $i; $i = $i + 1; ?></td>
+                                <td><?= $this->acl('activity_acl')->isAllowed('activitySignup', 'view') ? $i : '' ?></td>
                                 <td><?= $this->escapeHtml($signup->getFullName()) ?></td>
                                 <?php foreach ($fields as $field): ?>
                                     <?php foreach($signup->getFieldValues() as $fieldValue):?>
@@ -124,6 +134,7 @@ $this->headTitle($this->translate('Activities')); ?>
                                     <?php endforeach;?>
                                 <?php endforeach; ?>
                             </tr>
+                            <?php $i = $i + 1;?>
                         <?php endif; ?>
                     <?php endforeach;?>
                 </tbody>

--- a/module/Activity/view/partial/create.phtml
+++ b/module/Activity/view/partial/create.phtml
@@ -208,6 +208,17 @@ $subscriptionDeadline->setAttribute('class', 'form-control')->setAttribute('id',
         </label>
     </div>
     <?php
+    $displaySubscribedNumber = $form->get('displaySubscribedNumber');
+    ?>
+    <div class="form-group<?= count($displaySubscribedNumber->getMessages()) > 0 ? ' has-error' : '' ?>">
+        <label>
+            <?= $this->formCheckbox($displaySubscribedNumber) ?>
+            <?= $this->translate('Display number of subscribed members') ?>
+            <span data-toggle="tooltip" data-placement="right" title="<?= $this->translate('Select this to display the number of subscribed GEWIS members to external visitors.') ?>" class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            <?= $this->formElementErrors($displaySubscribedNumber) ?>
+        </label>
+    </div>
+    <?php
     $isFood = $form->get('isFood');
     ?>
     <div class="form-group<?= count($isFood->getMessages()) > 0 ? ' has-error' : '' ?>">


### PR DESCRIPTION
Resolves #741. 
Any external subscriptions do not have numbers displayed by default, 
as they cannot be displayed without revealing information on the number of internal subscriptions.

@gafderks Could you check if the row replacing the subscribed member details is acceptable from a design perspective?