### PR TITLE
Added Extensions To Composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
     "require": {
         "php": ">=5.4.0",
         "ext-gd": "^0.0.0",
+        "ext-pgsql": "*",
+        "ext-pdo": "*",
         "ext-exif": "^0.0.0",
         "ext-imagick": "^3.1",
         "zendframework/zendframework": "2.4.*",


### PR DESCRIPTION
First attempt at any open source contributions so feed back is appreciated. I believe this is what was requested in the issue. I did notice that the pdo_pgsql extension was not available in the fpm environment and it was configured in the php.ini. Not sure if is suppose to be, and didn't want to go outside the request. Willing to help more.