### PR TITLE
Fix album edit validation and update form style

### DIFF
--- a/module/Photo/src/Form/EditAlbum.php
+++ b/module/Photo/src/Form/EditAlbum.php
@@ -28,6 +28,7 @@ class EditAlbum extends Form
                 'name' => 'startDateTime',
                 'type' => 'Laminas\Form\Element\DateTime',
                 'options' => [
+                    'format' => 'Y/m/d H:i',
                     'label' => $translate->translate('Start date'),
                 ],
             ]
@@ -38,6 +39,7 @@ class EditAlbum extends Form
                 'name' => 'endDateTime',
                 'type' => 'Laminas\Form\Element\DateTime',
                 'options' => [
+                    'format' => 'Y/m/d H:i',
                     'label' => $translate->translate('End date'),
                 ],
             ]

--- a/module/Photo/view/photo/album-admin/edit.phtml
+++ b/module/Photo/view/photo/album-admin/edit.phtml
@@ -1,4 +1,76 @@
 <?php
+$this->headLink()
+    ->appendStylesheet($this->basePath() . '/css/jquery.datetimepicker.css');
+$this->headScript()
+    ->appendFile($this->basePath() . '/js/jquery.datetimepicker.full.min.js');
+
 $form->prepare();
-echo $this->form()->render($form);
 ?>
+<div class="row">
+    <div class="col-md-12">
+        <h2><?= $this->translate('Update Album') ?></h2>
+    </div>
+    <div class="col-md-6">
+        <?= $this->form()->openTag($form) ?>
+        <div class="row">
+            <div class="col-md-12">
+                <?php
+                $name = $form->get('name')
+                    ->setAttribute('class', 'form-control')
+                    ->setAttribute('id', 'name');
+                ?>
+                <div class="form-group <?= $this->bootstrapElementError($name) ?>">
+                    <label for="<?= $name->getAttribute('id') ?>" class="control-label label-required">
+                        <?= $this->translate('Name') ?>
+                    </label>
+                    <?= $this->formInput($name) ?>
+                    <?= $this->formElementErrors($name) ?>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <?php
+                $startDateTime = $form->get('startDateTime')
+                    ->setAttribute('class', 'form-control')
+                    ->setAttribute('id', 'start-date');
+                ?>
+                <div class="form-group <?= $this->bootstrapElementError($startDateTime) ?>">
+                    <label for="<?= $startDateTime->getAttribute('id') ?>">
+                        <?= $startDateTime->getLabel() ?>
+                    </label>
+                    <?= $this->formInput($startDateTime) ?>
+                    <?= $this->formElementErrors($startDateTime) ?>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <?php
+                $endDateTime = $form->get('endDateTime')
+                    ->setAttribute('class', 'form-control')
+                    ->setAttribute('id', 'end-date');
+                ?>
+                <div class="form-group <?= $this->bootstrapElementError($endDateTime) ?>">
+                    <label for="<?= $endDateTime->getAttribute('id') ?>">
+                        <?= $endDateTime->getLabel() ?>
+                    </label>
+                    <?= $this->formInput($endDateTime) ?>
+                    <?= $this->formElementErrors($endDateTime) ?>
+                </div>
+                <br>
+            </div>
+            <div class="col-md-12">
+                <?php
+                $submit = $form->get('submit')
+                    ->setAttribute('class', 'btn btn-primary');
+                ?>
+                <div class="form-group">
+                    <?= $this->formButton($submit) ?>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?= $this->form()->closeTag(); ?>
+
+<script>
+    $('[name="startDateTime"]').datetimepicker();
+    $('[name="endDateTime"]').datetimepicker();
+</script>


### PR DESCRIPTION
This resolves the issue where form validation failed when updating albums. This was because the Laminas datetime form elements did not accept the correct input. To prevent mistakes I have added the datetimepicker (also used in the activity creation form) to standardise the input.

Furthermore, I have improved the album edit form regarding looks and style.

Before:
![image](https://user-images.githubusercontent.com/4983571/129755165-5b78f1fb-3943-4f52-8d75-81ca20963b92.png)

After:
![image](https://user-images.githubusercontent.com/4983571/129755385-55ed469b-46fe-4f2d-8594-1c3ea705212c.png)

Fixes #1145.