### PR TITLE
Exchange rsync for sFTP to fix public archive sync

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -43,6 +43,7 @@ DOCKER_DB2_DATABASE=database
 # These settings are for accessing the server containing the public archive for synchronization (production only)
 SSH_USERNAME=gewis
 SSH_PASSWORD=gewis
+SSH_REMOTE=gewis
 
 # These are the settings for Matomo (Analytics)
 MATOMO_DATABASE_HOST=mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
 #            - DOCKER_DB2_DATABASE=
 #            - SSH_USERNAME=
 #            - SSH_PASSWORD=
+#            - SSH_REMOTE=
         depends_on:
             - memcached
             - postfix

--- a/publicarchive.sh
+++ b/publicarchive.sh
@@ -1,2 +1,13 @@
 #!/bin/sh
-rsync -aWPu --delete --chown www-data:www-data --rsh="/usr/bin/sshpass -p ${SSH_PASSWORD} ssh -o StrictHostKeyChecking=no -l ${SSH_USERNAME}" files.gewis.nl:/home/public/* /code/public/publicarchive
+# Remove the old files
+rm -rf /code/public/publicarchive/*
+
+# Download the new files
+sshpass -p "${SSH_PASSWORD}" sftp "${SSH_USERNAME}"@"${SSH_REMOTE}" <<!
+cd "/datas/Public Archive/"
+mget -r * /code/public/publicarchive/
+quit
+!
+
+# Give new files proper attributes
+chown -R www-data:www-data /code/public/publicarchive/


### PR DESCRIPTION
The old file server will stop working not too far in the future and the public archive is already present on the new server. Hence, we can already switch to the new server.

Unfortunately, this server does not have rsync capabilities, nor does it allow SCP. Hence, we need to switch to the only supported protocol, sFTP.

Previously, rsync would keep track of files to be removed. Implementing this with sFTP is not feasible, as such it is just easier to remove all files before downloading them. If something fails during the download, the files will be missing, but I think this is acceptable, as we can easily manually sync the files (unless they are no longer present on the remote).

Additionally, I have put the remote address in an environment variable (`SSH_REMOTE`) to make it easier to configure it if necessary.

Code has been tested on the test website (you can check it out).

Fixes #1303.