### PR TITLE
Fix premature session invalidation

### DIFF
--- a/module/User/src/User/Authentication/Storage/Session.php
+++ b/module/User/src/User/Authentication/Storage/Session.php
@@ -69,11 +69,11 @@ class Session extends Storage\Session
 
         $request = $this->sm->get('Request');
         $cookies = $request->getHeaders()->get('cookie');
-        if (!isset($cookies->SESSTOKEN)) {
+        if (!isset($cookies->GEWISSESSTOKEN)) {
             return false;
         }
         try {
-            $session = JWT::decode($cookies->SESSTOKEN, $key, ['RS256']);
+            $session = JWT::decode($cookies->GEWISSESSTOKEN, $key, ['RS256']);
         } catch (\UnexpectedValueException $e) {
             return false;
         }


### PR DESCRIPTION
By changing `SESSTOKEN` to `GEWISSESSTOKEN` we initially fixed a major problem when migrating the website. However, we have missed these two occurrences of that specific cookie. This meant that sessions were incorrectly invalidated before they expired.