### PR TITLE
Fix public archive cronjob

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,7 @@ Vagrantfile
 Makefile
 autoload_classmap.php
 composer.phar
+config/ssh.env
 config/autoload/doctrine.local.php
 config/autoload/doctrine.external.php
 config/autoload/gewisdb.local.php

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ autoload_classmap.php
 .mysql
 .vagrant/
 .vs/
+config/ssh.env

--- a/docker/web/development/crontab
+++ b/docker/web/development/crontab
@@ -8,7 +8,7 @@
 # │ │ │ │ │
 # * * * * *  command to execute
 # Don't remove the empty line at the end of this file. It is required to run the cron job
-# 0 0 * * 1 /code/web photo weeklyphoto >> /code/data/cron-weeklyphoto.log 2>&1
-# 58 1 * * * php /code/importdb.php >> /code/data/cron-importdb.log 2>&1
-# 0 23 * * * /code/web activity calendar notify >> /code/data/cron-activitycalendar.log 2>&1
-# 0 * * * * /code/publicarchive.sh >> /code/data/cron-publicarchive.log 2>&1
+# 0 0 * * 1 /code/web photo weeklyphoto >> /code/data/logs/cron-weeklyphoto.log 2>&1
+# 58 1 * * * php /code/importdb.php >> /code/data/logs/cron-importdb.log 2>&1
+# 0 23 * * * /code/web activity calendar notify >> /code/data/logs/cron-activitycalendar.log 2>&1
+# 0 * * * * /code/publicarchive.sh >> /code/data/logs/cron-publicarchive.log 2>&1

--- a/docker/web/development/crontab
+++ b/docker/web/development/crontab
@@ -8,7 +8,7 @@
 # │ │ │ │ │
 # * * * * *  command to execute
 # Don't remove the empty line at the end of this file. It is required to run the cron job
-# 0 0 * * 1 /code/web photo weeklyphoto >> /code/data/cron-weeklyphoto.log
-# 58 1 * * * php /code/importdb.php >> /code/data/cron-importdb.log
-# 0 23 * * * /code/web activity calendar notify >> /code/data/cron-activitycalendar.log
-# 0 * * * * /code/publicarchive.sh >> /code/data/cron-publicarchive.log
+# 0 0 * * 1 /code/web photo weeklyphoto >> /code/data/cron-weeklyphoto.log 2>&1
+# 58 1 * * * php /code/importdb.php >> /code/data/cron-importdb.log 2>&1
+# 0 23 * * * /code/web activity calendar notify >> /code/data/cron-activitycalendar.log 2>&1
+# 0 * * * * /code/publicarchive.sh >> /code/data/cron-publicarchive.log 2>&1

--- a/docker/web/development/docker-entrypoint.sh
+++ b/docker/web/development/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+printenv | sed 's/^\(.*\)$/export \1/g' | grep -E "^export SSH_" > ./config/ssh.env
 service cron start
 ./web orm:generate-proxies
 php-fpm -F -O

--- a/docker/web/production/crontab
+++ b/docker/web/production/crontab
@@ -8,7 +8,7 @@
 # │ │ │ │ │
 # * * * * *  command to execute
 # Don't remove the empty line at the end of this file. It is required to run the cron job
-0 0 * * 1 /code/web photo weeklyphoto >> /code/data/cron-weeklyphoto.log
-58 1 * * * php /code/importdb.php >> /code/data/cron-importdb.log
-0 23 * * * /code/web activity calendar notify >> /code/data/cron-activitycalendar.log
-0 * * * * /code/publicarchive.sh >> /code/data/cron-publicarchive.log
+0 0 * * 1 /code/web photo weeklyphoto >> /code/data/cron-weeklyphoto.log 2>&1
+58 1 * * * php /code/importdb.php >> /code/data/cron-importdb.log 2>&1
+0 23 * * * /code/web activity calendar notify >> /code/data/cron-activitycalendar.log 2>&1
+0 * * * * /code/publicarchive.sh >> /code/data/cron-publicarchive.log 2>&1

--- a/docker/web/production/crontab
+++ b/docker/web/production/crontab
@@ -8,7 +8,7 @@
 # │ │ │ │ │
 # * * * * *  command to execute
 # Don't remove the empty line at the end of this file. It is required to run the cron job
-0 0 * * 1 /code/web photo weeklyphoto >> /code/data/cron-weeklyphoto.log 2>&1
-58 1 * * * php /code/importdb.php >> /code/data/cron-importdb.log 2>&1
-0 23 * * * /code/web activity calendar notify >> /code/data/cron-activitycalendar.log 2>&1
-0 * * * * /code/publicarchive.sh >> /code/data/cron-publicarchive.log 2>&1
+0 0 * * 1 /code/web photo weeklyphoto >> /code/data/logs/cron-weeklyphoto.log 2>&1
+58 1 * * * php /code/importdb.php >> /code/data/logs/cron-importdb.log 2>&1
+0 23 * * * /code/web activity calendar notify >> /code/data/logs/cron-activitycalendar.log 2>&1
+0 * * * * /code/publicarchive.sh >> /code/data/logs/cron-publicarchive.log 2>&1

--- a/docker/web/production/docker-entrypoint.sh
+++ b/docker/web/production/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+printenv | sed 's/^\(.*\)$/export \1/g' | grep -E "^export SSH_" > ./config/ssh.env
 service cron start
 ./web orm:generate-proxies
 php-fpm -F -O

--- a/publicarchive.sh
+++ b/publicarchive.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+. /code/config/ssh.env
 rsync -aWPu --delete --chown www-data:www-data --rsh="/usr/bin/sshpass -p ${SSH_PASSWORD} ssh -o StrictHostKeyChecking=no -l ${SSH_USERNAME}" files.gewis.nl:/home/public/* /code/public/publicarchive


### PR DESCRIPTION
The public archive cronjob requires `SSH_PASSWORD` and `SSH_USERNAME`. These Docker environment variables are not available in `cron`'s `SHELL` environment.

This change exports the variables to a special `.env` file which is `source`d for every execution of the public archive cronjob.

Additionally, `stderr` is now also piped to the logs (and the logs are now in the correct directory).