### PR TITLE
Fixed Acl by returning RoleInterface instead of role name

### DIFF
--- a/module/User/src/Authorization/GenericAclService.php
+++ b/module/User/src/Authorization/GenericAclService.php
@@ -40,15 +40,11 @@ abstract class GenericAclService extends AbstractAclService
     protected function getRole()
     {
         if ($this->authService->hasIdentity()) {
-            $user = $this->authService->getIdentity();
-
-            return $user->getRoleId();
+            return $this->authService->getIdentity();
         }
 
         if ($this->apiAuthService->hasIdentity()) {
-            $user = $this->apiAuthService->getIdentity();
-
-            return $user->getRoleId();
+            return $this->apiAuthService->getIdentity();
         }
 
         // TODO: We could create an assertion for this.


### PR DESCRIPTION
This solves among others an issue where the assertions on activity permissions do not work. (issue reported by Romy)