### PR TITLE
Added profile picture

### DIFF
--- a/module/Decision/src/Decision/Service/Member.php
+++ b/module/Decision/src/Decision/Service/Member.php
@@ -61,6 +61,9 @@ class Member extends AbstractAclService
         }
 
         $tags = $this->getPhotoService()->getTagsForMember($member);
+
+        $profilePhoto = $this->getPhotoService()->determineProfilePhoto($lidnr);
+
         // Base directory for retrieving photos
         $basedir = $this->getPhotoService()->getBaseDirectory();
 
@@ -68,6 +71,7 @@ class Member extends AbstractAclService
             'member' => $member,
             'memberships' => $memberships,
             'tags' => $tags,
+            'profilePhoto' => $profilePhoto,
             'basedir' => $basedir
         ];
     }

--- a/module/Decision/view/decision/member/self.phtml
+++ b/module/Decision/view/decision/member/self.phtml
@@ -139,13 +139,15 @@ $this->headTitle($member->getFullName());
                 <?php endforeach ?>
             </div>
             <div class="col-md-6">
-                <div class="row">
-                        <div class="col-sm-12 col-xs-12">
-                          <a class="thumbnail" href="<?= $this->url('photo/photo', ['photo_id' => $profilePhoto->getId()]); ?>">
-                              <img class="img-responsive" src="<?= $this->fileUrl($profilePhoto->getLargeThumbPath()) ?>" alt="">
-                          </a>
-                        </div>
-                </div>
+                <?php if ($profilePhoto != null): ?>
+                    <div class="row">
+                            <div class="col-sm-12 col-xs-12">
+                              <a class="thumbnail" href="<?= $this->url('photo/photo', ['photo_id' => $profilePhoto->getId()]); ?>">
+                                  <img class="img-responsive" src="<?= $this->fileUrl($profilePhoto->getLargeThumbPath()) ?>" alt="">
+                              </a>
+                            </div>
+                    </div>
+                <?php endif; ?>
                 <div class="row">
                     <div class="col-sm-6 col-xs-6">
                         <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">

--- a/module/Decision/view/decision/member/self.phtml
+++ b/module/Decision/view/decision/member/self.phtml
@@ -140,11 +140,18 @@ $this->headTitle($member->getFullName());
             </div>
             <div class="col-md-6">
                 <div class="row">
+                        <div class="col-sm-12 col-xs-12">
+                          <a class="thumbnail" href="<?= $this->url('photo/photo', ['photo_id' => $profilePhoto->getId()]); ?>">
+                              <img class="img-responsive" src="<?= $this->fileUrl($profilePhoto->getLargeThumbPath()) ?>" alt="">
+                          </a>
+                        </div>
+                </div>
+                <div class="row">
                     <div class="col-sm-6 col-xs-6">
                         <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">
                             <div class="panel-body">
                                 <div class="glyphicon glyphicon-picture"></div>
-                                <h4><?= $this->translate("My photo's"); ?></h4>
+                                <h4><?= $this->translate("More of my photo's"); ?></h4>
                             </div>
                         </a>
                     </div>

--- a/module/Decision/view/decision/member/view.phtml
+++ b/module/Decision/view/decision/member/view.phtml
@@ -100,6 +100,13 @@ use Decision\Model\Address;
             </div>
             <div class="col-md-6">
                 <div class="row">
+                        <div class="col-sm-12 col-xs-12">
+                          <a class="thumbnail" href="<?= $this->url('photo/photo', ['photo_id' => $profilePhoto->getId()]); ?>">
+                              <img class="img-responsive" src="<?= $this->fileUrl($profilePhoto->getLargeThumbPath()) ?>" alt="">
+                          </a>
+                        </div>
+                </div>
+                <div class="row">
                     <div class="col-sm-6 col-xs-6">
                         <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">
                             <div class="panel-body">

--- a/module/Decision/view/decision/member/view.phtml
+++ b/module/Decision/view/decision/member/view.phtml
@@ -100,14 +100,14 @@ use Decision\Model\Address;
             </div>
             <div class="col-md-6">
                 <?php if ($profilePhoto != null): ?>
