### PR TITLE
Decrease the amount of logged exceptions

### DIFF
--- a/module/Application/Module.php
+++ b/module/Application/Module.php
@@ -15,6 +15,7 @@ use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
 use Zend\Session\Container as SessionContainer;
 use Zend\Validator\AbstractValidator;
+use User\Permissions\NotAllowedException;
 
 class Module
 {
@@ -39,8 +40,18 @@ class Module
         $sm = $e->getApplication()->getServiceManager();
         $logger = $sm->get('logger');
 
+        if ($e->getError() === 'error-router-no-match') {
+            // not an interesting error
+            return;
+        }
         if ($e->getError() === 'error-exception') {
             $ex = $e->getParam('exception');
+
+            if ($ex instanceof NotAllowedException) {
+                // we do not need to log access denied
+                return;
+            }
+
             $logger->error($ex);
             return;
         }


### PR DESCRIPTION
This makes sure we do not log uninteresting exceptions and errors, such
as a user typing in a wrong URL (404) or going to an unauthorized
page (403).

Fixes #857