### PR TITLE
Updates the layout of the meeting page

### DIFF
--- a/module/Application/Module.php
+++ b/module/Application/Module.php
@@ -32,6 +32,7 @@ class Module
         $translator->setlocale($locale);
 
         Carbon::setLocale($locale);
+        \Locale::setDefault($locale);
 
         $eventManager->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'logError']);
         $eventManager->attach(MvCEvent::EVENT_RENDER_ERROR, [$this, 'logError']);

--- a/module/Decision/view/decision/decision/view.phtml
+++ b/module/Decision/view/decision/decision/view.phtml
@@ -1,54 +1,72 @@
 <?php
-// set title
-$this->headTitle(sprintf('%s %d', $meeting->getType(), $meeting->getNumber())); ?>
+$meetingName = sprintf('%s %d', $meeting->getType(), $meeting->getNumber());
+
+$this->headTitle($meetingName);
+?>
 <section class="section">
     <div class="container">
-        <h1><?= $meeting->getType() ?> <?= $meeting->getNumber() ?>
-            <small><?= $this->dateFormat(
-                    $meeting->getDate(),
-                    \IntlDateFormatter::FULL,
-                    \IntlDateFormatter::NONE,
-                    'nl_NL'
-                ) ?></small>
-        </h1>
+        <h1><?= $meetingName ?></h1>
+        <h2>
+            <?= $this->dateFormat($meeting->getDate(), \IntlDateFormatter::FULL, \IntlDateFormatter::NONE) ?>
+        </h2>
         <div class="row">
             <div class="col-md-6">
+                <h3><?= $this->translate('Documents') ?></h3>
+                <table class="table table-striped table-hover">
+                    <?php foreach ($meeting->getDocuments() as $document): ?>
+                    <tr>
+                        <td>
+                            <a href="<?= $this->url('decision/document', ['id' => $document->getId()]) ?>" class="d-block">
+                                <?= $document->getName() ?>
+                            </a>
+                        </td>
+                    </tr>
+                    <?php endforeach ?>
+                </table>
+            </div>
+            <div class="col-md-6">
+                <h3><?= $this->translate('Minutes') ?></h3>
                 <?php if (!is_null($meeting->getNotes())): ?>
-                    <a
-                        href="<?= $this->url('decision/meeting/notes', [
-                            'type' => $meeting->getType(),
+                    <?php
+                        $notesUrl = $this->url('decision/meeting/notes', [
+                            'type'   => $meeting->getType(),
                             'number' => $meeting->getNumber()
-                        ]) ?>"
-                    >
-                        <?= $this->translate('Notes for this meeting') ?></a>
+                        ])
+                    ?>
+                    <a href="<?= $notesUrl ?>">
+                        <?= sprintf($this->translate('View the minutes of %s'), $meetingName) ?>
+                    </a>
+                <?php else: ?>
+                    <p class="text-muted">
+                        <?= $this->translate("The minutes aren't available yet.") ?>
+                    </p>
                 <?php endif ?>
             </div>
-
-            <div class="col-md-6">
-                <ul>
-                    <?php foreach ($meeting->getDocuments() as $document): ?>
-                        <li><a
-                                href="<?= $this->url('decision/document', [
-                                    'id' => $document->getId()
-                                ]) ?>"
-                            >
-                                <?= $document->getName() ?></a></li>
-                    <?php endforeach ?>
-                </ul>
-            </div>
         </div>
-
-        <div class="row">
-            <div class="col-md-12">
-                <ul>
-                    <?php foreach ($meeting->getDecisions() as $decision): ?>
-                        <li><?= $meeting->getType() ?> <?= $meeting->getNumber() ?>
-                            .<?= $decision->getPoint() ?>
-                            .<?= $decision->getNumber() ?>
-                            <?= $decision->getContent() ?></li>
-                    <?php endforeach ?>
-                </ul>
+        <?php if ($meeting->getDecisions()->count() > 0): ?>
+            <div class="row">
+                <div class="col-md-12">
+                    <h3><?= $this->translate('Decisions') ?></h3>
+                    <ul>
+                        <?php foreach ($meeting->getDecisions() as $decision): ?>
+                            <?php
+                                $id = vsprintf('%s %s.%s.%s', [
+                                    $meeting->getType(),
+                                    $meeting->getNumber(),
+                                    $decision->getPoint(),
+                                    $decision->getNumber(),
+                                ]);
+                            ?>
+                            <li id="<?= urlencode($id) ?>" class="link-permalink-container">
+                                <?= sprintf('%s %s', $id, $decision->getContent()) ?>
+                                <a href="#<?= urlencode($id) ?>" class="link-permalink">
+                                    <span class="glyphicon glyphicon-link"></span>
+                                </a>
+                            </li>
+                        <?php endforeach ?>
+                    </ul>
+                </div>
             </div>
-        </div>
+        <?php endif; ?>
     </div>
 </section>

--- a/module/Decision/view/decision/decision/view.phtml
+++ b/module/Decision/view/decision/decision/view.phtml
@@ -12,17 +12,23 @@ $this->headTitle($meetingName);
         <div class="row">
             <div class="col-md-6">
                 <h3><?= $this->translate('Documents') ?></h3>
