### PR TITLE
Fix mistake in calendar option proposal creation checking logic

### DIFF
--- a/module/Activity/src/Activity/Service/ActivityCalendar.php
+++ b/module/Activity/src/Activity/Service/ActivityCalendar.php
@@ -255,7 +255,7 @@ class ActivityCalendar extends AbstractAclService
     protected function getMaxActivities($organId, $periodId)
     {
         $mapper = $this->getMaxActivitiesMapper();
-        $maxActivities = $mapper->getMaxActivityOptionsByOrganPeriod($organId, 1);
+        $maxActivities = $mapper->getMaxActivityOptionsByOrganPeriod($organId, $periodId);
         $max = 0;
         if ($maxActivities) {
             $max = $maxActivities->getValue();


### PR DESCRIPTION
This fixes a tiny mistake in `getMaxActivities()` where period_id `1` was hardcoded. The period_id should actually be `$periodId`. Fixes #1068.

This should **not** be merged and deployed before the database has been updated.