### PR TITLE
Added reply-to header to GEFLITST email

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/module/Activity/src/Activity/Service/Activity.php
+++ b/module/Activity/src/Activity/Service/Activity.php
@@ -91,14 +91,36 @@ class Activity extends AbstractAclService implements ServiceManagerAwareInterfac
 
         // Send email to GEFLITST if user checked checkbox of GEFLITST
         if ($activity->getRequireGEFLITST()) {
-            $this->getEmailService()->sendEmail('activity_creation_require_GEFLITST', 'email/activity_created_require_GEFLITST',
-                'Er is een fotograaf nodig voor een nieuwe GEWIS activiteit | A GEWIS activity needs a photographer of GEFLITST',
-                ['activity' => $activity]);
-
-
+            $this->requestGEFLITST($activity, $user, $organ);
         }
 
         return $activity;
+    }
+
+    /**
+     * @param $activity ActivityModel
+     * @param $user \User\Model\User
+     * @param $organ Organ
+     */
+    private function requestGEFLITST($activity, $user, $organ)
+    {
+        $type = 'activity_creation_require_GEFLITST';
+        $view = 'email/activity_created_require_GEFLITST';
+        $subject = 'Er is een fotograaf nodig voor een nieuwe GEWIS activiteit | A GEWIS activity needs a photographer of GEFLITST';
+
+        if ($organ != null) {
+            if ($organ->getApprovedOrganInformation()->getEmail() != null) {
+                $this->getEmailService()->sendEmailAsOrgan($type, $view, $subject,
+                    ['activity' => $activity, 'requester' => $organ->getName()], $organ);
+            } else {
+                // The organ did not fill in it's email address, so send the email as the requested user.
+                $this->getEmailService()->sendEmailAsUser($type, $view, $subject,
+                    ['activity' => $activity, 'requester' => $organ->getName()], $user);
+            }
+        } else {
+            $this->getEmailService()->sendEmailAsUser($type, $view, $subject,
+                ['activity' => $activity, 'requester' => $user->getMember()->getFullName()], $user);
+        }
     }
 
     /**

--- a/module/Activity/src/Activity/Service/Activity.php
+++ b/module/Activity/src/Activity/Service/Activity.php
@@ -109,9 +109,10 @@ class Activity extends AbstractAclService implements ServiceManagerAwareInterfac
         $subject = 'Er is een fotograaf nodig voor een nieuwe GEWIS activiteit | A GEWIS activity needs a photographer of GEFLITST';
 
         if ($organ != null) {
-            if ($organ->getApprovedOrganInformation()->getEmail() != null) {
+            $organInfo = $organ->getApprovedOrganInformation();
+            if ($organInfo->getEmail() != null) {
                 $this->getEmailService()->sendEmailAsOrgan($type, $view, $subject,
-                    ['activity' => $activity, 'requester' => $organ->getName()], $organ);
+                    ['activity' => $activity, 'requester' => $organ->getName()], $organInfo);
             } else {
                 // The organ did not fill in it's email address, so send the email as the requested user.
                 $this->getEmailService()->sendEmailAsUser($type, $view, $subject,

--- a/module/Activity/src/Activity/Service/Activity.php
+++ b/module/Activity/src/Activity/Service/Activity.php
@@ -110,7 +110,7 @@ class Activity extends AbstractAclService implements ServiceManagerAwareInterfac
 
         if ($organ != null) {
             $organInfo = $organ->getApprovedOrganInformation();
-            if ($organInfo->getEmail() != null) {
+            if ($organInfo != null && $organInfo->getEmail() != null) {
                 $this->getEmailService()->sendEmailAsOrgan($type, $view, $subject,
                     ['activity' => $activity, 'requester' => $organ->getName()], $organInfo);
             } else {

--- a/module/Activity/view/email/activity_created_require_GEFLITST.phtml
+++ b/module/Activity/view/email/activity_created_require_GEFLITST.phtml
@@ -11,7 +11,8 @@ Er is een nieuwe activiteit aangemaakt op de GEWIS website waarvoor een fotograa
 
 <br/>
 
-Ze zouden graag een antwoord van jullie horen. Kunnen jullie dat sturen naar '<b><?= $this->escapeHtml($activity->getResourceOrgan()->getName())?></b>'?
+Ze zouden graag een antwoord van jullie horen. Kunnen jullie dat sturen naar '<b><?= $this->escapeHtml($requester)?></b>'?
+Je kunt een antwoord sturen door te reageren op deze email.
 <br/><br/>
 
 Met vriendelijke groeten,<br />
@@ -28,7 +29,8 @@ A new activity has been created on the GEWIS website that needs a photographer o
 
 <br/>
 
-The organ that created this activity would love to have a reply back from you. Can you send this to '<b><?= $this->escapeHtml($activity->getResourceOrgan()->getName())?></b>'?
+The organ that created this activity would love to have a reply back from you. Can you send this to '<b><?= $this->escapeHtml($requester)?></b>'?
+You can send a response by replying to this email.
 <br/><br/>
 
 With kind regards,<br />

--- a/module/Application/src/Application/Service/Email.php
+++ b/module/Application/src/Application/Service/Email.php
@@ -4,10 +4,12 @@ namespace Application\Service;
 
 use Application\Service\AbstractService;
 
+use Decision\Model\Organ;
 use User\Model\NewUser as NewUserModel;
 
 use Decision\Model\Member as MemberModel;
 
+use User\Model\User;
 use Zend\Mail\Message;
 use Zend\View\Model\ViewModel;
 use Activity\Model\Activity as ActivityModel;
@@ -31,6 +33,72 @@ class Email extends AbstractService
      */
     public function sendEmail($type, $view, $subject, $data)
     {
+        $message = $this->createMessageFromView($view, $data);
+
+        $config = $this->getConfig();
+
+        $message->addFrom($config['from']);
+        $message->addTo($config['to'][$type]);
+        $message->setSubject($subject);
+
+        $this->getTransport()->send($message);
+    }
+
+    /**
+     * Send an email as a given user. The user will be added as reply-to header to the email.
+     *
+     * @param $type String Type that this email belongs to. A key in the config file for email.
+     * @param $view String Template of the email
+     * @param $subject String Subject of the email
+     * @param $data array Variables that you want to have available in the template.
+     * @param $user User The user as which the email should be sent.
+     */
+    public function sendEmailAsUser($type, $view, $subject, $data, $user)
+    {
+        $message = $this->createMessageFromView($view, $data);
+
+        $config = $this->getConfig();
+
+        $message->addFrom($config['from']);
+        $message->addTo($config['to'][$type]);
+        $message->setSubject($subject);
+        $message->setReplyTo($user->getEmail());
+
+        $this->getTransport()->send($message);
+    }
+
+    /**
+     * Send an email as a given user. The user will be added as reply-to header to the email.
+     *
+     * @param $type String Type that this email belongs to. A key in the config file for email.
+     * @param $view String Template of the email
+     * @param $subject String Subject of the email
+     * @param $data array Variables that you want to have available in the template.
+     * @param $organ Organ The user as which the email should be sent.
+     */
+    public function sendEmailAsOrgan($type, $view, $subject, $data, $organ)
+    {
+        $message = $this->createMessageFromView($view, $data);
+
+        $config = $this->getConfig();
+
+        $message->addFrom($config['from']);
+        $message->addTo($config['to'][$type]);
+        $message->setSubject($subject);
+        $message->setReplyTo($organ->getApprovedOrganInformation()->getEmail());
+
+        $this->getTransport()->send($message);
+    }
+
+    /**
+     * Constructs the Message instance for a given view with given variables.
+     *
+     * @param $view String Template of the email
+     * @param $data array Variables that you want to have available in the template.
+     * @return Message The constructed instance containing the given view as HTML body.
+     */
+    private function createMessageFromView($view, $data)
+    {
         $body = $this->render($view, $data);
 
         $html = new MimePart($body);
@@ -40,15 +108,9 @@ class Email extends AbstractService
         $mimeMessage->setParts([$html]);
 
         $message = new Message();
-
-        $config = $this->getConfig();
-
-        $message->addFrom($config['from']);
-        $message->addTo($config['to'][$type]);
-        $message->setSubject($subject);
         $message->setBody($mimeMessage);
 
-        $this->getTransport()->send($message);
+        return $message;
     }
 
 

