### PR TITLE
Fix incorrect comparison when showing option values (activity admin overview)

### DIFF
--- a/module/Activity/view/activity/admin/participantsTable.phtml
+++ b/module/Activity/view/activity/admin/participantsTable.phtml
@@ -47,7 +47,7 @@
                                     echo $this->escapeHtml($fieldValue->getValue());
                                     break;
                                 case 1:
-                                    if ($fieldValue->getValue()) {
+                                    if ($fieldValue->getValue() === "Yes") {
                                         echo $this->translate('Yes');
                                     } else {
                                         echo $this->translate('No');


### PR DESCRIPTION
Fixes an incorrect comparison in the admin overview of an activity's participants table.