### PR TITLE
Fix missing members when getting 'latest' organ

### DIFF
--- a/module/Decision/src/Decision/Mapper/Organ.php
+++ b/module/Decision/src/Decision/Mapper/Organ.php
@@ -137,7 +137,7 @@ class Organ
                 throw new \Doctrine\ORM\NoResultException('no organ found');
             }
 
-            // the query did at least return 1 record, use that record
+            // the query returned at least 1 record, use first (= latest) record
             return $queryResult[0];
         }
 

--- a/module/Decision/src/Decision/Mapper/Organ.php
+++ b/module/Decision/src/Decision/Mapper/Organ.php
@@ -122,17 +122,24 @@ class Organ
         $qb->select('o, om, m')
             ->leftJoin('o.members', 'om')
             ->leftJoin('om.member', 'm')
-            ->where('o.abbr = :abbr');
+            ->where('o.abbr = :abbr')
+            ->setParameter('abbr', $abbr);
         if (!is_null($type)) {
             $qb->andWhere('o.type = :type')
                 ->setParameter('type', $type);
         }
         if ($latest) {
-            $qb->orderBy('o.foundationDate', 'DESC')
-                ->setMaxResults(1);
+            $qb->orderBy('o.foundationDate', 'DESC');
+            $queryResult = $qb->getQuery()->getResult();
+            
+            if (count($queryResult) == 0) {
+                // the query did not return any records
+                throw new \Doctrine\ORM\NoResultException('no organ found');
+            }
+            
+            // the query did at least return 1 record, use that record
+            return $queryResult[0];
         }
-
-        $qb->setParameter('abbr', $abbr);
 
         return $qb->getQuery()->getSingleResult();
     }

--- a/module/Decision/src/Decision/Mapper/Organ.php
+++ b/module/Decision/src/Decision/Mapper/Organ.php
@@ -106,7 +106,7 @@ class Organ
      *
      * It is possible that multiple organs with the same abbreviation exist,
      * for example, through the reinstatement of an previously abrogated organ.
-     * To retrieve the latest occurence of such an organ use `$latest`. 
+     * To retrieve the latest occurence of such an organ use `$latest`.
      *
      * @param string $abbr
      * @param string $type
@@ -131,12 +131,12 @@ class Organ
         if ($latest) {
             $qb->orderBy('o.foundationDate', 'DESC');
             $queryResult = $qb->getQuery()->getResult();
-            
+
             if (count($queryResult) == 0) {
                 // the query did not return any records
                 throw new \Doctrine\ORM\NoResultException('no organ found');
             }
-            
+
             // the query did at least return 1 record, use that record
             return $queryResult[0];
         }


### PR DESCRIPTION
This fixes #984.

I introduced a bug in #982, which let to only one (or zero) members being shown when viewing organs. This was due to a misunderstanding of the query used, which I then forcefully limited to one result (i.e. one member).

I have "fixed" this by getting all results and only return the first - most recent - instance of an organ.