### PR TITLE
Redesign member page

### DIFF
--- a/module/Decision/src/Decision/Controller/MemberController.php
+++ b/module/Decision/src/Decision/Controller/MemberController.php
@@ -11,7 +11,19 @@ class MemberController extends AbstractActionController
 
     public function indexAction()
     {
-        return new ViewModel(['member' => $this->identity()->getMember()]);
+        $decisionService = $this->getServiceLocator()->get('decision_service_decision');
+
+        // Get the latest 5 meetings that have taken place
+        $meetings = $decisionService->getMeetings(5, false);
+
+        // Flatten array
+        $meetings = array_map(function ($item) { return $item[0]; }, $meetings);
+
+        return new ViewModel([
+            'member'   => $this->identity()->getMember(),
+            'meetings' => $meetings,
+            'upcoming' => $decisionService->getLatestAV()
+        ]);
     }
 
     /**

--- a/module/Decision/src/Decision/Controller/MemberController.php
+++ b/module/Decision/src/Decision/Controller/MemberController.php
@@ -21,8 +21,11 @@ class MemberController extends AbstractActionController
             return $item[0];
         }, $meetings);
 
+        $member = $this->identity()->getMember();
+
         return new ViewModel([
-            'member'   => $this->identity()->getMember(),
+            'member'   => $member,
+            'isActive' => $this->getMemberService()->isActiveMember($member),
             'meetings' => $meetings,
             'upcoming' => $decisionService->getUpcomingAV()
         ]);

--- a/module/Decision/src/Decision/Controller/MemberController.php
+++ b/module/Decision/src/Decision/Controller/MemberController.php
@@ -14,7 +14,7 @@ class MemberController extends AbstractActionController
         $decisionService = $this->getServiceLocator()->get('decision_service_decision');
 
         // Get the latest 5 meetings that have taken place
-        $meetings = $decisionService->getMeetings(5, false);
+        $meetings = $decisionService->getPastMeetings(5);
 
         // Flatten array
         $meetings = array_map(function ($item) {

--- a/module/Decision/src/Decision/Controller/MemberController.php
+++ b/module/Decision/src/Decision/Controller/MemberController.php
@@ -17,7 +17,9 @@ class MemberController extends AbstractActionController
         $meetings = $decisionService->getMeetings(5, false);
 
         // Flatten array
-        $meetings = array_map(function ($item) { return $item[0]; }, $meetings);
+        $meetings = array_map(function ($item) {
+            return $item[0];
+        }, $meetings);
 
         return new ViewModel([
             'member'   => $this->identity()->getMember(),

--- a/module/Decision/src/Decision/Controller/MemberController.php
+++ b/module/Decision/src/Decision/Controller/MemberController.php
@@ -24,7 +24,7 @@ class MemberController extends AbstractActionController
         return new ViewModel([
             'member'   => $this->identity()->getMember(),
             'meetings' => $meetings,
-            'upcoming' => $decisionService->getLatestAV()
+            'upcoming' => $decisionService->getUpcomingAV()
         ]);
     }
 

--- a/module/Decision/src/Decision/Controller/MemberController.php
+++ b/module/Decision/src/Decision/Controller/MemberController.php
@@ -24,7 +24,7 @@ class MemberController extends AbstractActionController
 
         return new ViewModel([
             'member'             => $member,
-            'isActive'           => $this->getMemberService()->isActiveMember($member),
+            'isActive'           => $this->getMemberService()->isActiveMember(),
             'upcoming'           => $decisionService->getUpcomingAV(),
             'meetingsCollection' => $meetingsCollection,
         ]);

--- a/module/Decision/src/Decision/Controller/MemberController.php
+++ b/module/Decision/src/Decision/Controller/MemberController.php
@@ -13,21 +13,20 @@ class MemberController extends AbstractActionController
     {
         $decisionService = $this->getServiceLocator()->get('decision_service_decision');
 
-        // Get the latest 5 meetings that have taken place
-        $meetings = $decisionService->getPastMeetings(5);
-
-        // Flatten array
-        $meetings = array_map(function ($item) {
-            return $item[0];
-        }, $meetings);
+        // Get the latest 3 meetings of each type and flatten result
+        $meetingsCollection = [
+            'AV' => array_column($decisionService->getPastMeetings(3, 'AV'), 0),
+            'BV' => array_column($decisionService->getPastMeetings(3, 'BV'), 0),
+            'VV' => array_column($decisionService->getPastMeetings(3, 'VV'), 0),
+        ];
 
         $member = $this->identity()->getMember();
 
         return new ViewModel([
-            'member'   => $member,
-            'isActive' => $this->getMemberService()->isActiveMember($member),
-            'meetings' => $meetings,
-            'upcoming' => $decisionService->getUpcomingAV()
+            'member'             => $member,
+            'isActive'           => $this->getMemberService()->isActiveMember($member),
+            'upcoming'           => $decisionService->getUpcomingAV(),
+            'meetingsCollection' => $meetingsCollection,
         ]);
     }
 

--- a/module/Decision/src/Decision/Mapper/Meeting.php
+++ b/module/Decision/src/Decision/Mapper/Meeting.php
@@ -112,19 +112,7 @@ class Meeting
      */
     public function findLatestAV()
     {
-        $qb = $this->em->createQueryBuilder();
-
-        $today = new \DateTime();
-        $maxDate = $today->sub(new \DateInterval('P1D'));
-        $qb->select('m')
-            ->from('Decision\Model\Meeting', 'm')
-            ->where('m.type = AV')
-            ->where('m.date >= :date')
-            ->orderBy('m.date', 'DESC')
-            ->setParameter('date', $maxDate)
-            ->setMaxResults(1);
-
-        return $qb->getQuery()->getOneOrNullResult();
+        return $this->findFutureAV('DESC');
     }
 
     /**
@@ -134,20 +122,7 @@ class Meeting
      */
     public function findUpcomingAV()
     {
-        $qb = $this->em->createQueryBuilder();
-
-        $today = new \DateTime();
-        $maxDate = $today->sub(new \DateInterval('P1D'));
-
-        $qb->select('m')
-            ->from('Decision\Model\Meeting', 'm')
-            ->where('m.type = AV')
-            ->where('m.date >= :date')
-            ->orderBy('m.date', 'ASC')
-            ->setParameter('date', $maxDate)
-            ->setMaxResults(1);
-
-        return $qb->getQuery()->getOneOrNullResult();
+        return $this->findFutureAV('ASC');
     }
 
     /**
@@ -223,5 +198,29 @@ class Meeting
     public function getRepository()
     {
         return $this->em->getRepository('Decision\Model\Meeting');
+    }
+
+    /**
+     * Finds an AV planned in the future
+     *
+     * @param string $order Order of the future AV's
+     * @return \Decision\Model\Meeting|null
+     */
+    private function findFutureAV($order)
+    {
+        $qb = $this->em->createQueryBuilder();
+
+        $today = new \DateTime();
+        $maxDate = $today->sub(new \DateInterval('P1D'));
+
+        $qb->select('m')
+            ->from('Decision\Model\Meeting', 'm')
+            ->where('m.type = AV')
+            ->where('m.date >= :date')
+            ->orderBy('m.date', $order)
+            ->setParameter('date', $maxDate)
+            ->setMaxResults(1);
+
+        return $qb->getQuery()->getOneOrNullResult();
     }
 }

