### PR TITLE
Fix missing poll vote view and incorrect vote casting

### DIFF
--- a/module/Frontpage/src/Frontpage/Controller/PollController.php
+++ b/module/Frontpage/src/Frontpage/Controller/PollController.php
@@ -54,8 +54,12 @@ class PollController extends AbstractActionController
         $request = $this->getRequest();
         if ($request->isPost()) {
             $pollService = $this->getPollService();
-            $optionId = $request->getPost()['option'];
-            $pollService->submitVote($pollService->getPollOption($optionId));
+
+            if (isset($request->getPost()['option'])) {
+                $optionId = $request->getPost()['option'];
+                $pollService->submitVote($pollService->getPollOption($optionId));
+            }
+
             $this->redirect()->toRoute('poll');
         }
 

--- a/module/Frontpage/src/Frontpage/Controller/PollController.php
+++ b/module/Frontpage/src/Frontpage/Controller/PollController.php
@@ -51,7 +51,9 @@ class PollController extends AbstractActionController
      */
     public function voteAction()
     {
+        $pollId = (int) $this->params('poll_id');
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $pollService = $this->getPollService();
 
@@ -59,10 +61,9 @@ class PollController extends AbstractActionController
                 $optionId = $request->getPost()['option'];
                 $pollService->submitVote($pollService->getPollOption($optionId));
             }
-
-            $this->redirect()->toRoute('poll');
         }
 
+        $this->redirect()->toRoute('poll/view', ['poll_id' => $pollId]);
         return $this->getResponse();
     }
 

--- a/module/Frontpage/src/Frontpage/Controller/PollController.php
+++ b/module/Frontpage/src/Frontpage/Controller/PollController.php
@@ -58,6 +58,8 @@ class PollController extends AbstractActionController
             $pollService->submitVote($pollService->getPollOption($optionId));
             $this->redirect()->toRoute('poll');
         }
+
+        return $this->getResponse();
     }
 
     /**


### PR DESCRIPTION
Due to a missing return in the `voteAction`-action Zend tried to load the `frontpage/poll/vote` view which does not exist. By returing the response data of the request, Zend will not try to load the missing view. This should resolve the issues with our big logs.

Furthermore, an issue existed that meant that casting a vote without selecting an option resulted in an internal server error.

This fixes #996 and fixes #1020.