### PR TITLE
WIP: Delete models cascade

### DIFF
--- a/module/Activity/src/Activity/Model/Activity.php
+++ b/module/Activity/src/Activity/Model/Activity.php
@@ -123,7 +123,7 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     /**
      * Who did approve this activity.
      *
-     * @ORM\ManyToOne(targetEntity="User\Model\User")
+     * @ORM\ManyToOne(targetEntity="User\Model\User", onDelete="CASCADE")
      * @ORM\JoinColumn(referencedColumnName="lidnr")
      */
     protected $approver;
@@ -131,7 +131,7 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     /**
      * Who created this activity.
      *
-     * @ORM\ManyToOne(targetEntity="User\Model\User")
+     * @ORM\ManyToOne(targetEntity="User\Model\User", onDelete="CASCADE")
      * @ORM\JoinColumn(referencedColumnName="lidnr",nullable=false)
      */
     protected $creator;
@@ -146,7 +146,7 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     /**
      * The update proposal associated with this activity
      *
-     * @ORM\OneToMany(targetEntity="Activity\Model\ActivityUpdateProposal", mappedBy="old")
+     * @ORM\OneToMany(targetEntity="Activity\Model\ActivityUpdateProposal", mappedBy="old", cascade={"delete"})
      */
     protected $updateProposal;
 
@@ -167,7 +167,7 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     /**
      * all the people who signed up for this activity
      *
-     * @ORM\OneToMany(targetEntity="ActivitySignup", mappedBy="activity")
+     * @ORM\OneToMany(targetEntity="ActivitySignup", mappedBy="activity", cascade={"remove"})
      * @ORM\OrderBy({"id" = "ASC"})
      */
     protected $signUps;
@@ -175,7 +175,7 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     /**
      * All additional fields belonging to the activity.
      *
-     * @ORM\OneToMany(targetEntity="ActivityField", mappedBy="activity")
+     * @ORM\OneToMany(targetEntity="ActivityField", mappedBy="activity", cascade={"remove"})
      */
     protected $fields;
 

--- a/module/Activity/src/Activity/Model/ActivityCalendarOption.php
+++ b/module/Activity/src/Activity/Model/ActivityCalendarOption.php
@@ -51,7 +51,7 @@ class ActivityCalendarOption
     /**
      * To what activity proposal does the option belong
      *
-     * @ORM\ManyToOne(targetEntity="Activity\Model\ActivityOptionProposal")
+     * @ORM\ManyToOne(targetEntity="Activity\Model\ActivityOptionProposal", onDelete="CASCADE")
      * @ORM\JoinColumn(referencedColumnName="id",nullable=false)
      */
     protected $proposal;
@@ -59,7 +59,7 @@ class ActivityCalendarOption
     /**
      * Who modified this activity option, if null then the option is not modified
      *
-     * @ORM\ManyToOne(targetEntity="User\Model\User")
+     * @ORM\ManyToOne(targetEntity="User\Model\User", onDelete="CASCADE")
      * @ORM\JoinColumn(referencedColumnName="lidnr",nullable=true)
      */
     protected $modifiedBy;

--- a/module/Activity/src/Activity/Model/ActivityField.php
+++ b/module/Activity/src/Activity/Model/ActivityField.php
@@ -23,7 +23,7 @@ class ActivityField
     /**
      * Activity that the field belongs to.
      *
-     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity", inversedBy="fields", cascade={"persist"})
+     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity", inversedBy="fields", cascade={"persist"}, onDelete="CASCADE")
      * @ORM\JoinColumn(name="activity_id",referencedColumnName="id")
      */
     protected $activity;
@@ -66,7 +66,7 @@ class ActivityField
     /**
      * The allowed options for the field of the ``option'' type.
      *
-     * @ORM\OneToMany(targetEntity="ActivityOption", mappedBy="field")
+     * @ORM\OneToMany(targetEntity="ActivityOption", mappedBy="field", cascade={"remove"})
      */
     protected $options;
 

