### PR TITLE
Bring back the rainbow navigation for board members

### DIFF
--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -1,7 +1,26 @@
 <?php
 $lang = $this->plugin('translate')->getTranslator()->getLocale();
 ?>
-<nav class="navbar navbar-gewis navbar-static-top" role="navigation">
+<?php if ($this->identity()?->getMember()->isBoardMember()): ?>
+    <?php $this->headStyle()->captureStart(); ?>
+        .rainbow {
+            background: linear-gradient(to right bottom, #ff334d, #ff338b);
+            animation: rainbow 6s steps(128, end) infinite;
+        }
+
+        @keyframes rainbow {
+            from {
+                filter: hue-rotate(0deg);
+            }
+
+            100% {
+                filter: hue-rotate(360deg);
+            }
+        }
+    <?php $this->headStyle()->captureEnd(); ?>
+    <?= $this->headStyle() ?>
+<?php endif; ?>
+<nav class="navbar navbar-gewis navbar-static-top rainbow" role="navigation">
     <div class="container">
         <div class="navbar-header navbar-left pull-left">
             <a href="<?= $this->url('home') ?>" class="navbar-brand">


### PR DESCRIPTION
As the cobo for the board is this week, I thought it would be nice to give them a little present. This brings back the beloved rainbow navigation for board members. I have improved the rainbow a bit to make sure they love it even more.

**After:**
![output](https://user-images.githubusercontent.com/4983571/134878540-7cc33851-fdaa-4ffe-b9b2-a8398c291ad2.gif)