### PR TITLE
Fix NonUniqueResultException when retrieving an organ based on its abbreviation

### DIFF
--- a/module/Decision/src/Decision/Mapper/Organ.php
+++ b/module/Decision/src/Decision/Mapper/Organ.php
@@ -121,6 +121,8 @@ class Organ
             $qb->andWhere('o.type = :type')
                 ->setParameter('type', $type);
         }
+        $qb->orderBy('o.foundationDate', 'DESC')
+            ->setMaxResults(1);
 
         $qb->setParameter('abbr', $abbr);
 

--- a/module/Decision/src/Decision/Mapper/Organ.php
+++ b/module/Decision/src/Decision/Mapper/Organ.php
@@ -104,12 +104,18 @@ class Organ
     /**
      * Find an organ by its abbreviation
      *
+     * It is possible that multiple organs with the same abbreviation exist,
+     * for example, through the reinstatement of an previously abrogated organ.
+     * To retrieve the latest occurence of such an organ use `$latest`. 
+     *
      * @param string $abbr
      * @param string $type
+     * @param bool $latest
+     *    Whether to retrieve the latest occurence of an organ or not.
      *
      * @return \Decision\Model\Organ
      */
-    public function findByAbbr($abbr, $type = null)
+    public function findByAbbr($abbr, $type = null, $latest = false)
     {
         $qb = $this->getRepository()->createQueryBuilder('o');
 
@@ -121,8 +127,10 @@ class Organ
             $qb->andWhere('o.type = :type')
                 ->setParameter('type', $type);
         }
-        $qb->orderBy('o.foundationDate', 'DESC')
-            ->setMaxResults(1);
+        if ($latest) {
+            $qb->orderBy('o.foundationDate', 'DESC')
+                ->setMaxResults(1);
+        }
 
         $qb->setParameter('abbr', $abbr);
 

--- a/module/Decision/src/Decision/Service/Organ.php
+++ b/module/Decision/src/Decision/Service/Organ.php
@@ -122,16 +122,20 @@ class Organ extends AbstractAclService
     }
 
     /**
-     * Finds an organ by its abbreviation
+     * Finds an organ by its abbreviation.
+     *
+     * @see Decision/Mapper/Organ::findByAbbr()
      *
      * @param $abbr
      * @param string $type
+     * @param bool $latest
+     *    Whether to retrieve the latest occurence of an organ or not.
      *
      * @return OrganModel
      */
-    public function findOrganByAbbr($abbr, $type = null)
+    public function findOrganByAbbr($abbr, $type = null, $latest = false)
     {
-        return $this->getOrganMapper()->findByAbbr($abbr, $type);
+        return $this->getOrganMapper()->findByAbbr($abbr, $type, $latest);
     }
 
     /**

--- a/module/Frontpage/src/Frontpage/Controller/OrganController.php
+++ b/module/Frontpage/src/Frontpage/Controller/OrganController.php
@@ -36,7 +36,7 @@ class OrganController extends AbstractActionController
         $abbr = $this->params()->fromRoute('abbr');
         $organService = $this->getOrganService();
         try {
-            $organ = $organService->findOrganByAbbr($abbr, $type);
+            $organ = $organService->findOrganByAbbr($abbr, $type, true);
             $organMemberInformation = $organService->getOrganMemberInformation($organ);
 
             $activities = $this->getActivityQueryService()->getOrganActivities($organ, 3);


### PR DESCRIPTION
This fixes #978. 

Previously Doctrine's ORM would throw an `NonUniqueResultException` when two (or more) organs shared the same abbreviation. This limits the selection of an organ based on its abbreviation to the latest record. In other words, now the organ with the most recent `foundationDate` is retrieved.