### PR TITLE
Fixed text wrap of photos

### DIFF
--- a/public/scss/modules/_photo.scss
+++ b/public/scss/modules/_photo.scss
@@ -37,6 +37,9 @@ Photo
 }
 
 .thumbnail .caption {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   padding: 9px 0 0;
   min-height: 50px;
 }


### PR DESCRIPTION
Multi-line captions of photo collections are now shortened to one line with ellipsis styling to avoid other tile collections not being appended properly