### PR TITLE
Fix location of Doctrine command to bypass Composer

### DIFF
--- a/orm
+++ b/orm
@@ -10,4 +10,4 @@ chdir(__DIR__);
 
 require 'bootstrap.php';
 
-include 'vendor/bin/doctrine-module';
+include 'vendor/doctrine/doctrine-module/bin/doctrine-module';


### PR DESCRIPTION
Composer automatically generated a proxy for the Doctrine commands, however, in certain instances this proxy look in the wrong place which means the command fails. This bypasses the Composer proxy to ensure the correct location is used.