### PR TITLE
Configure Doctrine to use UTF8MB4

### DIFF
--- a/config/autoload/doctrine.local.development.php.dist
+++ b/config/autoload/doctrine.local.development.php.dist
@@ -29,6 +29,8 @@ return [
                     'user'     => getenv('DOCKER_DB_USERNAME'),
                     'password' => getenv('DOCKER_DB_PASSWORD'),
                     'dbname'   => getenv('DOCKER_DB_DATABASE'),
+                    'charset' => 'utf8mb4',
+                    'collate' => 'utf8mb4_unicode_ci',
                 ]
             ],
         ],

--- a/config/autoload/doctrine.local.production.php.dist
+++ b/config/autoload/doctrine.local.production.php.dist
@@ -29,6 +29,8 @@ return [
                     'user'     => getenv('DOCKER_DB_USERNAME'),
                     'password' => getenv('DOCKER_DB_PASSWORD'),
                     'dbname'   => getenv('DOCKER_DB_DATABASE'),
+                    'charset' => 'utf8mb4',
+                    'collate' => 'utf8mb4_unicode_ci',
                 ]
             ],
         ],


### PR DESCRIPTION
Requires Doctrine to use `utf8mb4`, which is the only encoding fully covering UTF-8. This does require an update of the database (which can be automated). This prevents weird issues where certain unicode characters cannot be entered in the database or are incorrectly displayed on the website.

Closes #1121.