--- a/module/Activity/src/Activity/Model/ActivityFieldTranslation.php
+++ b/module/Activity/src/Activity/Model/ActivityFieldTranslation.php
@@ -17,6 +17,9 @@ class ActivityFieldTranslation
 
     /**
      * Activity that the field belongs to.
+     *
+     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity", inversedBy="fields", cascade={"persist"}, onDelete="CASCADE")
+     * @ORM\JoinColumn(name="activity_id",referencedColumnName="id")
      */
     protected $activity;
 
@@ -42,6 +45,8 @@ class ActivityFieldTranslation
 
     /**
      * The allowed options for the field of the ``option'' type.
+     *
+     * @ORM\OneToMany(targetEntity="ActivityOption", mappedBy="field", cascade={"remove"})
      */
     protected $options;
 

--- a/module/Activity/src/Activity/Model/ActivityFieldValue.php
+++ b/module/Activity/src/Activity/Model/ActivityFieldValue.php
@@ -23,7 +23,7 @@ class ActivityFieldValue
     /**
      * Field which the value belongs to.
      *
-     * @ORM\ManyToOne(targetEntity="ActivityField")
+     * @ORM\ManyToOne(targetEntity="ActivityField", onDelete="CASCADE")
      * @ORM\JoinColumn(name="field_id",referencedColumnName="id")
      */
     protected $field;
@@ -31,7 +31,7 @@ class ActivityFieldValue
     /**
      * Signup which the value belongs to.
      *
-     * @ORM\ManyToOne(targetEntity="ActivitySignup", inversedBy="fieldValues")
+     * @ORM\ManyToOne(targetEntity="ActivitySignup", inversedBy="fieldValues", onDelete="CASCADE")
      * @ORM\JoinColumn(name="signup_id", referencedColumnName="id")
      */
     protected $signup;
@@ -46,7 +46,7 @@ class ActivityFieldValue
     /**
      * The option chosen.
      *
-     * @ORM\ManyToOne(targetEntity="ActivityOption")
+     * @ORM\ManyToOne(targetEntity="ActivityOption", onDelete="CASCADE")
      * @ORM\JoinColumn(name="option_id", referencedColumnName="id")
      */
     protected $option;

--- a/module/Activity/src/Activity/Model/ActivityOption.php
+++ b/module/Activity/src/Activity/Model/ActivityOption.php
@@ -24,7 +24,7 @@ class ActivityOption
     /**
      * Field that the option belongs to.
      *
-     * @ORM\ManyToOne(targetEntity="ActivityField", inversedBy="options", cascade={"persist"})
+     * @ORM\ManyToOne(targetEntity="ActivityField", inversedBy="options", cascade={"persist"}, onDelete="CASCADE")
      * @ORM\JoinColumn(name="field_id",referencedColumnName="id")
      */
     protected $field;

--- a/module/Activity/src/Activity/Model/ActivityOptionProposal.php
+++ b/module/Activity/src/Activity/Model/ActivityOptionProposal.php
@@ -39,7 +39,7 @@ class ActivityOptionProposal implements OrganResourceInterface
     /**
      * Who created this activity option.
      *
-     * @ORM\ManyToOne(targetEntity="User\Model\User")
+     * @ORM\ManyToOne(targetEntity="User\Model\User", onDelete="CASCADE")
      * @ORM\JoinColumn(referencedColumnName="lidnr",nullable=false)
      */
     protected $creator;

--- a/module/Activity/src/Activity/Model/ActivityOptionTranslation.php
+++ b/module/Activity/src/Activity/Model/ActivityOptionTranslation.php
@@ -17,6 +17,9 @@ class ActivityOptionTranslation
 
     /**
      * Field that the option belongs to.
+     *
+     * @ORM\ManyToOne(targetEntity="ActivityField", inversedBy="options", cascade={"persist"}, onDelete="CASCADE")
+     * @ORM\JoinColumn(name="field_id",referencedColumnName="id")
      */
     protected $field;
 

