### PR TITLE
Update old hrefs

### DIFF
--- a/module/Education/view/education/education/index.phtml
+++ b/module/Education/view/education/education/index.phtml
@@ -172,7 +172,7 @@ $this->headTitle($this->translate('Education'));
                     <?=
                     sprintf(
                         $this->translate('Do you have a complaint or suggestion concerning the education at the TU/e? Contact the %seducation officer%s to share your ideas.'),
-                        '<a href="mailto:klachten@gewis.nl" title="' . $this->translate('Mail the education officer') . '">',
+                        '<a href="mailto:feedback@gewis.nl" title="' . $this->translate('Mail the education officer') . '">',
                         '</a>'
                     )
                     ?>

--- a/module/Frontpage/view/frontpage/frontpage/home.phtml
+++ b/module/Frontpage/view/frontpage/frontpage/home.phtml
@@ -116,7 +116,7 @@ use Activity\Model\Activity;
                         <p class="small">
                             <?= sprintf(
                                 $this->translate('Donderdags is er %sborrel%s van 16.30 tot 19.00 uur.'),
-                                '<a href="~bac">',
+                                '<a href="//bac.gewis.nl">',
                                 '</a>'
                             )
                             ?>


### PR DESCRIPTION
A member told me the URL for social drinks on the homepage no longer worked and I combined it with the new education feedback email address