### PR TITLE
Update Doctrine/ORM patch to v2.9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         },
         "patches": {
             "doctrine/orm": {
-                "Fix issues with SubDecisions.": "https://raw.githubusercontent.com/GEWIS/orm/2.8.x/1-to-1-multiple-join-columns.patch"
+                "Fix issues with SubDecisions.": "https://raw.githubusercontent.com/GEWIS/orm/2.9.x/1-to-1-multiple-join-columns.patch"
             }
         }
     },


### PR DESCRIPTION
#1119 upgraded the Doctrine/ORM patch to v2.8.x, however, we actually use v2.9.x. This reflects that change in version.