### PR TITLE
Show minutes instead of the month when displaying poll comments

### DIFF
--- a/module/Frontpage/view/frontpage/poll/index.phtml
+++ b/module/Frontpage/view/frontpage/poll/index.phtml
@@ -41,7 +41,7 @@ $this->headTitle($this->translate('Current poll')); ?>
                                 <?php $lidnr = $comment->getUser()->getLidnr() ?>
                                 (<a href="<?= $this->url('member/view', ['lidnr' => $lidnr]) ?>"><?= $lidnr ?></a>)
                                 <br>
-                                <?= $comment->getCreatedOn()->format('Y-m-d H:M:s') ?>
+                                <?= $comment->getCreatedOn()->format('Y-m-d H:i:s') ?>
                             <?php endif ?>
                         </div>
                         <div class="col-sm-10">


### PR DESCRIPTION
This fixes #1001 by replacing `M` (abbreviated month) with `i` (minutes).