-                <div class="row">
-                        <div class="col-sm-12 col-xs-12">
-                          <a class="thumbnail" href="<?= $this->url('photo/photo', ['photo_id' => $profilePhoto->getId()]); ?>">
-                              <img class="img-responsive" src="<?= $this->fileUrl($profilePhoto->getLargeThumbPath()) ?>" alt="">
-                          </a>
-                        </div>
-                </div>
-            <?php endif; ?>
+                    <div class="row">
+                            <div class="col-sm-12 col-xs-12">
+                              <a class="thumbnail" href="<?= $this->url('photo/photo', ['photo_id' => $profilePhoto->getId()]); ?>">
+                                  <img class="img-responsive" src="<?= $this->fileUrl($profilePhoto->getLargeThumbPath()) ?>" alt="">
+                              </a>
+                            </div>
+                    </div>
+                <?php endif; ?>
                 <div class="row">
                     <div class="col-sm-6 col-xs-6">
                         <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">

--- a/module/Decision/view/decision/member/view.phtml
+++ b/module/Decision/view/decision/member/view.phtml
@@ -99,6 +99,7 @@ use Decision\Model\Address;
                 <?php endif; ?>
             </div>
             <div class="col-md-6">
+                <?php if ($profilePhoto != null): ?>
                 <div class="row">
                         <div class="col-sm-12 col-xs-12">
                           <a class="thumbnail" href="<?= $this->url('photo/photo', ['photo_id' => $profilePhoto->getId()]); ?>">
@@ -106,6 +107,7 @@ use Decision\Model\Address;
                           </a>
                         </div>
                 </div>
+            <?php endif; ?>
                 <div class="row">
                     <div class="col-sm-6 col-xs-6">
                         <a href="<?= $this->url('photo/member', ['lidnr' => $member->getLidnr(), 'page' => null]) ?>" class="panel panel-image">

--- a/module/Photo/src/Photo/Model/Photo.php
+++ b/module/Photo/src/Photo/Model/Photo.php
@@ -320,6 +320,14 @@ class Photo implements ResourceInterface
     }
 
     /**
+     * @return \Photo\Model\Hit
+     */
+    public function getHits()
+    {
+        return $this->hits;
+    }
+
+    /**
      * @return \Photo\Model\WeeklyPhoto|null
      */
     public function getWeeklyPhoto()

--- a/module/Photo/src/Photo/Model/Photo.php
+++ b/module/Photo/src/Photo/Model/Photo.php
@@ -320,11 +320,19 @@ class Photo implements ResourceInterface
     }
 
     /**
-     * @return \Photo\Model\Hit
+     * @return int
      */
-    public function getHits()
+    public function getTagCount()
     {
-        return $this->hits;
+        return $this->tags->count();
+    }
+
+    /**
+     * @return int
+     */
+    public function getHitCount()
+    {
+        return $this->hits->count();
     }
 
     /**

--- a/module/Photo/src/Photo/Service/Photo.php
+++ b/module/Photo/src/Photo/Service/Photo.php
@@ -430,7 +430,7 @@ class Photo extends AbstractAclService
         $now = new \DateTime();
         $age = $now->diff($photo->getDateTime(), true)->days;
 
-        $hits = $this->countHit($photo);
+        $hits = count($photo->getHits());
         $tags = count($photo->getTags());
 
         $base_rating = $hits / $tags;

--- a/module/Photo/src/Photo/Service/Photo.php
+++ b/module/Photo/src/Photo/Service/Photo.php
@@ -436,7 +436,7 @@ class Photo extends AbstractAclService
         $base_rating = $hits / $tags;
         // Prevent division by zero.
         if ($age == 0) {
-            return $base_rating * 1.5;
+            return $base_rating * 2;
         } else {
             return $base_rating + $base_rating / $age;
         }

--- a/module/Photo/src/Photo/Service/Photo.php
+++ b/module/Photo/src/Photo/Service/Photo.php
@@ -384,7 +384,7 @@ class Photo extends AbstractAclService
 
         foreach ($results as $res) {
             $photo = $res->getPhoto();
-            $rating = $this->ratePhotoForMember($photo, $lidnr);
+            $rating = $this->ratePhotoForMember($photo);
             if ($rating > $bestRating) {
                 $bestPhoto = $photo;
                 $bestRating = $rating;
@@ -425,21 +425,20 @@ class Photo extends AbstractAclService
      *
      * @return float
      */
