### PR TITLE
Show URL for jobs when set

### DIFF
--- a/module/Company/view/company/company/jobs.phtml
+++ b/module/Company/view/company/company/jobs.phtml
@@ -62,6 +62,9 @@ $this->headTitle($category->getPluralName());
                             <p class="job-email">
                                 <a href="mailto:<?= rawurlencode($job->getEmail()) ?>"><?= $job->getEmail() ?></a>
                             </p>
+                            <?php if ($job->getWebsite() !== ""): ?>
+                                <p class="job-website"><a href="<?= $escaper->escapeHtmlAttr($job->getWebsite()) ?>"><?= $this->translate('View') . " ". $job->getCategory()->getName(); ?></a></p>
+                            <?php endif; ?>
                             <?php if (!is_null($job->getAttachment())): ?>
                                 <p class="job-vacancy">
                                     <a href="<?= $this->fileUrl($job->getAttachment()); ?>"><?= $this->translate('View') . " ". $job->getCategory()->getName(); ?></a>

--- a/module/Company/view/company/company/jobs.phtml
+++ b/module/Company/view/company/company/jobs.phtml
@@ -63,7 +63,11 @@ $this->headTitle($category->getPluralName());
                                 <a href="mailto:<?= rawurlencode($job->getEmail()) ?>"><?= $job->getEmail() ?></a>
                             </p>
                             <?php if ($job->getWebsite() !== ""): ?>
-                                <p class="job-website"><a href="<?= $escaper->escapeHtmlAttr($job->getWebsite()) ?>"><?= $this->translate('View') . " ". $job->getCategory()->getName(); ?></a></p>
+                                <p class="job-website">
+                                    <a href="<?= $escaper->escapeHtmlAttr($job->getWebsite()) ?>" rel="noreferrer">
+                                        <?= $this->translate('View') . " ". $job->getCategory()->getName(); ?>
+                                    </a>
+                                </p>
                             <?php endif; ?>
                             <?php if (!is_null($job->getAttachment())): ?>
                                 <p class="job-vacancy">


### PR DESCRIPTION
Once again, URLs are shown on Job pages when properly set.

The board / company admins should be made aware that affiliate links are not supposed to be placed here and that the link is an alternative for the job attachment.