### PR TITLE
Prevent proxied traffic from getting incorrect user roles

### DIFF
--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -13,6 +13,15 @@
 
 return [
     /**
+     * Proxy configuration, used when determinining user roles.
+     */
+    'proxy' => [
+        'enabled' => false,
+        'ip_addresses' => [],
+        'header' => 'X-Real-IP',
+    ],
+
+    /**
      * Dreamspark credentials.
      */
     'dreamspark' => [

--- a/module/User/Module.php
+++ b/module/User/Module.php
@@ -230,6 +230,14 @@ class Module
                 },
                 'user_remoteaddress' => function ($sm) {
                     $remote = new \Zend\Http\PhpEnvironment\RemoteAddress();
+                    $isProxied = $sm->get('config')['proxy']['enabled'];
+                    $trustedProxies = $sm->get('config')['proxy']['ip_addresses'];
+                    $proxyHeader = $sm->get('config')['proxy']['header'];
+
+                    $remote->setUseProxy($isProxied)
+                        ->setTrustedProxies($trustedProxies)
+                        ->setProxyHeader($proxyHeader);
+
                     return $remote->getIpAddress();
                 },
                 'user_role' => function ($sm) {


### PR DESCRIPTION
A possibility existed where proxied traffic was incorrectly assigned
the `tueguest` user role, while the original traffic did not originate
from within the specified range.