### PR TITLE
[WIP] Add day and night mode

### DIFF
--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -65,19 +65,21 @@
 
                 if (!(typeof systemPreferredTheme === 'undefined' || systemPreferredTheme === null)) {
                     if (systemPreferredTheme.matches) {
+                        document.body.className = 'theme-night';
                         document.getElementById("theme-icon").className = "fas fa-moon";
                     } else {
+                        document.body.className = 'theme-day';
                         document.getElementById("theme-icon").className = "fas fa-sun";
                     }
 
                     // Update the theme automatically based on system preferences.
                     function updateSystemThemePreference(systemPreferredTheme) {
                         if (systemPreferredTheme.matches) {
-                            document.documentElement.setAttribute('current-theme', 'night');		
+                            document.body.className = 'theme-night';
                             document.getElementById("theme-icon").className = "fas fa-moon";
                             storageBox.setItem('preferred-theme', '');
                         } else {
-                            document.documentElement.setAttribute('current-theme', 'day');
+                            document.body.className = 'theme-day';
                             document.getElementById("theme-icon").className = "fas fa-sun";
                             storageBox.setItem('preferred-theme', '');
                         }
@@ -87,11 +89,11 @@
 
                 // Overwrite the system preferred theme when needed.
                 if (userPreferredTheme === "night") {
-                	document.documentElement.setAttribute('current-theme', 'night');
+                	document.body.className = 'theme-night';
                 	storageBox.setItem('preferred-theme', 'night');
                 	document.getElementById("theme-icon").className = "fas fa-moon";
                 } else if (userPreferredTheme === "day") {
-                	document.documentElement.setAttribute('current-theme', 'day');
+                	document.body.className = 'theme-day';
                 	storageBox.setItem('preferred-theme', 'day');
                 	document.getElementById("theme-icon").className = "fas fa-sun";
                 }
@@ -102,21 +104,21 @@
                     userPreferredTheme = storageBox.getItem('preferred-theme');
 
                     if (userPreferredTheme === "night") {
-                        document.documentElement.setAttribute('current-theme', 'day');
+                        document.body.className = 'theme-day';
                         storageBox.setItem('preferred-theme', 'day');
                         document.getElementById("theme-icon").className = "fas fa-sun";
                     } else if (userPreferredTheme === "day") {
-                        document.documentElement.setAttribute('current-theme', 'night');
+                        document.body.className = 'theme-night';
                         storageBox.setItem('preferred-theme', 'night');
                         document.getElementById("theme-icon").className = "fas fa-moon";
                     } else if (!(typeof systemPreferredTheme === 'undefined' || systemPreferredTheme === null)) {
                         if (systemPreferredTheme.matches) {	
-                            document.documentElement.setAttribute('current-theme', 'day');
+                            document.body.className = 'theme-day';
                             storageBox.setItem('preferred-theme', 'day');
                             document.getElementById("theme-icon").className = "fas fa-sun";
                         }
                     } else {
-                        document.documentElement.setAttribute('current-theme', 'night');
+                        document.body.className = 'theme-night';
                         storageBox.setItem('preferred-theme', 'night');
                         document.getElementById("theme-icon").className = "fas fa-moon";
                     }

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -40,6 +40,89 @@
 
         <?= $this->partial('partial/footer.phtml') ?>
 
+        <?php $this->inlineScript()->captureStart('prepend'); ?>
+            var storageBox;
+            var storageFailed;
+            var systemPreferredTheme;
+            var userPreferredTheme;
+            
+            // Determine if we are able to use localStorage to store the preferred theme.
+            try {
+                (storageBox = window.localStorage).setItem('GEWIS', 'GEWIS');
+                storageFailed = storageBox.getItem('GEWIS') != 'GEWIS';
+                storageBox.removeItem('GEWIS');
+
+                storageFailed && (storageBox = false);
+            } catch (e) {}
+
+            // Check if we can watch and match the system preferred theme.
+            if (typeof window.matchMedia != "undefined" || typeof window.msMatchMedia != "undefined") {
+                systemPreferredTheme = window.matchMedia("(prefers-color-scheme: dark)");
+            }
+
+            if (storageBox) {
+                userPreferredTheme = storageBox.getItem('preferred-theme');
+
+                if (!(typeof systemPreferredTheme === 'undefined' || systemPreferredTheme === null)) {
+                    if (systemPreferredTheme.matches) {
+                        document.getElementById("theme-icon").className = "fas fa-moon";
+                    } else {
+                        document.getElementById("theme-icon").className = "fas fa-sun";
+                    }
+
+                    // Update the theme automatically based on system preferences.
+                    function updateSystemThemePreference(systemPreferredTheme) {
+                        if (systemPreferredTheme.matches) {
+                            document.documentElement.setAttribute('current-theme', 'night');		
+                            document.getElementById("theme-icon").className = "fas fa-moon";
+                            storageBox.setItem('preferred-theme', '');
+                        } else {
+                            document.documentElement.setAttribute('current-theme', 'day');
+                            document.getElementById("theme-icon").className = "fas fa-sun";
+                            storageBox.setItem('preferred-theme', '');
+                        }
+                    }
+                    systemPreferredTheme.addListener(updateSystemThemePreference);
+                }
+
+                // Overwrite the system preferred theme when needed.
+                if (userPreferredTheme === "night") {
+                	document.documentElement.setAttribute('current-theme', 'night');
+                	storageBox.setItem('preferred-theme', 'night');
+                	document.getElementById("theme-icon").className = "fas fa-moon";
+                } else if (userPreferredTheme === "day") {
+                	document.documentElement.setAttribute('current-theme', 'day');
+                	storageBox.setItem('preferred-theme', 'day');
+                	document.getElementById("theme-icon").className = "fas fa-sun";
+                }
+            }
+
+            function switchTheme() {
+                if (storageBox) {
+                    userPreferredTheme = storageBox.getItem('preferred-theme');
+
+                    if (userPreferredTheme === "night") {
+                        document.documentElement.setAttribute('current-theme', 'day');
+                        storageBox.setItem('preferred-theme', 'day');
+                        document.getElementById("theme-icon").className = "fas fa-sun";
+                    } else if (userPreferredTheme === "day") {
+                        document.documentElement.setAttribute('current-theme', 'night');
+                        storageBox.setItem('preferred-theme', 'night');
+                        document.getElementById("theme-icon").className = "fas fa-moon";
+                    } else if (!(typeof systemPreferredTheme === 'undefined' || systemPreferredTheme === null)) {
+                        if (systemPreferredTheme.matches) {	
+                            document.documentElement.setAttribute('current-theme', 'day');
+                            storageBox.setItem('preferred-theme', 'day');
+                            document.getElementById("theme-icon").className = "fas fa-sun";
+                        }
+                    } else {
+                        document.documentElement.setAttribute('current-theme', 'night');
+                        storageBox.setItem('preferred-theme', 'night');
+                        document.getElementById("theme-icon").className = "fas fa-moon";
+                    }
+                }
+            }
+        <?php $this->inlineScript()->captureEnd(); ?>
         <?= $this->inlineScript() ?>
         <script>
             <?php foreach($this->scriptUrl()->getUrls() as $name => $url): ?>

--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -59,6 +59,11 @@ $lang = $this->plugin('translate')->getTranslator()->getLocale();
                         </li>
                     </ul>
                 </li>
+                <li class="pull-right">
+                    <a href="#" class="theme-toggle" onclick="switchTheme()">
+                        <i class="fas fa-sun" id="theme-icon"></i>
+                    </a>
+                </li>
                 <?php if (null === $this->identity()): ?>
                     <li class="visible-xs pull-left">
                         <a href="<?= $this->url('user') ?>">

--- a/public/scss/functions/_lightness.scss
+++ b/public/scss/functions/_lightness.scss
@@ -1,0 +1,8 @@
+@function fakeLightness($color, $lightnessMultiplier){
+    $color: str-replace($color, 'var(');
+    $color: str-replace($color, ')');
+    $color-h: var(#{$color+'-h'});
+    $color-s: var(#{$color+'-s'});
+    $color-l: var(#{$color+'-l'});
+    @return hsl($color-h, $color-s, calc(#{$color-l} * #{$lightnessMultiplier}));
+}

--- a/public/scss/mixins/_hsl-variables.scss
+++ b/public/scss/mixins/_hsl-variables.scss
@@ -1,0 +1,6 @@
+@mixin createHSLColorVars($id, $hue, $saturation, $lightness){
+  #{$id}: unquote("hsl(#{$hue}, #{$saturation}, #{$lightness})");
+  #{$id}-h: #{$hue};
+  #{$id}-s: #{$saturation};
+  #{$id}-l: #{$lightness};
+}


### PR DESCRIPTION
Adds a button to the main navigation bar which is used to switch themes. It also shows what the current theme is.

There are several ways the theme of the website can be changed. By default the day theme is selected. If the OS of the user prefers a night theme, the night theme is applied. Finally, if the user has a preferred theme this will overwrite the two previous themes.

This closes #1004.