### PR TITLE
Fix incorrect form for logged out password resets

### DIFF
--- a/module/User/src/Controller/UserController.php
+++ b/module/User/src/Controller/UserController.php
@@ -183,7 +183,7 @@ class UserController extends AbstractActionController
 
         return new ViewModel(
             [
-                'form' => $this->userService->getPasswordForm(),
+                'form' => $this->userService->getRegisterForm(),
             ]
         );
     }


### PR DESCRIPTION
This reverts a change made in 599a1a73a1f1d68f253aa019a411bbce35527429 which replaced the register form used for password resets with the password reset form. The password reset form can only be used after a password reset has been requested (this is done using the register form).