### PR TITLE
Made activity homepage visible again for guests

### DIFF
--- a/module/Activity/Module.php
+++ b/module/Activity/Module.php
@@ -143,6 +143,7 @@ class Module
                 'activity_acl' => function ($sm) {
                     $acl = $sm->get('acl');
                     $acl->addResource('activity');
+                    $acl->addResource('myActivities');
                     $acl->addResource('activitySignup');
                     $acl->addResource('model');
                     $acl->addResource('activity_calendar_option');
@@ -152,6 +153,7 @@ class Module
                     $acl->allow('guest', 'activitySignup', 'externalSignup');
 
                     $acl->allow('user', 'activity', 'create');
+                    $acl->allow('user', 'myActivities', 'view');
                     $acl->allow('user', 'activitySignup', ['view', 'signup', 'signoff', 'checkUserSignedUp']);
 
                     $acl->allow('admin', 'activity', ['update', 'viewDetails', 'adminSignup']);

--- a/module/Activity/src/Activity/Controller/ActivityController.php
+++ b/module/Activity/src/Activity/Controller/ActivityController.php
@@ -21,8 +21,7 @@ class ActivityController extends AbstractActionController
         $queryService = $this->getServiceLocator()->get('activity_service_activityQuery');
         $translatorService = $this->getServiceLocator()->get('activity_service_activityTranslator');
         $langSession = new SessionContainer('lang');
-        $user = $this->getServiceLocator()->get('user_service_user')->getIdentity();
-        $activities = $queryService->getUpcomingActivities($this->params('category'), $user);
+        $activities = $queryService->getUpcomingActivities($this->params('category'));
         $translatedActivities = [];
         foreach ($activities as $activity){
             $translatedActivities[] = $translatorService->getTranslatedActivity($activity, $langSession->lang);

--- a/module/Activity/src/Activity/Service/ActivityQuery.php
+++ b/module/Activity/src/Activity/Service/ActivityQuery.php
@@ -207,11 +207,10 @@ class ActivityQuery extends AbstractAclService implements ServiceManagerAwareInt
      * Get all activities that are approved by the board and which occur in the future
      *
      * @param String $category Type of activities requested
-     * @param Decision/Model/Member $user User for which activities are selected if category === 'my'
      *
      * @return array Array of activities
      */
-    public function getUpcomingActivities($category = null, $user = null)
+    public function getUpcomingActivities($category = null)
     {
         if (!$this->isAllowed('view', 'activity')) {
             $translator = $this->getTranslator();
@@ -222,6 +221,7 @@ class ActivityQuery extends AbstractAclService implements ServiceManagerAwareInt
 
         $activityMapper = $this->getServiceManager()->get('activity_mapper_activity');
         if ($category === 'my') {
+            $user = $this->getServiceLocator()->get('user_service_user')->getIdentity();
             return $activityMapper->getUpcomingActivitiesForMember($user);
         }
         return $activityMapper->getUpcomingActivities(null, null, $category);

--- a/module/Activity/src/Activity/Service/ActivityQuery.php
+++ b/module/Activity/src/Activity/Service/ActivityQuery.php
@@ -221,7 +221,7 @@ class ActivityQuery extends AbstractAclService implements ServiceManagerAwareInt
 
         $activityMapper = $this->getServiceManager()->get('activity_mapper_activity');
         if ($category === 'my') {
-            if (!$this->getRole() === 'guest') {
+            if (!$this->isAllowed('view', 'myActivities')) {
                 $translator = $this->getTranslator();
                 throw new \User\Permissions\NotAllowedException(
                     $translator->translate('You are not allowed to view upcoming activities coupled to a member account')

--- a/module/Activity/src/Activity/Service/ActivityQuery.php
+++ b/module/Activity/src/Activity/Service/ActivityQuery.php
@@ -221,6 +221,12 @@ class ActivityQuery extends AbstractAclService implements ServiceManagerAwareInt
 
         $activityMapper = $this->getServiceManager()->get('activity_mapper_activity');
         if ($category === 'my') {
+            if (!$this->getRole() === 'guest') {
+                $translator = $this->getTranslator();
+                throw new \User\Permissions\NotAllowedException(
+                    $translator->translate('You are not allowed to view upcoming activities coupled to a member account')
+                );
+            }
             $user = $this->getServiceLocator()->get('user_service_user')->getIdentity();
             return $activityMapper->getUpcomingActivitiesForMember($user);
         }


### PR DESCRIPTION
This resolves #885 and resolves #878.
The identity of the user will now only requested when trying to view the My Activities page.
All activities can now be viewed by external members, just not the subscription lists.

I will await issue #884 before making additional changes.
This PR may be merged.