--- a/module/Application/src/Application/Service/Email.php
+++ b/module/Application/src/Application/Service/Email.php
@@ -4,7 +4,7 @@ namespace Application\Service;
 
 use Application\Service\AbstractService;
 
-use Decision\Model\Organ;
+use Decision\Model\OrganInformation;
 use User\Model\NewUser as NewUserModel;
 
 use Decision\Model\Member as MemberModel;
@@ -74,7 +74,7 @@ class Email extends AbstractService
      * @param $view String Template of the email
      * @param $subject String Subject of the email
      * @param $data array Variables that you want to have available in the template.
-     * @param $organ Organ The user as which the email should be sent.
+     * @param $organ OrganInformation The organ as which the email should be sent.
      */
     public function sendEmailAsOrgan($type, $view, $subject, $data, $organ)
     {
@@ -85,7 +85,7 @@ class Email extends AbstractService
         $message->addFrom($config['from']);
         $message->addTo($config['to'][$type]);
         $message->setSubject($subject);
-        $message->setReplyTo($organ->getApprovedOrganInformation()->getEmail());
+        $message->setReplyTo($organ->getEmail());
 
         $this->getTransport()->send($message);
     }


### PR DESCRIPTION
Implemented issue #790 by adding the organ email as reply-to if it is specified, or the user email if the organ is not specified.
Since the problem in #789 was related, it is also fixed with this PR.