### PR TITLE
Remove unneccessary data from member search

### DIFF
--- a/module/Decision/src/Decision/Controller/MemberController.php
+++ b/module/Decision/src/Decision/Controller/MemberController.php
@@ -46,8 +46,11 @@ class MemberController extends AbstractActionController
         if (!empty($name)) {
             $members = [];
             foreach ($this->getMemberService()->searchMembersByName($name) as $member) {
-                //TODO: this returns a lot of data, much more than is needed in most cases.
-                $members[] = $member->toArray();
+                $members[] = [
+                    'lidnr'      => $member->getLidnr(),
+                    'fullName'   => $member->getFullname(),
+                    'generation' => $member->getGeneration()
+                ];
             }
 
             return new JsonModel([


### PR DESCRIPTION
Expose no more data than needed for search queries. Tested with all references to member search: search a member, photo tagging and authorizations.