-                <table class="table table-striped table-hover">
-                    <?php foreach ($meeting->getDocuments() as $document): ?>
-                    <tr>
-                        <td>
-                            <a href="<?= $this->url('decision/document', ['id' => $document->getId()]) ?>" class="d-block">
-                                <?= $document->getName() ?>
-                            </a>
-                        </td>
-                    </tr>
-                    <?php endforeach ?>
-                </table>
+                <?php if (count($meeting->getDocuments()) > 0): ?>
+                    <table class="table table-striped table-hover">
+                        <?php foreach ($meeting->getDocuments() as $document): ?>
+                        <tr>
+                            <td>
+                                <a href="<?= $this->url('decision/document', ['id' => $document->getId()]) ?>" class="d-block">
+                                    <?= $document->getName() ?>
+                                </a>
+                            </td>
+                        </tr>
+                        <?php endforeach ?>
+                    </table>
+                <?php else: ?>
+                    <p class="text-muted">
+                        <?= $this->translate("No documents have been added yet.") ?>
+                    </p>
+                <?php endif; ?>
             </div>
             <div class="col-md-6">
                 <h3><?= $this->translate('Minutes') ?></h3>

--- a/module/Decision/view/decision/decision/view.phtml
+++ b/module/Decision/view/decision/decision/view.phtml
@@ -6,9 +6,7 @@ $this->headTitle($meetingName);
 <section class="section">
     <div class="container">
         <h1><?= $meetingName ?></h1>
-        <h2>
-            <?= $this->dateFormat($meeting->getDate(), \IntlDateFormatter::FULL, \IntlDateFormatter::NONE) ?>
-        </h2>
+        <h2><?= $this->dateFormat($meeting->getDate(), \IntlDateFormatter::FULL, \IntlDateFormatter::NONE) ?></h2>
         <div class="row">
             <div class="col-md-6">
                 <h3><?= $this->translate('Documents') ?></h3>
@@ -39,9 +37,11 @@ $this->headTitle($meetingName);
                             'number' => $meeting->getNumber()
                         ])
                     ?>
-                    <a href="<?= $notesUrl ?>">
-                        <?= sprintf($this->translate('View the minutes of %s'), $meetingName) ?>
-                    </a>
+                    <p>
+                        <a href="<?= $notesUrl ?>">
+                            <?= sprintf($this->translate('View the minutes of %s'), $meetingName) ?>
+                        </a>
+                    </p>
                 <?php else: ?>
                     <p class="text-muted">
                         <?= $this->translate("The minutes aren't available yet.") ?>
@@ -49,7 +49,7 @@ $this->headTitle($meetingName);
                 <?php endif ?>
             </div>
         </div>
-        <?php if ($meeting->getDecisions()->count() > 0): ?>
+        <?php if (count($meeting->getDecisions()) > 0): ?>
             <div class="row">
                 <div class="col-md-12">
                     <h3><?= $this->translate('Decisions') ?></h3>

--- a/module/Decision/view/decision/decision/view.phtml
+++ b/module/Decision/view/decision/decision/view.phtml
@@ -24,13 +24,13 @@ $this->headTitle($meetingName);
                     </table>
                 <?php else: ?>
                     <p class="text-muted">
-                        <?= $this->translate("No documents have been added yet.") ?>
+                        <?= $this->translate("No documents have been added.") ?>
                     </p>
                 <?php endif; ?>
             </div>
-            <div class="col-md-6">
-                <h3><?= $this->translate('Minutes') ?></h3>
-                <?php if (!is_null($meeting->getNotes())): ?>
+            <?php if (!is_null($meeting->getNotes())): ?>
+                <div class="col-md-6">
+                    <h3><?= $this->translate('Minutes') ?></h3>
                     <?php
                         $notesUrl = $this->url('decision/meeting/notes', [
                             'type'   => $meeting->getType(),
@@ -42,12 +42,8 @@ $this->headTitle($meetingName);
                             <?= sprintf($this->translate('View the minutes of %s'), $meetingName) ?>
                         </a>
                     </p>
-                <?php else: ?>
-                    <p class="text-muted">
-                        <?= $this->translate("The minutes aren't available yet.") ?>
-                    </p>
-                <?php endif ?>
-            </div>
+                </div>
+            <?php endif; ?>
         </div>
         <?php if (count($meeting->getDecisions()) > 0): ?>
             <div class="row">

--- a/public/scss/components/_layout.scss
+++ b/public/scss/components/_layout.scss
@@ -75,3 +75,7 @@ a[href^='mailto:klachten@gewis.nl'] .panel-special {
     display: inline-flex;
     align-items: center;
 }
+
+.d-block {
+    display: block;
+}

--- a/public/scss/components/_links.scss
+++ b/public/scss/components/_links.scss
@@ -1,0 +1,7 @@
+.link-permalink {
+    visibility: hidden;
+}
+
+.link-permalink-container:hover .link-permalink {
+    visibility: visible;
+}

--- a/public/scss/main.scss
+++ b/public/scss/main.scss
@@ -33,6 +33,7 @@
 @import 'components/thumbnails';
 @import 'components/type';
 @import 'components/grid';
+@import 'components/links';
 
 // Module specific styles
 @import 'modules/company';


### PR DESCRIPTION
This PR updates the layout of the meeting page (user-faced) and adds the ability to directly link to specific decisions. Furthermore, I've fixed an issue which caused the meeting date to only show in Dutch.

## Screenshots
- [Meeting page with data](https://user-images.githubusercontent.com/706385/69879538-fa93bf00-12c7-11ea-88d6-cb1a364d1eeb.png)
- [Meeting page with data (hover over decision)](https://user-images.githubusercontent.com/706385/69879559-067f8100-12c8-11ea-849a-50fc0dc81ca9.png)
- [Meeting page without data](https://user-images.githubusercontent.com/706385/69879588-18612400-12c8-11ea-94b8-9974ac600117.png)

## Translations

- [Translations.txt](https://github.com/GEWIS/gewisweb/files/3905827/Translations.txt)


