### PR TITLE
Separate album children from album photos

### DIFF
--- a/module/Photo/view/photo/album/index-new.phtml
+++ b/module/Photo/view/photo/album/index-new.phtml
@@ -99,21 +99,23 @@ $this->scriptUrl()->requireUrl('member/search')
             $path = $this->url('photo/album', ['album_id' => $album->getId()]);
         }
         ?>
-
-        <div class="photo-grid">
-            <div class="grid-sizer"></div>
-            <div class="gutter-sizer"></div>
-            <?php foreach ($album->getChildren() as $item): ?>
-                    <!-- TODO: fix this -->
-                   <!-- <div class="photo-grid-item photo-grid-item-album">
+        <?php if ($album->getAlbumCount() > 0): ?>
+            <div class="row">
+                <?php foreach ($album->getChildren() as $item): ?>
+                    <div class="col-lg-2 col-md-3 col-xs-6 thumb">
                         <a class="thumbnail" href="<?= $this->url('photo/album', ['album_id' => $item->getId()]); ?>">
                             <img src="<?= $this->fileUrl($item->getCoverPath()); ?>">
                             <div class="caption">
                                 <?= $this->escapeHtml($item->getName()); ?>
                             </div>
                         </a>
-                    </div> -->
-            <?php endforeach ?>
+                    </div>
+                <?php endforeach ?>
+            </div>
+        <?php endif; ?>
+        <div class="photo-grid">
+            <div class="grid-sizer"></div>
+            <div class="gutter-sizer"></div>
             <?php foreach ($album->getPhotos() as $item): ?>
                 <?php
                     $ar = $item->getAspectRatio();


### PR DESCRIPTION
Separates album children from album photos. This is required to prevent children and photos overlapping children.

Fixes #926.

**Old Viewer (incorrect):**
![GEWIS-WEB Sub-album overlap old viewer](https://user-images.githubusercontent.com/4983571/66204686-b0b5a080-e6ab-11e9-8192-7c0a103ec98e.png)

**New Viewer (incorect):**
![GEWIS-WEB Sub-album overlap new viewer](https://user-images.githubusercontent.com/4983571/66204693-b4e1be00-e6ab-11e9-8875-09d7eb349278.png)

**New Viewer (correct):**
![GEWIS-WEB Sub-album no overlap](https://user-images.githubusercontent.com/4983571/66204697-b7441800-e6ab-11e9-8b70-cac3a3859c7b.png)