### PR TITLE
Correctly format timestamp for Javascript

### DIFF
--- a/module/Company/view/company/company/job-list.phtml
+++ b/module/Company/view/company/company/job-list.phtml
@@ -103,7 +103,7 @@ $this->headTitle($this->category->getPluralName());
                             'category'        => $job->getCategory()->getSlug(),
                         ]);
                     ?>
-                    <a href="<?= $jobUrl ?>" class="card job-card" data-index="<?= $index ?>" data-posted="<?= $job->getTimestamp() ?>">
+                    <a href="<?= $jobUrl ?>" class="card job-card" data-index="<?= $index ?>" data-posted="<?= $job->getTimestamp()->format(DateTime::ATOM) ?>">
                         <div class="card-img">
                             <img
                                 src="<?= $this->fileUrl($company->getTranslationFromLocale($locale)->getLogo()) ?>"


### PR DESCRIPTION
Solves the bug in the new jobs sorting feature. This bug was caused by an invalid date format. Chrome is more forgiving when parsing string dates; it understands strings that don't follow the spec. Safari, however, implements the spec (in this case) to the letter.

Answer on stackoverflow for future reference: https://stackoverflow.com/a/4310986/3512012

Fixes #977 