### PR TITLE
Fix package forms not validating due to localisable dependency

### DIFF
--- a/module/Application/src/Form/Localisable.php
+++ b/module/Application/src/Form/Localisable.php
@@ -17,35 +17,36 @@ abstract class Localisable extends Form implements InputFilterProviderInterface
      */
     private Translator $translator;
 
-    public function __construct(Translator $translator)
+    public function __construct(Translator $translator, bool $addElements = true)
     {
         parent::__construct();
-
         $this->translator = $translator;
 
-        $this->add(
-            [
-                'name' => 'language_dutch',
-                'type' => Checkbox::class,
-                'options' => [
-                    'label' => $this->getTranslator()->translate('Enable Dutch Translations'),
-                    'checked_value' => '1',
-                    'unchecked_value' => '0',
-                ],
-            ]
-        );
+        if ($addElements) {
+            $this->add(
+                [
+                    'name' => 'language_dutch',
+                    'type' => Checkbox::class,
+                    'options' => [
+                        'label' => $this->getTranslator()->translate('Enable Dutch Translations'),
+                        'checked_value' => '1',
+                        'unchecked_value' => '0',
+                    ],
+                ]
+            );
 
-        $this->add(
-            [
-                'name' => 'language_english',
-                'type' => Checkbox::class,
-                'options' => [
-                    'label' => $this->getTranslator()->translate('Enable English Translations'),
-                    'checked_value' => '1',
-                    'unchecked_value' => '0',
-                ],
-            ]
-        );
+            $this->add(
+                [
+                    'name' => 'language_english',
+                    'type' => Checkbox::class,
+                    'options' => [
+                        'label' => $this->getTranslator()->translate('Enable English Translations'),
+                        'checked_value' => '1',
+                        'unchecked_value' => '0',
+                    ],
+                ]
+            );
+        }
     }
 
     /**

--- a/module/Company/src/Form/Package.php
+++ b/module/Company/src/Form/Package.php
@@ -28,7 +28,7 @@ class Package extends LocalisableForm implements InputFilterProviderInterface
 
     public function __construct(Translator $translator, string $type)
     {
-        parent::__construct($translator);
+        parent::__construct($translator, ('featured' === $type));
         $this->type = $type;
         $this->setAttribute('method', 'post');
 


### PR DESCRIPTION
Unfortunately, the `Localisable` form added the two checkboxes for
the two package forms (job and banner) where this is not required.
As these elements are not present on the page, the form would not
validate because it was missing elements.

I have changed the `Localisable` form to by default always add the
checkboxes, however, a second argument can be provided to not do
this.

This could have been fixed by altering the `validationGroup` for
the specific package forms, however, that is not a universal fix
for the problem at hand. Hence, delegating the "validation" to
the `Localisable` form by removing the elements when not
necessary is more maintainable.

Issue was reported by Eline.