### PR TITLE
Fix company language profiles not updating correctly

### DIFF
--- a/module/Company/config/module.config.php
+++ b/module/Company/config/module.config.php
@@ -160,7 +160,7 @@ return [
                                         'action' => 'editPackage',
                                     ],
                                     'constraints' => [
-                                        'packageId' => '[a-zA-Z0-9_-]*',
+                                        'packageId' => '[0-9]*',
                                     ],
                                 ],
                                 'may_terminate' => true,

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -113,6 +113,10 @@ class AdminController extends AbstractActionController
      */
     public function addCompanyAction()
     {
+        if (!$this->aclService->isAllowed('insert', 'company')) {
+            throw new NotAllowedException($this->translator->translate('You are not allowed to create a company'));
+        }
+
         // Handle incoming form results
         $request = $this->getRequest();
         if ($request->isPost()) {

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -126,7 +126,7 @@ class AdminController extends AbstractActionController
                 $request->getFiles(),
             );
 
-            if (!is_null($company)) {
+            if ($company) {
                 // Redirect to edit page
                 return $this->redirect()->toRoute(
                     'admin_company/default',
@@ -423,6 +423,7 @@ class AdminController extends AbstractActionController
         $request = $this->getRequest();
         if ($request->isPost()) {
             $post = $request->getPost();
+
             if (
                 $this->companyService->saveCompanyByData(
                     $company,

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -119,8 +119,9 @@ class AdminController extends AbstractActionController
             // Check if data is valid, and insert when it is
             $company = $this->companyService->insertCompanyByData(
                 $request->getPost(),
-                $request->getFiles()
+                $request->getFiles(),
             );
+
             if (!is_null($company)) {
                 // Redirect to edit page
                 return $this->redirect()->toRoute(
@@ -422,7 +423,7 @@ class AdminController extends AbstractActionController
                 $this->companyService->saveCompanyByData(
                     $company,
                     $post,
-                    $request->getFiles()
+                    $request->getFiles(),
                 )
             ) {
                 $companyName = $request->getPost()['slugName'];

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -175,13 +175,11 @@ class AdminController extends AbstractActionController
         // Handle incoming form results
         $request = $this->getRequest();
         if ($request->isPost()) {
-            $files = $request->getFiles();
-
             if (
                 $this->companyService->insertPackageForCompanySlugNameByData(
                     $companyName,
                     $request->getPost(),
-                    $files['banner'],
+                    $request->getFiles(),
                     $type
                 )
             ) {
@@ -220,7 +218,7 @@ class AdminController extends AbstractActionController
      */
     public function addJobAction()
     {
-        // Get useful stuf
+        // Get useful stuff
         $companyForm = $this->companyService->getJobForm();
 
         // Get parameters

--- a/module/Company/src/Controller/CompanyController.php
+++ b/module/Company/src/Controller/CompanyController.php
@@ -76,12 +76,19 @@ class CompanyController extends AbstractActionController
 
         if (!is_null($company)) {
             if (!$company->isHidden()) {
-                return new ViewModel(
-                    [
-                        'company' => $company,
-                        'translator' => $this->translator,
-                    ]
-                );
+                if (
+                    in_array(
+                        $this->translator->getTranslator()->getLocale(),
+                        $company->getAvailableLanguages()->toArray(),
+                    )
+                ) {
+                    return new ViewModel(
+                        [
+                            'company' => $company,
+                            'translator' => $this->translator,
+                        ]
+                    );
+                }
             }
         }
 

--- a/module/Company/src/Model/Company.php
+++ b/module/Company/src/Model/Company.php
@@ -88,8 +88,6 @@ class Company // implements ArrayHydrator (for zend2 form)
      */
     protected $packages;
 
-    private $languageNeutralId;
-
     /**
      * Constructor.
      */
@@ -112,15 +110,11 @@ class Company // implements ArrayHydrator (for zend2 form)
     /**
      * Get the company's translations.
      *
-     * @return Collection|array
+     * @return Collection
      */
     public function getTranslations()
     {
-        if (!is_null($this->translations)) {
-            return $this->translations;
-        }
-
-        return [];
+        return $this->translations;
     }
 
     /**
@@ -399,47 +393,35 @@ class Company // implements ArrayHydrator (for zend2 form)
     }
 
     /**
-     * Get the company's language.
+     * Returns the available languages (translations) for this company.
      *
-     * @return int
+     * @return Collection
      */
-    public function getLanguageNeutralId()
+    public function getAvailableLanguages(): Collection
     {
-        return $this->languageNeutralId;
-    }
-
-    /**
-     * Set the company's language neutral id.
-     *
-     * @param int $language
-     */
-    public function setLanguageNeutralId($language)
-    {
-        $this->languageNeutralId = $language;
-    }
-
-    /**
-     * If this object contains an translation for a given locale, it is returned, otherwise null is returned.
-     */
-    public function getTranslationFromLocale($locale)
-    {
-        $companyLanguages = $this->getTranslations()->map(
+        return $this->getTranslations()->map(
             function ($value) {
                 return $value->getLanguage();
             }
         );
+    }
+
+    /**
+     * If this object contains an translation for a given locale, it is returned, otherwise null is returned.
+     *
+     * @param $locale
+     *
+     * @return mixed|null
+     */
+    public function getTranslationFromLocale($locale)
+    {
+        $companyLanguages = $this->getAvailableLanguages();
 
         if ($companyLanguages->contains($locale)) {
             return $this->getTranslations()[$companyLanguages->indexOf($locale)];
         }
 
-        throw new Exception(
-            sprintf(
-                'Requested non-existent translation for locale %s of company with language neutral id %d',
-                $locale,
-                $this->getLanguageNeutralId()
-            )
-        );
+        return null;
     }
 
     /**
@@ -466,7 +448,7 @@ class Company // implements ArrayHydrator (for zend2 form)
      * @param mixed $data
      * @param mixed $language
      */
-    public function getTranslationFromArray($data, $language)
+    public function updateTranslationFromArray($data, $language)
     {
         if ('' !== $language) {
             $translation = $this->getTranslationFromLocale($language);
@@ -495,19 +477,10 @@ class Company // implements ArrayHydrator (for zend2 form)
     {
         $languages = $data['languages'];
 
-        $newTranslations = new ArrayCollection();
-
         foreach ($languages as $language) {
-            $newTranslationObject = $this->getTranslationFromArray($data, $language);
-            $newTranslations->add($newTranslationObject);
+            $this->updateTranslationFromArray($data, $language);
         }
 
-        // Delete old translations
-        foreach ($this->getTranslations() as $translation) {
-            if (!$newTranslations->contains($translation)) {
-                $translation->remove();
-            }
-        }
         $this->setName($this->updateIfSet($data['name'], ''));
         $this->setContactName($this->updateIfSet($data['contactName'], ''));
         $this->setSlugName($this->updateIfSet($data['slugName'], ''));
@@ -515,7 +488,6 @@ class Company // implements ArrayHydrator (for zend2 form)
         $this->setEmail($this->updateIfSet($data['email'], ''));
         $this->setPhone($this->updateIfSet($data['phone'], ''));
         $this->setHidden($this->updateIfSet($data['hidden'], ''));
-        $this->translations = $newTranslations;
     }
 
     /**

--- a/module/Company/src/Model/Company.php
+++ b/module/Company/src/Model/Company.php
@@ -407,13 +407,13 @@ class Company // implements ArrayHydrator (for zend2 form)
     }
 
     /**
-     * If this object contains an translation for a given locale, it is returned, otherwise null is returned.
+     * If this object contains a translation for a given locale, it is returned, otherwise null is returned.
      *
-     * @param $locale
+     * @param string $locale
      *
      * @return mixed|null
      */
-    public function getTranslationFromLocale($locale)
+    public function getTranslationFromLocale(string $locale)
     {
         $companyLanguages = $this->getAvailableLanguages();
 

--- a/module/Company/src/Model/CompanyI18n.php
+++ b/module/Company/src/Model/CompanyI18n.php
@@ -203,9 +203,4 @@ class CompanyI18n //implements ArrayHydrator (for zend2 form)
     {
         $this->language = $language;
     }
-
-    public function remove()
-    {
-        $this->company = null;
-    }
 }

--- a/module/Company/src/Service/Company.php
+++ b/module/Company/src/Service/Company.php
@@ -756,21 +756,23 @@ class Company
      *
      * @param int|string $languageNeutralId Identifier of the Job to save
      * @param array $jobs The Job to save
-     * @param array $data The (new) data to save
-     * @param array $files The (new) files to save
+     * @param Parameters $data The (new) data to save
+     * @param Parameters $files The (new) files to save
      *
      * @return bool
      */
-    public function saveJobData($languageNeutralId, $jobs, $data, $files)
+    public function saveJobData($languageNeutralId, $jobs, Parameters $data, Parameters $files)
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit jobs'));
         }
 
         $jobForm = $this->getJobForm();
+        $dataArray = $data->toArray();
+        $filesArray = $files->toArray();
         $mergedData = array_merge_recursive(
-            $data,
-            $files
+            $dataArray,
+            $filesArray,
         );
         $jobForm->setCompanySlug(current($jobs)->getCompany()->getSlugName());
         $jobForm->setCurrentSlug($data['slugName']);

--- a/module/Company/src/Service/Company.php
+++ b/module/Company/src/Service/Company.php
@@ -566,7 +566,18 @@ class Company
                     }
                 }
             }
+
+            // Save the company data, removing any translations cannot be done in the same UnitOfWork.
             $this->saveCompany();
+
+            // Remove translations if necessary.
+            $enabledLanguages = $data['languages'];
+            foreach ($company->getTranslations() as $translation) {
+                if (!in_array($translation->getLanguage(), $enabledLanguages)) {
+                    $company->removeTranslation($translation);
+                    $this->companyMapper->removeTranslation($translation);
+                }
+            }
 
             return true;
         }
@@ -601,7 +612,7 @@ class Company
     /**
      * Saves all modified companies.
      */
-    public function saveCompany()
+    public function saveCompany(): void
     {
         $this->companyMapper->save();
     }

--- a/module/Company/src/Service/Company.php
+++ b/module/Company/src/Service/Company.php
@@ -13,6 +13,7 @@ use Company\Form\{
 use Company\Mapper\{
     BannerPackage as BannerPackageMapper,
     Category as CategoryMapper,
+    Company as CompanyMapper,
     FeaturedPackage as FeaturedPackageMapper,
     Job as JobMapper,
     Label as LabelMapper,
@@ -22,8 +23,8 @@ use Company\Mapper\{
 use Company\Model\{
     Company as CompanyModel,
     Job as JobModel,
-    JobCategory as CategoryModel,
-    JobLabel as LabelModel,
+    JobCategory as JobCategoryModel,
+    JobLabel as JobLabelModel,
     JobLabelAssignment as JobLabelAssignmentModel,
 };
 use DateTime;
@@ -41,98 +42,102 @@ class Company
     /**
      * @var Translator
      */
-    private $translator;
+    private Translator $translator;
 
     /**
      * @var FileStorage
      */
-    private $storageService;
+    private FileStorage $storageService;
 
     /**
-     * @var \Company\Mapper\Company
+     * @var CompanyMapper
      */
-    private $companyMapper;
+    private CompanyMapper $companyMapper;
 
     /**
      * @var PackageMapper
      */
-    private $packageMapper;
+    private PackageMapper $packageMapper;
 
     /**
      * @var BannerPackageMapper
      */
-    private $bannerPackageMapper;
+    private BannerPackageMapper $bannerPackageMapper;
 
     /**
      * @var FeaturedPackageMapper
      */
-    private $featuredPackageMapper;
+    private FeaturedPackageMapper $featuredPackageMapper;
 
     /**
      * @var JobMapper
      */
-    private $jobMapper;
+    private JobMapper $jobMapper;
 
     /**
      * @var CategoryMapper
      */
-    private $categoryMapper;
+    private CategoryMapper $categoryMapper;
 
     /**
      * @var LabelMapper
      */
-    private $labelMapper;
+    private LabelMapper $labelMapper;
 
     /**
      * @var LabelAssignmentMapper
      */
-    private $labelAssignmentMapper;
+    private LabelAssignmentMapper $labelAssignmentMapper;
 
     /**
      * @var EditCompanyForm
      */
-    private $editCompanyForm;
+    private EditCompanyForm $editCompanyForm;
 
     /**
      * @var EditPackageForm
      */
-    private $editPackageForm;
+    private EditPackageForm $editPackageForm;
 
     /**
      * @var EditPackageForm
      */
-    private $editBannerPackageForm;
+    private EditPackageForm $editBannerPackageForm;
 
     /**
      * @var EditPackageForm
      */
-    private $editFeaturedPackageForm;
+    private EditPackageForm $editFeaturedPackageForm;
 
     /**
      * @var EditJobForm
      */
-    private $editJobForm;
+    private EditJobForm $editJobForm;
 
     /**
      * @var EditCategoryForm
      */
-    private $editCategoryForm;
+    private EditCategoryForm $editCategoryForm;
 
     /**
      * @var EditLabelForm
      */
-    private $editLabelForm;
+    private EditLabelForm $editLabelForm;
 
     /**
      * @var array
      */
-    private $languages;
+    private array $languages;
+
+    /**
+     * @var AclService
+     */
     private AclService $aclService;
 
     public function __construct(
         Translator $translator,
         FileStorage $storageService,
-        \Company\Mapper\Company $companyMapper,
+        CompanyMapper $companyMapper,
         PackageMapper $packageMapper,
         BannerPackageMapper $bannerPackageMapper,
         FeaturedPackageMapper $featuredPackageMapper,
@@ -288,7 +293,7 @@ class Company
      *
      * @param int $id
      *
-     * @return \Company\Model\Company|null
+     * @return CompanyModel|null
      */
     public function getCompanyById($id)
     {
@@ -316,15 +321,15 @@ class Company
     }
 
     /**
-     * Creates a new JobCategory.
+     * Creates a new JobCategoryModel.
      *
-     * @param array $data Category data from the EditCategory form
+     * @param Parameters $data Category data from the EditCategory form
      *
      * @return bool|int Returns false on failure, and the languageNeutralId on success
      *
      * @throws NotAllowedException When a user is not allowed to create a job category
      */
-    public function createCategory($data)
+    public function createCategory(Parameters $data)
     {
         if (!$this->aclService->isAllowed('insert', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to insert a job category'));
@@ -332,24 +337,24 @@ class Company
 
         $categoryDict = [];
         foreach ($this->languages as $lang) {
-            $category = new CategoryModel();
+            $category = new JobCategoryModel();
             $category->setLanguage($lang);
             $categoryDict[$lang] = $category;
         }
 
-        return $this->saveCategoryData('', $categoryDict, $data);
+        return $this->saveCategoryData(null, $categoryDict, $data);
     }
 
     /**
-     * Checks if the data is valid, and if it is, saves the JobCategory.
+     * Checks if the data is valid, and if it is, saves the JobCategoryModel.
      *
-     * @param int|string $languageNeutralId Identifier of the JobCategories to save
+     * @param int|null $languageNeutralId Identifier of the JobCategories to save
      * @param array $categories The JobCategories to save
-     * @param array $data The (new) data to save
+     * @param Parameters $data The (new) data to save
      *
      * @return bool|int Returns false on failure, and the languageNeutralId on success
      */
-    public function saveCategoryData($languageNeutralId, $categories, $data)
+    public function saveCategoryData(?int $languageNeutralId, array $categories, Parameters $data)
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit job categories'));
@@ -370,26 +375,26 @@ class Company
             $this->saveCategory();
         }
 
-        return ('' == $languageNeutralId) ? $id : $languageNeutralId;
+        return (null === $languageNeutralId) ? $id : $languageNeutralId;
     }
 
     /**
-     * Sets the languageNeutralId for this JobCategory.
+     * Sets the languageNeutralId for this JobCategoryModel.
      *
-     * @param int $id The id of the JobCategory
-     * @param CategoryModel $category The JobCategory
-     * @param int|string $languageNeutralId The languageNeutralId of the JobCategory
+     * @param int $id The id of the JobCategoryModel
+     * @param JobCategoryModel $category The JobCategoryModel
+     * @param int|null $languageNeutralId The languageNeutralId of the JobCategoryModel
      *
      * @return int
      */
-    private function setLanguageNeutralCategoryId($id, $category, $languageNeutralId)
+    private function setLanguageNeutralCategoryId(int $id, JobCategoryModel $category, ?int $languageNeutralId): int
     {
-        if ('' == $languageNeutralId) {
+        if (null === $languageNeutralId) {
             $category->setLanguageNeutralId($id);
             $this->categoryMapper->persist($category);
             $this->saveCategory();
 
-            if (-1 == $id) {
+            if (-1 === $id) {
                 $id = $category->getId();
             }
 
@@ -404,15 +409,15 @@ class Company
     }
 
     /**
-     * Creates a new JobLabel.
+     * Creates a new JobLabelModel.
      *
-     * @param array $data Label data from the EditLabel form
+     * @param Parameters $data Label data from the EditLabel form
      *
      * @return bool|int Returns false on failure, and the languageNeutralId on success
      *
      * @throws NotAllowedException When a user is not allowed to create a job label
      */
-    public function createLabel($data)
+    public function createLabel(Parameters $data)
     {
         if (!$this->aclService->isAllowed('insert', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to insert a job label'));
@@ -420,24 +425,24 @@ class Company
 
         $labelDict = [];
         foreach ($this->languages as $lang) {
-            $label = new LabelModel();
+            $label = new JobLabelModel();
             $label->setLanguage($lang);
             $labelDict[$lang] = $label;
         }
 
-        return $this->saveLabelData('', $labelDict, $data);
+        return $this->saveLabelData(null, $labelDict, $data);
     }
 
     /**
-     * Checks if the data is valid, and if it is, saves the JobLabel.
+     * Checks if the data is valid, and if it is, saves the JobLabelModel.
      *
-     * @param int|string $languageNeutralId Identifier of the JobLabel to save
-     * @param array $labels The JobLabels to save
-     * @param array $data The data to validate, and apply to the label
+     * @param int|null $languageNeutralId Identifier of the JobLabelModel to save
+     * @param array $labels The JobLabelModels to save
+     * @param Parameters $data The data to validate, and apply to the label
      *
      * @return bool|int
      */
-    public function saveLabelData($languageNeutralId, $labels, $data)
+    public function saveLabelData(?int $languageNeutralId, array $labels, Parameters $data)
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit job labels'));
@@ -458,26 +463,26 @@ class Company
             $this->saveLabel();
         }
 
-        return ('' == $languageNeutralId) ? $id : $languageNeutralId;
+        return (null === $languageNeutralId) ? $id : $languageNeutralId;
     }
 
     /**
-     * Sets the languageNeutralId for this JobLabel.
+     * Sets the languageNeutralId for this JobLabelModel.
      *
-     * @param int $id The id of the JobLabel
-     * @param LabelModel $label The JobLabel
-     * @param int|string $languageNeutralId The languageNeutralId of the JobLabel
+     * @param int $id The id of the JobLabelModel
+     * @param JobLabelModel $label The JobLabelModel
+     * @param int|null $languageNeutralId The languageNeutralId of the JobLabelModel
      *
      * @return int
      */
-    private function setLanguageNeutralLabelId($id, $label, $languageNeutralId)
+    private function setLanguageNeutralLabelId(int $id, JobLabelModel $label, ?int $languageNeutralId): int
     {
-        if ('' == $languageNeutralId) {
+        if (null === $languageNeutralId) {
             $label->setLanguageNeutralId($id);
             $this->labelMapper->persist($label);
             $this->saveLabel();
 
-            if (-1 == $id) {
+            if (-1 === $id) {
                 $id = $label->getId();
             }
 
@@ -495,32 +500,44 @@ class Company
      * Checks if the data is valid, and if it is saves the package.
      *
      * @param mixed $package
-     * @param mixed $data
+     * @param Parameters $data
+     * @param Parameters $files
+     *
+     * @return bool
+     * @throws Exception
      */
-    public function savePackageByData($package, $data, $files)
+    public function savePackageByData($package, Parameters $data, Parameters $files): bool
     {
         $packageForm = $this->getPackageForm();
         $packageForm->setData($data);
+
         if ($packageForm->isValid()) {
             $package->exchangeArray($data);
+
             if ('banner' == $package->getType()) {
                 $file = $files['banner'];
+
                 if (UPLOAD_ERR_NO_FILE !== $file['error']) {
                     if (UPLOAD_ERR_OK !== $file['error']) {
                         return false;
                     }
+
                     $oldPath = $package->getImage();
                     $newPath = $this->storageService->storeUploadedFile($file);
                     $package->setImage($newPath);
-                    if ('' != $oldPath && $oldPath != $newPath) {
+
+                    if ('' !== $oldPath && $oldPath !== $newPath) {
                         $this->storageService->removeFile($oldPath);
                     }
                 }
             }
+
             $this->savePackage();
 
             return true;
         }
+
+        return false;
     }
 
     /**
@@ -688,19 +705,32 @@ class Company
     /**
      * Checks if the data is valid, and if it is, inserts the package, and assigns it to the given company.
      *
-     * @param mixed $companySlugName
-     * @param mixed $data
+     * @param string $companySlugName
+     * @param Parameters $data
+     * @param Parameters $files
+     * @param string $type
+     *
+     * @return bool
+     * @throws Exception
      */
-    public function insertPackageForCompanySlugNameByData($companySlugName, $data, $files, $type = 'job')
-    {
+    public function insertPackageForCompanySlugNameByData(
+        string $companySlugName,
+        Parameters $data,
+        Parameters $files,
+        string $type = 'job',
+    ): bool {
         $packageForm = $this->getPackageForm($type);
         $packageForm->setData($data);
+
         if ($packageForm->isValid()) {
             $package = $this->insertPackageForCompanySlugName($companySlugName, $type);
+
             if ('banner' === $type) {
-                $newPath = $this->storageService->storeUploadedFile($files);
+                // TODO: Check if a file is uploaded.
+                $newPath = $this->storageService->storeUploadedFile($files['banner']);
                 $package->setImage($newPath);
             }
+
             $package->exchangeArray($data);
             $this->savePackage();
 
@@ -731,12 +761,12 @@ class Company
      * Creates a new job and adds it to the specified package.
      *
      * @param int $packageId
-     * @param array $data
-     * @param array $files
+     * @param Parameters $data
+     * @param Parameters $files
      *
      * @return bool
      */
-    public function createJob($packageId, $data, $files)
+    public function createJob(int $packageId, Parameters $data, Parameters $files): bool
     {
         $package = $this->packageMapper->findPackage($packageId);
         $jobs = [];
@@ -748,20 +778,20 @@ class Company
             $jobs[$lang] = $job;
         }
 
-        return $this->saveJobData('', $jobs, $data, $files);
+        return $this->saveJobData(null, $jobs, $data, $files);
     }
 
     /**
      * Checks if the data is valid, and if it is, saves the Job.
      *
-     * @param int|string $languageNeutralId Identifier of the Job to save
+     * @param int|null $languageNeutralId Identifier of the Job to save
      * @param array $jobs The Job to save
      * @param Parameters $data The (new) data to save
      * @param Parameters $files The (new) files to save
      *
      * @return bool
      */
-    public function saveJobData($languageNeutralId, $jobs, Parameters $data, Parameters $files)
+    public function saveJobData(?int $languageNeutralId, array $jobs, Parameters $data, Parameters $files): bool
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit jobs'));
@@ -828,10 +858,10 @@ class Company
     }
 
     /**
-     * @param Job $job
+     * @param JobModel $job
      * @param array $labels
      */
-    private function setLabelsForJob($job, $labels)
+    private function setLabelsForJob(JobModel $job, array $labels): void
     {
         $mapper = $this->labelAssignmentMapper;
         $currentAssignments = $mapper->findAssignmentsByJobId($job->getId());
@@ -848,16 +878,17 @@ class Company
     }
 
     /**
-     * @param Job $job
+     * @param JobModel $job
      * @param array $labels
      */
-    private function addLabelsToJob($job, $labels)
+    private function addLabelsToJob(JobModel $job, array $labels): void
     {
         $mapperLabel = $this->labelMapper;
         $mapperLabelAssignment = $this->labelAssignmentMapper;
         $mapperJob = $this->jobMapper;
+
         foreach ($labels as $label) {
-            $jobLabelAssignment = new JobLabelAssignment();
+            $jobLabelAssignment = new JobLabelAssignmentModel();
             $labelModel = $mapperLabel->findLabelById($label);
             $jobLabelAssignment->setLabel($labelModel);
             $job->addLabel($jobLabelAssignment);
@@ -867,32 +898,42 @@ class Company
     }
 
     /**
-     * @param Job $job
+     * @param JobModel $job
      * @param array $labels
      */
-    private function removeLabelsFromJob($job, $labels)
+    private function removeLabelsFromJob(JobModel $job, array $labels): void
     {
         $mapper = $this->labelAssignmentMapper;
+
         foreach ($labels as $label) {
             $toRemove = $mapper->findAssignmentByJobIdAndLabelId($job->getId(), $label);
             $mapper->delete($toRemove);
         }
     }
 
-    private function setLanguageNeutralJobId($id, $job, $languageNeutralId)
+    /**
+     * @param int $id
+     * @param JobModel $job
+     * @param int|null $languageNeutralId
+     *
+     * @return int
+     */
+    private function setLanguageNeutralJobId(int $id, JobModel $job, ?int $languageNeutralId): int
     {
-        if ('' == $languageNeutralId) {
+        if (null === $languageNeutralId) {
             $job->setLanguageNeutralId($id);
             $this->jobMapper->persist($job);
             $this->saveJob();
 
-            if (-1 == $id) {
+            if (-1 === $id) {
                 $id = $job->getId();
             }
+
             $job->setLanguageNeutralId($id);
 
             return $id;
         }
+
         $job->setLanguageNeutralId($languageNeutralId);
 
         return $id;
@@ -1049,9 +1090,9 @@ class Company
     /**
      * Get the Category Edit form.
      *
-     * @return EditCategory For for editing JobCategories
+     * @return EditCategoryForm For for editing JobCategories
      */
-    public function getCategoryForm()
+    public function getCategoryForm(): EditCategoryForm
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit categories'));
@@ -1063,9 +1104,9 @@ class Company
     /**
      * Get the Label Edit form.
      *
-     * @return EditLabel Form for editing JobLabels
+     * @return EditLabelForm Form for editing JobLabelModels
      */
-    public function getLabelForm()
+    public function getLabelForm(): EditLabelForm
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit labels'));
@@ -1077,13 +1118,14 @@ class Company
     /**
      * Returns a the form for entering packages.
      *
-     * @return EditPackage Form
+     * @return EditPackageForm Form
      */
-    public function getPackageForm($type = 'job')
+    public function getPackageForm($type = 'job'): EditPackageForm
     {
         if ('banner' === $type) {
             return $this->editBannerPackageForm;
         }
+
         if ('featured' === $type) {
             return $this->editFeaturedPackageForm;
         }
@@ -1094,9 +1136,9 @@ class Company
     /**
      * Returns the form for entering jobs.
      *
-     * @return EditJob Job edit form
+     * @return EditJobForm Job edit form
      */
-    public function getJobForm()
+    public function getJobForm(): EditJobForm
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit jobs'));
@@ -1110,12 +1152,12 @@ class Company
      *
      * @return string
      */
-    protected function getDefaultResourceId()
+    protected function getDefaultResourceId(): string
     {
         return 'company';
     }
 
-    public static function getLanguageDescription($lang)
+    public static function getLanguageDescription($lang): string
     {
         if ('en' === $lang) {
             return 'English';

--- a/module/Company/view/company/company/companyStory.phtml
+++ b/module/Company/view/company/company/companyStory.phtml
@@ -11,7 +11,7 @@ $companyURL = $this->url('company/companyItem', // Route url
 <div class="col-md-3">
     <?php
     $translation = $company->getTranslationFromLocale($locale);
-    if (!isset($translation)) {
+    if (!is_null($translation)) {
         $translation = $company->getTranslations()[0];
     }
     ?>

--- a/module/Company/view/company/company/companyStory.phtml
+++ b/module/Company/view/company/company/companyStory.phtml
@@ -11,7 +11,7 @@ $companyURL = $this->url('company/companyItem', // Route url
 <div class="col-md-3">
     <?php
     $translation = $company->getTranslationFromLocale($locale);
-    if (!is_null($translation)) {
+    if (null === $translation) {
         $translation = $company->getTranslations()[0];
     }
     ?>

--- a/module/Company/view/company/company/job-list.phtml
+++ b/module/Company/view/company/company/job-list.phtml
@@ -99,7 +99,7 @@ $this->headScript()
                                data-posted="<?= $job->getTimestamp()->format(DateTime::ATOM) ?>">
                                 <div class="card-img">
                                     <img
-                                        src="<?= $this->fileUrl($company->getTranslationFromLocale($locale)->getLogo()) ?>"
+                                        src="<?= $this->fileUrl($company->getTranslationFromLocale($locale)?->getLogo()) ?>"
                                         alt="<?= $this->escapeHtmlAttr($company->getName()) ?>"/>
                                 </div>
                                 <h2 class="card-title"><?= $job->getName() ?></h2>

--- a/module/Company/view/company/company/jobs.phtml
+++ b/module/Company/view/company/company/jobs.phtml
@@ -53,7 +53,7 @@ $this->headScript()
                     <div class="col-md-3">
                         <a href="<?= $this->url('company/companyItem', ['slugCompanyName' => $company->getSlugName()]) ?>">
                             <img class="company-logo img-responsive center-block"
-                                 src="<?= $this->fileUrl($company->getTranslationFromLocale($locale)->getLogo()); ?>"
+                                 src="<?= $this->fileUrl($company->getTranslationFromLocale($locale)?->getLogo()); ?>"
                                  alt="<?= $this->translate('Logo of') ?> <?= $escaper->escapeHtmlAttr($company->getName()); ?>"/>
                         </a>
                         <div>


### PR DESCRIPTION
This PR addresses multiple issues. First and foremost, a security vulnerability existed in the company module allowing unauthenticated users to add new companies.

Secondly, users were not able to add new companies and/or jobs due to incorrect typing (see #1157 for more information).

Lastly, this fixes the issue where when editing a company profile, the language profiles for that company would be destroyed. Doctrine cannot perform merge operations on its own, the last operation performed is what a UnitOfWork will execute. In this case it meant that saving a company's information would not only not save any new information regarding its I18n language profiles, the language profiles would be proactively deleted.

To fix this, edits to language profiles are now first persisted and after that has completed, any languages which are to be removed are removed.

This fixes #958, fixes #1118, and fixes #1170.