### PR TITLE
Fix overdue options including old already approved options

### DIFF
--- a/module/Activity/src/Service/ActivityCalendar.php
+++ b/module/Activity/src/Service/ActivityCalendar.php
@@ -125,7 +125,7 @@ class ActivityCalendar
     {
         $date = new DateTime();
         $date->sub(new DateInterval('P3W'));
-        $oldOptions = $this->calendarOptionMapper->getPastOptions($date);
+        $oldOptions = $this->calendarOptionMapper->getOverdueOptions($date);
         if (!empty($oldOptions)) {
             $this->emailService->sendEmail(
                 'activity_calendar',


### PR DESCRIPTION
Fixes #1223.

It appears that from #912 onwards, old already approved options were included when sending overdue options. This is because with `$withDeleted = false`, an `OR` was added to the query for `status = 'approved'`, which meant that old already approved options were added to the overdue options list (Doctrine grouped all `AND`s, like `(... AND ...) OR ... `).

I have simplified the query and requirements for an option to be "overdue":

1) The proposal must be created before a certain date (currently 3 weeks before now).
2) The option (i.e. activity) must begin after now.
3) The proposal must not yet bet modified (i.e. it has not been deleted or approved).