### PR TITLE
Remove additional width from photos that are "PotW"

### DIFF
--- a/public/scss/modules/_photo.scss
+++ b/public/scss/modules/_photo.scss
@@ -34,15 +34,15 @@ Photo
 }
 
 .photo-grid-item.potw-thumb {
-  width: 98%;
+  width: 98.498%;
   @media (min-width: $screen-sm-min) {
-    width: 66%;
+    width: 66.499%;
   }
   @media (min-width: $screen-md-min) {
-    width: 49%;
+    width: 49.499%;
   }
   @media (min-width: $screen-lg-min) {
-    width: 32.4%;
+    width: 32.899%;
   }
 }
 

--- a/public/scss/modules/_photo.scss
+++ b/public/scss/modules/_photo.scss
@@ -18,6 +18,7 @@ Photo
 .gutter-sizer {
   width: 0.5%;
 }
+
 .grid-sizer, .photo-grid-item {
   width: 49%;
   @media (min-width: $screen-sm-min) {
@@ -32,9 +33,23 @@ Photo
   margin-bottom: 0.5%;
 }
 
+.photo-grid-item.potw-thumb {
+  width: 98%;
+  @media (min-width: $screen-sm-min) {
+    width: 66%;
+  }
+  @media (min-width: $screen-md-min) {
+    width: 49%;
+  }
+  @media (min-width: $screen-lg-min) {
+    width: 32.4%;
+  }
+}
+
 .photo-grid-item-photo {
   background-color: #d40026;
 }
+
 .photo-grid-item {
   float: left;
 }
@@ -42,11 +57,6 @@ Photo
 .photo-grid-item-photo img {
   display: block;
   max-width: 100%;
-}
-
-.potw-thumb {
-  width: 49%;
-  margin-bottom: 1%;
 }
 
 .thumbnail .caption {


### PR DESCRIPTION
This fixes #979.

I have prioritised the new photo viewer. Therefore, the photos can appear just a tiny bit too small or too large in the old photo viewer.

**Old view (note the additional white-space and image border):**
![GEWIS-WEB #979 NOT Fixed](https://user-images.githubusercontent.com/4983571/73950279-f30e1900-48fb-11ea-98c9-5ac23466ef35.png)

**New view:**
![GEWIS-WEB #979 Fixed](https://user-images.githubusercontent.com/4983571/73950277-f30e1900-48fb-11ea-9310-87ea3ae56299.png)