-    public function ratePhotoForMember($photo, $lidnr)
+    public function ratePhotoForMember($photo)
     {
         $now = new \DateTime();
         $age = $now->diff($photo->getDateTime(), true)->days;
 
-        $hits = count($photo->getHits());
-        $tags = count($photo->getTags());
+        $hits = $photo->getHitCount();
+        $tags = $photo->getTagCount();
 
-        $base_rating = $hits / $tags;
+        $baseRating = $hits / $tags;
         // Prevent division by zero.
         if ($age == 0) {
-            return $base_rating * 5;
-        } else {
-            return $base_rating + $base_rating / $age;
+            return $baseRating * 5;
         }
+        return $baseRating + $baseRating / $age;
     }
 
     /**

--- a/module/Photo/src/Photo/Service/Photo.php
+++ b/module/Photo/src/Photo/Service/Photo.php
@@ -436,7 +436,7 @@ class Photo extends AbstractAclService
         $base_rating = $hits / $tags;
         // Prevent division by zero.
         if ($age == 0) {
-            return $base_rating * 2;
+            return $base_rating * 5;
         } else {
             return $base_rating + $base_rating / $age;
         }

--- a/module/Photo/src/Photo/Service/Photo.php
+++ b/module/Photo/src/Photo/Service/Photo.php
@@ -29,11 +29,11 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to view photos')
             );
         }
-        
+
         return $this->getPhotoMapper()->getAlbumPhotos($album, $start,
             $maxResults);
     }
-    
+
     /**
      * Get the photo mapper.
      *
@@ -43,7 +43,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('photo_mapper_photo');
     }
-    
+
     /**
      * Returns a zend response to be used for downloading a photo.
      *
@@ -59,14 +59,14 @@ class Photo extends AbstractAclService
                     ->translate('Not allowed to download photos')
             );
         }
-        
+
         $photo = $this->getPhoto($photoId);
         $path = $photo->getPath();
         $fileName = $this->getPhotoFileName($photo);
-        
+
         return $this->getFileStorageService()->downloadFile($path, $fileName);
     }
-    
+
     /**
      * Retrieves a photo by an id.
      *
@@ -81,10 +81,10 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to view photos')
             );
         }
-        
+
         return $this->getPhotoMapper()->getPhotoById($id);
     }
-    
+
     /**
      * Returns a unique file name for a photo.
      *
@@ -97,18 +97,18 @@ class Photo extends AbstractAclService
         // filtering is required to prevent invalid characters in file names.
         $filter = new \Zend\I18n\Filter\Alnum(true);
         $albumName = $filter->filter($photo->getAlbum()->getName());
-        
+
         // don't put spaces in file names
         $albumName = str_replace(' ', '-', $albumName);
-        
+
         $extension = substr($photo->getPath(), strpos($photo->getPath(), '.'));
-        
+
         $photoName = $albumName . '-' . $photo->getDateTime()->format('Y') . '-'
             . $photo->getId() . $extension;
-        
+
         return $photoName;
     }
-    
+
     /**
      * Gets the storage service.
      *
@@ -118,7 +118,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('application_service_storage');
     }
-    
+
     /**
      * Get the photo data belonging to a certain photo
      *
@@ -134,29 +134,29 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to view photos')
             );
         }
-        
+
         $photo = $this->getPhoto($photoId);
-        
+
         // photo does not exist
         if (is_null($photo)) {
             return null;
         }
-        
+
         if (is_null($album)) {
             // Default type for albums is Album.
             $album = new \Photo\Model\Album();
         }
-        
+
         $next = $this->getNextPhoto($photo, $album);
         $previous = $this->getPreviousPhoto($photo, $album);
-        
+
         return [
             'photo'    => $photo,
             'next'     => $next,
             'previous' => $previous
         ];
     }
-    
+
     /**
      * Returns the next photo in the album to display
      *
@@ -173,10 +173,10 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to view photos')
             );
         }
-        
+
         return $this->getPhotoMapper()->getNextPhoto($photo, $album);
     }
-    
+
     /**
      * Returns the previous photo in the album to display
      *
@@ -193,10 +193,10 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to view photos')
             );
         }
-        
+
         return $this->getPhotoMapper()->getPreviousPhoto($photo, $album);
     }
-    
+
     /**
      * Removes a photo from the database and deletes its files, including thumbs
      * from the server.
@@ -213,18 +213,18 @@ class Photo extends AbstractAclService
                     ->translate('Not allowed to delete photos.')
             );
         }
-        
+
         $photo = $this->getPhoto($photoId);
         if (is_null($photo)) {
             return false;
         }
         $this->getPhotoMapper()->remove($photo);
         $this->getPhotoMapper()->flush();
-        
+
         return true;
-        
+
     }
-    
+
     /**
      * Deletes all files associated with a photo.
      *
@@ -236,7 +236,7 @@ class Photo extends AbstractAclService
         $this->deletePhotoFile($photo->getLargeThumbPath());
         $this->deletePhotoFile($photo->getSmallThumbPath());
     }
-    
+
     /**
      * Deletes a stored photo at a given path.
      *
@@ -247,9 +247,9 @@ class Photo extends AbstractAclService
     public function deletePhotoFile($path)
     {
         return $this->getFileStorageService()->removeFile($path);
-        
+
     }
-    
+
     /**
      * Moves a photo to a new album.
      *
@@ -266,20 +266,20 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to move photos')
             );
         }
-        
+
         $photo = $this->getPhoto($photoId);
         $album = $this->getAlbumService()->getAlbum($albumId);
         if (is_null($photo) || is_null($album)) {
             return false;
         }
-        
+
         $photo->setAlbum($album);
         $this->getAlbumMapper()->flush();
-        
+
         return true;
-        
+
     }
-    
+
     /**
      * Gets the album service.
      *
@@ -289,7 +289,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('photo_service_album');
     }
-    
+
     /**
      * Get the album mapper.
      *
@@ -299,7 +299,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('photo_mapper_album');
     }
-    
+
     /**
      * Generates the PhotoOfTheWeek and adds it to the list
      * if at least one photo has been viewed in the specified time.
@@ -326,10 +326,10 @@ class Photo extends AbstractAclService
         $mapper = $this->getWeeklyPhotoMapper();
         $mapper->persist($weeklyPhoto);
         $mapper->flush();
-        
+
         return $weeklyPhoto;
     }
-    
+
     /**
      * Determine which photo is the photo of the week
      *
@@ -356,15 +356,49 @@ class Photo extends AbstractAclService
                 $bestRating = $rating;
             }
         }
-        
+
         return $bestPhoto;
     }
-    
+
+    /**
+     * Determine which photo is best suited as profile picture
+     *
+     * @param \int $lidnr
+     *
+     * @return \Photo\Model\Photo|null
+     */
+    public function determineProfilePhoto($lidnr)
+    {
+        if (!$this->isAllowed('view', 'tag')) {
+            return null;
+        }
+
+        $results = $this->getTagMapper()->getTagsByLidnr($lidnr);
+
+        if (empty($results)) {
+            return null;
+        }
+
+        $bestRating = -1;
+        $bestPhoto = null;
+
+        foreach ($results as $res) {
+            $photo = $res->getPhoto();
+            $rating = $this->ratePhotoForMember($photo, $lidnr);
+            if ($rating > $bestRating) {
+                $bestPhoto = $photo;
+                $bestRating = $rating;
+            }
+        }
+
+        return $bestPhoto;
+    }
+
     public function getHitMapper()
     {
         return $this->sm->get('photo_mapper_hit');
     }
