### PR TITLE
Enable new photo viewer on Member's pages

### DIFF
--- a/module/Photo/config/module.config.php
+++ b/module/Photo/config/module.config.php
@@ -45,6 +45,19 @@ return [
                             ],
                         ],
                     ],
+                    'member_beta' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/beta/member/:lidnr',
+                            'constraints' => [
+                                'lidnr' => '\d+',
+                            ],
+                            'defaults' => [
+                                'controller' => 'Album',
+                                'action' => 'memberNew',
+                            ],
+                        ],
+                    ],
                     'album' => [
                         'type' => 'Segment',
                         'options' => [

--- a/module/Photo/src/Photo/Controller/AlbumController.php
+++ b/module/Photo/src/Photo/Controller/AlbumController.php
@@ -71,5 +71,28 @@ class AlbumController extends AbstractActionController
         
         return $vm;
     }
-    
+
+    /**
+     * Shows a page with photo's of a member, or a 404 if this page does not
+     * exist
+     *
+     * @return array|ViewModel
+     */
+    public function memberNewAction()
+    {
+        $lidnr = (int)$this->params()->fromRoute('lidnr');
+        $albumService = $this->getServiceLocator()->get('photo_service_album');
+
+        $album = $albumService->getAlbum($lidnr, 'member');
+        if ($album === null) {
+            return $this->notFoundAction();
+        }
+
+        return new ViewModel([
+            'cache' => $this->getServiceLocator()->get('album_page_cache'),
+            'album'     => $album,
+            'basedir'   => '/',
+            'config' => $this->getServiceLocator()->get('config')['photo']
+        ]);
+    }    
 }

--- a/module/Photo/view/photo/album/index-new.phtml
+++ b/module/Photo/view/photo/album/index-new.phtml
@@ -29,7 +29,6 @@ $this->scriptUrl()->requireUrl('member/search')
                     <?= $this->translate('Photos') ?>
                 </a>
             </li>
-            <?php if (!$currentAlbum instanceof \Photo\Model\MemberAlbum): ?>
             <li>
                 <?php
                 // determine association year
@@ -39,7 +38,6 @@ $this->scriptUrl()->requireUrl('member/search')
                     <?= $associationYear->getYearString() ?>
                 </a>
             </li>
-            <?php endif; ?>
             <?php
             // first we need to get all parents
             $crumbs = [];
@@ -63,10 +61,6 @@ $this->scriptUrl()->requireUrl('member/search')
                 </li>
             <?php endforeach; ?>
             <li class="active">
-                <?php if ($album instanceof \Photo\Model\MemberAlbum): ?>
-                    <span class="fas fa-user"></span>
-                    &nbsp;
-                <?php endif; ?>
                 <?= $this->escapeHtml($album->getName()); ?>
             </li>
         </ol>
@@ -79,25 +73,12 @@ $this->scriptUrl()->requireUrl('member/search')
             <div class="col-lg-12">
                 <h1 class="page-header">
                     <?= $this->escapeHtml($album->getName()); ?>
-                    <small>
-                        <?php if ($album instanceof \Photo\Model\MemberAlbum): ?>
-                            <a href="<?= $this->url('member/view', ['lidnr' => $album->getMember()->getLidnr()]) ?>">
-                                <?= strtolower($this->translate("View user profile")) ?>
-                            </a>
-                        <?php else: ?>
-                            <?= $album->getStartDateTime()->format('d-m-Y') ?>
-                        <?php endif; ?>
-                    </small>
+                    <small><?= $album->getStartDateTime()->format('d-m-Y') ?></small>
                 </h1>
             </div>
         </div>
         <?php
-        $path = '';
-        if ($album instanceof \Photo\Model\MemberAlbum) {
-            $path = $this->url('photo/member', ['lidnr' => $album->getMember()->getLidnr()]);
-        } else {
-            $path = $this->url('photo/album', ['album_id' => $album->getId()]);
-        }
+        $path = $this->url('photo/album', ['album_id' => $album->getId()]);
         ?>
         <?php if ($album->getAlbumCount() > 0): ?>
             <div class="row">

--- a/module/Photo/view/photo/album/index.phtml
+++ b/module/Photo/view/photo/album/index.phtml
@@ -70,7 +70,13 @@ $this->headTitle($this->translate('Photos'));
             <div class="col-lg-12">
                 <div class="alert alert-danger" role="alert">
                     <?= $this->translate('Do you want to help test new features of the website?')?>
