### PR TITLE
Remove locale overrides in `dateFormat()` view helper

### DIFF
--- a/module/Activity/view/activity/activity/list.phtml
+++ b/module/Activity/view/activity/activity/list.phtml
@@ -1,4 +1,3 @@
-<?php $lang = $this->plugin('translate')->getTranslator()->getLocale(); ?>
 <ul class="list-group">
     <?php if ($activities instanceof \Zend\Paginator\Paginator): ?>
         <li class="list-group-item agenda-item">
@@ -41,15 +40,15 @@
                         <div class="col-md-4">
                             <dl>
                                 <dt><?= $this->translate('Start') ?></dt>
-                                <dd><?= $this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></dd>
+                                <dd><?= $this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT); ?></dd>
                                 <dt><?= $this->translate('End') ?></dt>
-                                <dd><?= $this->dateFormat($activity->getEndTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></dd>
+                                <dd><?= $this->dateFormat($activity->getEndTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT); ?></dd>
 
                                 <dt><?= $this->translate('Location') ?></dt>
                                 <dd><?= $this->escapeHtml($activity->getLocation()) ?></dd>
                                 <?php if ($activity->getSubscriptionDeadline() != $activity->getEndTime()) : ?>
                                     <dt><?= $this->translate('Subscribe before') ?></dt>
-                                    <dd><?= $this->dateFormat($activity->getSubscriptionDeadline(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></dd>
+                                    <dd><?= $this->dateFormat($activity->getSubscriptionDeadline(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT); ?></dd>
                                 <?php endif; ?>
                                 <dt><?= $this->translate('Costs') ?></dt>
                                 <dd><?= $this->escapeHtml($activity->getCosts()) ?></dd>

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -52,16 +52,16 @@ $this->headTitle($this->translate('Activities')); ?>
                             <div class="col-md-4">
                                 <dl>
                                     <dt><?= $this->translate('Start') ?></dt>
-                                    <dd><?= $this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></dd>
-                                
+                                    <dd><?= $this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT); ?></dd>
+
                                     <dt><?= $this->translate('End') ?></dt>
-                                    <dd><?= $this->dateFormat($activity->getEndTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></dd>
-                                
+                                    <dd><?= $this->dateFormat($activity->getEndTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT); ?></dd>
+
                                     <dt><?= $this->translate('Location') ?></dt>
                                     <dd><?= $this->escapeHtml($activity->getLocation()) ?></dd>
                                     <?php if ($activity->getSubscriptionDeadline() != $activity->getEndTime()) : ?>
                                         <dt><?= $this->translate('Subscribe before') ?></dt>
-                                        <dd><?= $this->dateFormat($activity->getSubscriptionDeadline(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></dd>
+                                        <dd><?= $this->dateFormat($activity->getSubscriptionDeadline(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT); ?></dd>
                                     <?php endif; ?>
                                     <dt><?= $this->translate('Costs') ?></dt>
                                     <dd><?= $this->escapeHtml($activity->getCosts()) ?></dd>
@@ -74,7 +74,7 @@ $this->headTitle($this->translate('Activities')); ?>
                                             />
                                         </a>
                                     <?php endif ?>
-                                    
+
                                     <?php
                                         $begin = $activity->getBeginTime()->format('Ymd\THis');
                                         $end = $activity->getEndTime()->format('Ymd\THis');
@@ -85,9 +85,9 @@ $this->headTitle($this->translate('Activities')); ?>
                                             'location' => $activity->getLocation(),
                                         ]);
                                     ?>
-                                    
+
                                      <a class="btn btn-default" target="_blank" href= "<?php echo $link ?>"> Google Calendar </a>
-                                            
+
                                 </dl>
                             </div>
                         </div>
@@ -95,7 +95,7 @@ $this->headTitle($this->translate('Activities')); ?>
                 </div>
             </li>
         </ul>
-        
+
         <?php if ($isSignedUp) : ?>
             <button class="btn btn-default btn-lg agenda-subscription-button" type="button" data-toggle="collapse" data-target="#subscriptionForm"
                     aria-expanded="false" aria-controls="subscriptionForm">
@@ -181,7 +181,7 @@ $this->headTitle($this->translate('Activities')); ?>
             <?php endif; ?>
         </div>
     </div>
-    
+
     <?php if ($activity->getCanSignUp()): ?>
         <h2>
             <?= $this->translate('Current subscriptions') ?>
@@ -254,5 +254,5 @@ $this->headTitle($this->translate('Activities')); ?>
             </table>
         </div>
     <?php endif; ?>
-    
+
 </section>

--- a/module/Activity/view/email/activity.phtml
+++ b/module/Activity/view/email/activity.phtml
@@ -1,4 +1,3 @@
-<?php $lang = 'en'; ?>
 For English, see below.
 
 L.s.<br /><br />
@@ -12,11 +11,11 @@ Er is een nieuwe activiteit aangemaakt op de GEWIS website.
 <table>
     <tr>
         <td><b>Starttijd:</b></td>
-        <td><?= $this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></td>
+        <td><?= $this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, 'nl'); ?></td>
     </tr>
     <tr>
         <td><b>Eindtijd</b></td>
-        <td><?= $this->dateFormat($activity->getEndTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></td>
+        <td><?= $this->dateFormat($activity->getEndTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT), 'nl'; ?></td>
     </tr>
     <tr>
         <td><b>Locatie:</b></td>
@@ -25,7 +24,7 @@ Er is een nieuwe activiteit aangemaakt op de GEWIS website.
     <?php if ($activity->getSubscriptionDeadline() != $activity->getEndTime()) : ?>
     <tr>
         <td><b>Inschrijfdeadline:</b></td>
-        <td><?= $this->dateFormat($activity->getSubscriptionDeadline(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></td>
+        <td><?= $this->dateFormat($activity->getSubscriptionDeadline(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, 'nl'); ?></td>
     </tr>
     <?php endif; ?>
      <tr>
@@ -52,11 +51,11 @@ A new activity was created at the GEWIS website. See below for details.
 <table>
     <tr>
         <td><b>Starting time:</b></td>
-        <td><?= $this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></td>
+        <td><?= $this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, 'en'); ?></td>
     </tr>
     <tr>
         <td><b>Ending time:</b></td>
-        <td><?= $this->dateFormat($activity->getEndTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></td>
+        <td><?= $this->dateFormat($activity->getEndTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, 'en'); ?></td>
     </tr>
     <tr>
         <td><b>Location:</b></td>
@@ -65,7 +64,7 @@ A new activity was created at the GEWIS website. See below for details.
     <?php if ($activity->getSubscriptionDeadline() != $activity->getEndTime()) : ?>
     <tr>
         <td><b>Subscription deadline:</b></td>
-        <td><?= $this->dateFormat($activity->getSubscriptionDeadline(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang); ?></td>
+        <td><?= $this->dateFormat($activity->getSubscriptionDeadline(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, 'en'); ?></td>
     </tr>
     <?php endif; ?>
      <tr>

--- a/module/Decision/view/decision/decision/index.phtml
+++ b/module/Decision/view/decision/decision/index.phtml
@@ -25,8 +25,7 @@ $this->headTitle($this->translate('Meetings')); ?>
                             href="<?= $url ?>"><?= $this->dateFormat(
                             $meeting->getDate(),
                             \IntlDateFormatter::FULL,
-                            \IntlDateFormatter::NONE,
-                            'nl_NL'
+                            \IntlDateFormatter::NONE
                         ) ?></td>
                     <td><a style="display: block; height: 100%; width: 100%"
                             href="<?= $url ?>"><?= $info[1] ?></a></td>

--- a/module/Decision/view/decision/member/birthdays.phtml
+++ b/module/Decision/view/decision/member/birthdays.phtml
@@ -27,7 +27,6 @@ $this->headTitle($this->translate('Members')); ?>
                             $member->getBirth(),
                             \IntlDateFormatter::LONG,
                             \IntlDateFormatter::NONE,
-                            'nl_NL'
                         ) ?></td>
                     <td><?= $member->getFullName() ?></td>
                     <td><?= $years ?> <?= $this->translate('years') ?></td>

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -1,7 +1,6 @@
 <?php
 // set title
 $this->headTitle($this->translate('Members'));
-$lang = $this->plugin('translate')->getTranslator()->getLocale();
 
 $sections = [];
 $sections[$this->translate('Personal')] = [
@@ -88,7 +87,7 @@ $meetings = $this->meetings;
                                     $this->upcoming->getType(),
                                     $this->upcoming->getNumber(),
                                     '</a>',
-                                    $this->dateFormat($this->upcoming->getDate()->getTimestamp(), IntlDateFormatter::FULL, IntlDateFormatter::NONE, $lang)
+                                    $this->dateFormat($this->upcoming->getDate()->getTimestamp(), IntlDateFormatter::FULL, IntlDateFormatter::NONE)
                                 )
                             ?>
                         </div>
@@ -123,7 +122,7 @@ $meetings = $this->meetings;
                                             $this->translate('%s %s on %s'),
                                             $meeting->getType(),
                                             $meeting->getNumber(),
-                                            $this->dateFormat($meeting->getDate()->getTimestamp(), IntlDateFormatter::FULL, IntlDateFormatter::NONE, $lang)
+                                            $this->dateFormat($meeting->getDate()->getTimestamp(), IntlDateFormatter::FULL, IntlDateFormatter::NONE)
                                         )
                                     ?>
                                 </a>

--- a/module/Frontpage/view/frontpage/frontpage/home.phtml
+++ b/module/Frontpage/view/frontpage/frontpage/home.phtml
@@ -100,8 +100,7 @@
                             <?php foreach ($activities as $activity): ?>
                                 <a class="list-group-item" href="<?= $this->url('activity/view', ['id' => $activity->getId()]) ?>">
                                     <h4 class="list-group-item-heading"><?= $activity->getNameEn() ?></h4>
-                                    <?php $lang = $this->plugin('translate')->getTranslator()->getLocale(); ?>
-                                    <p class="list-group-item-text text-muted"><?= ucfirst($this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang)); ?></p>
+                                    <p class="list-group-item-text text-muted"><?= ucfirst($this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT)); ?></p>
                                 </a>
                             <?php endforeach; ?>
                         </div>

--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -99,8 +99,7 @@ function getOrganDescription($organInformation, $lang)
                         <a class="list-group-item" href="<?= $this->url('activity/view', ['id' => $activity->getId()]) ?>">
 
                             <h4 class="list-group-item-heading"><?= $activity->getName() ?></h4>
-                            <?php $lang = $this->plugin('translate')->getTranslator()->getLocale(); ?>
-                            <p class="list-group-item-text text-muted"><?= ucfirst($this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT, $lang)); ?></p>
+                            <p class="list-group-item-text text-muted"><?= ucfirst($this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT)); ?></p>
                         </a>
                     <?php endforeach; ?>
                 </div>


### PR DESCRIPTION
This PR removes the unnecessary locale parameter in calls to the `dateFormat()` view helper. The view helper should rely on the default locale set in the bootstrap code of the Application module.

We shouldn't rely on the default locale in _activity emails_. These contain Dutch and English texts so the dates should be formatted accordingly.

**Note**: Relies on code in #965 that [sets the global locale](https://github.com/GEWIS/gewisweb/pull/965/files#diff-627ee89ffa9e0e61c9dab22d2c8bae21R35).