### PR TITLE
Fix issue with being unable to logout with persisting sessions

### DIFF
--- a/module/User/src/Authentication/AuthenticationService.php
+++ b/module/User/src/Authentication/AuthenticationService.php
@@ -19,22 +19,21 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @var Session
      */
-    protected $storage;
+    protected Session $storage;
 
     /**
      * Authentication adapter.
      *
      * @var Mapper|PinMapper
      */
-    protected $adapter;
+    protected Mapper|PinMapper $adapter;
 
     /**
      * Constructor.
      *
-     * @param Session $storage
-     * @param Mapper|PinMapper $adapter
+     * @param StorageInterface $storage
+     * @param AdapterInterface $adapter
      *
-     * @throws RuntimeException
      */
     public function __construct(StorageInterface $storage, AdapterInterface $adapter)
     {
@@ -47,7 +46,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @return Mapper|PinMapper
      */
-    public function getAdapter()
+    public function getAdapter(): PinMapper|Mapper
     {
         return $this->adapter;
     }
@@ -59,13 +58,14 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @return self Provides a fluent interface
      */
-    public function setAdapter(AdapterInterface $adapter)
+    public function setAdapter(AdapterInterface $adapter): static
     {
         if (
             $adapter instanceof Mapper
             || $adapter instanceof PinMapper
         ) {
             $this->adapter = $adapter;
+
             return $this;
         }
 
@@ -79,7 +79,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @return Session
      */
-    public function getStorage()
+    public function getStorage(): Session
     {
         return $this->storage;
     }
@@ -91,10 +91,11 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @return self Provides a fluent interface
      */
-    public function setStorage(StorageInterface $storage)
+    public function setStorage(StorageInterface $storage): static
     {
         if ($storage instanceof Session) {
             $this->storage = $storage;
+
             return $this;
         }
 
@@ -107,14 +108,14 @@ class AuthenticationService implements AuthenticationServiceInterface
      * Authenticates against the authentication adapter. The default values must be `null` to be compatible with the
      * `AuthenticationServiceInterface`. We can safely assume they are provided, but if not throw a `RuntimeException`.
      *
-     * @param mixed $login
-     * @param string $securityCode
+     * @param mixed|null $login
+     * @param string|null $securityCode
      *
      * @return Result
      *
      * @throws RuntimeException
      */
-    public function authenticate($login = null, $securityCode = null)
+    public function authenticate(mixed $login = null, string $securityCode = null): Result
     {
         if (
             is_null($login)
@@ -146,7 +147,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @return bool
      */
-    public function hasIdentity()
+    public function hasIdentity(): bool
     {
         return !$this->getStorage()->isEmpty();
     }
@@ -158,7 +159,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      */
     public function getIdentity(): ?User
     {
-        if ($this->getStorage()->isEmpty()) {
+        if (!$this->hasIdentity()) {
             return null;
         }
 
@@ -177,7 +178,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @return void
      */
-    public function clearIdentity()
+    public function clearIdentity(): void
     {
         $this->getStorage()->clear();
     }
@@ -189,7 +190,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @return void
      */
-    public function setRememberMe($rememberMe = false)
+    public function setRememberMe(bool $rememberMe): void
     {
         $this->getStorage()->setRememberMe($rememberMe);
     }

--- a/module/User/src/Authentication/AuthenticationService.php
+++ b/module/User/src/Authentication/AuthenticationService.php
@@ -136,7 +136,7 @@ class AuthenticationService implements AuthenticationServiceInterface
 
         // If the authentication was successful, persist the identity.
         if ($result->isValid()) {
-            $this->getStorage()->write($result->getIdentity());
+            $this->getStorage()->write($result->getIdentity()->getLidnr());
         }
 
         return $result;
@@ -165,10 +165,6 @@ class AuthenticationService implements AuthenticationServiceInterface
 
         $mapper = $this->getAdapter()->getMapper();
         $user = $this->getStorage()->read();
-
-        if (is_object($user)) {
-            $user = $user->getLidnr();
-        }
 
         return $mapper->findByLidnr($user);
     }

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -93,6 +93,15 @@ class Session extends SessionStorage
             return false;
         }
 
+        // Stop validation if we are destroying the session.
+        if ($this->response->getHeaders()->has('set-cookie')) {
+            foreach ($this->response->getHeaderS()->get('set-cookie') as $cookie) {
+                if ($cookie->getName() === 'GEWISSESSTOKEN' && $cookie->getValue() === 'deleted') {
+                    return false;
+                }
+            }
+        }
+
         try {
             $session = JWT::decode($cookies->GEWISSESSTOKEN, $key, ['RS256']);
         } catch (UnexpectedValueException $e) {
@@ -164,6 +173,8 @@ class Session extends SessionStorage
     public function clear(): void
     {
         // Clear the session
+        $this->setRememberMe(false);
+        parent::write(null);
         parent::clear();
         $this->clearCookie();
     }

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -4,36 +4,41 @@ namespace User\Authentication\Storage;
 
 use DateTime;
 use Firebase\JWT\JWT;
-use Laminas\Authentication\Storage;
-use Laminas\Http\Header\SetCookie;
-use Laminas\Http\Request;
-use Laminas\Http\Response;
+use Laminas\Authentication\Storage\Session as SessionStorage;
+use Laminas\Http\{
+    Header\SetCookie,
+    Request,
+    Response,
+};
 use UnexpectedValueException;
 
-class Session extends Storage\Session
+class Session extends SessionStorage
 {
     /**
      * @var bool indicating whether we should remember the user
      */
-    protected $rememberMe;
+    protected bool $rememberMe;
 
     /**
      * @var Request
      */
-    private $request;
+    private Request $request;
 
     /**
      * @var Response
      */
-    private $response;
+    private Response $response;
 
     /**
      * @var array
      */
-    private $config;
+    private array $config;
 
-    public function __construct($request, $response, array $config)
-    {
+    public function __construct(
+        Request $request,
+        Response $response,
+        array $config,
+    ) {
         $this->request = $request;
         $this->response = $response;
         $this->config = $config;
@@ -46,7 +51,7 @@ class Session extends Storage\Session
      *
      * @param bool $rememberMe
      */
-    public function setRememberMe($rememberMe = false)
+    public function setRememberMe(bool $rememberMe): void
     {
         $this->rememberMe = $rememberMe;
 
@@ -60,7 +65,7 @@ class Session extends Storage\Session
      *
      * @return bool
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         if (!parent::isEmpty()) {
             return false;
@@ -74,7 +79,7 @@ class Session extends Storage\Session
      *
      * @return bool indicating whether a session was loaded
      */
-    protected function validateSession()
+    protected function validateSession(): bool
     {
         $key = $this->getPublicKey();
 
@@ -107,7 +112,7 @@ class Session extends Storage\Session
      *
      * @return void
      */
-    public function write($contents)
+    public function write($contents): void
     {
         parent::write($contents);
 
@@ -123,7 +128,7 @@ class Session extends Storage\Session
      *
      * @return void
      */
-    protected function saveSession($lidnr)
+    protected function saveSession(int $lidnr): void
     {
         $key = $this->getPrivateKey();
 
@@ -150,7 +155,7 @@ class Session extends Storage\Session
      *
      * @return void
      */
-    public function clear()
+    public function clear(): void
     {
         // Clear the session
         parent::clear();
@@ -207,7 +212,7 @@ class Session extends Storage\Session
      *
      * @return string|bool returns false if the private key is not readable
      */
-    protected function getPrivateKey()
+    protected function getPrivateKey(): bool|string
     {
         if (!is_readable($this->config['jwt_key_path'])) {
             return false;
@@ -221,7 +226,7 @@ class Session extends Storage\Session
      *
      * @return string|bool returns false if the public key is not readable
      */
-    protected function getPublicKey()
+    protected function getPublicKey(): bool|string
     {
         if (!is_readable($this->config['jwt_pub_key_path'])) {
             return false;

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -11,6 +11,7 @@ use Laminas\Http\{
     Response,
 };
 use UnexpectedValueException;
+use User\Model\User as UserModel;
 
 class Session extends SessionStorage
 {
@@ -119,7 +120,7 @@ class Session extends SessionStorage
     /**
      * Defined by Laminas\Authentication\Storage\StorageInterface.
      *
-     * @param mixed $contents
+     * @param int $contents
      *
      * @return void
      */

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -54,10 +54,6 @@ class Session extends SessionStorage
     public function setRememberMe(bool $rememberMe): void
     {
         $this->rememberMe = $rememberMe;
-
-        if ($rememberMe) {
-            $this->saveSession(parent::read()->getLidnr());
-        }
     }
 
     /**

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -99,6 +99,12 @@ class Session extends SessionStorage
             return false;
         }
 
+        // Check if the session has not expired.
+        $now = (new DateTime())->getTimestamp();
+        if ($now >= $session->exp) {
+            return false;
+        }
+
         parent::write($session->lidnr);
         $this->saveSession($session->lidnr);
 

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -164,16 +164,10 @@ class Session extends Storage\Session
      *
      * @return void
      */
-    protected function saveCookie($jwt)
+    protected function saveCookie(string $jwt): void
     {
         $sessionToken = new SetCookie('GEWISSESSTOKEN', $jwt, strtotime('+2 weeks'), '/');
-
-        // Use secure cookies in production
-        if (APP_ENV === 'production') {
-            $sessionToken->setSecure(true)->setHttponly(true);
-        }
-
-        $sessionToken->setDomain($this->config['cookie_domain']);
+        $sessionToken = $this->setCookieParameters($sessionToken);
 
         $this->response->getHeaders()->addHeader($sessionToken);
     }
@@ -183,16 +177,29 @@ class Session extends Storage\Session
      *
      * @return void
      */
-    protected function clearCookie()
+    protected function clearCookie(): void
     {
         $sessionToken = new SetCookie('GEWISSESSTOKEN', 'deleted', strtotime('-1 Year'), '/');
+        $sessionToken = $this->setCookieParameters($sessionToken);
 
+        $this->response->getHeaders()->addHeader($sessionToken);
+    }
+
+    /**
+     * @param SetCookie $sessionToken
+     *
+     * @return SetCookie
+     */
+    private function setCookieParameters(SetCookie $sessionToken): SetCookie
+    {
         // Use secure cookies in production
         if (APP_ENV === 'production') {
             $sessionToken->setSecure(true)->setHttponly(true);
         }
 
-        $this->response->getHeaders()->addHeader($sessionToken);
+        $sessionToken->setDomain($this->config['cookie_domain']);
+
+        return $sessionToken;
     }
 
     /**

--- a/module/User/src/Service/User.php
+++ b/module/User/src/Service/User.php
@@ -350,7 +350,7 @@ class User
         }
 
         // Try to authenticate the user.
-        $this->authService->setRememberMe($data['remember'] === 1);
+        $this->authService->setRememberMe($data['remember'] === '1');
         $result = $this->authService->authenticate($data['login'], $data['password']);
 
         // Check if authentication was successful.

--- a/module/User/src/Service/User.php
+++ b/module/User/src/Service/User.php
@@ -329,7 +329,7 @@ class User
      *
      * @return UserModel|null Authenticated user. Null if not authenticated.
      */
-    public function login($data)
+    public function login(array $data): ?UserModel
     {
         $form = $this->getLoginForm();
         $form->setData($data);
@@ -339,6 +339,7 @@ class User
         }
 
         // Try to authenticate the user.
+        $this->authService->setRememberMe($data['remember'] === 1);
         $result = $this->authService->authenticate($data['login'], $data['password']);
 
         // Check if authentication was successful.
@@ -347,8 +348,6 @@ class User
 
             return null;
         }
-
-        $this->authService->setRememberMe($data['remember'] === 1);
 
         return $this->authService->getIdentity();
     }


### PR DESCRIPTION
An issue existed where sessions based on our JWT cookie could not be invalidated. This meant that users could not logout without clearing cookies.

This also properly validates the `exp` in the JWT cookie to ensure that no one can use JWT cookies from the past. Additionally, we would occasionally put the whole `User`/`Member` model into the JWT cookie before overwriting it with the `lidnr`. To ensure we never accidentally expose this information I have removed this "functionality" (`lidnr` is used at all times).

Fixes #1173.