-                    <?= sprintf($this->translate('Then try the new photo viewer %sHERE%s!'), '<a href="' .$this->url('photo/album_beta', ['album_id' => $currentAlbum->getId()]) . '">', '</a>' ) ?>
+                    <?php
+                    if ($album instanceof \Photo\Model\MemberAlbum) {
+                        echo sprintf($this->translate('Then try the new photo viewer %sHERE%s!'), '<a href="' .$this->url('photo/member_beta', ['lidnr' => $currentAlbum->getId()]) . '">', '</a>' );
+                    } else {
+                        echo sprintf($this->translate('Then try the new photo viewer %sHERE%s!'), '<a href="' .$this->url('photo/album_beta', ['album_id' => $currentAlbum->getId()]) . '">', '</a>' );
+                    }
+                    ?>
                 </div>
                 <h1 class="page-header">
                     <?= $this->escapeHtml($album->getName()); ?>

--- a/module/Photo/view/photo/album/member-new.phtml
+++ b/module/Photo/view/photo/album/member-new.phtml
@@ -1,0 +1,211 @@
+<?php
+// set title
+$this->headTitle($album->getName());
+$currentAlbum = $album;
+while(!is_null($currentAlbum->getParent())) {
+    $this->headTitle($currentAlbum->getParent()->getName());
+    $currentAlbum = $currentAlbum->getParent();
+}
+$this->headTitle($this->translate('Photos'));
+ ?>
+<?php $this->headScript()->appendFile($this->basePath() . '/js/photo-new.js')
+        ->appendFile($this->basePath() . '/js/masonry.pkgd.min.js')
+        ->appendFile($this->basePath() . '/js/imagesloaded.pkgd.min.js')
+        ->appendFile($this->basePath() . '/js/lazyload.min.js')
+        ->appendFile($this->basePath() . '/js/photoswipe.min.js')
+        ->appendFile($this->basePath() . '/js/photoswipe-ui-default.min.js')
+        ->prependFile($this->basePath() . '/js/jquery.autocomplete.js');
+$this->headLink()->appendStylesheet($this->basePath() . '/css/photoswipe.css')
+->appendStylesheet($this->basePath() . '/css/photoswipe-skin/default-skin.css');
+
+$this->scriptUrl()->requireUrl('member/search')
+        ->requireUrl('photo/photo/vote', ['photo_id']);
+?>
+<section class="section section-breadcrumb">
+    <div class="container">
+        <ol class="breadcrumb">
+            <li>
+                <a href="<?= $this->url('photo') ?>">
+                    <?= $this->translate('Photos') ?>
+                </a>
+            </li>
+            <?php
+            // first we need to get all parents
+            $crumbs = [];
+            if (!is_null($album->getParent())) {
+                $currentAlbum = $album;
+                while(!is_null($currentAlbum->getParent())) {
+                    // prepend parent to array
+                    array_unshift($crumbs, [
+                        'url'  => $this->url('photo/album', ['album_id' => $currentAlbum->getParent()->getId()]),
+                        'name' => $currentAlbum->getParent()->getName()
+                    ]);
+                    $currentAlbum = $currentAlbum->getParent();
+                }
+            }
+            // then we print them
+            foreach($crumbs as $crumb): ?>
+                <li>
+                    <a href="<?= $crumb['url'] ?>">
+                        <?= $this->escapeHtml($crumb['name']) ?>
+                    </a>
+                </li>
+            <?php endforeach; ?>
+            <li class="active">
+                <span class="fas fa-user"></span><?= $this->escapeHtml($album->getName()); ?>
+            </li>
+        </ol>
+    </div>
+</section>
+
+<section class="section">
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-12">
+                <h1 class="page-header">
+                    <?= $this->escapeHtml($album->getName()); ?>
+                    <small>
+                        <a href="<?= $this->url('member/view', ['lidnr' => $album->getMember()->getLidnr()]) ?>">
+                            <?= strtolower($this->translate("View user profile")) ?>
+                        </a>
+                    </small>
+                </h1>
+            </div>
+        </div>
+        <?php
+        $path = $this->url('photo/member', ['lidnr' => $album->getMember()->getLidnr()]);
+        ?>
+        <?php if ($album->getAlbumCount() > 0): ?>
+            <div class="row">
+                <?php foreach ($album->getChildren() as $item): ?>
+                    <div class="col-lg-2 col-md-3 col-xs-6 thumb">
+                        <a class="thumbnail" href="<?= $this->url('photo/album', ['album_id' => $item->getId()]); ?>">
+                            <img src="<?= $this->fileUrl($item->getCoverPath()); ?>">
+                            <div class="caption">
+                                <?= $this->escapeHtml($item->getName()); ?>
+                            </div>
+                        </a>
+                    </div>
+                <?php endforeach ?>
+            </div>
+        <?php endif; ?>
+        <div class="photo-grid">
+            <div class="grid-sizer"></div>
+            <div class="gutter-sizer"></div>
+            <?php foreach ($album->getPhotos() as $item): ?>
+                <?php
+                    $ar = $item->getAspectRatio();
+                    $width = $config['small_thumb_size']['width'];
+                    $smallSize = [
+                        'w' => $width,
+                        'h' => round($width * $ar)
+                    ];
+
+                    $width = $config['large_thumb_size']['width'];
+                    $largeSize = [
+                        'w' => $width,
+                        'h' => round($width * $ar)
+                    ];
+                ?>
+                <figure class="photo-grid-item photo-grid-item-photo<?= is_null($item->getWeeklyPhoto()) ? '' : ' potw-thumb' ?>">
+                    <a
+                        href="<?=  $this->glideUrl()->getUrl($item->getPath(), $largeSize) ?>"
+                        data-size="<?= $largeSize['w'] . 'x' . $largeSize['h'] ?>"
+                        data-author="GEWIS"
+                        class="gallery-image"
+                        data-raw-url="<?= $this->url('photo/photo_download', ['photo_id' => $item->getId()]); ?>"
+                        data-vote-url="<?= $this->url('photo/photo/vote', ['photo_id' => $item->getId()]); ?>"
+                    >
+                        <img
+                            class="lazy-load"
+                            data-width="<?= $smallSize['w'] ?>" data-height="<?= $smallSize['h'] ?>"
+                            data-src="<?= $this->glideUrl()->getUrl($item->getPath(), $smallSize) ?>"
+                            alt=""
+                            data-size="<?= $smallSize['w'] . 'x' . $smallSize['h'] ?>"
+                        >
+                    </a>
+                    <figcaption style="display:none">
+                        <?= $this->partial('partial/metadata.phtml', ['photo' => $item]) ?>
+                    </figcaption>
+                    <figtags style="display:none">
+                        <?= $this->partial('partial/tags-new.phtml', ['photo' => $item]) ?>
+                    </figtags>
+                </figure>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <!-- Root element of PhotoSwipe. Must have class pswp. -->
+    <div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+
+        <!-- Background of PhotoSwipe.
+             It's a separate element as animating opacity is faster than rgba(). -->
+        <div class="pswp__bg"></div>
+
+        <!-- Slides wrapper with overflow:hidden. -->
+        <div class="pswp__scroll-wrap">
+
+            <!-- Container that holds slides.
+                PhotoSwipe keeps only 3 of them in the DOM to save memory.
+                Don't modify these 3 pswp__item elements, data is added later on. -->
+            <div class="pswp__container">
+                <div class="pswp__item"></div>
+                <div class="pswp__item"></div>
+                <div class="pswp__item"></div>
+            </div>
+
+            <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+            <div class="pswp__ui pswp__ui--hidden">
+
+                <div class="pswp__top-bar">
+
+                    <div class="pswp__counter"></div>
+
+                    <button class="button_top pswp__button--close fas fa-times" title="Close (Esc)"></button>
+                    <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+                    <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+
+                    <button class="button_top pswp__button--download fas fa-file-download" title="<?= $this->translate('Download') ?>" data-toggle="tooltip" data-placement="bottom"></button>
+                    <button class="button_top pswp__button--like fas fa-thumbs-up" title="<?= $this->translate('Vote for photo of the week') ?>" data-toggle="tooltip" data-placement="bottom"></button>
+                    <button class="button_top pswp__button--info fas fa-info-circle" title="<?= $this->translate('Metadata') ?>" data-toggle="tooltip" data-placement="bottom"></button>
+
+                    <!-- Preloader -->
+                    <!-- element will get class pswp__preloader--active when preloader is running -->
+                    <div class="pswp__preloader">
+                        <div class="pswp__preloader__icn">
+                            <div class="pswp__preloader__cut">
+                                <div class="pswp__preloader__donut"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                    <div class="pswp__share-tooltip"></div>
+                </div>
+
+                <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+                </button>
+
+                <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+                </button>
+
+                <div class="pswp__caption">
+                    <div class="pswp__caption__center"></div>
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>
+</section>
+
+<script>
+    $(document).ready(function () {
+        Photo.initGrid();
+    });
+    initPhotoSwipeFromDOM('.photo-grid');
+    var lazyLoadInstance = new LazyLoad({
+        elements_selector: ".lazy-load"
+    });
+</script>

--- a/module/Photo/view/photo/album/member-new.phtml
+++ b/module/Photo/view/photo/album/member-new.phtml
@@ -52,7 +52,7 @@ $this->scriptUrl()->requireUrl('member/search')
                 </li>
             <?php endforeach; ?>
             <li class="active">
-                <span class="fas fa-user"></span><?= $this->escapeHtml($album->getName()); ?>
+                <span class="fas fa-user"></span> <?= $this->escapeHtml($album->getName()); ?>
             </li>
         </ol>
     </div>


### PR DESCRIPTION
This enables the photo viewer on Member's pages (and thus fixes #935) and fixes the "try this out"-link.

After this we should (as discussed today) make the new photo viewer the default and have the old photo viewer as a backup (separate PR).