### PR TITLE
Change controller factories from closures to files

### DIFF
--- a/module/Activity/config/module.config.php
+++ b/module/Activity/config/module.config.php
@@ -1,9 +1,22 @@
 <?php
 
 use Activity\Command\CalendarNotify;
-use Activity\Controller\ActivityCalendarController;
-use Activity\Controller\AdminCategoryController;
-use Interop\Container\ContainerInterface;
+use Activity\Controller\{
+    ActivityCalendarController,
+    ActivityController,
+    AdminApprovalController,
+    AdminCategoryController,
+    AdminController,
+    ApiController,
+};
+use Activity\Controller\Factory\{
+    ActivityCalendarControllerFactory,
+    ActivityControllerFactory,
+    AdminApprovalControllerFactory,
+    AdminCategoryControllerFactory,
+    AdminControllerFactory,
+    ApiControllerFactory,
+};
 
 return [
     'router' => [
@@ -13,8 +26,7 @@ return [
                 'options' => [
                     'route' => '/activity',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Activity\Controller',
-                        'controller' => 'Activity',
+                        'controller' => ActivityController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -146,8 +158,7 @@ return [
                 'options' => [
                     'route' => '/admin/activity',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Activity\Controller',
-                        'controller' => 'admin',
+                        'controller' => AdminController::class,
                         'action' => 'view',
                     ],
                 ],
@@ -161,7 +172,6 @@ return [
                                 'page' => '[0-9]+',
                             ],
                             'defaults' => [
-                                'controller' => 'admin',
                                 'action' => 'view',
                             ],
                         ],
@@ -175,7 +185,6 @@ return [
                                 'signupList' => '\d+',
                             ],
                             'defaults' => [
-                                'controller' => 'admin',
                                 'action' => 'participants',
                             ],
                         ],
@@ -189,7 +198,6 @@ return [
                                 'signupList' => '\d+',
                             ],
                             'defaults' => [
-                                'controller' => 'admin',
                                 'action' => 'externalSignup',
                             ],
                         ],
@@ -202,7 +210,6 @@ return [
                                 'id' => '\d+',
                             ],
                             'defaults' => [
-                                'controller' => 'admin',
                                 'action' => 'externalSignoff',
                             ],
                         ],
@@ -215,7 +222,6 @@ return [
                                 'id' => '\d+',
                             ],
                             'defaults' => [
-                                'controller' => 'admin',
                                 'action' => 'update',
                             ],
                         ],