--- a/module/Activity/src/Activity/Model/ActivitySignup.php
+++ b/module/Activity/src/Activity/Model/ActivitySignup.php
@@ -27,7 +27,7 @@ abstract class ActivitySignup
     /**
      * The activity the signup is for.
      *
-     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity", inversedBy="signUps")
+     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity", inversedBy="signUps", onDelete="CASCADE")
      * @ORM\JoinColumn(name="activity_id",referencedColumnName="id")
      */
     protected $activity;

--- a/module/Activity/src/Activity/Model/ActivityTranslation.php
+++ b/module/Activity/src/Activity/Model/ActivityTranslation.php
@@ -73,11 +73,17 @@ class ActivityTranslation
 
     /**
      * Who did approve this activity.
+     *
+     * @ORM\ManyToOne(targetEntity="User\Model\User", onDelete="CASCADE")
+     * @ORM\JoinColumn(referencedColumnName="lidnr")
      */
     protected $approver;
 
     /**
      * Who created this activity.
+     *
+     * @ORM\ManyToOne(targetEntity="User\Model\User", onDelete="CASCADE")
+     * @ORM\JoinColumn(referencedColumnName="lidnr",nullable=false)
      */
     protected $creator;
 
@@ -93,11 +99,16 @@ class ActivityTranslation
 
     /**
      * all the people who signed up for this activity
+     *
+     * @ORM\OneToMany(targetEntity="ActivitySignup", mappedBy="activity", cascade={"remove"})
+     * @ORM\OrderBy({"id" = "ASC"})
      */
     protected $signUps;
 
     /**
      * All additional fields belonging to the activity.
+     *
+     * @ORM\OneToMany(targetEntity="ActivityField", mappedBy="activity", cascade={"remove"})
      */
     protected $fields;
 

--- a/module/Activity/src/Activity/Model/ActivityUpdateProposal.php
+++ b/module/Activity/src/Activity/Model/ActivityUpdateProposal.php
@@ -25,7 +25,7 @@ class ActivityUpdateProposal
     /**
      * The previous activity version, if any.
      *
-     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity", inversedBy="updateProposal")
+     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity", inversedBy="updateProposal", onDelete="CASCADE")
      * @ORM\JoinColumn(referencedColumnName="id")
      */
     protected $old;
@@ -33,7 +33,7 @@ class ActivityUpdateProposal
     /**
      * The new activity
      *
-     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity")
+     * @ORM\ManyToOne(targetEntity="Activity\Model\Activity", onDelete="CASCADE")
      * @ORM\JoinColumn(referencedColumnName="id")
      */
     protected $new;

--- a/module/Activity/src/Activity/Model/MaxActivities.php
+++ b/module/Activity/src/Activity/Model/MaxActivities.php
@@ -38,7 +38,7 @@ class MaxActivities
     /**
      * The associated period
      *
-     * @ORM\ManyToOne(targetEntity="Activity\Model\ActivityOptionCreationPeriod")
+     * @ORM\ManyToOne(targetEntity="Activity\Model\ActivityOptionCreationPeriod", onDelete="CASCADE")
      */
     protected $period;
 

--- a/module/Activity/src/Activity/Model/UserActivitySignup.php
+++ b/module/Activity/src/Activity/Model/UserActivitySignup.php
@@ -15,7 +15,7 @@ class UserActivitySignup extends ActivitySignup
     /**
      * Who is subscribed.
      *
-     * @ORM\ManyToOne(targetEntity="User\Model\User")
+     * @ORM\ManyToOne(targetEntity="User\Model\User", onDelete="CASCADE")
      * @ORM\JoinColumn(name="user_lidnr", referencedColumnName="lidnr")
      */
     protected $user;


### PR DESCRIPTION
In order to delete user information when a membership ends, it's likely a good idea to implement a cascading delete.

Currently, I only did it for the activity module, but feedback is welcome.