### PR TITLE
Fix #1200: Activity (dis)approver not being saved

### DIFF
--- a/module/Activity/src/Service/Activity.php
+++ b/module/Activity/src/Service/Activity.php
@@ -713,7 +713,9 @@ class Activity
                 $this->translator->translate('You are not allowed to change the status of the activity')
             );
         }
+
         $activity->setStatus(ActivityModel::STATUS_APPROVED);
+        $activity->setApprover($this->aclService->getIdentity());
         $em = $this->entityManager;
         $em->persist($activity);
         $em->flush();
@@ -731,6 +733,7 @@ class Activity
         }
 
         $activity->setStatus(ActivityModel::STATUS_TO_APPROVE);
+        $activity->setApprover(null);
         $em = $this->entityManager;
         $em->persist($activity);
         $em->flush();
@@ -748,6 +751,7 @@ class Activity
         }
 
         $activity->setStatus(ActivityModel::STATUS_DISAPPROVED);
+        $activity->setApprover($this->aclService->getIdentity());
         $em = $this->entityManager;
         $em->persist($activity);
         $em->flush();


### PR DESCRIPTION
This is a hotfix cherry-picked from 6297b22bb1c31efbcb34bf5b2356ff95ad173d41. This fixes #1200.