@@ -227,8 +233,7 @@ return [
                 'options' => [
                     'route' => '/activity/calendar/',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Activity\Controller',
-                        'controller' => 'activityCalendar',
+                        'controller' => ActivityCalendarController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -269,8 +274,7 @@ return [
                 'options' => [
                     'route' => '/admin/activity/approval',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Activity\Controller',
-                        'controller' => 'adminApproval',
+                        'controller' => AdminApprovalController::class,
                     ],
                 ],
                 'may_terminate' => true,
@@ -280,7 +284,6 @@ return [
                         'options' => [
                             'route' => '/view/[:id]',
                             'defaults' => [
-                                'controller' => 'adminApproval',
                                 'action' => 'view',
                             ],
                         ],
@@ -290,7 +293,6 @@ return [
                         'options' => [
                             'route' => '/proposal/[:id]',
                             'defaults' => [
-                                'controller' => 'adminApproval',
                                 'action' => 'viewProposal',
                             ],
                         ],
@@ -300,7 +302,6 @@ return [
                         'options' => [
                             'route' => '/proposal/[:id]/apply',
                             'defaults' => [
-                                'controller' => 'adminApproval',
                                 'action' => 'applyProposal',
                             ],
                         ],
@@ -310,7 +311,6 @@ return [
                         'options' => [
                             'route' => '/proposal/[:id]/revoke',
                             'defaults' => [
-                                'controller' => 'adminApproval',
                                 'action' => 'revokeProposal',
                             ],
                         ],
@@ -320,7 +320,6 @@ return [
                         'options' => [
                             'route' => '/approve/[:id]',
                             'defaults' => [
-                                'controller' => 'adminApproval',
                                 'action' => 'approve',
                             ],
                         ],
@@ -330,7 +329,6 @@ return [
                         'options' => [
                             'route' => '/disapprove/[:id]',
                             'defaults' => [
-                                'controller' => 'adminApproval',
                                 'action' => 'disapprove',
                             ],
                         ],
@@ -340,7 +338,6 @@ return [
                         'options' => [
                             'route' => '/reset/[:id]',
                             'defaults' => [
-                                'controller' => 'adminApproval',
                                 'action' => 'reset',
                             ],
                         ],
@@ -352,8 +349,7 @@ return [
                 'options' => [
                     'route' => '/admin/activity/categories',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Activity\Controller',
-                        'controller' => 'adminCategory',
+                        'controller' => AdminCategoryController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -364,7 +360,6 @@ return [
                         'options' => [
                             'route' => '/add',
                             'defaults' => [
-                                'controller' => 'adminCategory',
                                 'action' => 'add',
                             ],
                         ],
@@ -377,7 +372,6 @@ return [
                                 'id' => '\d+',
                             ],
                             'defaults' => [
-                                'controller' => 'adminCategory',
                                 'action' => 'delete',
                             ],
                         ],
@@ -390,7 +384,6 @@ return [
                                 'id' => '\d+',
                             ],
                             'defaults' => [
-                                'controller' => 'adminCategory',
                                 'action' => 'edit',
                             ],
                         ],
@@ -402,8 +395,7 @@ return [
                 'options' => [
                     'route' => '/api/activity',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Activity\Controller',
-                        'controller' => 'Api',
+                        'controller' => ApiController::class,
                         'action' => 'list',
                     ],
                 ],
@@ -470,75 +462,12 @@ return [
     ],
     'controllers' => [
         'factories' => [
-            'Activity\Controller\Activity' => function (ContainerInterface $container) {
-                $translator = $container->get('translator');
-                $activityService = $container->get('activity_service_activity');
-                $activityQueryService = $container->get('activity_service_activityQuery');
-                $signupService = $container->get('activity_service_signup');
-                $signupListQueryService = $container->get('activity_service_signupListQuery');
-                $aclService = $container->get('activity_service_acl');
-
-                return new Activity\Controller\ActivityController(
-                    $translator,
-                    $activityService,
-                    $activityQueryService,
-                    $signupService,
-                    $signupListQueryService,
-                    $aclService
-                );
-            },
-            'Activity\Controller\AdminApproval' => function (ContainerInterface $container) {
-                $translator = $container->get('translator');
-                $activityService = $container->get('activity_service_activity');
-                $activityQueryService = $container->get('activity_service_activityQuery');
-                $aclService = $container->get('activity_service_acl');
-
-                return new Activity\Controller\AdminApprovalController(
-                    $translator,
-                    $activityService,
-                    $activityQueryService,
-                    $aclService
-                );
-            },
-            'Activity\Controller\AdminCategory' => function (ContainerInterface $container) {
-                $translator = $container->get('translator');
-                $categoryService = $container->get('activity_service_category');
-
-                return new AdminCategoryController($translator, $categoryService);
-            },
-            'Activity\Controller\Api' => function (ContainerInterface $container) {
-                $activityQueryService = $container->get('activity_service_activityQuery');
-                $signupService = $container->get('activity_service_signup');
-                $aclService = $container->get('activity_service_acl');
-
-                return new Activity\Controller\ApiController($activityQueryService, $signupService, $aclService);
-            },
-            'Activity\Controller\Admin' => function (ContainerInterface $container) {
-                $translator = $container->get('translator');
-                $activityService = $container->get('activity_service_activity');
-                $activityQueryService = $container->get('activity_service_activityQuery');
-                $signupService = $container->get('activity_service_signup');
-                $signupListQueryService = $container->get('activity_service_signupListQuery');
-                $signupMapper = $container->get('activity_mapper_signup');
-                $aclService = $container->get('activity_service_acl');
-
-                return new Activity\Controller\AdminController(
-                    $translator,
-                    $activityService,
-                    $activityQueryService,
-                    $signupService,
-                    $signupListQueryService,
-                    $signupMapper,
-                    $aclService
-                );
-            },
-            'Activity\Controller\ActivityCalendar' => function (ContainerInterface $container) {
-                $calendarService = $container->get('activity_service_calendar');
-                $calendarFormService = $container->get('activity_service_calendar_form');
-                $calendarConfig = $container->get('config')['calendar'];
-
-                return new ActivityCalendarController($calendarService, $calendarFormService, $calendarConfig);
-            },
+            ActivityCalendarController::class => ActivityCalendarControllerFactory::class,
+            ActivityController::class => ActivityControllerFactory::class,
+            AdminApprovalController::class => AdminApprovalControllerFactory::class,
+            AdminCategoryController::class => AdminCategoryControllerFactory::class,
+            AdminController::class => AdminControllerFactory::class,
+            ApiController::class => ApiControllerFactory::class,
         ],
     ],
     'view_manager' => [

--- a/module/Activity/src/Controller/ActivityCalendarController.php
+++ b/module/Activity/src/Controller/ActivityCalendarController.php
@@ -2,30 +2,42 @@
 
 namespace Activity\Controller;
 
-use Activity\Service\ActivityCalendar;
-use Activity\Service\ActivityCalendarForm;
+use Activity\Service\{
+    ActivityCalendar as ActivityCalendarService,
+    ActivityCalendarForm as ActivityCalendarFormService,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
 class ActivityCalendarController extends AbstractActionController
 {
     /**
-     * @var ActivityCalendar
+     * @var ActivityCalendarService
      */
-    private $calendarService;
+    private ActivityCalendarService $calendarService;
 
     /**
-     * @var ActivityCalendarForm
+     * @var ActivityCalendarFormService
      */
-    private $calendarFormService;
+    private ActivityCalendarFormService $calendarFormService;
 
     /**
      * @var array
      */
-    private $calendarConfig;
+    private array $calendarConfig;
 
-    public function __construct(ActivityCalendar $calendarService, ActivityCalendarForm $calendarFormService, array $calendarConfig)
-    {
+    /**
+     * ActivityCalendarController constructor.
+     *
+     * @param ActivityCalendarService $calendarService
+     * @param ActivityCalendarFormService $calendarFormService
+     * @param array $calendarConfig
+     */
+    public function __construct(
+        ActivityCalendarService $calendarService,
+        ActivityCalendarFormService $calendarFormService,
+        array $calendarConfig
+    ) {
         $this->calendarService = $calendarService;
         $this->calendarFormService = $calendarFormService;
         $this->calendarConfig = $calendarConfig;

--- a/module/Activity/src/Controller/AdminApprovalController.php
+++ b/module/Activity/src/Controller/AdminApprovalController.php
@@ -3,9 +3,11 @@
 namespace Activity\Controller;
 
 use Activity\Form\ModifyRequest as RequestForm;
-use Activity\Service\AclService;
-use Activity\Service\Activity;
-use Activity\Service\ActivityQuery;
+use Activity\Service\{
+    AclService,
+    Activity as ActivityService,
+    ActivityQuery as ActivityQueryService,
+};
 use InvalidArgumentException;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
@@ -19,27 +21,43 @@ use User\Permissions\NotAllowedException;
 class AdminApprovalController extends AbstractActionController
 {
     /**
-     * @var Activity
+     * @var ActivityService
      */
-    private $activityService;
+    private ActivityService $activityService;
 
     /**
-     * @var ActivityQuery
+     * @var ActivityQueryService
      */
-    private $activityQueryService;
-    private Translator $translator;
+    private ActivityQueryService $activityQueryService;
+
+    /**
+     * @var AclService
+     */
     private AclService $aclService;
 
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
+     * AdminApprovalController constructor.
+     *
+     * @param ActivityService $activityService
+     * @param ActivityQueryService $activityQueryService
+     * @param AclService $aclService
+     * @param Translator $translator
+     */
     public function __construct(
-        Translator $translator,
-        Activity $activityService,
-        ActivityQuery $activityQueryService,
-        AclService $aclService
+        ActivityService $activityService,
+        ActivityQueryService $activityQueryService,
+        AclService $aclService,
+        Translator $translator
     ) {
         $this->activityService = $activityService;
         $this->activityQueryService = $activityQueryService;
-        $this->translator = $translator;
         $this->aclService = $aclService;
+        $this->translator = $translator;
     }
 
     /**

--- a/module/Activity/src/Controller/AdminCategoryController.php
+++ b/module/Activity/src/Controller/AdminCategoryController.php
@@ -2,7 +2,7 @@
 
 namespace Activity\Controller;
 
-use Activity\Service\ActivityCategory;
+use Activity\Service\ActivityCategory as ActivityCategoryService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Session\Container as SessionContainer;
@@ -11,13 +11,25 @@ use Laminas\View\Model\ViewModel;
 class AdminCategoryController extends AbstractActionController
 {
     /**
-     * @var ActivityCategory
+     * @var ActivityCategoryService
      */
-    private $categoryService;
+    private ActivityCategoryService $categoryService;
+
+    /**
+     * @var Translator
+     */
     private Translator $translator;
 
-    public function __construct(Translator $translator, ActivityCategory $categoryService)
-    {
+    /**
+     * AdminCategoryController constructor.
+     *
+     * @param ActivityCategoryService $categoryService
+     * @param Translator $translator
+     */
+    public function __construct(
+        ActivityCategoryService $categoryService,
+        Translator $translator
+    ) {
         $this->categoryService = $categoryService;
         $this->translator = $translator;
     }

--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -117,7 +117,7 @@ class AdminController extends AbstractActionController
                 $participants += $signupList->getSignups()->count();
             }
 
-            if (min($openingDates) < new DateTime() || Activity::STATUS_APPROVED === $activity->getStatus()) {
+            if (min($openingDates) < new DateTime() || ActivityModel::STATUS_APPROVED === $activity->getStatus()) {
                 $message = $this->translator->translate('Activities that have sign-up lists which are open or approved cannot be updated.');
 
                 $this->redirectActivityAdmin(false, $message);

--- a/module/Activity/src/Controller/ApiController.php
+++ b/module/Activity/src/Controller/ApiController.php
@@ -2,9 +2,11 @@
 
 namespace Activity\Controller;
 
-use Activity\Service\AclService;
-use Activity\Service\ActivityQuery;
-use Activity\Service\Signup;
+use Activity\Service\{
+    AclService,
+    ActivityQuery as ActivityQueryService,
+    Signup as SignupService,
+};
 use Laminas\Form\FormInterface;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
@@ -13,19 +15,30 @@ use User\Permissions\NotAllowedException;
 class ApiController extends AbstractActionController
 {
     /**
-     * @var ActivityQuery
+     * @var ActivityQueryService
      */
-    private $activityQueryService;
+    private ActivityQueryService $activityQueryService;
 
     /**
-     * @var Signup
+     * @var SignupService
      */
-    private $signupService;
+    private SignupService$signupService;
+
+    /**
+     * @var AclService
+     */
     private AclService $aclService;
 
+    /**
+     * ApiController constructor.
+     *
+     * @param ActivityQueryService $activityQueryService
+     * @param SignupService $signupService
+     * @param AclService $aclService
+     */
     public function __construct(
-        ActivityQuery $activityQueryService,
-        Signup $signupService,
+        ActivityQueryService $activityQueryService,
+        SignupService $signupService,
         AclService $aclService
     ) {
         $this->activityQueryService = $activityQueryService;

--- a/module/Activity/src/Controller/Factory/ActivityCalendarControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ActivityCalendarControllerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Activity\Controller\Factory;
+
+use Activity\Controller\ActivityCalendarController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class ActivityCalendarControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return ActivityCalendarController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): ActivityCalendarController {
+        return new ActivityCalendarController(
+            $container->get('activity_service_calendar'),
+            $container->get('activity_service_calendar_form'),
+            $container->get('config')['calendar'],
+        );
+    }
+}

--- a/module/Activity/src/Controller/Factory/ActivityControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ActivityControllerFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Activity\Controller\Factory;
+
+use Activity\Controller\ActivityController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class ActivityControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return ActivityController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): ActivityController {
+        return new ActivityController(
+            $container->get('activity_service_activity'),
+            $container->get('activity_service_activityQuery'),
+            $container->get('activity_service_signup'),
+            $container->get('activity_service_signupListQuery'),
+            $container->get('activity_service_acl'),
+            $container->get('translator'),
+        );
+    }
+}

--- a/module/Activity/src/Controller/Factory/AdminApprovalControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminApprovalControllerFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Activity\Controller\Factory;
+
+use Activity\Controller\AdminApprovalController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class AdminApprovalControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AdminApprovalController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AdminApprovalController {
+        return new AdminApprovalController(
+            $container->get('activity_service_activity'),
+            $container->get('activity_service_activityQuery'),
+            $container->get('activity_service_acl'),
+            $container->get('translator'),
+        );
+    }
+}

--- a/module/Activity/src/Controller/Factory/AdminCategoryControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminCategoryControllerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Activity\Controller\Factory;
+
+use Activity\Controller\AdminCategoryController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class AdminCategoryControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AdminCategoryController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AdminCategoryController {
+        return new AdminCategoryController(
+            $container->get('activity_service_category'),
+            $container->get('translator'),
+        );
+    }
+}

--- a/module/Activity/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminControllerFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Activity\Controller\Factory;
+
+use Activity\Controller\AdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class AdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AdminController {
+        return new AdminController(
+            $container->get('activity_service_activity'),
+            $container->get('activity_service_activityQuery'),
+            $container->get('activity_service_signup'),
+            $container->get('activity_service_signupListQuery'),
+            $container->get('activity_mapper_signup'),
+            $container->get('activity_service_acl'),
+            $container->get('translator'),
+        );
+    }
+}

--- a/module/Activity/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ApiControllerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Activity\Controller\Factory;
+
+use Activity\Controller\ApiController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class ApiControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return ApiController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): ApiController {
+        return new ApiController(
+            $container->get('activity_service_activityQuery'),
+            $container->get('activity_service_signup'),
+            $container->get('activity_service_acl'),
+        );
+    }
+}

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -1,15 +1,7 @@
 <?php
 
-/**
- * Zend Framework (http://framework.zend.com/).
- *
- * @see      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
- *
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
- */
-
 use Application\Controller\IndexController;
+use Application\Controller\Factory\IndexControllerFactory;
 use Application\View\Helper\BootstrapElementError;
 use Application\View\Helper\FeaturedCompanyPackage;
 use Application\View\Helper\LocalisedTextElement;
@@ -24,8 +16,7 @@ return [
                 'options' => [
                     'route' => '/lang/:lang/',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Application\Controller',
-                        'controller' => 'Index',
+                        'controller' => IndexController::class,
                         'action' => 'lang',
                         'lang' => 'nl',
                     ],
@@ -37,8 +28,7 @@ return [
                 'options' => [
                     'route' => '/coffee',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Application\Controller',
-                        'controller' => 'Index',
+                        'controller' => IndexController::class,
                         'action' => 'teapot',
                     ],
                 ],
@@ -85,9 +75,7 @@ return [
     ],
     'controllers' => [
         'factories' => [
-            'Application\Controller\Index' => function () {
-                return new IndexController();
-            },
+            IndexController::class => IndexControllerFactory::class,
         ],
     ],
     'view_manager' => [

--- a/module/Application/src/Controller/Factory/IndexControllerFactory.php
+++ b/module/Application/src/Controller/Factory/IndexControllerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Application\Controller\Factory;
+
+use Application\Controller\IndexController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class IndexControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return IndexController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): IndexController {
+        return new IndexController();
+    }
+}

--- a/module/Application/src/Controller/IndexController.php
+++ b/module/Application/src/Controller/IndexController.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * Zend Framework (http://framework.zend.com/).
- *
- * @see      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
- *
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
- */
-
 namespace Application\Controller;
 
 use Laminas\Mvc\Controller\AbstractActionController;

--- a/module/Application/view/partial/admin-nav.phtml
+++ b/module/Application/view/partial/admin-nav.phtml
@@ -69,7 +69,19 @@
                             </a>
                             <ul class="dropdown-menu">
                                 <li>
-                                    <a href="<?= $this->url('admin_poll') ?>"><?= $this->translate('Polls') ?></a>
+                                    <a href="<?= $this->url('admin_education/bulk_upload_exam') ?>">
+                                        <?= $this->translate('Upload exams') ?>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="<?= $this->url('admin_education/bulk_upload_summary') ?>">
+                                        <?= $this->translate('Upload summaries') ?>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="<?= $this->url('admin_education/add_course') ?>">
+                                        <?= $this->translate('Add courses') ?>
+                                    </a>
                                 </li>
                             </ul>
                         </li>

--- a/module/Company/config/module.config.php
+++ b/module/Company/config/module.config.php
@@ -1,9 +1,14 @@
 <?php
 
 use Application\View\Helper\Truncate;
-use Company\Controller\AdminController;
-use Company\Controller\CompanyController;
-use Interop\Container\ContainerInterface;
+use Company\Controller\{
+    AdminController,
+    CompanyController,
+};
+use Company\Controller\Factory\{
+    AdminControllerFactory,
+    CompanyControllerFactory,
+};
 
 return [
     'router' => [
@@ -14,10 +19,8 @@ return [
                     'route' => '/career',
                     'priority' => 2,
                     'defaults' => [
-                        '__NAMESPACE__' => 'Company\Controller',
-                        'controller' => 'Company',
+                        'controller' => CompanyController::class,
                         'action' => 'list', // index is reserved for some magical frontpage for the company module, but since it is not yet implemented, a company list will be presented.
-                        'actionArgument' => '',
                     ],
                 ],
                 'may_terminate' => true,
@@ -31,10 +34,7 @@ return [
                                 'category' => '[a-zA-Z0-9_\-\.]*',
                             ],
                             'defaults' => [
-                                '__NAMESPACE__' => 'Company\Controller',
-                                'controller' => 'Company',
                                 'action' => 'jobList',
-                                'actionArgument' => '',
                             ],
                         ],
                     ],
@@ -44,10 +44,7 @@ return [
                         'options' => [
                             'route' => '/spotlight',
                             'defaults' => [
-                                '__NAMESPACE__' => 'Company\Controller',
-                                'controller' => 'Company',
                                 'action' => 'spotlight',
-                                'actionArgument' => '',
                             ],
                         ],
                     ],
@@ -57,7 +54,6 @@ return [
                         'options' => [
                             'route' => '/list',
                             'defaults' => [
-                                'controller' => 'Company\Controller\Company',
                                 'action' => 'list',
                                 'slugCompanyName' => '',
                             ],
@@ -91,7 +87,6 @@ return [
                                 'options' => [
                                     'route' => '/:category',
                                     'defaults' => [
-                                        'controller' => 'Company\Controller\Company',
                                         'action' => 'jobList',
                                     ],
                                 ],
@@ -105,7 +100,6 @@ return [
                                                 'slugJobName' => '[a-zA-Z0-9_-]*',
                                             ],
                                             'defaults' => [
-                                                'controller' => 'Company\Controller\Company',
                                                 'action' => 'jobs',
                                             ],
                                         ],
@@ -123,8 +117,7 @@ return [
                 'options' => [
                     'route' => '/admin/company',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Company\Controller',
-                        'controller' => 'Admin',
+                        'controller' => AdminController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -297,32 +290,8 @@ return [
     ],
     'controllers' => [
         'factories' => [
-            'Company\Controller\Company' => function (ContainerInterface $container) {
-                $translator = $container->get('translator');
-                $companyService = $container->get('company_service_company');
-                $companyQueryService = $container->get('company_service_companyquery');
-
-                return new CompanyController($translator, $companyService, $companyQueryService);
-            },
-            'Company\Controller\Admin' => function (ContainerInterface $container) {
-                $translator = $container->get('translator');
-                $companyService = $container->get('company_service_company');
-                $companyQueryService = $container->get('company_service_companyquery');
-                $labelMapper = $container->get('company_mapper_label');
-                $companyForm = $container->get('company_form_company');
-                $languages = $container->get('languages');
-                $aclService = $container->get('company_service_acl');
-
-                return new AdminController(
-                    $translator,
-                    $companyService,
-                    $companyQueryService,
-                    $labelMapper,
-                    $companyForm,
-                    $languages,
-                    $aclService
-                );
-            },
+            AdminController::class => AdminControllerFactory::class,
+            CompanyController::class => CompanyControllerFactory::class,
         ],
     ],
     'view_manager' => [

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -2,11 +2,13 @@
 
 namespace Company\Controller;
 
-use Company\Form\EditCompany;
-use Company\Mapper\Label;
-use Company\Service\AclService;
-use Company\Service\Company as CompanyService;
-use Company\Service\CompanyQuery;
+use Company\Form\EditCompany as EditCompanyForm;
+use Company\Mapper\Label as LabelMapper;
+use Company\Service\{
+    AclService,
+    Company as CompanyService,
+    CompanyQuery as CompanyQueryService,
+};
 use DateInterval;
 use DateTime;
 use Laminas\Mvc\Controller\AbstractActionController;
@@ -17,49 +19,67 @@ use User\Permissions\NotAllowedException;
 class AdminController extends AbstractActionController
 {
     /**
-     * @var Translator
-     */
-    private $translator;
-
-    /**
      * @var CompanyService
      */
-    private $companyService;
+    private CompanyService $companyService;
+
     /**
-     * @var Label
+     * @var CompanyQueryService
      */
-    private $labelMapper;
+    private CompanyQueryService $companyQueryService;
+
     /**
-     * @var EditCompany
+     * @var LabelMapper
      */
-    private $companyForm;
+    private LabelMapper $labelMapper;
+
+    /**
+     * @var EditCompanyForm
+     */
+    private EditCompanyForm $companyForm;
+
     /**
      * @var array
      */
-    private $languages;
+    private array $languages;
 
     /**
-     * @var CompanyQuery
+     * @var AclService
      */
-    private $companyQueryService;
     private AclService $aclService;
 
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
+     * AdminController constructor.
+     *
+     * @param CompanyService $companyService
+     * @param CompanyQueryService $companyQueryService
+     * @param LabelMapper $labelMapper
+     * @param EditCompanyForm $companyForm
+     * @param array $languages
+     * @param AclService $aclService
+     * @param Translator $translator
+     */
     public function __construct(
-        Translator $translator,
         CompanyService $companyService,
-        CompanyQuery $companyQueryService,
-        Label $labelMapper,
-        EditCompany $companyForm,
+        CompanyQueryService $companyQueryService,
+        LabelMapper $labelMapper,
+        EditCompanyForm $companyForm,
         array $languages,
-        AclService $aclService
+        AclService $aclService,
+        Translator $translator
     ) {
-        $this->translator = $translator;
         $this->companyService = $companyService;
         $this->companyQueryService = $companyQueryService;
         $this->labelMapper = $labelMapper;
         $this->companyForm = $companyForm;
         $this->languages = $languages;
         $this->aclService = $aclService;
+        $this->translator = $translator;
     }
 
     /**

--- a/module/Company/src/Controller/CompanyController.php
+++ b/module/Company/src/Controller/CompanyController.php
@@ -2,8 +2,10 @@
 
 namespace Company\Controller;
 
-use Company\Service\Company;
-use Company\Service\CompanyQuery;
+use Company\Service\{
+    Company as CompanyService,
+    CompanyQuery as CompanyQueryService,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
@@ -11,25 +13,35 @@ use Laminas\View\Model\ViewModel;
 class CompanyController extends AbstractActionController
 {
     /**
+     * @var CompanyService
+     */
+    private CompanyService $companyService;
+
+    /**
+     * @var CompanyQueryService
+     */
+    private CompanyQueryService $companyQueryService;
+
+    /**
      * @var Translator
      */
-    private $translator;
+    private Translator $translator;
 
     /**
-     * @var Company
+     * CompanyController constructor.
+     *
+     * @param CompanyService $companyService
+     * @param CompanyQueryService $companyQueryService
+     * @param Translator $translator
      */
-    private $companyService;
-
-    /**
-     * @var CompanyQuery
-     */
-    private $companyQueryService;
-
-    public function __construct(Translator $translator, Company $companyService, CompanyQuery $companyQueryService)
-    {
-        $this->translator = $translator;
+    public function __construct(
+        CompanyService $companyService,
+        CompanyQueryService $companyQueryService,
+        Translator $translator
+    ) {
         $this->companyService = $companyService;
         $this->companyQueryService = $companyQueryService;
+        $this->translator = $translator;
     }
 
     /**
@@ -96,7 +108,7 @@ class CompanyController extends AbstractActionController
         }
 
         // There is no company is the spotlight, so throw a 404
-        $this->getResponse()->setStatusCode(404);
+        return $this->notFoundAction();
     }
 
     /**

--- a/module/Company/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Company/src/Controller/Factory/AdminControllerFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Company\Controller\Factory;
+
+use Company\Controller\AdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class AdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AdminController {
+        return new AdminController(
+            $container->get('company_service_company'),
+            $container->get('company_service_companyquery'),
+            $container->get('company_mapper_label'),
+            $container->get('company_admin_edit_company_form'),
+            $container->get('application_get_languages'),
+            $container->get('company_service_acl'),
+            $container->get('translator'),
+        );
+    }
+}

--- a/module/Company/src/Controller/Factory/CompanyControllerFactory.php
+++ b/module/Company/src/Controller/Factory/CompanyControllerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Company\Controller\Factory;
+
+use Company\Controller\CompanyController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class CompanyControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return CompanyController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): CompanyController {
+        return new CompanyController(
+            $container->get('company_service_company'),
+            $container->get('company_service_companyquery'),
+            $container->get('translator'),
+        );
+    }
+}

--- a/module/Decision/config/module.config.php
+++ b/module/Decision/config/module.config.php
@@ -1,12 +1,21 @@
 <?php
 
-use Decision\Controller\AdminController;
-use Decision\Controller\DecisionController;
-use Decision\Controller\MemberApiController;
-use Decision\Controller\MemberController;
-use Decision\Controller\OrganAdminController;
-use Decision\Controller\OrganController;
-use Interop\Container\ContainerInterface;
+use Decision\Controller\{
+    AdminController,
+    DecisionController,
+    MemberApiController,
+    MemberController,
+    OrganAdminController,
+    OrganController,
+};
+use Decision\Controller\Factory\{
+    AdminControllerFactory,
+    DecisionControllerFactory,
+    MemberApiControllerFactory,
+    MemberControllerFactory,
+    OrganAdminControllerFactory,
+    OrganControllerFactory,
+};
 
 return [
     'router' => [
@@ -16,8 +25,7 @@ return [
                 'options' => [
                     'route' => '/decision',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Decision\Controller',
-                        'controller' => 'Decision',
+                        'controller' => DecisionController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -105,8 +113,7 @@ return [
                 'options' => [
                     'route' => '/admin/decision',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Decision\Controller',
-                        'controller' => 'Admin',
+                        'controller' => AdminController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -181,8 +188,7 @@ return [
                 'options' => [
                     'route' => '/organ',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Decision\Controller',
-                        'controller' => 'Organ',
+                        'controller' => OrganController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -208,8 +214,7 @@ return [
                 'options' => [
                     'route' => '/member',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Decision\Controller',
-                        'controller' => 'Member',
+                        'controller' => MemberController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -292,8 +297,7 @@ return [
                 'options' => [
                     'route' => '/api/member',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Decision\Controller',
-                        'controller' => 'MemberApi',
+                        'controller' => MemberApiController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -316,8 +320,7 @@ return [
                 'options' => [
                     'route' => '/admin/organ',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Decision\Controller',
-                        'controller' => 'OrganAdmin',
+                        'controller' => OrganAdminController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -351,47 +354,12 @@ return [
     ],
     'controllers' => [
         'factories' => [
-            'Decision\Controller\Decision' => function (ContainerInterface $container) {
-                $decisionService = $container->get('decision_service_decision');
-                $fileReader = $container->get('decision_fileReader');
-
-                return new DecisionController($decisionService, $fileReader);
-            },
-            'Decision\Controller\Organ' => function (ContainerInterface $container) {
-                $organService = $container->get('decision_service_organ');
-
-                return new OrganController($organService);
-            },
-            'Decision\Controller\Admin' => function (ContainerInterface $container) {
-                $decisionService = $container->get('decision_service_decision');
-
-                return new AdminController($decisionService);
-            },
-            'Decision\Controller\OrganAdmin' => function (ContainerInterface $container) {
-                $organService = $container->get('decision_service_organ');
-
-                return new OrganAdminController($organService);
-            },
-            'Decision\Controller\Member' => function (ContainerInterface $container) {
-                $memberService = $container->get('decision_service_member');
-                $memberInfoService = $container->get('decision_service_memberinfo');
-                $decisionService = $container->get('decision_service_decision');
-                $regulationsConfig = $container->get('config')['regulations'];
-                $aclService = $container->get('decision_service_acl');
-
-                return new MemberController(
-                    $memberService,
-                    $memberInfoService,
-                    $decisionService,
-                    $regulationsConfig,
-                    $aclService
-                );
-            },
-            'Decision\Controller\MemberApi' => function (ContainerInterface $container) {
-                $memberService = $container->get('decision_service_member');
-
-                return new MemberApiController($memberService);
-            },
+            AdminController::class => AdminControllerFactory::class,
+            DecisionController::class => DecisionControllerFactory::class,
+            MemberApiController::class => MemberApiControllerFactory::class,
+            MemberController::class => MemberControllerFactory::class,
+            OrganAdminController::class => OrganAdminControllerFactory::class,
+            OrganController::class => OrganControllerFactory::class,
         ],
     ],
     'view_manager' => [

--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -2,7 +2,7 @@
 
 namespace Decision\Controller;
 
-use Decision\Service\Decision;
+use Decision\Service\Decision as DecisionService;
 use Laminas\Http\Response;
 use Laminas\Json\Json;
 use Laminas\Mvc\Controller\AbstractActionController;
@@ -11,11 +11,16 @@ use Laminas\View\Model\ViewModel;
 class AdminController extends AbstractActionController
 {
     /**
-     * @var Decision
+     * @var DecisionService
      */
-    private $decisionService;
+    private DecisionService $decisionService;
 
-    public function __construct(Decision $decisionService)
+    /**
+     * AdminController constructor.
+     *
+     * @param DecisionService $decisionService
+     */
+    public function __construct(DecisionService $decisionService)
     {
         $this->decisionService = $decisionService;
     }

--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -3,7 +3,7 @@
 namespace Decision\Controller;
 
 use Decision\Controller\FileBrowser\FileReader;
-use Decision\Service\Decision;
+use Decision\Service\Decision as DecisionService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use User\Permissions\NotAllowedException;
@@ -11,13 +11,25 @@ use User\Permissions\NotAllowedException;
 class DecisionController extends AbstractActionController
 {
     /**
-     * @var Decision
+     * @var DecisionService
      */
-    private $decisionService;
+    private DecisionService $decisionService;
+
+    /**
+     * @var FileReader
+     */
     private FileReader $fileReader;
 
-    public function __construct(Decision $decisionService, FileReader $fileReader)
-    {
+    /**
+     * DecisionController constructor.
+     *
+     * @param DecisionService $decisionService
+     * @param FileReader $fileReader
+     */
+    public function __construct(
+        DecisionService $decisionService,
+        FileReader $fileReader
+    ) {
         $this->decisionService = $decisionService;
         $this->fileReader = $fileReader;
     }

--- a/module/Decision/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/AdminControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Decision\Controller\Factory;
+
+use Decision\Controller\AdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class AdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AdminController {
+        return new AdminController(
+            $container->get('decision_service_decision'),
+        );
+    }
+}

--- a/module/Decision/src/Controller/Factory/DecisionControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/DecisionControllerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Decision\Controller\Factory;
+
+use Decision\Controller\DecisionController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class DecisionControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return DecisionController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): DecisionController {
+        return new DecisionController(
+            $container->get('decision_service_decision'),
+            $container->get('decision_fileReader'),
+        );
+    }
+}

--- a/module/Decision/src/Controller/Factory/MemberApiControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/MemberApiControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Decision\Controller\Factory;
+
+use Decision\Controller\MemberApiController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class MemberApiControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return MemberApiController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): MemberApiController {
+        return new MemberApiController(
+            $container->get('decision_service_member'),
+        );
+    }
+}

--- a/module/Decision/src/Controller/Factory/MemberControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/MemberControllerFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Decision\Controller\Factory;
+
+use Decision\Controller\MemberController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class MemberControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return MemberController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): MemberController {
+        return new MemberController(
+            $container->get('decision_service_member'),
+            $container->get('decision_service_memberinfo'),
+            $container->get('decision_service_decision'),
+            $container->get('config')['regulations'],
+            $container->get('decision_service_acl'),
+        );
+    }
+}

--- a/module/Decision/src/Controller/Factory/OrganAdminControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/OrganAdminControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Decision\Controller\Factory;
+
+use Decision\Controller\OrganAdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class OrganAdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return OrganAdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): OrganAdminController {
+        return new OrganAdminController(
+            $container->get('decision_service_organ'),
+        );
+    }
+}

--- a/module/Decision/src/Controller/Factory/OrganControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/OrganControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Decision\Controller\Factory;
+
+use Decision\Controller\OrganController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class OrganControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return OrganController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): OrganController {
+        return new OrganController(
+            $container->get('decision_service_organ'),
+        );
+    }
+}

--- a/module/Decision/src/Controller/MemberApiController.php
+++ b/module/Decision/src/Controller/MemberApiController.php
@@ -2,18 +2,23 @@
 
 namespace Decision\Controller;
 
-use Decision\Service\Member;
+use Decision\Service\Member as MemberService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
 
 class MemberApiController extends AbstractActionController
 {
     /**
-     * @var Member
+     * @var MemberService
      */
-    private $memberService;
+    private MemberService $memberService;
 
-    public function __construct(Member $memberService)
+    /**
+     * MemberApiController constructor.
+     *
+     * @param MemberService $memberService
+     */
+    public function __construct(MemberService $memberService)
     {
         $this->memberService = $memberService;
     }

--- a/module/Decision/src/Controller/MemberController.php
+++ b/module/Decision/src/Controller/MemberController.php
@@ -2,41 +2,58 @@
 
 namespace Decision\Controller;
 
-use Decision\Service\AclService;
-use Decision\Service\Decision;
-use Decision\Service\Member;
-use Decision\Service\MemberInfo;
+use Decision\Service\{
+    AclService,
+    Decision as DecisionService,
+    Member as MemberService,
+    MemberInfo as MemberInfoService,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\View\Model\JsonModel;
-use Laminas\View\Model\ViewModel;
+use Laminas\View\Model\{
+    JsonModel,
+    ViewModel,
+};
 
 class MemberController extends AbstractActionController
 {
     /**
-     * @var Member
+     * @var MemberService
      */
-    private $memberService;
+    private MemberService $memberService;
 
     /**
-     * @var MemberInfo
+     * @var MemberInfoService
      */
-    private $memberInfoService;
+    private MemberInfoService $memberInfoService;
 
     /**
-     * @var Decision
+     * @var DecisionService
      */
-    private $decisionService;
+    private DecisionService $decisionService;
 
     /**
      * @var array
      */
-    private $regulationsConfig;
+    private array $regulationsConfig;
+
+    /**
+     * @var AclService
+     */
     private AclService $aclService;
 
+    /**
+     * MemberController constructor.
+     *
+     * @param MemberService $memberService
+     * @param MemberInfoService $memberInfoService
+     * @param DecisionService $decisionService
+     * @param array $regulationsConfig
+     * @param AclService $aclService
+     */
     public function __construct(
-        Member $memberService,
-        MemberInfo $memberInfoService,
-        Decision $decisionService,
+        MemberService $memberService,
+        MemberInfoService $memberInfoService,
+        DecisionService $decisionService,
         array $regulationsConfig,
         AclService $aclService
     ) {

--- a/module/Decision/src/Controller/OrganAdminController.php
+++ b/module/Decision/src/Controller/OrganAdminController.php
@@ -2,18 +2,23 @@
 
 namespace Decision\Controller;
 
-use Decision\Service\Organ;
+use Decision\Service\Organ as OrganService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
 class OrganAdminController extends AbstractActionController
 {
     /**
-     * @var Organ
+     * @var OrganService
      */
-    private $organService;
+    private OrganService $organService;
 
-    public function __construct(Organ $organService)
+    /**
+     * OrganAdminController constructor.
+     *
+     * @param OrganService $organService
+     */
+    public function __construct(OrganService $organService)
     {
         $this->organService = $organService;
     }

--- a/module/Decision/src/Controller/OrganController.php
+++ b/module/Decision/src/Controller/OrganController.php
@@ -2,18 +2,23 @@
 
 namespace Decision\Controller;
 
-use Decision\Service\Organ;
+use Decision\Service\Organ as OrganService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
 class OrganController extends AbstractActionController
 {
     /**
-     * @var Organ
+     * @var OrganService
      */
-    private $organService;
+    private OrganService $organService;
 
-    public function __construct(Organ $organService)
+    /**
+     * OrganController constructor.
+     *
+     * @param OrganService $organService
+     */
+    public function __construct(OrganService $organService)
     {
         $this->organService = $organService;
     }

--- a/module/Education/config/module.config.php
+++ b/module/Education/config/module.config.php
@@ -1,8 +1,13 @@
 <?php
 
-use Education\Controller\AdminController;
-use Education\Controller\EducationController;
-use Interop\Container\ContainerInterface;
+use Education\Controller\{
+    AdminController,
+    EducationController,
+};
+use Education\Controller\Factory\{
+    AdminControllerFactory,
+    EducationControllerFactory,
+};
 
 return [
     'router' => [
@@ -12,8 +17,7 @@ return [
                 'options' => [
                     'route' => '/education',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Education\Controller',
-                        'controller' => 'Education',
+                        'controller' => EducationController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -63,8 +67,7 @@ return [
                 'options' => [
                     'route' => '/admin/education',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Education\Controller',
-                        'controller' => 'Admin',
+                        'controller' => AdminController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -143,19 +146,8 @@ return [
     ],
     'controllers' => [
         'factories' => [
-            'Education\Controller\Education' => function (ContainerInterface $container) {
-                $examService = $container->get('education_service_exam');
-                $searchCourseForm = $container->get('education_form_searchcourse');
-
-                return new EducationController($examService, $searchCourseForm);
-            },
-            'Education\Controller\Admin' => function (ContainerInterface $container) {
-                $examService = $container->get('education_service_exam');
-                $uploadSummaryForm = $container->get('education_form_summaryupload');
-                $educationTempConfig = $container->get('config')['education_temp'];
-
-                return new AdminController($examService, $uploadSummaryForm, $educationTempConfig);
-            },
+            AdminController::class => AdminControllerFactory::class,
+            EducationController::class => EducationControllerFactory::class,
         ],
     ],
     'view_manager' => [

--- a/module/Education/src/Controller/AdminController.php
+++ b/module/Education/src/Controller/AdminController.php
@@ -2,28 +2,44 @@
 
 namespace Education\Controller;
 
-use Education\Form\SummaryUpload;
-use Education\Service\Exam;
+use Education\Form\SummaryUpload as SummaryUploadForm;
+use Education\Service\Exam as ExamService;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\View\Model\JsonModel;
-use Laminas\View\Model\ViewModel;
+use Laminas\View\Model\{
+    JsonModel,
+    ViewModel,
+};
 use Laminas\View\View;
 
 class AdminController extends AbstractActionController
 {
     /**
-     * @var Exam
+     * @var ExamService
      */
-    private $examService;
+    private ExamService $examService;
 
     /**
-     * @var SummaryUpload
+     * @var SummaryUploadForm
      */
-    private $summaryUploadForm;
+    private SummaryUploadForm $summaryUploadForm;
+
+    /**
+     * @var array
+     */
     private array $educationTempConfig;
 
-    public function __construct(Exam $examService, SummaryUpload $summaryUploadForm, array $educationTempConfig)
-    {
+    /**
+     * AdminController constructor.
+     *
+     * @param ExamService $examService
+     * @param SummaryUploadForm $summaryUploadForm
+     * @param array $educationTempConfig
+     */
+    public function __construct(
+        ExamService $examService,
+        SummaryUploadForm $summaryUploadForm,
+        array $educationTempConfig
+    ) {
         $this->examService = $examService;
         $this->summaryUploadForm = $summaryUploadForm;
         $this->educationTempConfig = $educationTempConfig;

--- a/module/Education/src/Controller/EducationController.php
+++ b/module/Education/src/Controller/EducationController.php
@@ -2,25 +2,33 @@
 
 namespace Education\Controller;
 
-use Education\Form\SearchCourse;
-use Education\Service\Exam;
+use Education\Form\SearchCourse as SearchCourseForm;
+use Education\Service\Exam as ExamService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
 class EducationController extends AbstractActionController
 {
     /**
-     * @var Exam
+     * @var ExamService
      */
-    private $examService;
+    private ExamService $examService;
 
     /**
-     * @var SearchCourse
+     * @var SearchCourseForm
      */
-    private $searchCourseForm;
+    private SearchCourseForm $searchCourseForm;
 
-    public function __construct(Exam $examService, SearchCourse $searchCourseForm)
-    {
+    /**
+     * EducationController constructor.
+     *
+     * @param ExamService $examService
+     * @param SearchCourseForm $searchCourseForm
+     */
+    public function __construct(
+        ExamService $examService,
+        SearchCourseForm $searchCourseForm
+    ) {
         $this->examService = $examService;
         $this->searchCourseForm = $searchCourseForm;
     }

--- a/module/Education/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Education/src/Controller/Factory/AdminControllerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Education\Controller\Factory;
+
+use Education\Controller\AdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class AdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AdminController {
+        return new AdminController(
+            $container->get('education_service_exam'),
+            $container->get('education_form_summaryupload'),
+            $container->get('config')['education_temp'],
+        );
+    }
+}

--- a/module/Education/src/Controller/Factory/EducationControllerFactory.php
+++ b/module/Education/src/Controller/Factory/EducationControllerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Education\Controller\Factory;
+
+use Education\Controller\EducationController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class EducationControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return EducationController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): EducationController {
+        return new EducationController(
+            $container->get('education_service_exam'),
+            $container->get('education_form_searchcourse'),
+        );
+    }
+}

--- a/module/Frontpage/config/module.config.php
+++ b/module/Frontpage/config/module.config.php
@@ -1,60 +1,27 @@
 <?php
 
-use Frontpage\Controller\AdminController;
-use Frontpage\Controller\FrontpageController;
-use Frontpage\Controller\NewsAdminController;
-use Frontpage\Controller\OrganController;
-use Frontpage\Controller\PageAdminController;
-use Frontpage\Controller\PageController;
-use Frontpage\Controller\PollAdminController;
-use Frontpage\Controller\PollController;
-use Interop\Container\ContainerInterface;
+use Frontpage\Controller\{
+    AdminController,
+    FrontpageController,
+    NewsAdminController,
+    OrganController,
+    PageAdminController,
+    PageController,
+    PollAdminController,
+    PollController,
+};
+use Frontpage\Controller\Factory\{
+    AdminControllerFactory,
+    FrontpageControllerFactory,
+    NewsAdminControllerFactory,
+    OrganControllerFactory,
+    PageAdminControllerFactory,
+    PageControllerFactory,
+    PollAdminControllerFactory,
+    PollControllerFactory,
+};
 
 return [
-    'controllers' => [
-        'factories' => [
-            'Frontpage\Controller\Frontpage' => function (ContainerInterface $container) {
-                $frontpageService = $container->get('frontpage_service_frontpage');
-
-                return new FrontpageController($frontpageService);
-            },
-            'Frontpage\Controller\Organ' => function (ContainerInterface $container) {
-                $organService = $container->get('decision_service_organ');
-                $activityQueryService = $container->get('activity_service_activityQuery');
-
-                return new OrganController($organService, $activityQueryService);
-            },
-            'Frontpage\Controller\Page' => function (ContainerInterface $container) {
-                $pageService = $container->get('frontpage_service_page');
-
-                return new PageController($pageService);
-            },
-            'Frontpage\Controller\PageAdmin' => function (ContainerInterface $container) {
-                $pageService = $container->get('frontpage_service_page');
-
-                return new PageAdminController($pageService);
-            },
-            'Frontpage\Controller\Poll' => function (ContainerInterface $container) {
-                $pollService = $container->get('frontpage_service_poll');
-                $pollCommentForm = $container->get('frontpage_form_poll_comment');
-
-                return new PollController($pollService, $pollCommentForm);
-            },
-            'Frontpage\Controller\PollAdmin' => function (ContainerInterface $container) {
-                $pollService = $container->get('frontpage_service_poll');
-
-                return new PollAdminController($pollService);
-            },
-            'Frontpage\Controller\NewsAdmin' => function (ContainerInterface $container) {
-                $newsService = $container->get('frontpage_service_news');
-
-                return new NewsAdminController($newsService);
-            },
-            'Frontpage\Controller\Admin' => function () {
-                return new AdminController();
-            },
-        ],
-    ],
     'router' => [
         'routes' => [
             'home' => [
@@ -62,8 +29,7 @@ return [
                 'options' => [
                     'route' => '/',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Frontpage\Controller',
-                        'controller' => 'Frontpage',
+                        'controller' => FrontpageController::class,
                         'action' => 'home',
                     ],
                 ],
@@ -79,8 +45,7 @@ return [
                                 'name' => '[a-zA-Z][a-zA-Z0-9_-]*',
                             ],
                             'defaults' => [
-                                '__NAMESPACE__' => 'Frontpage\Controller',
-                                'controller' => 'Page',
+                                'controller' => PageController::class,
                                 'action' => 'page',
                             ],
                         ],
@@ -95,8 +60,8 @@ return [
                                 'abbr' => '[^/]*',
                             ],
                             'defaults' => [
+                                'controller' => OrganController::class,
                                 'action' => 'organ',
-                                'controller' => 'Organ',
                             ],
                         ],
                         'priority' => 100,
@@ -106,8 +71,8 @@ return [
                         'options' => [
                             'route' => 'association/committees',
                             'defaults' => [
+                                'controller' => OrganController::class,
                                 'action' => 'committeeList',
-                                'controller' => 'Organ',
                             ],
                         ],
                         'priority' => 100,
@@ -117,8 +82,8 @@ return [
                         'options' => [
                             'route' => 'association/fraternities',
                             'defaults' => [
+                                'controller' => OrganController::class,
                                 'action' => 'fraternityList',
-                                'controller' => 'Organ',
                             ],
                         ],
                         'priority' => 100,
@@ -130,8 +95,7 @@ return [
                 'options' => [
                     'route' => '/admin/page',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Frontpage\Controller',
-                        'controller' => 'PageAdmin',
+                        'controller' => PageAdminController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -187,8 +151,7 @@ return [
                 'options' => [
                     'route' => '/poll',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Frontpage\Controller',
-                        'controller' => 'Poll',
+                        'controller' => PollController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -259,8 +222,7 @@ return [
                 'options' => [
                     'route' => '/admin/poll',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Frontpage\Controller',
-                        'controller' => 'PollAdmin',
+                        'controller' => PollAdminController::class,
                         'action' => 'list',
                     ],
                 ],
@@ -310,8 +272,7 @@ return [
                 'options' => [
                     'route' => '/admin/news',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Frontpage\Controller',
-                        'controller' => 'NewsAdmin',
+                        'controller' => NewsAdminController::class,
                         'action' => 'list',
                     ],
                 ],
@@ -370,14 +331,25 @@ return [
                 'options' => [
                     'route' => '/admin[/]',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Frontpage\Controller',
-                        'controller' => 'Admin',
+                        'controller' => AdminController::class,
                         'action' => 'index',
                     ],
                 ],
                 'may_terminate' => true,
                 'priority' => 100,
             ],
+        ],
+    ],
+    'controllers' => [
+        'factories' => [
+            AdminController::class => AdminControllerFactory::class,
+            FrontpageController::class => FrontpageControllerFactory::class,
+            NewsAdminController::class => NewsAdminControllerFactory::class,
+            OrganController::class => OrganControllerFactory::class,
+            PageAdminController::class => PageAdminControllerFactory::class,
+            PageController::class => PageControllerFactory::class,
+            PollAdminController::class => PollAdminControllerFactory::class,
+            PollController::class => PollControllerFactory::class,
         ],
     ],
     'view_manager' => [

--- a/module/Frontpage/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/AdminControllerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Frontpage\Controller\Factory;
+
+use Frontpage\Controller\AdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class AdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AdminController {
+        return new AdminController();
+    }
+}

--- a/module/Frontpage/src/Controller/Factory/FrontpageControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/FrontpageControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Frontpage\Controller\Factory;
+
+use Frontpage\Controller\FrontpageController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class FrontpageControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return FrontpageController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): FrontpageController {
+        return new FrontpageController(
+            $container->get('frontpage_service_frontpage'),
+        );
+    }
+}

--- a/module/Frontpage/src/Controller/Factory/NewsAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/NewsAdminControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Frontpage\Controller\Factory;
+
+use Frontpage\Controller\NewsAdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class NewsAdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return NewsAdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): NewsAdminController {
+        return new NewsAdminController(
+            $container->get('frontpage_service_news'),
+        );
+    }
+}

--- a/module/Frontpage/src/Controller/Factory/OrganControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/OrganControllerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Frontpage\Controller\Factory;
+
+use Frontpage\Controller\OrganController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class OrganControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return OrganController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): OrganController {
+        return new OrganController(
+            $container->get('activity_service_activityQuery'),
+            $container->get('decision_service_organ'),
+        );
+    }
+}

--- a/module/Frontpage/src/Controller/Factory/PageAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PageAdminControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Frontpage\Controller\Factory;
+
+use Frontpage\Controller\PageAdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class PageAdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return PageAdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): PageAdminController {
+        return new PageAdminController(
+            $container->get('frontpage_service_page'),
+        );
+    }
+}

--- a/module/Frontpage/src/Controller/Factory/PageControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PageControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Frontpage\Controller\Factory;
+
+use Frontpage\Controller\PageController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class PageControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return PageController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): PageController {
+        return new PageController(
+            $container->get('frontpage_service_page'),
+        );
+    }
+}

--- a/module/Frontpage/src/Controller/Factory/PollAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PollAdminControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Frontpage\Controller\Factory;
+
+use Frontpage\Controller\PollAdminController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class PollAdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return PollAdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): PollAdminController {
+        return new PollAdminController(
+            $container->get('frontpage_service_poll'),
+        );
+    }
+}

--- a/module/Frontpage/src/Controller/Factory/PollControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PollControllerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Frontpage\Controller\Factory;
+
+use Frontpage\Controller\PollController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class PollControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return PollController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): PollController {
+        return new PollController(
+            $container->get('frontpage_form_poll_comment'),
+            $container->get('frontpage_service_poll'),
+        );
+    }
+}

--- a/module/Frontpage/src/Controller/FrontpageController.php
+++ b/module/Frontpage/src/Controller/FrontpageController.php
@@ -2,18 +2,23 @@
 
 namespace Frontpage\Controller;
 
-use Frontpage\Service\Frontpage;
+use Frontpage\Service\Frontpage as FrontpageService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
 class FrontpageController extends AbstractActionController
 {
     /**
-     * @var Frontpage
+     * @var FrontpageService
      */
-    private $frontpageService;
+    private FrontpageService $frontpageService;
 
-    public function __construct(Frontpage $frontpageService)
+    /**
+     * FrontpageController constructor.
+     *
+     * @param FrontpageService $frontpageService
+     */
+    public function __construct(FrontpageService $frontpageService)
     {
         $this->frontpageService = $frontpageService;
     }

--- a/module/Frontpage/src/Controller/NewsAdminController.php
+++ b/module/Frontpage/src/Controller/NewsAdminController.php
@@ -2,7 +2,7 @@
 
 namespace Frontpage\Controller;
 
-use Frontpage\Service\News;
+use Frontpage\Service\News as NewsService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Paginator\Paginator;
 use Laminas\View\Model\ViewModel;
@@ -10,11 +10,16 @@ use Laminas\View\Model\ViewModel;
 class NewsAdminController extends AbstractActionController
 {
     /**
-     * @var News
+     * @var NewsService
      */
-    private $newsService;
+    private NewsService $newsService;
 
-    public function __construct(News $newsService)
+    /**
+     * NewsAdminController constructor.
+     *
+     * @param NewsService $newsService
+     */
+    public function __construct(NewsService $newsService)
     {
         $this->newsService = $newsService;
     }

--- a/module/Frontpage/src/Controller/OrganController.php
+++ b/module/Frontpage/src/Controller/OrganController.php
@@ -2,27 +2,35 @@
 
 namespace Frontpage\Controller;
 
-use Activity\Service\ActivityQuery;
-use Decision\Model\Organ;
+use Activity\Service\ActivityQuery as ActivityQueryService;
+use Decision\Service\Organ as OrganService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
 class OrganController extends AbstractActionController
 {
     /**
-     * @var \Decision\Service\Organ
+     * @var ActivityQueryService
      */
-    private $organService;
+    private ActivityQueryService $activityQueryService;
 
     /**
-     * @var ActivityQuery
+     * @var OrganService
      */
-    private $activityQueryService;
+    private OrganService $organService;
 
-    public function __construct(\Decision\Service\Organ $organService, ActivityQuery $activityQueryService)
-    {
-        $this->organService = $organService;
+    /**
+     * OrganController constructor.
+     *
+     * @param ActivityQueryService $activityQueryService
+     * @param OrganService $organService
+     */
+    public function __construct(
+        ActivityQueryService $activityQueryService,
+        OrganService $organService
+    ) {
         $this->activityQueryService = $activityQueryService;
+        $this->organService = $organService;
     }
 
     public function committeeListAction()

--- a/module/Frontpage/src/Controller/OrganController.php
+++ b/module/Frontpage/src/Controller/OrganController.php
@@ -3,6 +3,7 @@
 namespace Frontpage\Controller;
 
 use Activity\Service\ActivityQuery as ActivityQueryService;
+use Decision\Model\Organ;
 use Decision\Service\Organ as OrganService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;

--- a/module/Frontpage/src/Controller/PageAdminController.php
+++ b/module/Frontpage/src/Controller/PageAdminController.php
@@ -3,19 +3,26 @@
 namespace Frontpage\Controller;
 
 use Exception;
-use Frontpage\Service\Page;
+use Frontpage\Service\Page as PageService;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\View\Model\JsonModel;
-use Laminas\View\Model\ViewModel;
+use Laminas\View\Model\{
+    JsonModel,
+    ViewModel,
+};
 
 class PageAdminController extends AbstractActionController
 {
     /**
-     * @var Page
+     * @var PageService
      */
-    private $pageService;
+    private PageService $pageService;
 
-    public function __construct(Page $pageService)
+    /**
+     * PageAdminController constructor.
+     *
+     * @param PageService $pageService
+     */
+    public function __construct(PageService $pageService)
     {
         $this->pageService = $pageService;
     }

--- a/module/Frontpage/src/Controller/PageController.php
+++ b/module/Frontpage/src/Controller/PageController.php
@@ -2,18 +2,23 @@
 
 namespace Frontpage\Controller;
 
-use Frontpage\Service\Page;
+use Frontpage\Service\Page as PageService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
 class PageController extends AbstractActionController
 {
     /**
-     * @var Page
+     * @var PageService
      */
-    private $pageService;
+    private PageService $pageService;
 
-    public function __construct(Page $pageService)
+    /**
+     * PageController constructor.
+     *
+     * @param PageService $pageService
+     */
+    public function __construct(PageService $pageService)
     {
         $this->pageService = $pageService;
     }

--- a/module/Frontpage/src/Controller/PollAdminController.php
+++ b/module/Frontpage/src/Controller/PollAdminController.php
@@ -2,7 +2,7 @@
 
 namespace Frontpage\Controller;
 
-use Frontpage\Service\Poll;
+use Frontpage\Service\Poll as PollService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Paginator\Paginator;
 use Laminas\View\Model\ViewModel;
@@ -10,11 +10,16 @@ use Laminas\View\Model\ViewModel;
 class PollAdminController extends AbstractActionController
 {
     /**
-     * @var Poll
+     * @var PollService
      */
-    private $pollService;
+    private PollService $pollService;
 
-    public function __construct(Poll $pollService)
+    /**
+     * PollAdminController constructor.
+     *
+     * @param PollService $pollService
+     */
+    public function __construct(PollService $pollService)
     {
         $this->pollService = $pollService;
     }

--- a/module/Frontpage/src/Controller/PollController.php
+++ b/module/Frontpage/src/Controller/PollController.php
@@ -2,8 +2,9 @@
 
 namespace Frontpage\Controller;
 
-use Frontpage\Form\PollComment;
-use Frontpage\Service\Poll;
+use Frontpage\Form\PollComment as PollCommentForm;
+use Frontpage\Model\Poll as PollModel;
+use Frontpage\Service\Poll as PollService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Paginator\Paginator;
 use Laminas\View\Model\ViewModel;
@@ -11,19 +12,27 @@ use Laminas\View\Model\ViewModel;
 class PollController extends AbstractActionController
 {
     /**
-     * @var Poll
+     * @var PollCommentForm
      */
-    private $pollService;
+    private PollCommentForm $pollCommentForm;
 
     /**
-     * @var PollComment
+     * @var PollService
      */
-    private $pollCommentForm;
+    private PollService $pollService;
 
-    public function __construct(Poll $pollService, PollComment $pollCommentForm)
-    {
-        $this->pollService = $pollService;
+    /**
+     * PollController constructor.
+     *
+     * @param PollCommentForm $pollCommentForm
+     * @param PollService $pollService
+     */
+    public function __construct(
+        PollCommentForm $pollCommentForm,
+        PollService $pollService
+    ) {
         $this->pollCommentForm = $pollCommentForm;
+        $this->pollService = $pollService;
     }
 
     /**
@@ -53,7 +62,7 @@ class PollController extends AbstractActionController
     /**
      * Get the right from the route.
      *
-     * @return \Frontpage\Model\Poll|null
+     * @return PollModel|null
      */
     public function obtainPoll()
     {

--- a/module/Photo/config/module.config.php
+++ b/module/Photo/config/module.config.php
@@ -1,14 +1,24 @@
 <?php
 
-use Interop\Container\ContainerInterface;
 use Photo\Command\WeeklyPhoto;
-use Photo\Controller\AlbumAdminController;
-use Photo\Controller\AlbumController;
-use Photo\Controller\ApiController;
-use Photo\Controller\PhotoAdminController;
-use Photo\Controller\PhotoController;
-use Photo\Controller\Plugin\AlbumPlugin;
-use Photo\Controller\TagController;
+use Photo\Controller\{
+    AlbumAdminController,
+    AlbumController,
+    ApiController,
+    PhotoAdminController,
+    PhotoController,
+    TagController,
+    Plugin\AlbumPlugin,
+};
+use Photo\Controller\Factory\{
+    AlbumAdminControllerFactory,
+    AlbumControllerFactory,
+    ApiControllerFactory,
+    PhotoAdminControllerFactory,
+    PhotoControllerFactory,
+    TagControllerFactory,
+    Plugin\AlbumPluginFactory,
+};
 
 return [
     'router' => [
@@ -18,8 +28,7 @@ return [
                 'options' => [
                     'route' => '/photo',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Photo\Controller',
-                        'controller' => 'Photo',
+                        'controller' => PhotoController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -34,7 +43,7 @@ return [
                                 'page' => '[0-9]+',
                             ],
                             'defaults' => [
-                                'controller' => 'Album',
+                                'controller' => AlbumController::class,
                                 'action' => 'member',
                             ],
                         ],
@@ -48,7 +57,7 @@ return [
                                         'photo_id' => '[0-9]+',
                                     ],
                                     'defaults' => [
-                                        'controller' => 'Photo',
+                                        'controller' => PhotoController::class,
                                         'action' => 'member',
                                     ],
                                 ],
@@ -64,7 +73,7 @@ return [
                                 'page' => '[0-9]+',
                             ],
                             'defaults' => [
-                                'controller' => 'Album',
+                                'controller' => AlbumController::class,
                                 'action' => 'index',
                             ],
                         ],
@@ -78,7 +87,7 @@ return [
                                 'album_type' => '(album|member)',
                             ],
                             'defaults' => [
-                                'controller' => 'Album',
+                                'controller' => AlbumController::class,
                                 'action' => 'indexNew',
                             ],
                         ],
@@ -91,7 +100,6 @@ return [
                                 'photo_id' => '[0-9]+',
                             ],
                             'defaults' => [
-                                'controller' => 'Photo',
                                 'action' => 'view',
                             ],
                         ],
@@ -149,7 +157,6 @@ return [
                                 'photo_id' => '[0-9]+',
                             ],
                             'defaults' => [
-                                'controller' => 'Photo',
                                 'action' => 'download',
                             ],
                         ],
@@ -163,7 +170,6 @@ return [
                                 'year' => '\d{4}',
                             ],
                             'defaults' => [
-                                'controller' => 'Photo',
                                 'action' => 'index',
                             ],
                         ],
@@ -173,7 +179,6 @@ return [
                         'options' => [
                             'route' => '/weekly',
                             'defaults' => [
-                                'controller' => 'Photo',
                                 'action' => 'weekly',
                             ],
                         ],
@@ -186,7 +191,6 @@ return [
                                 'photo_id' => '[0-9]+',
                             ],
                             'defaults' => [
-                                'controller' => 'Photo',
                                 'action' => 'setProfilePhoto',
                             ],
                         ],
@@ -199,7 +203,6 @@ return [
                                 'photo_id' => '[0-9]+',
                             ],
                             'defaults' => [
-                                'controller' => 'Photo',
                                 'action' => 'removeProfilePhoto',
                             ],
                         ],
@@ -212,8 +215,7 @@ return [
                 'options' => [
                     'route' => '/admin/photo',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Photo\Controller',
-                        'controller' => 'AlbumAdmin',
+                        'controller' => AlbumAdminController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -230,7 +232,6 @@ return [
                         'options' => [
                             'route' => '/album',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'index',
                             ],
                         ],
@@ -240,7 +241,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'page',
                             ],
                             'constraints' => [
@@ -253,7 +253,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id][/:page]',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'page',
                             ],
                             'constraints' => [
@@ -267,7 +266,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]/edit',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'edit',
                             ],
                             'constraints' => [
@@ -280,7 +278,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]/create',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'create',
                             ],
                             'constraints' => [
@@ -293,7 +290,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]/add',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'add',
                             ],
                             'constraints' => [
@@ -306,7 +302,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]/import',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'import',
                             ],
                             'constraints' => [
@@ -319,7 +314,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]/upload',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'upload',
                             ],
                             'constraints' => [
@@ -332,7 +326,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]/move',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'move',
                             ],
                             'constraints' => [
@@ -345,7 +338,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]/delete',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'delete',
                             ],
                             'constraints' => [
@@ -358,7 +350,6 @@ return [
                         'options' => [
                             'route' => '/album[/:album_id]/cover',
                             'defaults' => [
-                                'controller' => 'AlbumAdmin',
                                 'action' => 'cover',
                             ],
                             'constraints' => [
@@ -371,7 +362,7 @@ return [
                         'options' => [
                             'route' => '/photo[/:photo_id]',
                             'defaults' => [
-                                'controller' => 'PhotoAdmin',
+                                'controller' => PhotoAdminController::class,
                                 'action' => 'index',
                             ],
                             'constraints' => [
@@ -384,7 +375,7 @@ return [
                         'options' => [
                             'route' => '/photo[/:photo_id]/move',
                             'defaults' => [
-                                'controller' => 'PhotoAdmin',
+                                'controller' => PhotoAdminController::class,
                                 'action' => 'move',
                             ],
                             'constraints' => [
@@ -397,7 +388,7 @@ return [
                         'options' => [
                             'route' => '/photo[/:photo_id]/delete',
                             'defaults' => [
-                                'controller' => 'PhotoAdmin',
+                                'controller' => PhotoAdminController::class,
                                 'action' => 'delete',
                             ],
                             'constraints' => [
@@ -413,8 +404,7 @@ return [
                 'options' => [
                     'route' => '/api/photo',
                     'defaults' => [
-                        '__NAMESPACE__' => 'Photo\Controller',
-                        'controller' => 'Api',
+                        'controller' => ApiController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -439,51 +429,20 @@ return [
     ],
     'controllers' => [
         'factories' => [
-            'Photo\Controller\Photo' => function (ContainerInterface $container) {
-                $photoService = $container->get('photo_service_photo');
-                $albumService = $container->get('photo_service_album');
-
-                return new PhotoController($photoService, $albumService);
-            },
-            'Photo\Controller\Tag' => function (ContainerInterface $container) {
-                $photoService = $container->get('photo_service_photo');
-
-                return new TagController($photoService);
-            },
-            'Photo\Controller\AlbumAdmin' => function (ContainerInterface $container) {
-                $adminService = $container->get('photo_service_admin');
-                $albumService = $container->get('photo_service_album');
-
-                return new AlbumAdminController($adminService, $albumService);
-            },
-            'Photo\Controller\Album' => function (ContainerInterface $container) {
-                $albumService = $container->get('photo_service_album');
-                $pageCache = $container->get('album_page_cache');
-                $photoConfig = $container->get('config')['photo'];
-
-                return new AlbumController($albumService, $pageCache, $photoConfig);
-            },
-            'Photo\Controller\PhotoAdmin' => function (ContainerInterface $container) {
-                $photoService = $container->get('photo_service_photo');
-                $albumService = $container->get('photo_service_album');
-                $entityManager = $container->get('doctrine.entitymanager.orm_default');
-
-                return new PhotoAdminController($photoService, $albumService, $entityManager);
-            },
-            'Photo\Controller\Api' => function () {
-                return new ApiController();
-            },
+            AlbumAdminController::class => AlbumAdminControllerFactory::class,
+            AlbumController::class => AlbumControllerFactory::class,
+            ApiController::class => ApiControllerFactory::class,
+            PhotoAdminController::class => PhotoAdminControllerFactory::class,
+            PhotoController::class => PhotoControllerFactory::class,
+            TagController::class => TagControllerFactory::class,
         ],
     ],
     'controller_plugins' => [
+        'aliases' => [
+            'AlbumPlugin' => AlbumPlugin::class,
+        ],
         'factories' => [
-            'AlbumPlugin' => function (ContainerInterface $container) {
-                $photoService = $container->get('photo_service_photo');
-                $albumService = $container->get('photo_service_album');
-                $photoConfig = $container->get('config')['photo'];
-
-                return new AlbumPlugin($photoService, $albumService, $photoConfig);
-            },
+            AlbumPlugin::class => AlbumPluginFactory::class,
         ],
     ],
     'view_manager' => [

--- a/module/Photo/src/Controller/AlbumAdminController.php
+++ b/module/Photo/src/Controller/AlbumAdminController.php
@@ -4,25 +4,37 @@ namespace Photo\Controller;
 
 use Exception;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\View\Model\JsonModel;
-use Laminas\View\Model\ViewModel;
-use Photo\Service\Admin;
-use Photo\Service\Album;
+use Laminas\View\Model\{
+    JsonModel,
+    ViewModel,
+};
+use Photo\Service\{
+    Admin as AdminService,
+    Album as AlbumService,
+};
 
 class AlbumAdminController extends AbstractActionController
 {
     /**
-     * @var Admin
+     * @var AdminService
      */
-    private $adminService;
+    private AdminService $adminService;
 
     /**
-     * @var Album
+     * @var AlbumService
      */
-    private $albumService;
+    private AlbumService $albumService;
 
-    public function __construct(Admin $adminService, Album $albumService)
-    {
+    /**
+     * AlbumAdminController constructor.
+     *
+     * @param AdminService $adminService
+     * @param AlbumService $albumService
+     */
+    public function __construct(
+        AdminService $adminService,
+        AlbumService $albumService
+    ) {
         $this->adminService = $adminService;
         $this->albumService = $albumService;
     }

--- a/module/Photo/src/Controller/AlbumController.php
+++ b/module/Photo/src/Controller/AlbumController.php
@@ -5,27 +5,37 @@ namespace Photo\Controller;
 use Laminas\Cache\Storage\StorageInterface;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
-use Photo\Service\Album;
+use Photo\Service\Album as AlbumService;
 
 class AlbumController extends AbstractActionController
 {
     /**
-     * @var Album
+     * @var AlbumService
      */
-    private $albumService;
+    private AlbumService $albumService;
 
     /**
      * @var StorageInterface
      */
-    private $pageCache;
+    private StorageInterface $pageCache;
 
     /**
      * @var array
      */
-    private $photoConfig;
+    private array $photoConfig;
 
-    public function __construct(Album $albumService, StorageInterface $pageCache, array $photoConfig)
-    {
+    /**
+     * AlbumController constructor.
+     *
+     * @param AlbumService $albumService
+     * @param StorageInterface $pageCache
+     * @param array $photoConfig
+     */
+    public function __construct(
+        AlbumService $albumService,
+        StorageInterface $pageCache,
+        array $photoConfig
+    ) {
         $this->albumService = $albumService;
         $this->pageCache = $pageCache;
         $this->photoConfig = $photoConfig;

--- a/module/Photo/src/Controller/Factory/AlbumAdminControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/AlbumAdminControllerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Photo\Controller\Factory;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Photo\Controller\AlbumAdminController;
+
+class AlbumAdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AlbumAdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AlbumAdminController {
+        return new AlbumAdminController(
+            $container->get('photo_service_admin'),
+            $container->get('photo_service_album'),
+        );
+    }
+}

--- a/module/Photo/src/Controller/Factory/AlbumControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/AlbumControllerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Photo\Controller\Factory;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Photo\Controller\AlbumController;
+
+class AlbumControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AlbumController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AlbumController {
+        return new AlbumController(
+            $container->get('photo_service_album'),
+            $container->get('album_page_cache'),
+            $container->get('config')['photo'],
+        );
+    }
+}

--- a/module/Photo/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/ApiControllerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Photo\Controller\Factory;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Photo\Controller\ApiController;
+
+class ApiControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return ApiController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): ApiController {
+        return new ApiController();
+    }
+}

--- a/module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Photo\Controller\Factory;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Photo\Controller\PhotoAdminController;
+
+class PhotoAdminControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return PhotoAdminController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): PhotoAdminController {
+        return new PhotoAdminController(
+            $container->get('photo_service_album'),
+            $container->get('photo_service_photo'),
+            $container->get('doctrine.entitymanager.orm_default'),
+        );
+    }
+}

--- a/module/Photo/src/Controller/Factory/PhotoControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/PhotoControllerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Photo\Controller\Factory;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Photo\Controller\PhotoController;
+
+class PhotoControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return PhotoController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): PhotoController {
+        return new PhotoController(
+            $container->get('photo_service_album'),
+            $container->get('photo_service_photo'),
+        );
+    }
+}

--- a/module/Photo/src/Controller/Factory/Plugin/AlbumPluginFactory.php
+++ b/module/Photo/src/Controller/Factory/Plugin/AlbumPluginFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Photo\Controller\Factory\Plugin;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Photo\Controller\Plugin\AlbumPlugin;
+
+class AlbumPluginFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return AlbumPlugin
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): AlbumPlugin {
+        return new AlbumPlugin(
+            $container->get('photo_service_album'),
+            $container->get('photo_service_photo'),
+            $container->get('config')['photo'],
+        );
+    }
+}

--- a/module/Photo/src/Controller/Factory/TagControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/TagControllerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Photo\Controller\Factory;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Photo\Controller\TagController;
+
+class TagControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     *
+     * @return TagController
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): TagController {
+        return new TagController(
+            $container->get('photo_service_photo'),
+        );
+    }
+}

--- a/module/Photo/src/Controller/PhotoAdminController.php
+++ b/module/Photo/src/Controller/PhotoAdminController.php
@@ -4,30 +4,44 @@ namespace Photo\Controller;
 
 use Doctrine\ORM\EntityManager;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\View\Model\JsonModel;
-use Laminas\View\Model\ViewModel;
-use Photo\Service\Album;
-use Photo\Service\Photo;
+use Laminas\View\Model\{
+    JsonModel,
+    ViewModel,
+};
+use Photo\Service\{
+    Album as AlbumService,
+    Photo as PhotoService,
+};
 
 class PhotoAdminController extends AbstractActionController
 {
     /**
-     * @var Photo
+     * @var AlbumService
      */
-    private $photoService;
+    private AlbumService $albumService;
+
+    /**
+     * @var PhotoService
+     */
+    private PhotoService $photoService;
 
     /**
      * @var EntityManager
      */
-    private $entityManager;
+    private EntityManager $entityManager;
 
     /**
-     * @var Album
+     * PhotoAdminController constructor.
+     *
+     * @param AlbumService $albumService
+     * @param PhotoService $photoService
+     * @param EntityManager $entityManager
      */
-    private $albumService;
-
-    public function __construct(Photo $photoService, Album $albumService, EntityManager $entityManager)
-    {
+    public function __construct(
+        AlbumService $albumService,
+        PhotoService $photoService,
+        EntityManager $entityManager
+    ) {
         $this->photoService = $photoService;
         $this->albumService = $albumService;
         $this->entityManager = $entityManager;

--- a/module/Photo/src/Controller/PhotoController.php
+++ b/module/Photo/src/Controller/PhotoController.php
@@ -4,25 +4,37 @@ namespace Photo\Controller;
 
 use Exception;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\View\Model\JsonModel;
-use Laminas\View\Model\ViewModel;
-use Photo\Service\Album;
-use Photo\Service\Photo;
+use Laminas\View\Model\{
+    JsonModel,
+    ViewModel,
+};
+use Photo\Service\{
+    Album as AlbumService,
+    Photo as PhotoService,
+};
 
 class PhotoController extends AbstractActionController
 {
     /**
-     * @var Photo
+     * @var AlbumService
      */
-    private $photoService;
+    private AlbumService $albumService;
 
     /**
-     * @var Album
+     * @var PhotoService
      */
-    private $albumService;
+    private PhotoService $photoService;
 
-    public function __construct(Photo $photoService, Album $albumService)
-    {
+    /**
+     * PhotoController constructor.
+     *
+     * @param AlbumService $albumService
+     * @param PhotoService $photoService
+     */
+    public function __construct(
+        AlbumService $albumService,
+        PhotoService $photoService
+    ) {
         $this->photoService = $photoService;
         $this->albumService = $albumService;
     }

--- a/module/Photo/src/Controller/Plugin/AlbumPlugin.php
+++ b/module/Photo/src/Controller/Plugin/AlbumPlugin.php
@@ -5,8 +5,10 @@ namespace Photo\Controller\Plugin;
 use Exception;
 use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
 use Laminas\Paginator;
-use Photo\Service\Album;
-use Photo\Service\Photo;
+use Photo\Service\{
+    Album as AlbumService,
+    Photo as PhotoService,
+};
 
 /**
  * This plugin helps with rendering the pages doing album related stuff.
@@ -14,22 +16,32 @@ use Photo\Service\Photo;
 class AlbumPlugin extends AbstractPlugin
 {
     /**
-     * @var Photo
+     * @var AlbumService
      */
-    private $photoService;
+    private AlbumService $albumService;
 
     /**
-     * @var Album
+     * @var PhotoService
      */
-    private $albumService;
+    private PhotoService $photoService;
 
     /**
      * @var array
      */
-    private $photoConfig;
+    private array $photoConfig;
 
-    public function __construct(Photo $photoService, Album $albumService, array $photoConfig)
-    {
+    /**
+     * AlbumPlugin constructor.
+     *
+     * @param AlbumService $albumService
+     * @param PhotoService $photoService
+     * @param array $photoConfig
+     */
+    public function __construct(
+        AlbumService $albumService,
+        PhotoService $photoService,
+        array $photoConfig
+    ) {
         $this->photoService = $photoService;
         $this->albumService = $albumService;
         $this->photoConfig = $photoConfig;

--- a/module/Photo/src/Controller/TagController.php
+++ b/module/Photo/src/Controller/TagController.php
@@ -4,16 +4,21 @@ namespace Photo\Controller;
 
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
-use Photo\Service\Photo;
+use Photo\Service\Photo as PhotoService;
 
 class TagController extends AbstractActionController
 {
     /**
-     * @var Photo
+     * @var PhotoService
      */
-    private $photoService;
+    private PhotoService $photoService;
 
-    public function __construct(Photo $photoService)
+    /**
+     * TagController constructor.
+     *
+     * @param PhotoService $photoService
+     */
+    public function __construct(PhotoService $photoService)
     {
         $this->photoService = $photoService;
     }

--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -1,11 +1,17 @@
 <?php
 
-use Interop\Container\ContainerInterface;
-use User\Controller\ApiAdminController;
-use User\Controller\ApiAuthenticationController;
-use User\Controller\ApiController;
-use User\Controller\Factory\ApiAuthenticationControllerFactory;
-use User\Controller\UserController;
+use User\Controller\{
+    ApiAdminController,
+    ApiAuthenticationController,
+    ApiController,
+    UserController,
+};
+use User\Controller\Factory\{
+    ApiAdminControllerFactory,
+    ApiAuthenticationControllerFactory,
+    ApiControllerFactory,
+    UserControllerFactory,
+};
 
 return [
     'router' => [
@@ -15,8 +21,7 @@ return [
                 'options' => [
                     'route' => '/user',
                     'defaults' => [
-                        '__NAMESPACE__' => 'User\Controller',
-                        'controller' => 'User',
+                        'controller' => UserController::class,
                         'action' => 'index',
                     ],
                 ],
@@ -88,9 +93,6 @@ return [
                 'type' => 'Literal',
                 'options' => [
                     'route' => '/admin/user',
-                    'defaults' => [
-                        '__NAMESPACE__' => 'User\Controller',
-                    ],
                 ],
                 'may_terminate' => false,
                 'child_routes' => [
@@ -99,7 +101,7 @@ return [
                         'options' => [
                             'route' => '/api',
                             'defaults' => [
-                                'controller' => 'ApiAdmin',
+                                'controller' => ApiAdminController::class,
                                 'action' => 'index',
                             ],
                         ],
@@ -136,7 +138,7 @@ return [
                 'options' => [
                     'route' => '/token/:appId',
                     'defaults' => [
-                        'controller' => '\User\Controller\ApiAuthenticationController',
+                        'controller' => ApiAuthenticationController::class,
                         'action' => 'token',
                     ],
                 ],
@@ -147,7 +149,7 @@ return [
                 'options' => [
                     'route' => '/api/validateLogin',
                     'defaults' => [
-                        'controller' => '\User\Controller\Api',
+                        'controller' => ApiController::class,
                         'action' => 'validate',
                     ],
                 ],
@@ -157,23 +159,10 @@ return [
     ],
     'controllers' => [
         'factories' => [
-            'User\Controller\User' => function (ContainerInterface $container) {
-                $userService = $container->get('user_service_user');
-
-                return new UserController($userService);
-            },
-            'User\Controller\Api' => function (ContainerInterface $container) {
-                $memberInfoService = $container->get('decision_service_memberinfo');
-                $aclService = $container->get('user_service_acl');
-
-                return new ApiController($memberInfoService, $aclService);
-            },
-            'User\Controller\ApiAdmin' => function (ContainerInterface $container) {
-                $apiUserService = $container->get('user_service_apiuser');
-
-                return new ApiAdminController($apiUserService);
-            },
+            ApiAdminController::class => ApiAdminControllerFactory::class,
             ApiAuthenticationController::class => ApiAuthenticationControllerFactory::class,
+            ApiController::class => ApiControllerFactory::class,
+            UserController::class => UserControllerFactory::class,
         ],
     ],
     'view_manager' => [

--- a/module/User/src/Controller/ApiAdminController.php
+++ b/module/User/src/Controller/ApiAdminController.php
@@ -4,17 +4,21 @@ namespace User\Controller;
 
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
-use User\Service\ApiUser;
-use User\Service\User;
+use User\Service\ApiUser as ApiUserService;
 
 class ApiAdminController extends AbstractActionController
 {
     /**
-     * @var ApiUser
+     * @var ApiUserService
      */
-    private $apiUserService;
+    private ApiUserService$apiUserService;
 
-    public function __construct(User $apiUserService)
+    /**
+     * ApiAdminController constructor.
+     *
+     * @param ApiUserService $apiUserService
+     */
+    public function __construct(ApiUserService $apiUserService)
     {
         $this->apiUserService = $apiUserService;
     }

--- a/module/User/src/Controller/ApiAuthenticationController.php
+++ b/module/User/src/Controller/ApiAuthenticationController.php
@@ -5,29 +5,33 @@ namespace User\Controller;
 use Laminas\Mvc\Controller\AbstractActionController;
 use User\Model\User;
 use User\Permissions\NotAllowedException;
-use User\Service\AclService;
-use User\Service\ApiApp;
-use User\Service\User as UserService;
+use User\Service\{
+    AclService,
+    ApiApp as ApiAppService,
+};
 
 class ApiAuthenticationController extends AbstractActionController
 {
     /**
-     * @var UserService
+     * @var ApiAppService
      */
-    protected $userService;
+    protected ApiAppService $apiAppService;
 
     /**
-     * @var ApiApp
+     * @var AclService
      */
-    protected $apiAppService;
     private AclService $aclService;
 
     /**
      * ApiAuthenticationController constructor.
+     *
+     * @param ApiAppService $apiAppService
+     * @param AclService $aclService
      */
-    public function __construct(UserService $userService, ApiApp $apiAppService, AclService $aclService)
-    {
-        $this->userService = $userService;
+    public function __construct(
+        ApiAppService $apiAppService,
+        AclService $aclService
+    ) {
         $this->apiAppService = $apiAppService;
         $this->aclService = $aclService;
     }
@@ -42,23 +46,7 @@ class ApiAuthenticationController extends AbstractActionController
         }
 
         return $this->redirect()->toUrl(
-            $this->getApiAppService()->callbackWithToken($appId, $identity)
+            $this->apiAppService->callbackWithToken($appId, $identity)
         );
-    }
-
-    /**
-     * @return UserService
-     */
-    public function getUserService()
-    {
-        return $this->userService;
-    }
-
-    /**
-     * @return ApiApp
-     */
-    public function getApiAppService()
-    {
-        return $this->apiAppService;
     }
 }

--- a/module/User/src/Controller/ApiController.php
+++ b/module/User/src/Controller/ApiController.php
@@ -1,30 +1,33 @@
 <?php
 
-/**
- * Zend Framework (http://framework.zend.com/).
- *
- * @see      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
- *
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
- */
-
 namespace User\Controller;
 
-use Decision\Service\MemberInfo;
+use Decision\Service\MemberInfo as MemberInfoService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use User\Service\AclService;
 
 class ApiController extends AbstractActionController
 {
     /**
-     * @var MemberInfo
+     * @var MemberInfoService
      */
-    private $memberInfoService;
+    private MemberInfoService $memberInfoService;
+
+    /**
+     * @var AclService
+     */
     private AclService $aclService;
 
-    public function __construct(MemberInfo $memberInfoService, AclService $aclService)
-    {
+    /**
+     * ApiController constructor.
+     *
+     * @param MemberInfoService $memberInfoService
+     * @param AclService $aclService
+     */
+    public function __construct(
+        MemberInfoService $memberInfoService,
+        AclService $aclService
+    ) {
         $this->memberInfoService = $memberInfoService;
         $this->aclService = $aclService;
     }

--- a/module/User/src/Controller/Factory/ApiAdminControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiAdminControllerFactory.php
@@ -4,26 +4,24 @@ namespace User\Controller\Factory;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use User\Controller\ApiAuthenticationController;
-use User\Service\ApiApp as ApiAppService;
+use User\Controller\ApiAdminController;
 
-class ApiAuthenticationControllerFactory implements FactoryInterface
+class ApiAdminControllerFactory implements FactoryInterface
 {
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
      * @param null|array $options
      *
-     * @return ApiAuthenticationController
+     * @return ApiAdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
         array $options = null
-    ): ApiAuthenticationController {
-        return new ApiAuthenticationController(
-            $container->get(ApiAppService::class),
-            $container->get('user_service_acl')
+    ): ApiAdminController {
+        return new ApiAdminController(
+            $container->get('user_service_apiuser')
         );
     }
 }

--- a/module/User/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiControllerFactory.php
@@ -4,25 +4,24 @@ namespace User\Controller\Factory;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use User\Controller\ApiAuthenticationController;
-use User\Service\ApiApp as ApiAppService;
+use User\Controller\ApiController;
 
-class ApiAuthenticationControllerFactory implements FactoryInterface
+class ApiControllerFactory implements FactoryInterface
 {
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
      * @param null|array $options
      *
-     * @return ApiAuthenticationController
+     * @return ApiController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
         array $options = null
-    ): ApiAuthenticationController {
-        return new ApiAuthenticationController(
-            $container->get(ApiAppService::class),
+    ): ApiController {
+        return new ApiController(
+            $container->get('decision_service_memberinfo'),
             $container->get('user_service_acl')
         );
     }

--- a/module/User/src/Controller/Factory/UserControllerFactory.php
+++ b/module/User/src/Controller/Factory/UserControllerFactory.php
@@ -4,26 +4,24 @@ namespace User\Controller\Factory;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use User\Controller\ApiAuthenticationController;
-use User\Service\ApiApp as ApiAppService;
+use User\Controller\UserController;
 
-class ApiAuthenticationControllerFactory implements FactoryInterface
+class UserControllerFactory implements FactoryInterface
 {
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
      * @param null|array $options
      *
-     * @return ApiAuthenticationController
+     * @return UserController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
         array $options = null
-    ): ApiAuthenticationController {
-        return new ApiAuthenticationController(
-            $container->get(ApiAppService::class),
-            $container->get('user_service_acl')
+    ): UserController {
+        return new UserController(
+            $container->get('user_service_user')
         );
     }
 }

--- a/module/User/src/Controller/UserController.php
+++ b/module/User/src/Controller/UserController.php
@@ -3,18 +3,25 @@
 namespace User\Controller;
 
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\View\Model\JsonModel;
-use Laminas\View\Model\ViewModel;
-use User\Service\User;
+use Laminas\View\Model\{
+    JsonModel,
+    ViewModel,
+};
+use User\Service\User as UserService;
 
 class UserController extends AbstractActionController
 {
     /**
-     * @var User
+     * @var UserService
      */
-    private $userService;
+    private UserService $userService;
 
-    public function __construct(User $userService)
+    /**
+     * UserController constructor.
+     *
+     * @param UserService $userService
+     */
+    public function __construct(UserService $userService)
     {
         $this->userService = $userService;
     }


### PR DESCRIPTION
This PR changes the way controller factories are created. Instead of closures in each module's `module.config.php` each controller now has its own factory under `./Controller/Factory/`.

This change should make the code easier to maintain and adapt.

This also fixes #1132 and fixes #1135.