### PR TITLE
Remove never shown message for unsuccessful activity option creation

### DIFF
--- a/module/Activity/view/activity/activity-calendar/create.phtml
+++ b/module/Activity/view/activity/activity-calendar/create.phtml
@@ -68,15 +68,6 @@ $form->prepare();
             </div>
         <?php endif ?>
         <?= $this->form()->openTag($form) ?>
-        <?php if ($success === false): ?>
-            <div class="row spacing-top--md">
-                <div class="col-md-12">
-                    <div class="alert alert-danger" role="alert">
-                        <i class="fas fa-exclamation-circle"></i> <?= $this->translate('The activity could not be saved. Check and correct your input data.') ?>
-                    </div>
-                </div>
-            </div>
-        <?php endif ?>
         <div class="row spacing-top--md">
             <div class="col-md-12">
                 <h3><?= $this->translate('Details') ?></h3>


### PR DESCRIPTION
The form itself gives errors which detail what the user should do. It is therefore not necessary to have an additional message to let the user know the form is invalid. The `success` variable was removed in ea5431dd129ee8f146317c213ef2b1e64b3b279e in favour of custom error messages in the form.

This fixes #1152.