### PR TITLE
Add a role for friends of GEWIS that want to view photos

### DIFF
--- a/module/Photo/Module.php
+++ b/module/Photo/Module.php
@@ -131,6 +131,10 @@ class Module
                     // Users are allowed to download photos
                     $acl->allow('user', 'photo', ['download', 'view_metadata']);
 
+                    $acl->allow('photo_guest', 'photo', 'view');
+                    $acl->allow('photo_guest', 'album', 'view');
+                    $acl->allow('photo_guest', 'photo', ['download', 'view_metadata']);
+
                     return $acl;
                 },
                 // fake 'alias' for entity manager, because doctrine uses an abstract factory

--- a/module/User/Module.php
+++ b/module/User/Module.php
@@ -253,6 +253,7 @@ class Module
                      * - user: GEWIS-member
                      * - apiuser: Automated tool given access by an admin
                      * - admin: Defined administrators
+                     * - photo_guest: Special role for non-members but friends of GEWIS nonetheless
                      */
                     $acl->addRole(new Role('guest'));
                     $acl->addRole(new Role('tueguest'), 'guest');
@@ -262,6 +263,7 @@ class Module
                     $acl->addrole(new Role('active_member'), 'user');
                     $acl->addrole(new Role('company_admin'), 'active_member');
                     $acl->addRole(new Role('admin'));
+                    $acl->addRole(new Role('photo_guest'), 'guest');
 
                     $user = $sm->get('user_role');
 
@@ -292,6 +294,7 @@ class Module
                     $acl->addResource(new Resource('user'));
 
                     $acl->allow('user', 'user', ['password_change']);
+                    $acl->allow('photo_guest', 'user', ['password_change']);
                     $acl->allow('tueguest', 'user', 'pin_login');
 
                     // sosusers can't do anything


### PR DESCRIPTION
This new role will be used to give a user slightly more privileges than a guest. The only extra privileges are that he can view activity photos and change his password. Private information such member data and general meeting minutes are still off limits.