-    
+
     /**
      * Determine the preference rating of the photo.
      *
@@ -379,10 +413,35 @@ class Photo extends AbstractAclService
         $now = new \DateTime();
         $age = $now->diff($photo->getDateTime(), true)->days;
         $res = $occurences * (1 + 1 / $age);
-        
+
         return $tagged ? 1.5 * $res : $res;
     }
-    
+
+    /**
+     * Determine the preference rating of the photo.
+     *
+     * @param \Photo\Model\Photo $photo
+     * @param int                $lidnr
+     *
+     * @return float
+     */
+    public function ratePhotoForMember($photo, $lidnr)
+    {
+        $now = new \DateTime();
+        $age = $now->diff($photo->getDateTime(), true)->days;
+
+        $hits = $this->countHit($photo);
+        $tags = count($photo->getTags());
+
+        $base_rating = $hits / $tags;
+        // Prevent division by zero.
+        if ($age == 0) {
+            return $base_rating * 1.5;
+        } else {
+            return $base_rating + $base_rating / $age;
+        }
+    }
+
     /**
      * Get the weekly photo mapper.
      *
@@ -392,7 +451,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('photo_mapper_weekly_photo');
     }
-    
+
     /**
      * Retrieves all WeeklyPhotos
      *
@@ -406,15 +465,15 @@ class Photo extends AbstractAclService
                     ->translate('Not allowed to view previous photos of the week')
             );
         }
-        
+
         return $this->getWeeklyPhotoMapper()->getPhotosOfTheWeek();
     }
-    
+
     public function getCurrentPhotoOfTheWeek()
     {
         return $this->getWeeklyPhotoMapper()->getCurrentPhotoOfTheWeek();
     }
-    
+
     /**
      * Count a hit for the specified photo. Should be called whenever a photo
      * is viewed.
@@ -426,10 +485,10 @@ class Photo extends AbstractAclService
         $hit = new HitModel();
         $hit->setDateTime(new \DateTime());
         $photo->addHit($hit);
-        
+
         $this->getPhotoMapper()->flush();
     }
-    
+
     /**
      * Tags a user in the specified photo.
      *
@@ -445,23 +504,23 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to add tags.')
             );
         }
-        
+
         if (is_null($this->findTag($photoId, $lidnr))) {
             $photo = $this->getPhoto($photoId);
             $member = $this->getMemberService()->findMemberByLidnr($lidnr);
             $tag = new TagModel();
             $tag->setMember($member);
             $photo->addTag($tag);
-            
+
             $this->getPhotoMapper()->flush();
-            
+
             return $tag;
         } else {
             // Tag exists
             return null;
         }
     }
-    
+
     /**
      * Retrieves a tag if it exists.
      *
@@ -477,10 +536,10 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to view tags.')
             );
         }
-        
+
         return $this->getTagMapper()->findTag($photoId, $lidnr);
     }
-    
+
     /**
      * Get the tag mapper.
      *
@@ -490,7 +549,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('photo_mapper_tag');
     }
-    
+
     /**
      * Get the member service.
      *
@@ -500,7 +559,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('decision_service_member');
     }
-    
+
     /**
      * Removes a tag
      *
@@ -516,18 +575,18 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to remove tags.')
             );
         }
-        
+
         $tag = $this->findTag($photoId, $lidnr);
         if (!is_null($tag)) {
             $this->getTagMapper()->remove($tag);
             $this->getTagMapper()->flush();
-            
+
             return true;
         } else {
             return false;
         }
     }
-    
+
     /**
      * Gets all photos in which a member has been tagged.
      *
@@ -542,10 +601,10 @@ class Photo extends AbstractAclService
                 $this->getTranslator()->translate('Not allowed to view tags.')
             );
         }
-        
+
         return $this->getTagMapper()->getTagsByLidnr($member->getLidnr());
     }
-    
+
     /**
      * Gets the base directory from which the photo paths should be requested
      *
@@ -554,10 +613,10 @@ class Photo extends AbstractAclService
     public function getBaseDirectory()
     {
         $config = $this->getConfig();
-        
+
         return str_replace('public', '', $config['upload_dir']);
     }
-    
+
     /**
      * Get the photo config, as used by this service.
      *
@@ -566,10 +625,10 @@ class Photo extends AbstractAclService
     public function getConfig()
     {
         $config = $this->sm->get('config');
-        
+
         return $config['photo'];
     }
-    
+
     /**
      * Get the storage config, as used by this service.
      *
@@ -578,10 +637,10 @@ class Photo extends AbstractAclService
     public function getStorageConfig()
     {
         $config = $this->sm->get('config');
-        
+
         return $config['storage'];
     }
-    
+
     /**
      * Gets the metadata service.
      *
@@ -591,7 +650,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('photo_service_metadata');
     }
-    
+
     /**
      * Get the Acl.
      *
@@ -601,7 +660,7 @@ class Photo extends AbstractAclService
     {
         return $this->sm->get('photo_acl');
     }
-    
+
     /**
      * Get the default resource ID.
      *


### PR DESCRIPTION
I have added a profile picture to public and self profile of members. Determination of the profile picture is done automatically based on the number of hits, number of tags and age of a picture the member is tagged in.

This is an example of a public profile with a beautiful picture.
![image](https://user-images.githubusercontent.com/32361020/52177738-ed03ca80-27c5-11e9-8787-db1a557b78d9.png)

This picture was selected with the following formula: 
Base rating = Amount of hits divided by the number of tags
Final Rating = Base Rating + Base rating / age
Age is determined in days

The idea is that the newer pictures are preferred over older ones; that profiles of a single or a few persons are preferred over group pictures; and that good profile pictures are obviously viewed often.