### PR TITLE
Move form option generation away from constructor in forms

### DIFF
--- a/module/Activity/src/Form/Activity.php
+++ b/module/Activity/src/Form/Activity.php
@@ -3,50 +3,50 @@
 namespace Activity\Form;
 
 use DateTime;
-use Decision\Model\Organ;
 use DomainException;
 use Exception;
+use Laminas\Form\Element\{
+    Checkbox,
+    Collection,
+    DateTime as DateTimeElement,
+    MultiCheckbox,
+    Select,
+    Submit,
+    Text,
+    Textarea,
+};
 use Laminas\Form\Form;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Mvc\I18n\Translator;
-use Laminas\Validator\Callback;
-use Laminas\Validator\NotEmpty;
+use Laminas\Validator\{
+    Callback,
+    NotEmpty,
+};
 
 class Activity extends Form implements InputFilterProviderInterface
 {
-    protected $organs;
-    protected $translator;
+    /**
+     * @var Translator
+     */
+    protected Translator $translator;
 
     /**
-     * @param Organ[] $organs
+     * @param Translator $translator
      */
-    public function __construct(array $organs, array $companies, array $categories, Translator $translator)
+    public function __construct(Translator $translator)
     {
         parent::__construct('activity');
         $this->translator = $translator;
 
         $this->setAttribute('method', 'post');
 
-        // all the organs that the user belongs to in organId => name pairs
-        $organOptions = [0 => $translator->translate('No organ')];
-        foreach ($organs as $organ) {
-            $organOptions[$organ->getId()] = $organ->getAbbr();
-        }
-
-        $companyOptions = [0 => $translator->translate('No Company')];
-        foreach ($companies as $company) {
-            $companyOptions[$company->getId()] = $company->getName();
-        }
-
-        $categoryOptions = [];
-        foreach ($categories as $category) {
-            $categoryOptions[$category->getId()] = $category->getName();
-        }
+        $organOptions = [0 => $this->translator->translate('No organ')];
+        $companyOptions = [0 => $this->translator->translate('No Company')];
 
         $this->add(
             [
                 'name' => 'organ',
-                'type' => 'select',
+                'type' => Select::class,
                 'options' => [
                     'value_options' => $organOptions,
                 ],
@@ -56,7 +56,7 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'company',
-                'type' => 'select',
+                'type' => Select::class,
                 'options' => [
                     'value_options' => $companyOptions,
                 ],
@@ -66,7 +66,7 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'beginTime',
-                'type' => 'datetime',
+                'type' => DateTimeElement::class,
                 'options' => [
                     'format' => 'Y/m/d H:i',
                 ],
@@ -76,7 +76,7 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'endTime',
-                'type' => 'datetime',
+                'type' => DateTimeElement::class,
                 'options' => [
                     'format' => 'Y/m/d H:i',
                 ],
@@ -86,7 +86,7 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'language_dutch',
-                'type' => 'Laminas\Form\Element\Checkbox',
+                'type' => Checkbox::class,
                 'options' => [
                     'checked_value' => 1,
                     'unchecked_value' => 0,
@@ -97,7 +97,7 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'language_english',
-                'type' => 'Laminas\Form\Element\Checkbox',
+                'type' => Checkbox::class,
                 'options' => [
                     'checked_value' => 1,
                     'unchecked_value' => 0,
@@ -108,78 +108,62 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'name',
-                'attributes' => [
-                    'type' => 'text',
-                ],
+                'type' => Text::class,
             ]
         );
 
         $this->add(
             [
                 'name' => 'nameEn',
-                'attributes' => [
-                    'type' => 'text',
-                ],
+                'type' => Text::class,
             ]
         );
 
         $this->add(
             [
                 'name' => 'location',
-                'attributes' => [
-                    'type' => 'text',
-                ],
+                'type' => Text::class,
             ]
         );
 
         $this->add(
             [
                 'name' => 'locationEn',
-                'attributes' => [
-                    'type' => 'text',
-                ],
+                'type' => Text::class,
             ]
         );
 
         $this->add(
             [
                 'name' => 'costs',
-                'attributes' => [
-                    'type' => 'text',
-                ],
+                'type' => Text::class,
             ]
         );
         $this->add(
             [
                 'name' => 'costsEn',
-                'attributes' => [
-                    'type' => 'text',
-                ],
+                'type' => Text::class,
             ]
         );
 
         $this->add(
             [
                 'name' => 'description',
-                'attributes' => [
-                    'type' => 'textarea',
-                ],
+                'type' => Textarea::class,
             ]
         );
 
         $this->add(
             [
                 'name' => 'descriptionEn',
-                'attributes' => [
-                    'type' => 'textarea',
-                ],
+                'type' => Textarea::class,
             ]
         );
 
         $this->add(
             [
                 'name' => 'isMyFuture',
-                'type' => 'Laminas\Form\Element\Checkbox',
+                'type' => Checkbox::class,
                 'options' => [
                     'checked_value' => 1,
                     'unchecked_value' => 0,
@@ -190,7 +174,7 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'requireGEFLITST',
-                'type' => 'Laminas\Form\Element\Checkbox',
+                'type' => Checkbox::class,
                 'options' => [
                     'checked_value' => 1,
                     'unchecked_value' => 0,
@@ -201,9 +185,9 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'categories',
-                'type' => 'Laminas\Form\Element\MultiCheckbox',
+                'type' => MultiCheckbox::class,
                 'options' => [
-                    'value_options' => $categoryOptions,
+                    'value_options' => [],
                 ],
             ]
         );
@@ -211,7 +195,7 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'signupLists',
-                'type' => 'Laminas\Form\Element\Collection',
+                'type' => Collection::class,
                 'options' => [
                     'count' => 0,
                     'should_create_template' => true,
@@ -225,12 +209,45 @@ class Activity extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'submit',
+                'type' => Submit::class,
                 'attributes' => [
-                    'type' => 'submit',
                     'value' => 'Create',
                 ],
             ]
         );
+    }
+
+    /**
+     * @param array $organs
+     * @param array $companies
+     * @param array $categories
+     *
+     * @return Activity
+     */
+    public function setAllOptions(array $organs, array $companies, array $categories): static
+    {
+        $organOptions = $this->get('organ')->getValueOptions();
+        foreach ($organs as $organ) {
+            $organOptions[$organ->getId()] = $organ->getAbbr();
+        }
+
+        $this->get('organ')->setValueOptions($organOptions);
+
+        $companyOptions = $this->get('company')->getValueOptions();
+        foreach ($companies as $company) {
+            $companyOptions[$company->getId()] = $company->getName();
+        }
+
+        $this->get('company')->setValueOptions($companyOptions);
+
+        $categoryOptions = [];
+        foreach ($categories as $category) {
+            $categoryOptions[$category->getId()] = $category->getName();
+        }
+
+        $this->get('categories')->setValueOptions($categoryOptions);
+
+        return $this;
     }
 
     /**

--- a/module/Activity/src/Module.php
+++ b/module/Activity/src/Module.php
@@ -125,29 +125,8 @@ class Module
                     return $form;
                 },
                 'activity_form_activity' => function (ContainerInterface $container) {
-                    $organService = $container->get('decision_service_organ');
-                    try {
-                        $organs = $organService->getEditableOrgans();
-                    } catch (NotAllowedException $e) {
-                        $organs = [];
-                    }
-
-                    $companyService = $container->get('company_service_company');
-                    try {
-                        $companies = $companyService->getHiddenCompanyList();
-                    } catch (NotAllowedException $e) {
-                        $companies = [];
-                    }
-
-                    $categoryService = $container->get('activity_service_category');
-                    try {
-                        $categories = $categoryService->findAll();
-                    } catch (NotAllowedException $e) {
-                        $categories = [];
-                    }
-
                     $translator = $container->get('translator');
-                    $form = new Form\Activity($organs, $companies, $categories, $translator);
+                    $form = new Form\Activity($translator);
                     $form->setHydrator($container->get('activity_hydrator'));
 
                     return $form;

--- a/module/Activity/src/Service/Activity.php
+++ b/module/Activity/src/Service/Activity.php
@@ -131,13 +131,31 @@ class Activity
      *
      * @return ActivityForm
      */
-    public function getActivityForm()
+    public function getActivityForm(): ActivityForm
     {
         if (!$this->aclService->isAllowed('create', 'activity')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to create an activity'));
         }
 
-        return $this->activityForm;
+        try {
+            $organs = $this->organService->getEditableOrgans();
+        } catch (NotAllowedException $e) {
+            $organs = [];
+        }
+
+        try {
+            $companies = $this->companyService->getHiddenCompanyList();
+        } catch (NotAllowedException $e) {
+            $companies = [];
+        }
+
+        try {
+            $categories = $this->categoryService->findAll();
+        } catch (NotAllowedException $e) {
+            $categories = [];
+        }
+
+        return $this->activityForm->setAllOptions($organs, $companies, $categories);
     }
 
     /**

--- a/module/Decision/src/Module.php
+++ b/module/Decision/src/Module.php
@@ -122,53 +122,52 @@ class Module
                 },
                 'decision_mapper_member' => function (ContainerInterface $container) {
                     return new Member(
-                        $container->get('doctrine.entitymanager.orm_default')
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'decision_mapper_organ' => function (ContainerInterface $container) {
                     return new Organ(
-                        $container->get('doctrine.entitymanager.orm_default')
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'decision_mapper_meeting' => function (ContainerInterface $container) {
                     return new Meeting(
-                        $container->get('doctrine.entitymanager.orm_default')
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'decision_mapper_decision' => function (ContainerInterface $container) {
                     return new Decision(
-                        $container->get('doctrine.entitymanager.orm_default')
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'decision_mapper_authorization' => function (ContainerInterface $container) {
                     return new Mapper\Authorization(
-                        $container->get('doctrine.entitymanager.orm_default')
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'decision_form_searchdecision' => function (ContainerInterface $container) {
                     return new SearchDecision(
-                        $container->get('translator')
+                        $container->get('translator'),
                     );
                 },
                 'decision_form_document' => function (ContainerInterface $container) {
                     return new Document(
-                        $container->get('translator')
+                        $container->get('translator'),
                     );
                 },
                 'decision_form_notes' => function (ContainerInterface $container) {
                     return new Notes(
                         $container->get('translator'),
-                        $container->get('decision_mapper_meeting')
                     );
                 },
                 'decision_form_authorization' => function (ContainerInterface $container) {
                     return new Authorization(
-                        $container->get('translator')
+                        $container->get('translator'),
                     );
                 },
                 'decision_form_organ_information' => function (ContainerInterface $container) {
                     $form = new OrganInformation(
-                        $container->get('translator')
+                        $container->get('translator'),
                     );
                     $form->setHydrator($container->get('decision_hydrator'));
 
@@ -183,7 +182,7 @@ class Module
                 },
                 'decision_hydrator' => function (ContainerInterface $container) {
                     return new DoctrineObject(
-                        $container->get('doctrine.entitymanager.orm_default')
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'decision_fileReader' => function (ContainerInterface $container) {
@@ -193,7 +192,7 @@ class Module
 
                     return new LocalFileReader(
                         $config['filebrowser_folder'],
-                        $validFile
+                        $validFile,
                     );
                 },
                 'decision_service_acl' => AclServiceFactory::class,

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -556,7 +556,7 @@ class Decision
             throw new NotAllowedException($this->translator->translate('You are not allowed to upload notes.'));
         }
 
-        return $this->notesForm;
+        return $this->notesForm->setMeetings($this->meetingMapper->findAllMeetings());
     }
 
     /**


### PR DESCRIPTION
Fixes #1244 and closes #1143.

The `Activity` and `Notes` forms both use dynamic options. These were always loaded (from the database) when passing the form to the their respective service. This meant, however, that on each page where this service was present, the form would be initialised and the options loaded.

Especially for the `Notes` form this was noticeable, as there are currently more than 1500 meetings in the database. This slowed down all pages under `/member`. To prevent the same issue with the `Activity` form (which uses companies) I have also edited that form.