### PR TITLE
Fixed ACL permissions for myActivities nav item

### DIFF
--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -193,7 +193,7 @@ $lang = $this->plugin('translate')->getTranslator()->getLocale();
                                 <?= $this->translate('Activities') ?>
                             </a>
                         </li>
-                        <?php if ($this->acl('activity_service_acl')->isAllowed('activity', 'view')): ?>
+                        <?php if ($this->acl('activity_service_acl')->isAllowed('myActivities', 'view')): ?>
                             <li><a href="<?= $this->url('activity/my') ?>"> <?= $this->translate('My activities') ?></a>
                             </li>
                         <?php endif; ?>


### PR DESCRIPTION
Fixed a bug which caused the "My activities" dropdown item to display when a user was not logged in. Done by changing the ACL permission from `isAllowed('activities', 'view')` to `isAllowed('myActivities', 'view')`.

This fixes #1162.