### PR TITLE
Improve image quality

### DIFF
--- a/module/Photo/src/Photo/Service/Admin.php
+++ b/module/Photo/src/Photo/Service/Admin.php
@@ -90,9 +90,10 @@ class Admin extends AbstractAclService
     {
         $image = new Imagick($path);
         $image->thumbnailImage($width, $height, true);
-        $image->setimageformat("png");
+        $image->setimageformat("jpeg");
+        $image->setImageCompressionQuality(90);
         //Tempfile is used to generate sha1, not sure this is the best method
-        $tempFileName = sys_get_temp_dir() . '/ThumbImage' . rand() . '.png';
+        $tempFileName = sys_get_temp_dir() . '/ThumbImage' . rand() . '.jpg';
         $image->writeImage($tempFileName);
         $newPath = $this->getFileStorageService()->storeFile($tempFileName);
 


### PR DESCRIPTION
Currently, image quality on the website is a little off. This is mostly because we convert stuff to PNG. This commit fixes this.

Note that this commit was written while drunk and was not tested at the time of writing. Will test as soon as I think about this.

Why we want to do this? Look at https://gewis.nl/photo/view/121342, and note the MWM logo, you see some kind of gradient in the logo here. Now look at the source image https://gewis.nl/photo/download/121342 where we do not see such gradient.

Also, note that serving files as PNG while they are originally JPEG, will actually transfer a lot of data which we do not need. PNG is a horrible format when it comes to serving photos, in which case lossy compression is nice (PNG is great however for things where we need lossless compression.).