--- a/module/Decision/src/Decision/Mapper/Meeting.php
+++ b/module/Decision/src/Decision/Mapper/Meeting.php
@@ -215,9 +215,10 @@ class Meeting
 
         $qb->select('m')
             ->from('Decision\Model\Meeting', 'm')
-            ->where('m.type = AV')
-            ->where('m.date >= :date')
+            ->where('m.type = :type')
+            ->andWhere('m.date >= :date')
             ->orderBy('m.date', $order)
+            ->setParameter('type', 'AV')
             ->setParameter('date', $maxDate)
             ->setMaxResults(1);
 

--- a/module/Decision/src/Decision/Mapper/Meeting.php
+++ b/module/Decision/src/Decision/Mapper/Meeting.php
@@ -75,7 +75,8 @@ class Meeting
      * @param int|null $limit The amount of results, default is all
      * @return array Meetings that have taken place
      */
-    public function findPast($limit = null) {
+    public function findPast($limit = null)
+    {
         $qb = $this->em->createQueryBuilder();
 
         // Use yesterday because a meeting might still take place later on the day

--- a/module/Decision/src/Decision/Mapper/Meeting.php
+++ b/module/Decision/src/Decision/Mapper/Meeting.php
@@ -101,6 +101,9 @@ class Meeting
     /**
      * Returns the latest upcoming AV or null if there is none.
      *
+     * Note that if multiple AVs are planned, the one that is planned furthest
+     * away is returned.
+     *
      * @return \Decision\Model\Meeting|null
      */
     public function findLatestAV()
@@ -114,6 +117,29 @@ class Meeting
             ->where('m.type = AV')
             ->where('m.date >= :date')
             ->orderBy('m.date', 'DESC')
+            ->setParameter('date', $maxDate)
+            ->setMaxResults(1);
+
+        return $qb->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * Returns the closest upcoming AV
+     *
+     * @return \Decision\Model\Meeting|null
+     */
+    public function findUpcomingAV()
+    {
+        $qb = $this->em->createQueryBuilder();
+
+        $today = new \DateTime();
+        $maxDate = $today->sub(new \DateInterval('P1D'));
+
+        $qb->select('m')
+            ->from('Decision\Model\Meeting', 'm')
+            ->where('m.type = AV')
+            ->where('m.date >= :date')
+            ->orderBy('m.date', 'ASC')
             ->setParameter('date', $maxDate)
             ->setMaxResults(1);
 

--- a/module/Decision/src/Decision/Mapper/Meeting.php
+++ b/module/Decision/src/Decision/Mapper/Meeting.php
@@ -29,10 +29,10 @@ class Meeting
     /**
      * Find all meetings.
      *
-     *
+     * @param int|null $limit   The amount of results, default is all
      * @return array Of all meetings
      */
-    public function findAll()
+    public function findAll($limit = null)
     {
         $qb = $this->em->createQueryBuilder();
 
@@ -41,6 +41,10 @@ class Meeting
             ->leftJoin('m.decisions', 'd')
             ->groupBy('m')
             ->orderBy('m.date', 'DESC');
+
+        if (is_int($limit) && $limit >= 0) {
+            $qb->setMaxResults($limit);
+        }
 
         return $qb->getQuery()->getResult();
     }
@@ -61,6 +65,34 @@ class Meeting
             ->where('m.type = :type')
             ->orderBy('m.date', 'DESC')
             ->setParameter(':type', $type);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Find all meetings that have taken place
+     *
+     * @param int|null $limit The amount of results, default is all
+     * @return array Meetings that have taken place
+     */
+    public function findPast($limit = null) {
+        $qb = $this->em->createQueryBuilder();
+
+        // Use yesterday because a meeting might still take place later on the day
+        $date = new \DateTime();
+        $date->add(\DateInterval::createFromDateString('yesterday'));
+
+        $qb->select('m, COUNT(d)')
+            ->from('Decision\Model\Meeting', 'm')
+            ->where('m.date <= :date')
+            ->leftJoin('m.decisions', 'd')
+            ->groupBy('m')
+            ->orderBy('m.date', 'DESC')
+            ->setParameter('date', $date);
+
+        if (is_int($limit) && $limit >= 0) {
+            $qb->setMaxResults($limit);
+        }
 
         return $qb->getQuery()->getResult();
     }

--- a/module/Decision/src/Decision/Mapper/Meeting.php
+++ b/module/Decision/src/Decision/Mapper/Meeting.php
@@ -75,7 +75,7 @@ class Meeting
      * @param int|null $limit The amount of results, default is all
      * @return array Meetings that have taken place
      */
-    public function findPast($limit = null)
+    public function findPast($limit = null, $type = null)
     {
         $qb = $this->em->createQueryBuilder();
 
@@ -93,6 +93,10 @@ class Meeting
 
         if (is_int($limit) && $limit >= 0) {
             $qb->setMaxResults($limit);
+        }
+
+        if (is_string($type)) {
+            $qb->andWhere('m.type = :type')->setParameter('type', $type);
         }
 
         return $qb->getQuery()->getResult();

--- a/module/Decision/src/Decision/Model/Member.php
+++ b/module/Decision/src/Decision/Model/Member.php
@@ -554,8 +554,14 @@ class Member
             return new ArrayCollection();
         }
 
-        return $this->getOrganInstallations()->filter(function (OrganMember $organ) {
-            return is_null($organ->getDischargeDate());
+        // Filter out past installations
+        $today = new \DateTime();
+
+        return $this->getOrganInstallations()->filter(function (OrganMember $organ) use ($today) {
+            $dischargeDate = $organ->getDischargeDate();
+
+            // Keep installation if not discharged or discharged in the future
+            return is_null($dischargeDate) || $dischargeDate >= $today;
         });
     }
 
@@ -567,6 +573,31 @@ class Member
     public function getBoardInstallations()
     {
         return $this->boardInstallations;
+    }
+
+    /**
+     * Get the current board the member is part of
+     *
+     * @return BoardMember|null
+     */
+    public function getCurrentBoardInstallation()
+    {
+        // Filter out past board installations
+        $today = new \DateTime();
+
+        $boards = $this->getBoardInstallations()->filter(function (BoardMember $boardMember) use ($today) {
+            $dischargeDate= $boardMember->getDischargeDate();
+
+            // Keep installation if not discharged or discharged in the future
+            return is_null($dischargeDate) || $dischargeDate >= $today;
+        });
+
+        if (count($boards) == 0) {
+            return null;
+        }
+
+        // Assume a member has a single board installation at a time
+        return $boards[0];
     }
 
     /**

--- a/module/Decision/src/Decision/Model/Member.php
+++ b/module/Decision/src/Decision/Model/Member.php
@@ -586,7 +586,7 @@ class Member
         $today = new \DateTime();
 
         $boards = $this->getBoardInstallations()->filter(function (BoardMember $boardMember) use ($today) {
-            $dischargeDate= $boardMember->getDischargeDate();
+            $dischargeDate = $boardMember->getDischargeDate();
 
             // Keep installation if not discharged or discharged in the future
             return is_null($dischargeDate) || $dischargeDate >= $today;

--- a/module/Decision/src/Decision/Service/Decision.php
+++ b/module/Decision/src/Decision/Service/Decision.php
@@ -87,6 +87,16 @@ class Decision extends AbstractAclService
     }
 
     /**
+     * Returns the closest upcoming AV
+     *
+     * @return \Decision\Model\Meeting|null
+     */
+    public function getUpcomingAV()
+    {
+        return $this->getMeetingMapper()->findUpcomingAV();
+    }
+
+    /**
      * Get meeting documents corresponding to a certain id.
      *
      * @param $id

--- a/module/Decision/src/Decision/Service/Decision.php
+++ b/module/Decision/src/Decision/Service/Decision.php
@@ -41,9 +41,10 @@ class Decision extends AbstractAclService
      * Get past meetings.
      *
      * @param int|null $limit The amount of meetings to retrieve, default is all
+     * @param string|null $type Constraint on the type of the meeting, default is none
      * @return array Of all meetings
      */
-    public function getPastMeetings($limit = null)
+    public function getPastMeetings($limit = null, $type = null)
     {
         if (!$this->isAllowed('list_meetings')) {
             $translator = $this->getTranslator();
@@ -53,7 +54,7 @@ class Decision extends AbstractAclService
             );
         }
 
-        return $this->getMeetingMapper()->findPast($limit);
+        return $this->getMeetingMapper()->findPast($limit, $type);
     }
 
     public function getMeetingsByType($type)

--- a/module/Decision/src/Decision/Service/Decision.php
+++ b/module/Decision/src/Decision/Service/Decision.php
@@ -21,11 +21,10 @@ class Decision extends AbstractAclService
     /**
      * Get all meetings.
      *
-     * @param int|null $limit           The amount of meetings to retrieve, default is all
-     * @param bool     $includeUpcoming Include upcoming meetings, default is true
+     * @param int|null $limit The amount of meetings to retrieve, default is all
      * @return array Of all meetings
      */
-    public function getMeetings($limit = null, $includeUpcoming = true)
+    public function getMeetings($limit = null)
     {
         if (!$this->isAllowed('list_meetings')) {
             $translator = $this->getTranslator();
@@ -35,13 +34,26 @@ class Decision extends AbstractAclService
             );
         }
 
-        $meetingMapper = $this->getMeetingMapper();
+        return $this->getMeetingMapper()->findAll($limit);
+    }
 
-        if (is_bool($includeUpcoming) && !$includeUpcoming) {
-            return $meetingMapper->findPast($limit);
+    /**
+     * Get past meetings.
+     *
+     * @param int|null $limit The amount of meetings to retrieve, default is all
+     * @return array Of all meetings
+     */
+    public function getPastMeetings($limit = null)
+    {
+        if (!$this->isAllowed('list_meetings')) {
+            $translator = $this->getTranslator();
+
+            throw new NotAllowedException(
+                $translator->translate('You are not allowed to list meetings.')
+            );
         }
 
-        return $meetingMapper->findAll($limit);
+        return $this->getMeetingMapper()->findPast($limit);
     }
 
     public function getMeetingsByType($type)

--- a/module/Decision/src/Decision/Service/Member.php
+++ b/module/Decision/src/Decision/Service/Member.php
@@ -75,19 +75,13 @@ class Member extends AbstractAclService
     /**
      * Returns is the member is active
      *
-     * An active member is a member that is part of at least one organ or is part of
-     * the board.
-     *
      * @param MemberModel $member
      * @return bool
      */
 
     public function isActiveMember(MemberModel $member)
     {
-        $organs = $member->getCurrentOrganInstallations();
-        $board = $member->getCurrentBoardInstallation();
-
-        return (count($organs) > 0) || !is_null($board);
+        return $this->isAllowed('edit', 'organ');
     }
 
     /**

--- a/module/Decision/src/Decision/Service/Member.php
+++ b/module/Decision/src/Decision/Service/Member.php
@@ -73,6 +73,24 @@ class Member extends AbstractAclService
     }
 
     /**
+     * Returns is the member is active
+     *
+     * An active member is a member that is part of at least one organ or is part of
+     * the board.
+     *
+     * @param MemberModel $member
+     * @return bool
+     */
+
+    public function isActiveMember(MemberModel $member)
+    {
+        $organs = $member->getCurrentOrganInstallations();
+        $board = $member->getCurrentBoardInstallation();
+
+        return (count($organs) > 0) || !is_null($board);
+    }
+
+    /**
      *
      */
     public function findMemberByLidNr($lidnr)

--- a/module/Decision/src/Decision/Service/Member.php
+++ b/module/Decision/src/Decision/Service/Member.php
@@ -79,7 +79,7 @@ class Member extends AbstractAclService
      * @return bool
      */
 
-    public function isActiveMember(MemberModel $member)
+    public function isActiveMember()
     {
         return $this->isAllowed('edit', 'organ');
     }

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -112,13 +112,13 @@ $meetings = $this->meetings;
                     <h2><?= $this->translate('Manage') ?></h2>
                     <p><?= $this->translate('A list of helpful pages to manage the organ(s) you are part of.') ?></p>
                     <div class="grid grid-col-3">
+                        <a href="<?= $this->url('admin_organ') ?>" class="panel panel-image">
+                            <div class="glyphicon glyphicon-align-left"></div>
+                            <div class="panel-heading"><?= $this->translate('Info') ?></div>
+                        </a>
                         <a href="<?= $this->url('activity_admin') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-tree-deciduous"></div>
                             <div class="panel-heading"><?= $this->translate('Activities') ?></div>
-                        </a>
-                        <a href="<?= $this->url('admin_organ') ?>" class="panel panel-image">
-                            <div class="glyphicon glyphicon-align-left"></div>
-                            <div class="panel-heading"><?= $this->translate('Organ page') ?></div>
                         </a>
                         <a href="<?= $this->url('activity_calendar') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-calendar"></div>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -9,6 +9,8 @@ $sections[$this->translate('Personal')] = [
     [$this->translate('Change password'), 'lock', $this->url('user/default', ['action' => 'password'])],
 ];
 
+/** @var \Decision\Model\Meeting[] $meetings */
+$meetings = $this->meetings;
 ?>
 <style>
     .row-spacing-top {
@@ -83,9 +85,17 @@ $sections[$this->translate('Personal')] = [
                     </p>
                     <hr />
                 <?php endif; ?>
+                <p><?= $this->translate('Search through the list of decisions accumulated from past meetings.') ?></p>
+                <form method="post" action="<?= $this->url('decision/search') ?>" class="form-inline">
+                    <input type="text" name="query" class="form-control" placeholder="<?= $this->translate('Search by keyword or meeting number') ?>" />
+                    <button type="submit" class="btn btn-default">
+                        <?= $this->translate('Search') ?>
+                    </button>
+                </form>
+                <hr />
                 <p><?= $this->translate('The last five meetings that took place:') ?></p>
                 <ul>
-                    <?php foreach($this->meetings as $meeting): ?>
+                    <?php foreach($meetings as $meeting): ?>
                         <li>
                             <a href="<?= $this->url('decision/meeting', [ 'type' => $meeting->getType(), 'number' => $meeting->getNumber() ]) ?>">
                                 <?=
@@ -103,13 +113,6 @@ $sections[$this->translate('Personal')] = [
                 <a href="<?= $this->url('decision') ?>">
                     <?= $this->translate('View all meetings') ?>
                 </a>
-                <hr />
-                <form method="post" action="<?= $this->url('decision/search') ?>" class="form-inline" style="margin-top: 3rem;">
-                    <input type="text" name="query" class="form-control" placeholder="<?= $this->translate('Search a decision') ?>" />
-                    <button type="submit" class="btn btn-default">
-                        <?= $this->translate('Search') ?>
-                    </button>
-                </form>
             </div>
             <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
                 <div class="col-md-6">

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -70,7 +70,7 @@ $meetings = $this->meetings;
                     <p>
                         <?=
                             sprintf(
-                                $this->translate('If you are not able to attend the meeting in person but you want your voice to be heard, consider %sauthorizing another member%s to act on your behalf.'),
+                                $this->translate('If you aren\'t able to attend the meeting in person but you want your voice to be heard, consider %sauthorizing another member%s to act on your behalf.'),
                                 '<a href="' . $this->url('decision/authorizations') . '">',
                                 '</a>'
                             )
@@ -86,7 +86,7 @@ $meetings = $this->meetings;
                     </button>
                 </form>
                 <hr />
-                <p><?= $this->translate('The last five meetings that took place:') ?></p>
+                <p><?= $this->translate('The latest meetings that took place:') ?></p>
                 <ul>
                     <?php foreach($meetings as $meeting): ?>
                         <li>
@@ -137,33 +137,33 @@ $meetings = $this->meetings;
             <?php endif; ?>
         </div>
         <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
-        <div class="row mt-2">
-            <div class="col-md-12">
-                <h2><?= $this->translate('Regulations') ?></h2>
-                <ul>
-                    <li>
-                        <a href="<?= $this->url('member/regulations', ['regulation' => 'borrel-reglement']) ?>">
-                            <?= $this->translate('Borrelreglement') ?>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="<?= $this->url('member/regulations', ['regulation' => 'computer-reglement']) ?>">
-                            <?= $this->translate('Computerreglement') ?>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="<?= $this->url('member/regulations', ['regulation' => 'poster-reglement']) ?>">
-                            <?= $this->translate('Posterreglement') ?>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="<?= $this->url('member/regulations', ['regulation' => 'sleutel-beleid']) ?>">
-                            <?= $this->translate('Sleutelbeleid') ?>
-                        </a>
-                    </li>
-                </ul>
+            <div class="row mt-2">
+                <div class="col-md-12">
+                    <h2><?= $this->translate('Regulations') ?></h2>
+                    <ul>
+                        <li>
+                            <a href="<?= $this->url('member/regulations', ['regulation' => 'borrel-reglement']) ?>">
+                                <?= $this->translate('Borrelreglement') ?>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="<?= $this->url('member/regulations', ['regulation' => 'computer-reglement']) ?>">
+                                <?= $this->translate('Computerreglement') ?>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="<?= $this->url('member/regulations', ['regulation' => 'poster-reglement']) ?>">
+                                <?= $this->translate('Posterreglement') ?>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="<?= $this->url('member/regulations', ['regulation' => 'sleutel-beleid']) ?>">
+                                <?= $this->translate('Sleutelbeleid') ?>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
             </div>
-        </div>
         <?php endif; ?>
     </section>
 </div>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -113,23 +113,25 @@ $meetings = $this->meetings;
                     </button>
                 </form>
                 <hr />
-                <p><?= $this->translate('The latest meetings that took place:') ?></p>
-                <ul>
-                    <?php foreach($meetings as $meeting): ?>
-                        <li>
-                            <a href="<?= $this->url('decision/meeting', [ 'type' => $meeting->getType(), 'number' => $meeting->getNumber() ]) ?>">
-                                <?=
-                                    sprintf(
-                                        $this->translate('%s %s on %s'),
-                                        $meeting->getType(),
-                                        $meeting->getNumber(),
-                                        strftime('%A %e %B %Y', $meeting->getDate()->getTimestamp())
-                                    )
-                                ?>
-                            </a>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
+                <?php foreach($meetingsCollection as $type => $meetings): ?>
+                    <p><?= sprintf($this->translate('The latest %s meetings that took place:'), $type) ?></p>
+                    <ul>
+                        <?php foreach($meetings as $meeting): ?>
+                            <li>
+                                <a href="<?= $this->url('decision/meeting', [ 'type' => $meeting->getType(), 'number' => $meeting->getNumber() ]) ?>">
+                                    <?=
+                                        sprintf(
+                                            $this->translate('%s %s on %s'),
+                                            $meeting->getType(),
+                                            $meeting->getNumber(),
+                                            strftime('%A %e %B %Y', $meeting->getDate()->getTimestamp())
+                                        )
+                                    ?>
+                                </a>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php endforeach; ?>
                 <a href="<?= $this->url('decision') ?>">
                     <?= $this->translate('View all meetings') ?>
                 </a>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -6,58 +6,143 @@ $this->headTitle($this->translate('Members')); ?>
 
 $sections = [];
 $sections[$this->translate('Personal')] = [
-    [$this->translate('Profile'), 'user', $this->url('member/self')],
-    [$this->translate('My photo\'s'), 'picture', $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null])],
     [$this->translate('Change password'), 'lock', $this->url('user/default', ['action' => 'password'])],
-    [$this->translate('SuSOS'), 'glass', 'https://gewis.nl/susos/account/websitelogin.php'],
-    [$this->translate('Find a member'), 'search', $this->url('member/search')],
-    [$this->translate('Microsoft Imagine'), 'cd', $this->url('member/dreamspark')],
-    [$this->translate('Links'), 'link', $this->url('home/page', ['category' => 'links'])],
 ];
-
-$sections[$this->translate('Meetings')] = [
-    [$this->translate('Meetings'), 'folder-open', $this->url('decision')],
-    [$this->translate('Decision Search'), 'search', $this->url('decision/search')],
-    [$this->translate('Authorizations'), 'pencil', $this->url('decision/authorizations')],
-    [$this->translate('Organs'), 'heart', $this->url('organ')],
-    [$this->translate('Public Archive'), 'download-alt', $this->url('decision/files', ['path' => ''])]
-];
-
-if ($this->acl('decision_acl')->isAllowed('organ', 'edit')) {
-    $sections[$this->translate('Active members')] = [
-        [$this->translate('Option calendar'), 'calendar', $this->url('activity_calendar')],
-        [$this->translate('Webmail'), 'inbox', '/webmail'],
-        [$this->translate('Website admin'), 'cog', $this->url('admin')],
-    ];
-
-    $sections[$this->translate('Regulations')] = [
-        [$this->translate('Borrelreglement'), 'glass', $this->url('member/regulations', ['regulation' => 'borrel-reglement'])],
-        [$this->translate('Computerreglement'), 'hdd', $this->url('member/regulations', ['regulation' => 'computer-reglement'])],
-        [$this->translate('Posterreglement'), 'file', $this->url('member/regulations', ['regulation' => 'poster-reglement'])],
-        [$this->translate('Sleutelbeleid'), 'lock', $this->url('member/regulations', ['regulation' => 'sleutel-beleid'])],
-    ];
-}
 
 ?>
+<style>
+    .row-spacing-top {
+        margin-top: 2rem;
+    }
+</style>
 
-<section class="section">
-    <div class="container">
-        <h1><?= $this->translate('Members') ?></h1>
 
-        <?php foreach ($sections as $heading => $items): ?>
-            <h2><?= $heading ?></h2>
-            <div class="row">
-                <?php foreach ($items as $item): ?>
-                    <div class="col-sm-3 col-xs-6">
-                        <a href="<?= $item[2] ?>" class="panel panel-image">
-                            <div class="panel-body">
-                                <div class="glyphicon glyphicon-<?= $item[1] ?>"></div>
-                                <h4><?= $item[0] ?></h4>
-                            </div>
+<div class="container">
+    <section class="section">
+        <div class="row">
+            <div class="col-md-12">
+                <h1><?= $this->translate('Members') ?></h1>
+            </div>
+        </div>
+        <div class="row row-spacing-top">
+            <div class="col-md-12">
+                <h2><?= $this->translate('Personal') ?></h2>
+                <div style="display: grid; grid-template-columns: repeat(4, 1fr); grid-gap: 1rem;">
+                    <a href="<?= $this->url('member/self') ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon-user"></div>
+                        <h4><?= $this->translate('Profile') ?></h4>
+                    </a>
+                    <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon-picture"></div>
+                        <h4><?= $this->translate('My photo\'s') ?></h4>
+                    </a>
+                    <a href="https://gewis.nl/susos/account/websitelogin.php" class="panel panel-image">
+                        <div class="glyphicon glyphicon-glass"></div>
+                        <h4><?= $this->translate('SuSOS') ?></h4>
+                    </a>
+                    <a href="<?= $this->url('member/search') ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon-search"></div>
+                        <h4><?= $this->translate('Find a member') ?></h4>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="row row-spacing-top" style="margin-top: 5rem;">
+            <div class="col-md-6">
+                <h2><?= $this->translate('Meetings') ?></h2>
+                <p><?= $this->translate('The last five meetings that took place:') ?></p>
+                <ul>
+                    <li><a href="#">AV 160 op 19 december 2017</a></li>
+                    <li><a href="#">BV 1383 op woensdag 13 december 2017</a></li>
+                    <li><a href="#">BV 1382 op woensdag 6 december 2017</a></li>
+                    <li><a href="#">BV 1381 op woensdag 29 november 2017</a></li>
+                    <li><a href="#">BV 1380 op dinsdag 21 november 2017</a></li>
+                </ul>
+                <a href="<?= $this->url('decision') ?>">
+                    <?= $this->translate('View previous meetings') ?>
+                </a>
+                <form method="post" action="<?= $this->url('decision/search') ?>" class="form-inline" style="margin-top: 3rem;">
+                    <input type="text" name="query" class="form-control" placeholder="<?= $this->translate('Search a decision') ?>" />
+                    <button type="submit" class="btn btn-default">
+                        <?= $this->translate('Search') ?>
+                    </button>
+                </form>
+                <hr />
+                <p>
+                    <?=
+                        sprintf(
+                            $this->translate('If you are not able to attend a meeting in person but you want your voice to be heard, consider %sauthorizing another member%s to act on your behalf.'),
+                            '<a href="' . $this->url('decision/authorizations') . '">',
+                            '</a>'
+                        )
+                    ?>
+                </p>
+            </div>
+            <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
+                <div class="col-md-6">
+                    <h2><?= $this->translate('Manage') ?></h2>
+                    <p><?= $this->translate('A list of helpful pages to manage the organ(s) you are part of.') ?></p>
+                    <style>
+                        .panel-image { margin: 0; padding 0; }
+                    </style>
+                    <div style="display: grid; grid-template-columns: repeat(3, 1fr); grid-gap: 1rem;">
+                        <a href="<?= $this->url('activity_admin') ?>" class="panel panel-image">
+                            <div class="glyphicon glyphicon-tree-deciduous"></div>
+                            <h4><?= $this->translate('Activities') ?></h4>
+                        </a>
+                        <a href="<?= $this->url('admin_organ') ?>" class="panel panel-image">
+                            <div class="glyphicon glyphicon-align-left"></div>
+                            <h4><?= $this->translate('Organ page') ?></h4>
+                        </a>
+                        <a href="<?= $this->url('activity_calendar') ?>" class="panel panel-image">
+                            <div class="glyphicon glyphicon-calendar"></div>
+                            <h4><?= $this->translate('Option calendar') ?></h4>
+                        </a>
+                        <a href="/webmail" class="panel panel-image">
+                            <div class="glyphicon glyphicon-inbox"></div>
+                            <h4><?= $this->translate('Webmail') ?></h4>
+                        </a>
+                        <a href="<?= $this->url('organ') ?>" class="panel panel-image">
+                            <div class="glyphicon glyphicon-heart"></div>
+                            <h4><?= $this->translate('Organs') ?></h4>
+                        </a>
+                        <a href="<?= $this->url('admin') ?>" class="panel panel-image">
+                            <div class="glyphicon glyphicon-cog"></div>
+                            <h4><?= $this->translate('Administrator') ?></h4>
                         </a>
                     </div>
-                <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </div>
+        <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
+        <div class="row row-spacing-top">
+            <div class="col-md-12">
+                <h2><?= $this->translate('Regulations') ?></h2>
+                <ul>
+                    <li>
+                        <a href="<?= $this->url('member/regulations', ['regulation' => 'borrel-reglement']) ?>">
+                            <?= $this->translate('Borrelreglement') ?>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="<?= $this->url('member/regulations', ['regulation' => 'computer-reglement']) ?>">
+                            <?= $this->translate('Computerreglement') ?>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="<?= $this->url('member/regulations', ['regulation' => 'poster-reglement']) ?>">
+                            <?= $this->translate('Posterreglement') ?>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="<?= $this->url('member/regulations', ['regulation' => 'sleutel-beleid']) ?>">
+                            <?= $this->translate('Sleutelbeleid') ?>
+                        </a>
+                    </li>
+                </ul>
             </div>
-        <?php endforeach; ?>
-    </div>
-</section>
+        </div>
+        <?php endif; ?>
+    </section>
+</div>
+

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -12,13 +12,6 @@ $sections[$this->translate('Personal')] = [
 /** @var \Decision\Model\Meeting[] $meetings */
 $meetings = $this->meetings;
 ?>
-<style>
-    .row-spacing-top {
-        margin-top: 2rem;
-    }
-</style>
-
-
 <div class="container">
     <section class="section">
         <div class="row">
@@ -26,35 +19,35 @@ $meetings = $this->meetings;
                 <h1><?= $this->translate('Members') ?></h1>
             </div>
         </div>
-        <div class="row row-spacing-top">
+        <div class="row mt-2">
             <div class="col-md-12">
                 <h2><?= $this->translate('Personal') ?></h2>
-                <div style="display: grid; grid-template-columns: repeat(5, 1fr); grid-gap: 1rem;">
+                <div class="grid grid-col-5">
                     <a href="<?= $this->url('member/self') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-user"></div>
-                        <div class="h4"><?= $this->translate('Profile') ?></div>
+                        <div class="panel-heading"><?= $this->translate('Profile') ?></div>
                     </a>
                     <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-picture"></div>
-                        <div class="h4"><?= $this->translate('My photo\'s') ?></div>
+                        <div class="panel-heading"><?= $this->translate('My photo\'s') ?></div>
                     </a>
                     <a href="https://gewis.nl/susos/account/websitelogin.php" class="panel panel-image">
                         <div class="glyphicon glyphicon-glass"></div>
-                        <div class="h4"><?= $this->translate('SuSOS') ?></div>
+                        <div class="panel-heading"><?= $this->translate('SuSOS') ?></div>
                     </a>
                     <a href="<?= $this->url('decision/authorizations') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon glyphicon-bullhorn"></div>
-                        <div class="h4"><?= $this->translate('Authorizations') ?></div>
+                        <div class="panel-heading"><?= $this->translate('Authorizations') ?></div>
                     </a>
                     <a href="<?= $this->url('member/search') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-search"></div>
-                        <div class="h4"><?= $this->translate('Find a member') ?></div>
+                        <div class="panel-heading"><?= $this->translate('Find a member') ?></div>
                     </a>
                 </div>
             </div>
         </div>
-        <div class="row row-spacing-top" style="margin-top: 5rem;">
-            <div class="col-md-6">
+        <div class="row mt-3">
+            <div class="col-md-6 mt-2">
                 <h2><?= $this->translate('Meetings') ?></h2>
                 <?php if (!is_null($this->upcoming)): ?>
                     <div class="panel panel-default">
@@ -115,39 +108,36 @@ $meetings = $this->meetings;
                 </a>
             </div>
             <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
-                <div class="col-md-6">
+                <div class="col-md-6 mt-2">
                     <h2><?= $this->translate('Manage') ?></h2>
                     <p><?= $this->translate('A list of helpful pages to manage the organ(s) you are part of.') ?></p>
-                    <style>
-                        .panel-image { margin: 0; padding 0; }
-                    </style>
-                    <div style="display: grid; grid-template-columns: repeat(3, 1fr); grid-gap: 1rem;">
+                    <div class="grid grid-col-3">
                         <a href="<?= $this->url('activity_admin') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-tree-deciduous"></div>
-                            <div class="h4"><?= $this->translate('Activities') ?></div>
+                            <div class="panel-heading"><?= $this->translate('Activities') ?></div>
                         </a>
                         <a href="<?= $this->url('admin_organ') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-align-left"></div>
-                            <div class="h4"><?= $this->translate('Organ page') ?></div>
+                            <div class="panel-heading"><?= $this->translate('Organ page') ?></div>
                         </a>
                         <a href="<?= $this->url('activity_calendar') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-calendar"></div>
-                            <div class="h4"><?= $this->translate('Option calendar') ?></div>
+                            <div class="panel-heading"><?= $this->translate('Option calendar') ?></div>
                         </a>
                         <a href="/webmail" class="panel panel-image">
                             <div class="glyphicon glyphicon-inbox"></div>
-                            <div class="h4"><?= $this->translate('Webmail') ?></div>
+                            <div class="panel-heading"><?= $this->translate('Webmail') ?></div>
                         </a>
                         <a href="<?= $this->url('admin') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-cog"></div>
-                            <div class="h4"><?= $this->translate('Administrator') ?></div>
+                            <div class="panel-heading"><?= $this->translate('Administrator') ?></div>
                         </a>
                     </div>
                 </div>
             <?php endif; ?>
         </div>
         <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
-        <div class="row row-spacing-top">
+        <div class="row mt-2">
             <div class="col-md-12">
                 <h2><?= $this->translate('Regulations') ?></h2>
                 <ul>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -27,7 +27,7 @@ $sections[$this->translate('Personal')] = [
         <div class="row row-spacing-top">
             <div class="col-md-12">
                 <h2><?= $this->translate('Personal') ?></h2>
-                <div style="display: grid; grid-template-columns: repeat(4, 1fr); grid-gap: 1rem;">
+                <div style="display: grid; grid-template-columns: repeat(5, 1fr); grid-gap: 1rem;">
                     <a href="<?= $this->url('member/self') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-user"></div>
                         <h4><?= $this->translate('Profile') ?></h4>
@@ -40,6 +40,10 @@ $sections[$this->translate('Personal')] = [
                         <div class="glyphicon glyphicon-glass"></div>
                         <h4><?= $this->translate('SuSOS') ?></h4>
                     </a>
+                    <a href="<?= $this->url('decision/authorizations') ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon glyphicon-bullhorn"></div>
+                        <h4><?= $this->translate('Authorizations') ?></h4>
+                    </a>
                     <a href="<?= $this->url('member/search') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-search"></div>
                         <h4><?= $this->translate('Find a member') ?></h4>
@@ -50,33 +54,62 @@ $sections[$this->translate('Personal')] = [
         <div class="row row-spacing-top" style="margin-top: 5rem;">
             <div class="col-md-6">
                 <h2><?= $this->translate('Meetings') ?></h2>
+                <?php if (!is_null($this->upcoming)): ?>
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <strong><?= $this->translate('Upcoming meeting') ?></strong>
+                        </div>
+                        <div class="panel-body">
+                            <?=
+                                sprintf(
+                                    $this->translate('The next meeting is %s%s %s%s on %s.'),
+                                    '<a href="' . $this->url('decision/meeting', [ 'type' => $this->upcoming->getType(), 'number' => $this->upcoming->getNumber() ]) . '">',
+                                    $this->upcoming->getType(),
+                                    $this->upcoming->getNumber(),
+                                    '</a>',
+                                    $this->upcoming->getDate()->format('l j F Y')
+                                )
+                            ?>
+                        </div>
+                    </div>
+                    <p>
+                        <?=
+                            sprintf(
+                                $this->translate('If you are not able to attend the meeting in person but you want your voice to be heard, consider %sauthorizing another member%s to act on your behalf.'),
+                                '<a href="' . $this->url('decision/authorizations') . '">',
+                                '</a>'
+                            )
+                        ?>
+                    </p>
+                    <hr />
+                <?php endif; ?>
                 <p><?= $this->translate('The last five meetings that took place:') ?></p>
                 <ul>
-                    <li><a href="#">AV 160 op 19 december 2017</a></li>
-                    <li><a href="#">BV 1383 op woensdag 13 december 2017</a></li>
-                    <li><a href="#">BV 1382 op woensdag 6 december 2017</a></li>
-                    <li><a href="#">BV 1381 op woensdag 29 november 2017</a></li>
-                    <li><a href="#">BV 1380 op dinsdag 21 november 2017</a></li>
+                    <?php foreach($this->meetings as $meeting): ?>
+                        <li>
+                            <a href="<?= $this->url('decision/meeting', [ 'type' => $meeting->getType(), 'number' => $meeting->getNumber() ]) ?>">
+                                <?=
+                                    sprintf(
+                                        $this->translate('%s %s on %s'),
+                                        $meeting->getType(),
+                                        $meeting->getNumber(),
+                                        $meeting->getDate()->format('l j F Y')
+                                    )
+                                ?>
+                            </a>
+                        </li>
+                    <?php endforeach; ?>
                 </ul>
                 <a href="<?= $this->url('decision') ?>">
-                    <?= $this->translate('View previous meetings') ?>
+                    <?= $this->translate('View all meetings') ?>
                 </a>
+                <hr />
                 <form method="post" action="<?= $this->url('decision/search') ?>" class="form-inline" style="margin-top: 3rem;">
                     <input type="text" name="query" class="form-control" placeholder="<?= $this->translate('Search a decision') ?>" />
                     <button type="submit" class="btn btn-default">
                         <?= $this->translate('Search') ?>
                     </button>
                 </form>
-                <hr />
-                <p>
-                    <?=
-                        sprintf(
-                            $this->translate('If you are not able to attend a meeting in person but you want your voice to be heard, consider %sauthorizing another member%s to act on your behalf.'),
-                            '<a href="' . $this->url('decision/authorizations') . '">',
-                            '</a>'
-                        )
-                    ?>
-                </p>
             </div>
             <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
                 <div class="col-md-6">
@@ -101,10 +134,6 @@ $sections[$this->translate('Personal')] = [
                         <a href="/webmail" class="panel panel-image">
                             <div class="glyphicon glyphicon-inbox"></div>
                             <h4><?= $this->translate('Webmail') ?></h4>
-                        </a>
-                        <a href="<?= $this->url('organ') ?>" class="panel panel-image">
-                            <div class="glyphicon glyphicon-heart"></div>
-                            <h4><?= $this->translate('Organs') ?></h4>
                         </a>
                         <a href="<?= $this->url('admin') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-cog"></div>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -107,7 +107,7 @@ $meetings = $this->meetings;
                     <?= $this->translate('View all meetings') ?>
                 </a>
             </div>
-            <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
+            <?php if ($isActive): ?>
                 <div class="col-md-6 mt-2">
                     <h2><?= $this->translate('Manage') ?></h2>
                     <p><?= $this->translate('A list of helpful pages to manage the organ(s) you are part of.') ?></p>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -27,6 +27,10 @@ $meetings = $this->meetings;
                         <div class="glyphicon glyphicon-user"></div>
                         <div class="panel-heading"><?= $this->translate('Profile') ?></div>
                     </a>
+                    <a href="<?= $this->url('user/default', ['action' => 'password']) ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon-lock"></div>
+                        <div class="panel-heading"><?= $this->translate('Change password') ?></div>
+                    </a>
                     <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-picture"></div>
                         <div class="panel-heading"><?= $this->translate('My photo\'s') ?></div>
@@ -39,9 +43,32 @@ $meetings = $this->meetings;
                         <div class="glyphicon glyphicon glyphicon-bullhorn"></div>
                         <div class="panel-heading"><?= $this->translate('Authorizations') ?></div>
                     </a>
+                </div>
+            </div>
+        </div>
+        <div class="row mt-3">
+            <div class="col-md-12">
+                <h2><?= $this->translate('Association') ?></h2>
+                <div class="grid grid-col-5">
+                    <a href="<?= $this->url('organ') ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon-heart"></div>
+                        <div class="panel-heading"><?= $this->translate('Organs') ?></div>
+                    </a>
+                    <a href="<?= $this->url('decision/files', ['path' => '']) ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon-download-alt"></div>
+                        <div class="panel-heading"><?= $this->translate('Public archive') ?></div>
+                    </a>
                     <a href="<?= $this->url('member/search') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-search"></div>
                         <div class="panel-heading"><?= $this->translate('Find a member') ?></div>
+                    </a>
+                    <a href="<?= $this->url('member/dreamspark') ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon-cd"></div>
+                        <div class="panel-heading"><?= $this->translate('Microsoft Imagine') ?></div>
+                    </a>
+                    <a href="<?= $this->url('home/page', ['category' => 'links']) ?>" class="panel panel-image">
+                        <div class="glyphicon glyphicon-link"></div>
+                        <div class="panel-heading"><?= $this->translate('Links') ?></div>
                     </a>
                 </div>
             </div>
@@ -136,35 +163,33 @@ $meetings = $this->meetings;
                 </div>
             <?php endif; ?>
         </div>
-        <?php if ($this->acl('decision_acl')->isAllowed('organ', 'edit')): ?>
-            <div class="row mt-2">
-                <div class="col-md-12">
-                    <h2><?= $this->translate('Regulations') ?></h2>
-                    <ul>
-                        <li>
-                            <a href="<?= $this->url('member/regulations', ['regulation' => 'borrel-reglement']) ?>">
-                                <?= $this->translate('Borrelreglement') ?>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="<?= $this->url('member/regulations', ['regulation' => 'computer-reglement']) ?>">
-                                <?= $this->translate('Computerreglement') ?>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="<?= $this->url('member/regulations', ['regulation' => 'poster-reglement']) ?>">
-                                <?= $this->translate('Posterreglement') ?>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="<?= $this->url('member/regulations', ['regulation' => 'sleutel-beleid']) ?>">
-                                <?= $this->translate('Sleutelbeleid') ?>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
+        <div class="row mt-2">
+            <div class="col-md-12">
+                <h2><?= $this->translate('Regulations') ?></h2>
+                <ul>
+                    <li>
+                        <a href="<?= $this->url('member/regulations', ['regulation' => 'borrel-reglement']) ?>">
+                            <?= $this->translate('Borrelreglement') ?>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="<?= $this->url('member/regulations', ['regulation' => 'computer-reglement']) ?>">
+                            <?= $this->translate('Computerreglement') ?>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="<?= $this->url('member/regulations', ['regulation' => 'poster-reglement']) ?>">
+                            <?= $this->translate('Posterreglement') ?>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="<?= $this->url('member/regulations', ['regulation' => 'sleutel-beleid']) ?>">
+                            <?= $this->translate('Sleutelbeleid') ?>
+                        </a>
+                    </li>
+                </ul>
             </div>
-        <?php endif; ?>
+        </div>
     </section>
 </div>
 

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -62,7 +62,7 @@ $meetings = $this->meetings;
                                     $this->upcoming->getType(),
                                     $this->upcoming->getNumber(),
                                     '</a>',
-                                    $this->upcoming->getDate()->format('l j F Y')
+                                    strftime('%A %e %B %Y', $this->upcoming->getDate()->getTimestamp())
                                 )
                             ?>
                         </div>
@@ -96,7 +96,7 @@ $meetings = $this->meetings;
                                         $this->translate('%s %s on %s'),
                                         $meeting->getType(),
                                         $meeting->getNumber(),
-                                        $meeting->getDate()->format('l j F Y')
+                                        strftime('%A %e %B %Y', $meeting->getDate()->getTimestamp())
                                     )
                                 ?>
                             </a>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -32,23 +32,23 @@ $meetings = $this->meetings;
                 <div style="display: grid; grid-template-columns: repeat(5, 1fr); grid-gap: 1rem;">
                     <a href="<?= $this->url('member/self') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-user"></div>
-                        <h4><?= $this->translate('Profile') ?></h4>
+                        <div class="h4"><?= $this->translate('Profile') ?></div>
                     </a>
                     <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-picture"></div>
-                        <h4><?= $this->translate('My photo\'s') ?></h4>
+                        <div class="h4"><?= $this->translate('My photo\'s') ?></div>
                     </a>
                     <a href="https://gewis.nl/susos/account/websitelogin.php" class="panel panel-image">
                         <div class="glyphicon glyphicon-glass"></div>
-                        <h4><?= $this->translate('SuSOS') ?></h4>
+                        <div class="h4"><?= $this->translate('SuSOS') ?></div>
                     </a>
                     <a href="<?= $this->url('decision/authorizations') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon glyphicon-bullhorn"></div>
-                        <h4><?= $this->translate('Authorizations') ?></h4>
+                        <div class="h4"><?= $this->translate('Authorizations') ?></div>
                     </a>
                     <a href="<?= $this->url('member/search') ?>" class="panel panel-image">
                         <div class="glyphicon glyphicon-search"></div>
-                        <h4><?= $this->translate('Find a member') ?></h4>
+                        <div class="h4"><?= $this->translate('Find a member') ?></div>
                     </a>
                 </div>
             </div>
@@ -124,23 +124,23 @@ $meetings = $this->meetings;
                     <div style="display: grid; grid-template-columns: repeat(3, 1fr); grid-gap: 1rem;">
                         <a href="<?= $this->url('activity_admin') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-tree-deciduous"></div>
-                            <h4><?= $this->translate('Activities') ?></h4>
+                            <div class="h4"><?= $this->translate('Activities') ?></div>
                         </a>
                         <a href="<?= $this->url('admin_organ') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-align-left"></div>
-                            <h4><?= $this->translate('Organ page') ?></h4>
+                            <div class="h4"><?= $this->translate('Organ page') ?></div>
                         </a>
                         <a href="<?= $this->url('activity_calendar') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-calendar"></div>
-                            <h4><?= $this->translate('Option calendar') ?></h4>
+                            <div class="h4"><?= $this->translate('Option calendar') ?></div>
                         </a>
                         <a href="/webmail" class="panel panel-image">
                             <div class="glyphicon glyphicon-inbox"></div>
-                            <h4><?= $this->translate('Webmail') ?></h4>
+                            <div class="h4"><?= $this->translate('Webmail') ?></div>
                         </a>
                         <a href="<?= $this->url('admin') ?>" class="panel panel-image">
                             <div class="glyphicon glyphicon-cog"></div>
-                            <h4><?= $this->translate('Administrator') ?></h4>
+                            <div class="h4"><?= $this->translate('Administrator') ?></div>
                         </a>
                     </div>
                 </div>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -78,7 +78,7 @@ $meetings = $this->meetings;
                     </p>
                     <hr />
                 <?php endif; ?>
-                <p><?= $this->translate('Search through the list of decisions accumulated from past meetings.') ?></p>
+                <p><?= $this->translate('Search through the list of decisions accumulated from past meetings:') ?></p>
                 <form method="post" action="<?= $this->url('decision/search') ?>" class="form-inline">
                     <input type="text" name="query" class="form-control" placeholder="<?= $this->translate('Search by keyword or meeting number') ?>" />
                     <button type="submit" class="btn btn-default">

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -3,9 +3,13 @@ $transition-duration: 200ms;
 $transition-duration-fast: 100ms;
 
 // breakpoints
+$screen-xs-min: 576px;
 $screen-sm-min: 768px;
 $screen-md-min: 992px;
 $screen-lg-min: 1200px;
 
 
 $panel-color: #414141;
+
+// Grid
+$grid-gap: 1rem;

--- a/public/scss/components/_grid.scss
+++ b/public/scss/components/_grid.scss
@@ -1,0 +1,44 @@
+.grid {
+    display: grid;
+    grid-gap: $grid-gap;
+
+    .panel-image {
+        margin: 0;
+    }
+}
+
+.grid-col-3 {
+    grid-template-columns: repeat(1, 1fr);
+}
+
+.grid-col-5 {
+    grid-template-columns: repeat(1, 1fr);
+}
+
+@media only screen and (max-width: $screen-xs-min - 1) {
+    .grid-col-3, .grid-col-5 {
+        grid-template-columns: repeat(1, 1fr);
+    }
+}
+
+@media only screen and (min-width: $screen-xs-min) {
+    .grid-col-3, .grid-col-5 {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media only screen and (min-width: $screen-sm-min) {
+    .grid-col-5 {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media only screen and (min-width: $screen-lg-min) {
+    .grid-col-3 {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .grid-col-5 {
+        grid-template-columns: repeat(5, 1fr);
+    }
+}

--- a/public/scss/components/_layout.scss
+++ b/public/scss/components/_layout.scss
@@ -65,3 +65,8 @@ a[href^='mailto:klachten@gewis.nl'] .panel-special {
 .no-pad {
     padding: 0;
 }
+
+.mt-2 { margin-top: 2rem; }
+.mt-3 { margin-top: 3rem; }
+.mt-4 { margin-top: 4rem; }
+.mt-5 { margin-top: 5rem; }

--- a/public/scss/components/_panels.scss
+++ b/public/scss/components/_panels.scss
@@ -197,6 +197,13 @@ a {
         margin-bottom: 0;
     }
 
+    .panel-heading {
+        padding: 0;
+        border: none;
+        font-size: 1.6rem;
+        font-weight: 500;
+    }
+
     .glyphicon {
         font-size: 3em;
     }

--- a/public/scss/components/_panels.scss
+++ b/public/scss/components/_panels.scss
@@ -193,7 +193,7 @@ a {
     box-shadow: none;
     border: none;
 
-    h4 {
+    h4, .h4 {
         margin-bottom: 0;
     }
 

--- a/public/scss/main.scss
+++ b/public/scss/main.scss
@@ -32,6 +32,7 @@
 @import 'components/tables';
 @import 'components/thumbnails';
 @import 'components/type';
+@import 'components/grid';
 
 // Module specific styles
 @import 'modules/company';


### PR DESCRIPTION
This PR includes a redesign of the [member page](https://gewis.nl/member). The goal of the redesign is to make relevant information easier to find.

Note that this PR is a work in progress. Things might move around. However, if you don't agree with one of the changes, please comment below.

> [Before](https://user-images.githubusercontent.com/706385/34313993-dcbb9c9e-e76f-11e7-81c0-b9174b983965.png) / [After](https://user-images.githubusercontent.com/706385/34313998-ee3009f6-e76f-11e7-88ac-d4712fb34fa3.png)

**Added:**
- _Latest meetings_ - Quickly navigate to recent meeting notes
- _Search form for decisions_ - Removes the need of navigating to another page to enter the search query.
- _Link to manage activities_ - Hopefully this helps members that haven't discovered the power of the admin page
- _Link to manage organ page_ - Same argument as above...

**Removed:**
- _Microsoft Imagine link_ - Does this link need to be here? It's also on the [education page](https://gewis.nl/education).
- _Change password link_ - Again, should this be here? This page is intended as a portal for GEWIS members. Changing one's password is an account specific action.