### PR TITLE
Fix Masonry Position Calculation in Firefox

### DIFF
--- a/public/scss/modules/_photo.scss
+++ b/public/scss/modules/_photo.scss
@@ -11,6 +11,10 @@ Photo
   clear: both;
 }
 
+.grid-sizer {
+  float: left;
+}
+
 .gutter-sizer {
   width: 0.5%;
 }


### PR DESCRIPTION
Fixes #864.

Adds an additional `left`-property to `.grid-sizer`. This allows Masonry to correctly calculate the width for `.photo-grid-item`s. This additional property is needed because Firefox recently (~7 months ago) changed a method which Masonry used to calculate the widths (represented in the `left`-property) and there has not been any response from Masonry regarding this issue (except for use this property).

Images are now correctly aligned in a grid:
![gewis ff masonry incorrect calculations fixed](https://user-images.githubusercontent.com/4983571/52742440-05e75980-2fd8-11e9-8be8-c843c3c4fe67.PNG)
