### PR TITLE
Modified composer.json to change GEWIS to lowercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "GEWIS/gewisweb",
+    "name": "gewis/gewisweb",
     "description": "GEWIS Website",
     "license": "GPL-3.0",
     "keywords": [


### PR DESCRIPTION
As much as I'd like to keep the GEWIS name in uppercase, composer is
saying this will not be allowed in the future.