### PR TITLE
Increase information density on members page for small screens

### DIFF
--- a/public/scss/components/_grid.scss
+++ b/public/scss/components/_grid.scss
@@ -19,6 +19,16 @@
     .grid-col-3, .grid-col-5 {
         grid-template-columns: repeat(1, 1fr);
     }
+
+    .grid a.panel-image {
+        display: flex;
+
+        .glyphicon {
+            font-size: 1em;
+            margin-right: 1em;
+            line-height: normal;
+        }
+    }
 }
 
 @media only screen and (min-width: $screen-xs-min) {


### PR DESCRIPTION
I decided to simply decrease the size of the icon and left-align the text. Side-by-side icons don't really work on small screens.

- [iPhone 5](https://user-images.githubusercontent.com/706385/65267904-47178d00-db16-11e9-9bb6-3ffb06dcda2f.png)
- [iPad](https://user-images.githubusercontent.com/706385/65267919-51398b80-db16-11e9-9ad2-7b09e44aa0bc.png)