### PR TITLE
Improve cookie and Matomo tracking notice (and switcher)

### DIFF
--- a/docker/matomo/Dockerfile
+++ b/docker/matomo/Dockerfile
@@ -18,6 +18,12 @@ RUN curl -o SecurityInfo.zip \
       && rm SecurityInfo.zip \
       && mv SecurityInfo /usr/src/matomo/plugins
 
+RUN curl -o TrackingOptOut.zip \
+      https://github.com/GEWIS/gewisweb-analytics-opt-out/archive/refs/tags/v1.0.0-gewisweb.zip \
+      && unzip -j TrackingOptOut.zip -d "TrackingOptOut" \
+      && rm TrackingOptOut.zip \
+      && mv TrackingOptOut /usr/src/matomo/plugins
+
 COPY --chown=www-data:www-data config.ini.php /var/www/html/config/config.ini.php.template
 
 CMD ["/bin/sh" , "-c" , "envsubst '${MATOMO_DATABASE_HOST} ${MATOMO_DATABASE_PORT} ${MATOMO_DATABASE_USERNAME} ${MATOMO_DATABASE_PASSWORD} ${MATOMO_DATABASE_DBNAME}' < /var/www/html/config/config.ini.php.template > /var/www/html/config/config.ini.php && chown www-data:www-data /var/www/html/config/config.ini.php && exec apache2-foreground"]

--- a/docker/matomo/Dockerfile
+++ b/docker/matomo/Dockerfile
@@ -18,8 +18,8 @@ RUN curl -o SecurityInfo.zip \
       && rm SecurityInfo.zip \
       && mv SecurityInfo /usr/src/matomo/plugins
 
-RUN curl -o TrackingOptOut.zip \
-      https://github.com/GEWIS/gewisweb-analytics-opt-out/archive/refs/tags/v1.0.0-gewisweb.zip \
+RUN curl -L -o TrackingOptOut.zip \
+      https://github.com/GEWIS/gewisweb-analytics-opt-out/archive/refs/tags/v1.0.2-gewisweb.zip \
       && unzip -j TrackingOptOut.zip -d "TrackingOptOut" \
       && rm TrackingOptOut.zip \
       && mv TrackingOptOut /usr/src/matomo/plugins

--- a/docker/matomo/config.ini.php
+++ b/docker/matomo/config.ini.php
@@ -92,6 +92,7 @@ Plugins[] = CustomDimensions
 
 Plugins[] = "LogViewer"
 Plugins[] = "SecurityInfo"
+Plugins[] = "TrackingOptOut"
 
 [PluginsInstalled]
 PluginsInstalled[] = Diagnostics

--- a/docker/matomo/config.ini.php
+++ b/docker/matomo/config.ini.php
@@ -105,3 +105,4 @@ PluginsInstalled[] = Intl
 
 PluginsInstalled[] = "LogViewer"
 PluginsInstalled[] = "SecurityInfo"
+PluginsInstalled[] = "TrackingOptOut"

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -60,6 +60,15 @@ http {
             add_header                  Content-Security-Policy             $content_security_policy;
         }
 
+        location /.well-known/security.txt  {
+            gzip_static                 on;
+            etag                        on;
+            add_header                  Cache-Control                       "private, max-age=86400";
+            add_header                  X-XSS-Protection                    $x_css_protection;
+            add_header                  X-Content-Type-Options              $x_content_type_options;
+            add_header                  Content-Security-Policy             $content_security_policy;
+        }
+
         location ~ ^/(images|javascript|js|css|flash|media|static)/  {
             gzip_static                 on;
             etag                        on;

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -48,14 +48,16 @@ if (strstr($viewModel->getTemplate(), 'admin')): ?>
     <div class="content-container">
         <?= $this->content ?>
     </div>
-
     <?= $this->partial('partial/footer.phtml') ?>
+    <?= $this->partial('partial/privacy-widget.phtml') ?>
 <?php endif; ?>
 
 <!-- Scripts -->
 <?= $this->inlineScript()
     ->prependFile($this->basePath() . '/js/bootstrap.min.js')
+    ->prependFile($this->basePath() . '/js/privacy-widget.js')
     ->prependFile($this->basePath() . '/js/navbar-submenu.js'); ?>
+
 <script>
     <?php foreach($this->scriptUrl()->getUrls() as $name => $url): ?>
     URLHelper.addUrl('<?= $name ?>', '<?= urldecode($url) ?>');

--- a/module/Application/view/partial/footer.phtml
+++ b/module/Application/view/partial/footer.phtml
@@ -31,13 +31,5 @@
                 </div>
             </div>
         </div>
-        <div class="content-container">
-            <div class="embed-responsive" style="padding-bottom: 25%;">
-                <iframe
-                    class="embed-responsive-item"
-                    src="https://analytics.gewis.nl/index.php?module=CoreAdminHome&action=optOut&language=nl&backgroundColor=ffffff&fontColor=330300&fontSize=15px&fontFamily=%22Lato%22%2C%22Arial%22%2Csans-serif"
-                ></iframe>
-            </div>
-        </div>
     </div>
 </footer>

--- a/module/Application/view/partial/privacy-widget.phtml
+++ b/module/Application/view/partial/privacy-widget.phtml
@@ -1,0 +1,24 @@
+<div class="privacy-widget closed">
+    <div class="widget-popout">
+        <p><?= $this->translate("S.v. GEWIS uses cookies on this website, these are required for the website to function. Additionally, we may collection information about how you use our website in order to improve your experience. If you do not want your behaviour to be tracked please opt out below.")?></p>
+        <div class="widget-opt-out">
+            <input type="checkbox" id="opt-out" name="opt-out">
+            <label for="opt-out">
+                <strong>
+                    <?= $this->translate("Tracking is currently") ?>
+                    <span id="opt-out-status-false" class="hidden"><?= $this->translate('enabled') ?></span>
+                    <span id="opt-out-status-true" class="hidden"><?= $this->translate('disabled') ?></span>
+                    <span id="opt-out-status-disabled" class="hidden"><?= $this->translate('disabled (Do Not Track)') ?></span>
+                    <span id="opt-out-status-unavailable"><?= $this->translate('unavailable') ?></span>
+                </strong>
+            </label>
+        </div>
+        <div class="widget-dismiss">
+            <a href="<?= $this->url('home/page', ['category' => 'vereniging', 'sub_category' => 'statuten']) ?>"><?= $this->translate('Privacy Policy') ?></a>
+            <button class="btn btn-primary"><?= $this->translate("Continue") ?></button>
+        </div>
+    </div>
+    <div class="widget-button">
+        <div class="gi gewis-base"></div>
+    </div>
+</div>

--- a/public/js/privacy-widget.js
+++ b/public/js/privacy-widget.js
@@ -1,0 +1,155 @@
+// Important elements
+let privacy_widget = document.querySelector('.privacy-widget');
+let privacy_widget_button = document.querySelector('.privacy-widget > .widget-button');
+let privacy_widget_dismiss = document.querySelector('.privacy-widget > .widget-popout > .widget-dismiss > button');
+let privacy_widget_checkbox = document.querySelector('.privacy-widget > .widget-popout input[name=opt-out]');
+
+// Statuses
+let status_disabled = document.getElementById('opt-out-status-true');
+let status_disabled_dnt = document.getElementById('opt-out-status-disabled');
+let status_enabled = document.getElementById('opt-out-status-false');
+let status_unavailable = document.getElementById('opt-out-status-unavailable');
+
+// JSONP handler.
+const trackingRequest = (action) => {
+    // action is expected to be one of; `isTracked`, `doIgnore`, or `doTrack`.
+    let url = 'https://analytics.gewis.nl/index.php?module=API&format=json&method=TrackingOptOut.';
+    let prefix = '__jsonp_tracking';
+    let target = document.head || document.getElementsByTagName("head")[0];
+    let timeout = 1000;
+    let timer;
+    let script;
+    let promise;
+
+    // Create a somewhat unique identifier for the script tag (to prevent caching and potential collisions).
+    let id = prefix + Date.now();
+
+    // Function to clean up data after the Promise is resolved or rejected.
+    let clean = () => {
+        // If script is present remove it.
+        if (script && script.parentNode) {
+            script.parentNode.removeChild(script);
+        }
+
+        // If callback is present remove it.
+        if (window[id]) {
+            delete window[id];
+        }
+
+        // If timeout timer is present clear it.
+        if (timer) {
+            clearTimeout(timer);
+        }
+    };
+
+    // Create the Promise for the request.
+    promise = new Promise((resolve, reject) => {
+        // Make sure the request can timeout.
+        timer = setTimeout(() => {
+            clean();
+            reject(new Error('Request timed out.'));
+        }, timeout);
+
+        // Set callback.
+        window[id] = (data) => {
+            clean();
+            resolve(data);
+        };
+
+        url += action + '&callback=' + id;
+
+        // Create the script.
+        script = document.createElement('script');
+        script.src = url;
+        script.onerror = () => {
+            clean();
+            reject(new Error('Unknown error occurred during request.'));
+        };
+
+        // Add script to DOM.
+        target.parentNode.insertBefore(script, target);
+    });
+
+    return promise;
+}
+
+const setTrackingState = (state) => {
+    return trackingRequest(state ? 'doTrack' : 'doIgnore');
+};
+
+const checkAndUpdateState = () => {
+    trackingRequest('isTracked').then((data) => {
+        status_unavailable.classList.add('hidden');
+        privacy_widget_checkbox.disabled = false;
+
+        if (data.isTracked) {
+            // User is being tracked.
+            privacy_widget_checkbox.checked = true;
+            status_enabled.classList.remove('hidden');
+        } else if (!data.isTracked && data.isDoNotTrackPresent) {
+            // User is not being tracked due to a Do Not Track signal.
+            privacy_widget_checkbox.checked = false;
+            privacy_widget_checkbox.disabled = true;
+            status_disabled_dnt.classList.remove('hidden');
+        } else if (!data.isTracked && !data.isDoNotTrackPresent) {
+            // User is not being tracked.
+            privacy_widget_checkbox.checked = false;
+            status_disabled.classList.remove('hidden');
+        }
+    }).catch((error) => {
+        console.log(error);
+        status_unavailable.classList.remove('hidden');
+        privacy_widget_checkbox.disabled = true;
+    });
+};
+
+// Register all events.
+privacy_widget_button.addEventListener('click', () => {
+    if (privacy_widget.classList.contains('closed')) {
+        checkAndUpdateState();
+
+        privacy_widget.classList.replace('closed', 'open');
+    }
+}, false);
+
+privacy_widget_checkbox.addEventListener('change', (event) => {
+    if (event.currentTarget.checked) {
+        status_disabled.classList.add('hidden');
+
+        setTrackingState(true).then((data) => {
+            if ("success" !== data.result) {
+                return Promise.reject('Could not remove matomo_ignore cookie.');
+            }
+
+            status_enabled.classList.remove('hidden');
+        }).catch((error) => {
+            status_unavailable.classList.remove('hidden');
+            privacy_widget_checkbox.disabled = true;
+        });
+    } else {
+        status_enabled.classList.add('hidden');
+
+        setTrackingState(false).then((data) => {
+            if ("success" !== data.result) {
+                return Promise.reject('Could not set matomo_ignore cookie.');
+            }
+
+            status_disabled.classList.remove('hidden');
+        }).catch((error) => {
+            status_unavailable.classList.remove('hidden');
+            privacy_widget_checkbox.disabled = true;
+        });
+    }
+})
+
+privacy_widget_dismiss.addEventListener('click', () => {
+    document.cookie = "privacyWidgetDismissed=1; Domain=gewis.nl; Max-Age=31536000; SameSite=Lax; Secure";
+    privacy_widget.classList.replace('open', 'closed');
+}, false);
+
+// Check if user has dismissed the privacy widget. If not, show it.
+if (!document.cookie.split('; ').find(row => row.startsWith('privacyWidgetDismissed'))) {
+    checkAndUpdateState();
+
+    privacy_widget.classList.replace('closed', 'open');
+}

--- a/public/scss/gewis-theme.scss
+++ b/public/scss/gewis-theme.scss
@@ -45,6 +45,7 @@
 @import 'modules/activity-calendar';
 @import 'modules/activity-form';
 @import 'modules/company-form';
+@import 'modules/privacy-widget';
 
 // FontAwesome
 @import "fontawesome/fontawesome.scss";

--- a/public/scss/modules/_privacy-widget.scss
+++ b/public/scss/modules/_privacy-widget.scss
@@ -1,0 +1,81 @@
+.privacy-widget {
+    left: 0;
+    bottom: 0;
+    z-index: 2147483647;
+    display: block;
+    position: fixed;
+    margin: 1rem;
+    filter: drop-shadow(2px 2px 10px rgba(0, 0, 0, 0.25));
+
+    &.open {
+        width: 30rem;
+        height: 30rem;
+        font-size: 1.25rem;
+        filter: drop-shadow(2px 2px 10px rgba(0, 0, 0, 0.5));
+    }
+
+    &.closed {
+        width: 4rem;
+        height: 4rem;
+        cursor: pointer;
+        opacity: 0.25;
+        transition: all 0.5s ease-in-out;
+
+        &:hover {
+            opacity: 1;
+            filter: drop-shadow(2px 2px 10px rgba(0, 0, 0, 0.5));
+        }
+
+        > .widget-popout {
+            display: none;
+        }
+    }
+
+    > .widget-popout {
+        padding: 1rem;
+        margin: 1rem;
+        background-color: #FFFFFF;
+        position: absolute;
+        bottom: 5rem;
+        left: -1rem;
+        border-radius: 0.375rem;
+
+        &:after {
+            top: 100%;
+            left: 2rem;
+            border: 1rem solid transparent;
+            content: "";
+            height: 0;
+            width: 0;
+            position: absolute;
+            pointer-events: none;
+            border-top-color: #FFFFFF;
+            margin-left: -1rem;
+        }
+
+        > .widget-dismiss {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+    }
+
+    > .widget-button {
+        font-size: 3rem;
+        background-color: #D40026;
+        width: 4rem;
+        height: 4rem;
+        left: 0;
+        bottom: 0;
+        position: absolute;
+        border-radius: 1rem;
+
+        > .gewis-base {
+            width: 4rem;
+            height: 4rem;
+            text-align: center;
+            color: #FFFFFF;
+            display: inline-block;
+        }
+    }
+}


### PR DESCRIPTION
This currently depends on https://github.com/matomo-org/matomo/issues/18133 being fixed and can therefore not be merged.

To ensure compliance with GDPR (and relevant laws) I have updated (read: replaced) the tracking notice produced by Matomo. In conjunction with the new privacy policy (updated by the board) this improve the experience of our users.

To do this, I have authored/forked a Matomo plugin: [TrackingOptOut](https://github.com/GEWIS/gewisweb-analytics-opt-out). This plugin provides an API-endpoint to replace the iframe functionality. It allows the client to determine and update their current tracking status.

**Old notice (no DNT):**
![image](https://user-images.githubusercontent.com/4983571/136953154-8057bcff-5679-427d-83cf-8b99cc4091b5.png)

**Old notice (with DNT):**
![image](https://user-images.githubusercontent.com/4983571/136953409-8a4080c2-cfef-4bb1-9e02-ebb9b2df421e.png)

New notice (no DNT):
![image](https://user-images.githubusercontent.com/4983571/136953602-4fc7158c-2939-444b-aeea-4722fdbc151f.png)

New notice (with DNT):
![image](https://user-images.githubusercontent.com/4983571/136953529-6f179abc-5178-4997-8fb9-62d4aae7be32.png)

When dismissed, the notice will become just the icon with reduced transparency. This is to make it non-intrusive, but also allows users to directly access their settings. The notice will stay dismissed for 1 year, each dismissal updates the expiry time.
![image](https://user-images.githubusercontent.com/4983571/136953687-d1111af0-c940-4d19-a0ac-efc184b71bb5.png)

Closes #1108.
