### PR TITLE
Fix typing for all modules

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -16,5 +16,8 @@
       <option name="level" value="5" />
       <option name="config" value="$PROJECT_DIR$/phpstan.neon" />
     </inspection_tool>
+    <inspection_tool class="PhpUnused" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="SUPPRESS_GETTERS_AND_SETTERS" value="true" />
+    </inspection_tool>
   </profile>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -8,7 +8,10 @@
       <option name="SHOW_SNIFF_NAMES" value="true" />
       <option name="EXTENSIONS" value="php" />
     </inspection_tool>
-    <inspection_tool class="PhpStanGlobal" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <inspection_tool class="PhpMissingFieldTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PhpMissingParamTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PhpMissingReturnTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PhpStanGlobal" enabled="false" level="WEAK WARNING" enabled_by_default="false">
       <option name="FULL_PROJECT" value="true" />
       <option name="level" value="5" />
       <option name="config" value="$PROJECT_DIR$/phpstan.neon" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,38 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
+  <component name="PhpEntryPointsManager">
+    <entry_point>
+      <entry_point TYPE="phpNamespace" FQNAME="\Activity\Command" />
+      <entry_point TYPE="phpNamespace" FQNAME="\Activity\Controller" />
+      <entry_point TYPE="phpNamespace" FQNAME="\ActivityTest" />
+      <entry_point TYPE="phpNamespace" FQNAME="\Application\Controller" />
+      <entry_point TYPE="phpNamespace" FQNAME="\ApplicationTest" />
+      <entry_point TYPE="phpNamespace" FQNAME="\Company\Controller" />
+      <entry_point TYPE="phpNamespace" FQNAME="\CompanyTest" />
+      <entry_point TYPE="phpNamespace" FQNAME="\Decision\Controller" />
+      <entry_point TYPE="phpNamespace" FQNAME="\Education\Controller" />
+      <entry_point TYPE="phpNamespace" FQNAME="\EducationTest" />
+      <entry_point TYPE="phpNamespace" FQNAME="\Frontpage\Controller" />
+      <entry_point TYPE="phpNamespace" FQNAME="\FrontpageTest" />
+      <entry_point TYPE="phpNamespace" FQNAME="\Photo\Command" />
+      <entry_point TYPE="phpNamespace" FQNAME="\Photo\Controller" />
+      <entry_point TYPE="phpNamespace" FQNAME="\PhotoTest" />
+      <entry_point TYPE="phpNamespace" FQNAME="\User\Controller" />
+      <entry_point TYPE="phpNamespace" FQNAME="\UserTest" />
+    </entry_point>
+    <pattern value="\*\Controller\*" member="*" />
+    <pattern value="\*\Module" member="*" />
+    <pattern value="\*\Command\*" member="*" />
+    <pattern value="\*\*\*Factory" member="*" />
+    <pattern value="\*\*\Factory\*Factory" member="*" />
+    <pattern value="\Application\Mapper\BaseMapper" member="*" />
+    <pattern value="\*Test\*Test" member="*" />
+    <pattern value="\*\Form\*" member="*" />
+    <pattern value="\*\Extensions\*\*" member="*" />
+    <pattern value="\*\View\Helper\*" member="*" />
+    <pattern value="\*\Listener\*" member="*" />
+    <pattern value="\User\Permissions\Assertion\*" member="*" />
+    <pattern value="\*\Service\*" />
+  </component>
 </project>

--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,9 @@ phpcsfix:
 		@vendor/bin/php-cs-fixer fix --cache-file=data/cache/.php-cs-fixer.cache --rules=@PSR1,@PSR12,@DoctrineAnnotation,@PHP81Migration,group_import,-single_import_per_statement module
 		@vendor/bin/php-cs-fixer fix --cache-file=data/cache/.php-cs-fixer.cache --rules=@PSR1,@PSR12,@DoctrineAnnotation,@PHP81Migration,group_import,-single_import_per_statement config
 
-phpcsfixtypes:
-		@vendor/bin/php-cs-fixer fix --cache-file=data/cache/.php-cs-fixer.cache --allow-risky=yes --rules=@PHP80Migration:risky module
-		@vendor/bin/php-cs-fixer fix --cache-file=data/cache/.php-cs-fixer.cache --allow-risky=yes --rules=@PHP80Migration:risky config
+phpcsfixrisky:
+		@vendor/bin/php-cs-fixer fix --cache-file=data/cache/.php-cs-fixer.cache --allow-risky=yes --rules=@PHP80Migration:risky,-declare_strict_types,-use_arrow_functions  module
+		@vendor/bin/php-cs-fixer fix --cache-file=data/cache/.php-cs-fixer.cache --allow-risky=yes --rules=@PHP80Migration:risky,-declare_strict_types,-use_arrow_functions  config
 
 updatecomposer:
 		@docker cp ./composer.json gewisweb_web_1:/code/composer.json

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -22,6 +22,9 @@ if (!class_exists(Application::class)) {
 
 class ConsoleRunner
 {
+    /**
+     * @return array
+     */
     public static function getConfig(): array
     {
         // Retrieve configuration
@@ -32,6 +35,10 @@ class ConsoleRunner
 
         return $appConfig;
     }
+
+    /**
+     * @return Application
+     */
     public static function getApplication(): Application
     {
         // Retrieve configuration
@@ -41,6 +48,9 @@ class ConsoleRunner
         return Application::init($appConfig);
     }
 
+    /**
+     * @return ServiceManager
+     */
     public static function getServiceManager(): ServiceManager
     {
         $appConfig = self::getConfig();

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,7 +5,6 @@ define('APP_ENV', getenv('APP_ENV') ?: 'production');
 // make sure we are in the correct directory
 chdir(__DIR__);
 
-use Laminas\ModuleManager\ModuleManagerInterface;
 use Laminas\Mvc\Application;
 use Laminas\Mvc\Service\ServiceManagerConfig;
 use Laminas\ServiceManager\ServiceManager;

--- a/module/Activity/src/Command/CalendarNotify.php
+++ b/module/Activity/src/Command/CalendarNotify.php
@@ -30,8 +30,6 @@ class CalendarNotify extends Command
 
     /**
      * @param ActivityCalendar $calendarService
-     *
-     * @return void
      */
     public function setCalendarService(ActivityCalendar $calendarService): void
     {

--- a/module/Activity/src/Command/CalendarNotify.php
+++ b/module/Activity/src/Command/CalendarNotify.php
@@ -9,16 +9,29 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CalendarNotify extends Command
 {
+    /**
+     * @var ActivityCalendar
+     */
     private ActivityCalendar $calendarService;
 
-    public function execute(InputInterface $input, OutputInterface $output)
-    {
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    public function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
         $this->calendarService->sendOverdueNotifications();
         return 1;
     }
 
     /**
      * @param ActivityCalendar $calendarService
+     *
+     * @return void
      */
     public function setCalendarService(ActivityCalendar $calendarService): void
     {

--- a/module/Activity/src/Controller/ActivityCalendarController.php
+++ b/module/Activity/src/Controller/ActivityCalendarController.php
@@ -16,6 +16,16 @@ use Laminas\Mvc\I18n\Translator;
 class ActivityCalendarController extends AbstractActionController
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
      * @var ActivityCalendarService
      */
     private ActivityCalendarService $calendarService;
@@ -24,8 +34,6 @@ class ActivityCalendarController extends AbstractActionController
      * @var ActivityCalendarFormService
      */
     private ActivityCalendarFormService $calendarFormService;
-
-    private AclService $aclService;
 
     /**
      * @var ActivityCalendarProposalForm
@@ -37,32 +45,30 @@ class ActivityCalendarController extends AbstractActionController
      */
     private array $calendarConfig;
 
-    private Translator $translator;
-
     /**
      * ActivityCalendarController constructor.
      *
+     * @param AclService $aclService
+     * @param Translator $translator
      * @param ActivityCalendarService $calendarService
      * @param ActivityCalendarFormService $calendarFormService
-     * @param AclService $aclService
      * @param ActivityCalendarProposalForm $calendarProposalForm
      * @param array $calendarConfig
-     * @param Translator $translator
      */
     public function __construct(
+        AclService $aclService,
+        Translator $translator,
         ActivityCalendarService $calendarService,
         ActivityCalendarFormService $calendarFormService,
-        AclService $aclService,
         ActivityCalendarProposalForm $calendarProposalForm,
         array $calendarConfig,
-        Translator $translator
     ) {
+        $this->aclService = $aclService;
+        $this->translator = $translator;
         $this->calendarService = $calendarService;
         $this->calendarFormService = $calendarFormService;
-        $this->aclService = $aclService;
         $this->calendarProposalForm = $calendarProposalForm;
         $this->calendarConfig = $calendarConfig;
-        $this->translator = $translator;
     }
 
     public function indexAction()

--- a/module/Activity/src/Controller/ActivityCalendarController.php
+++ b/module/Activity/src/Controller/ActivityCalendarController.php
@@ -8,6 +8,7 @@ use Activity\Service\{
     ActivityCalendar as ActivityCalendarService,
     ActivityCalendarForm as ActivityCalendarFormService,
 };
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use User\Permissions\NotAllowedException;
@@ -71,7 +72,7 @@ class ActivityCalendarController extends AbstractActionController
         $this->calendarConfig = $calendarConfig;
     }
 
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $config = $this->calendarConfig;
 
@@ -88,7 +89,7 @@ class ActivityCalendarController extends AbstractActionController
         );
     }
 
-    public function deleteAction()
+    public function deleteAction(): Response|ViewModel
     {
         $request = $this->getRequest();
 
@@ -100,7 +101,7 @@ class ActivityCalendarController extends AbstractActionController
         return $this->notFoundAction();
     }
 
-    public function approveAction()
+    public function approveAction(): Response|ViewModel
     {
         $request = $this->getRequest();
 
@@ -112,7 +113,7 @@ class ActivityCalendarController extends AbstractActionController
         return $this->notFoundAction();
     }
 
-    public function createAction()
+    public function createAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'activity_calendar_proposal')) {
             throw new NotAllowedException(

--- a/module/Activity/src/Controller/ActivityController.php
+++ b/module/Activity/src/Controller/ActivityController.php
@@ -87,7 +87,7 @@ class ActivityController extends AbstractActionController
     /**
      * View all activities.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $activities = $this->activityQueryService->getUpcomingActivities($this->params('category'));
 
@@ -101,8 +101,9 @@ class ActivityController extends AbstractActionController
 
     /**
      * View one activity.
+     * @return mixed
      */
-    public function viewAction()
+    public function viewAction(): mixed
     {
         $activityId = (int)$this->params('id');
         $activity = $this->activityQueryService->getActivity($activityId);
@@ -130,7 +131,7 @@ class ActivityController extends AbstractActionController
         );
     }
 
-    public function viewSignupListAction()
+    public function viewSignupListAction(): ViewModel
     {
         $activityId = (int)$this->params('id');
         $signupListId = (int)$this->params('signupList');
@@ -245,7 +246,7 @@ class ActivityController extends AbstractActionController
     /**
      * Create an activity.
      */
-    public function createAction()
+    public function createAction(): array|ViewModel
     {
         $form = $this->activityService->getActivityForm();
         $request = $this->getRequest();
@@ -273,7 +274,7 @@ class ActivityController extends AbstractActionController
     /**
      * Signup for a activity.
      */
-    public function signupAction()
+    public function signupAction(): Response|ViewModel
     {
         $activityId = (int)$this->params('id');
         $signupListId = (int)$this->params('signupList');
@@ -368,7 +369,7 @@ class ActivityController extends AbstractActionController
         );
     }
 
-    public function externalSignupAction()
+    public function externalSignupAction(): Response|ViewModel
     {
         $activityId = (int)$this->params('id');
         $signupListId = (int)$this->params('signupList');
@@ -430,7 +431,7 @@ class ActivityController extends AbstractActionController
     /**
      * Signup for a activity.
      */
-    public function signoffAction()
+    public function signoffAction(): Response|ViewModel
     {
         $activityId = (int)$this->params('id');
         $signupListId = (int)$this->params('signupList');
@@ -497,7 +498,7 @@ class ActivityController extends AbstractActionController
      *
      * @return ViewModel
      */
-    public function archiveAction()
+    public function archiveAction(): ViewModel
     {
         $years = $this->activityQueryService->getActivityArchiveYears();
         $year = $this->params()->fromRoute('year');

--- a/module/Activity/src/Controller/ActivityController.php
+++ b/module/Activity/src/Controller/ActivityController.php
@@ -246,7 +246,7 @@ class ActivityController extends AbstractActionController
     /**
      * Create an activity.
      */
-    public function createAction(): array|ViewModel
+    public function createAction(): ViewModel
     {
         $form = $this->activityService->getActivityForm();
         $request = $this->getRequest();
@@ -264,11 +264,13 @@ class ActivityController extends AbstractActionController
             }
         }
 
-        return [
-            'form' => $form,
-            'action' => $this->translator->translate('Create Activity'),
-            'allowSignupList' => true,
-        ];
+        return new ViewModel(
+            [
+                'form' => $form,
+                'action' => $this->translator->translate('Create Activity'),
+                'allowSignupList' => true,
+            ]
+        );
     }
 
     /**

--- a/module/Activity/src/Controller/AdminApprovalController.php
+++ b/module/Activity/src/Controller/AdminApprovalController.php
@@ -63,7 +63,7 @@ class AdminApprovalController extends AbstractActionController
     /**
      * View one activity.
      */
-    public function viewAction()
+    public function viewAction(): ViewModel
     {
         $id = (int)$this->params('id');
 
@@ -92,7 +92,7 @@ class AdminApprovalController extends AbstractActionController
     /**
      * Approve of an activity.
      */
-    public function approveAction()
+    public function approveAction(): Response|ViewModel
     {
         return $this->setApprovalStatus('approve');
     }
@@ -104,7 +104,7 @@ class AdminApprovalController extends AbstractActionController
      *
      * @return ViewModel|Response
      */
-    protected function setApprovalStatus(string $status)
+    protected function setApprovalStatus(string $status): Response|ViewModel
     {
         //Assure the form is used
         if (!$this->getRequest()->isPost()) {
@@ -146,7 +146,7 @@ class AdminApprovalController extends AbstractActionController
     /**
      * Disapprove an activity.
      */
-    public function disapproveAction()
+    public function disapproveAction(): Response|ViewModel
     {
         return $this->setApprovalStatus('disapprove');
     }
@@ -154,7 +154,7 @@ class AdminApprovalController extends AbstractActionController
     /**
      * Reset the approval status of an activity.
      */
-    public function resetAction()
+    public function resetAction(): Response|ViewModel
     {
         return $this->setApprovalStatus('reset');
     }
@@ -162,7 +162,7 @@ class AdminApprovalController extends AbstractActionController
     /**
      * Display the proposed update.
      */
-    public function viewProposalAction()
+    public function viewProposalAction(): array|ViewModel
     {
         $id = (int)$this->params('id');
 
@@ -182,7 +182,7 @@ class AdminApprovalController extends AbstractActionController
     /**
      * Apply the proposed update.
      */
-    public function applyProposalAction()
+    public function applyProposalAction(): Response|ViewModel
     {
         $id = (int)$this->params('id');
 
@@ -206,7 +206,7 @@ class AdminApprovalController extends AbstractActionController
         $newId = $proposal->getNew()->getId();
         $this->activityService->updateActivity($proposal);
 
-        $this->redirect()->toRoute(
+        return $this->redirect()->toRoute(
             'activity_admin_approval/view',
             [
                 'id' => $newId,
@@ -217,7 +217,7 @@ class AdminApprovalController extends AbstractActionController
     /**
      * Revoke the proposed update.
      */
-    public function revokeProposalAction()
+    public function revokeProposalAction(): Response|ViewModel
     {
         $id = (int)$this->params('id');
         //Assure the form is used
@@ -241,7 +241,7 @@ class AdminApprovalController extends AbstractActionController
         $oldId = $proposal->getOld()->getId();
         $this->activityService->revokeUpdateProposal($proposal);
 
-        $this->redirect()->toRoute(
+        return $this->redirect()->toRoute(
             'activity_admin_approval/view',
             [
                 'id' => $oldId,

--- a/module/Activity/src/Controller/AdminApprovalController.php
+++ b/module/Activity/src/Controller/AdminApprovalController.php
@@ -162,7 +162,7 @@ class AdminApprovalController extends AbstractActionController
     /**
      * Display the proposed update.
      */
-    public function viewProposalAction(): array|ViewModel
+    public function viewProposalAction(): ViewModel
     {
         $id = (int)$this->params('id');
 
@@ -172,11 +172,13 @@ class AdminApprovalController extends AbstractActionController
             return $this->notFoundAction();
         }
 
-        return [
-            'proposal' => $proposal,
-            'proposalApplyForm' => new RequestForm('proposalApply', 'Apply update'),
-            'proposalRevokeForm' => new RequestForm('proposalRevoke', 'Revoke update'),
-        ];
+        return new ViewModel(
+            [
+                'proposal' => $proposal,
+                'proposalApplyForm' => new RequestForm('proposalApply', 'Apply update'),
+                'proposalRevokeForm' => new RequestForm('proposalRevoke', 'Revoke update'),
+            ]
+        );
     }
 
     /**

--- a/module/Activity/src/Controller/AdminApprovalController.php
+++ b/module/Activity/src/Controller/AdminApprovalController.php
@@ -21,16 +21,6 @@ use User\Permissions\NotAllowedException;
 class AdminApprovalController extends AbstractActionController
 {
     /**
-     * @var ActivityService
-     */
-    private ActivityService $activityService;
-
-    /**
-     * @var ActivityQueryService
-     */
-    private ActivityQueryService $activityQueryService;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
@@ -41,23 +31,33 @@ class AdminApprovalController extends AbstractActionController
     private Translator $translator;
 
     /**
+     * @var ActivityService
+     */
+    private ActivityService $activityService;
+
+    /**
+     * @var ActivityQueryService
+     */
+    private ActivityQueryService $activityQueryService;
+
+    /**
      * AdminApprovalController constructor.
      *
-     * @param ActivityService $activityService
-     * @param ActivityQueryService $activityQueryService
      * @param AclService $aclService
      * @param Translator $translator
+     * @param ActivityService $activityService
+     * @param ActivityQueryService $activityQueryService
      */
     public function __construct(
+        AclService $aclService,
+        Translator $translator,
         ActivityService $activityService,
         ActivityQueryService $activityQueryService,
-        AclService $aclService,
-        Translator $translator
     ) {
-        $this->activityService = $activityService;
-        $this->activityQueryService = $activityQueryService;
         $this->aclService = $aclService;
         $this->translator = $translator;
+        $this->activityService = $activityService;
+        $this->activityQueryService = $activityQueryService;
     }
 
     /**

--- a/module/Activity/src/Controller/AdminCategoryController.php
+++ b/module/Activity/src/Controller/AdminCategoryController.php
@@ -49,7 +49,7 @@ class AdminCategoryController extends AbstractActionController
     /**
      * View all Categories.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $categories = $this->categoryService->findAll();
 
@@ -63,7 +63,7 @@ class AdminCategoryController extends AbstractActionController
     /**
      * Add Category.
      */
-    public function addAction()
+    public function addAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('addCategory', 'activity')) {
             throw new NotAllowedException(
@@ -116,7 +116,7 @@ class AdminCategoryController extends AbstractActionController
     /**
      * Delete Category.
      */
-    public function deleteAction()
+    public function deleteAction(): Response|ViewModel
     {
         $request = $this->getRequest();
 
@@ -139,7 +139,7 @@ class AdminCategoryController extends AbstractActionController
     /**
      * Edit Category.
      */
-    public function editAction()
+    public function editAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('editCategory', 'activity')) {
             throw new NotAllowedException(

--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -23,6 +23,7 @@ use Laminas\Session\{
     Container as SessionContainer,
 };
 use Laminas\Stdlib\Parameters;
+use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\ViewModel;
 use User\Permissions\NotAllowedException;
 
@@ -96,7 +97,7 @@ class AdminController extends AbstractActionController
         $this->signupMapper = $signupMapper;
     }
 
-    public function updateAction()
+    public function updateAction(): Response|ViewModel
     {
         $activityId = (int) $this->params('id');
         $activity = $this->activityQueryService->getActivityWithDetails($activityId);
@@ -218,7 +219,7 @@ class AdminController extends AbstractActionController
      *
      * @return ViewModel|array
      */
-    public function participantsAction()
+    public function participantsAction(): array|ViewModel
     {
         $activityId = (int) $this->params('id');
         $signupListId = (int) $this->params('signupList');
@@ -301,7 +302,7 @@ class AdminController extends AbstractActionController
         return $result;
     }
 
-    public function externalSignupAction()
+    public function externalSignupAction(): \Laminas\Http\PhpEnvironment\Response|ResponseInterface|ViewModel
     {
         $activityId = (int) $this->params('id');
         $signupListId = (int) $this->params('signupList');
@@ -386,7 +387,7 @@ class AdminController extends AbstractActionController
         );
     }
 
-    public function externalSignoffAction()
+    public function externalSignoffAction(): \Laminas\Http\PhpEnvironment\Response|ResponseInterface|ViewModel
     {
         $signupId = (int) $this->params('id');
         $signup = $this->signupMapper->find($signupId);
@@ -447,7 +448,7 @@ class AdminController extends AbstractActionController
     /**
      * Show a list of all activities this user can manage.
      */
-    public function viewAction()
+    public function viewAction(): array
     {
         if (!$this->aclService->isAllowed('viewAdmin', 'activity')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to administer activities'));

--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -33,6 +33,16 @@ use User\Permissions\NotAllowedException;
 class AdminController extends AbstractActionController
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
      * @var ActivityService
      */
     private ActivityService $activityService;
@@ -58,42 +68,32 @@ class AdminController extends AbstractActionController
     private SignupMapper $signupMapper;
 
     /**
-     * @var AclService
-     */
-    private AclService $aclService;
-
-    /**
-     * @var Translator
-     */
-    private Translator $translator;
-
-    /**
      * AdminController constructor.
      *
+     * @param AclService $aclService
+     * @param Translator $translator
      * @param ActivityService $activityService
      * @param ActivityQueryService $activityQueryService
      * @param SignupService $signupService
      * @param SignupListQueryService $signupListQueryService
      * @param SignupMapper $signupMapper
-     * @param AclService $aclService
-     * @param Translator $translator
      */
     public function __construct(
+        AclService $aclService,
+        Translator $translator,
         ActivityService $activityService,
         ActivityQueryService $activityQueryService,
         SignupService $signupService,
         SignupListQueryService $signupListQueryService,
         SignupMapper $signupMapper,
-        AclService $aclService,
-        Translator $translator
     ) {
+        $this->aclService = $aclService;
+        $this->translator = $translator;
         $this->activityService = $activityService;
         $this->activityQueryService = $activityQueryService;
         $this->signupService = $signupService;
         $this->signupListQueryService = $signupListQueryService;
         $this->signupMapper = $signupMapper;
-        $this->aclService = $aclService;
-        $this->translator = $translator;
     }
 
     public function updateAction()
@@ -194,8 +194,16 @@ class AdminController extends AbstractActionController
         return $viewModel;
     }
 
-    protected function redirectActivityAdmin($success, $message)
-    {
+    /**
+     * @param bool $success
+     * @param string $message
+     *
+     * @return Response
+     */
+    protected function redirectActivityAdmin(
+        bool $success,
+        string $message,
+    ): Response {
         if ($success) {
             $this->plugin('FlashMessenger')->addSuccessMessage($message);
         } else {

--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -217,9 +217,9 @@ class AdminController extends AbstractActionController
     /**
      * Return the data of the activity participants.
      *
-     * @return ViewModel|array
+     * @return ViewModel
      */
-    public function participantsAction(): array|ViewModel
+    public function participantsAction(): ViewModel
     {
         $activityId = (int) $this->params('id');
         $signupListId = (int) $this->params('signupList');
@@ -299,7 +299,7 @@ class AdminController extends AbstractActionController
             unset($activityAdminSession->message);
         }
 
-        return $result;
+        return new ViewModel($result);
     }
 
     public function externalSignupAction(): \Laminas\Http\PhpEnvironment\Response|ResponseInterface|ViewModel

--- a/module/Activity/src/Controller/AdminOptionController.php
+++ b/module/Activity/src/Controller/AdminOptionController.php
@@ -18,6 +18,16 @@ use User\Permissions\NotAllowedException;
 class AdminOptionController extends AbstractActionController
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
      * @var ActivityCalendarService
      */
     private ActivityCalendarService $activityCalendarService;
@@ -33,36 +43,26 @@ class AdminOptionController extends AbstractActionController
     private ActivityOptionCreationPeriodMapper $activityOptionCreationPeriodMapper;
 
     /**
-     * @var AclService
-     */
-    private AclService $aclService;
-
-    /**
-     * @var Translator
-     */
-    private Translator $translator;
-
-    /**
      * AdminOptionController constructor.
      *
+     * @param AclService $aclService
+     * @param Translator $translator
      * @param ActivityCalendarService $activityCalendarService
      * @param OrganService $organService
      * @param ActivityOptionCreationPeriodMapper $activityOptionCreationPeriodMapper
-     * @param AclService $aclService
-     * @param Translator $translator
      */
     public function __construct(
+        AclService $aclService,
+        Translator $translator,
         ActivityCalendarService $activityCalendarService,
         OrganService $organService,
         ActivityOptionCreationPeriodMapper $activityOptionCreationPeriodMapper,
-        AclService $aclService,
-        Translator $translator,
     ) {
+        $this->aclService = $aclService;
+        $this->translator = $translator;
         $this->activityCalendarService = $activityCalendarService;
         $this->organService = $organService;
         $this->activityOptionCreationPeriodMapper = $activityOptionCreationPeriodMapper;
-        $this->aclService = $aclService;
-        $this->translator = $translator;
     }
 
     public function indexAction()
@@ -200,8 +200,10 @@ class AdminOptionController extends AbstractActionController
      *
      * @return Response
      */
-    private function redirectWithMessage(bool $success, string $message): Response
-    {
+    private function redirectWithMessage(
+        bool $success,
+        string $message,
+    ): Response {
         if ($success) {
             $this->plugin('FlashMessenger')->addSuccessMessage($message);
         } else {

--- a/module/Activity/src/Controller/AdminOptionController.php
+++ b/module/Activity/src/Controller/AdminOptionController.php
@@ -65,7 +65,7 @@ class AdminOptionController extends AbstractActionController
         $this->activityOptionCreationPeriodMapper = $activityOptionCreationPeriodMapper;
     }
 
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('view', 'activity_calendar_period')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to administer option calendar periods'));
@@ -77,7 +77,7 @@ class AdminOptionController extends AbstractActionController
         ]);
     }
 
-    public function addAction()
+    public function addAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'activity_calendar_period')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to create option calendar periods'));
@@ -120,7 +120,7 @@ class AdminOptionController extends AbstractActionController
         ]);
     }
 
-    public function deleteAction()
+    public function deleteAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('delete', 'activity_calendar_period')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete option calendar periods'));
@@ -140,7 +140,7 @@ class AdminOptionController extends AbstractActionController
         return $this->notFoundAction();
     }
 
-    public function editAction()
+    public function editAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('edit', 'activity_calendar_period')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit option calendar periods'));

--- a/module/Activity/src/Controller/ApiController.php
+++ b/module/Activity/src/Controller/ApiController.php
@@ -39,7 +39,7 @@ class ApiController extends AbstractActionController
     /**
      * List all activities.
      */
-    public function listAction()
+    public function listAction(): JsonModel
     {
         if (!$this->aclService->isAllowed('list', 'activityApi')) {
             $translator = $this->activityQueryService->getTranslator();

--- a/module/Activity/src/Controller/ApiController.php
+++ b/module/Activity/src/Controller/ApiController.php
@@ -13,27 +13,27 @@ use User\Permissions\NotAllowedException;
 class ApiController extends AbstractActionController
 {
     /**
-     * @var ActivityQueryService
-     */
-    private ActivityQueryService $activityQueryService;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
 
     /**
+     * @var ActivityQueryService
+     */
+    private ActivityQueryService $activityQueryService;
+
+    /**
      * ApiController constructor.
      *
-     * @param ActivityQueryService $activityQueryService
      * @param AclService $aclService
+     * @param ActivityQueryService $activityQueryService
      */
     public function __construct(
-        ActivityQueryService $activityQueryService,
         AclService $aclService,
+        ActivityQueryService $activityQueryService,
     ) {
-        $this->activityQueryService = $activityQueryService;
         $this->aclService = $aclService;
+        $this->activityQueryService = $activityQueryService;
     }
 
     /**

--- a/module/Activity/src/Controller/Factory/ActivityCalendarControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ActivityCalendarControllerFactory.php
@@ -18,15 +18,15 @@ class ActivityCalendarControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): ActivityCalendarController {
         return new ActivityCalendarController(
+            $container->get('activity_service_acl'),
+            $container->get('translator'),
             $container->get('activity_service_calendar'),
             $container->get('activity_service_calendar_form'),
-            $container->get('activity_service_acl'),
             $container->get('activity_form_calendar_proposal'),
             $container->get('config')['calendar'],
-            $container->get('translator'),
         );
     }
 }

--- a/module/Activity/src/Controller/Factory/ActivityCalendarControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ActivityCalendarControllerFactory.php
@@ -11,14 +11,14 @@ class ActivityCalendarControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return ActivityCalendarController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): ActivityCalendarController {
         return new ActivityCalendarController(
             $container->get('activity_service_acl'),

--- a/module/Activity/src/Controller/Factory/ActivityControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ActivityControllerFactory.php
@@ -11,14 +11,14 @@ class ActivityControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return ActivityController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): ActivityController {
         return new ActivityController(
             $container->get('activity_service_acl'),

--- a/module/Activity/src/Controller/Factory/ActivityControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ActivityControllerFactory.php
@@ -18,15 +18,15 @@ class ActivityControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): ActivityController {
         return new ActivityController(
+            $container->get('activity_service_acl'),
+            $container->get('translator'),
             $container->get('activity_service_activity'),
             $container->get('activity_service_activityQuery'),
             $container->get('activity_service_signup'),
             $container->get('activity_service_signupListQuery'),
-            $container->get('activity_service_acl'),
-            $container->get('translator'),
         );
     }
 }

--- a/module/Activity/src/Controller/Factory/AdminApprovalControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminApprovalControllerFactory.php
@@ -18,13 +18,13 @@ class AdminApprovalControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AdminApprovalController {
         return new AdminApprovalController(
-            $container->get('activity_service_activity'),
-            $container->get('activity_service_activityQuery'),
             $container->get('activity_service_acl'),
             $container->get('translator'),
+            $container->get('activity_service_activity'),
+            $container->get('activity_service_activityQuery'),
         );
     }
 }

--- a/module/Activity/src/Controller/Factory/AdminApprovalControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminApprovalControllerFactory.php
@@ -11,14 +11,14 @@ class AdminApprovalControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AdminApprovalController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AdminApprovalController {
         return new AdminApprovalController(
             $container->get('activity_service_acl'),

--- a/module/Activity/src/Controller/Factory/AdminCategoryControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminCategoryControllerFactory.php
@@ -18,11 +18,12 @@ class AdminCategoryControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AdminCategoryController {
         return new AdminCategoryController(
-            $container->get('activity_service_category'),
+            $container->get('activity_service_acl'),
             $container->get('translator'),
+            $container->get('activity_service_category'),
         );
     }
 }

--- a/module/Activity/src/Controller/Factory/AdminCategoryControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminCategoryControllerFactory.php
@@ -11,14 +11,14 @@ class AdminCategoryControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AdminCategoryController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AdminCategoryController {
         return new AdminCategoryController(
             $container->get('activity_service_acl'),

--- a/module/Activity/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminControllerFactory.php
@@ -11,14 +11,14 @@ class AdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AdminController {
         return new AdminController(
             $container->get('activity_service_acl'),

--- a/module/Activity/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminControllerFactory.php
@@ -18,16 +18,16 @@ class AdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AdminController {
         return new AdminController(
+            $container->get('activity_service_acl'),
+            $container->get('translator'),
             $container->get('activity_service_activity'),
             $container->get('activity_service_activityQuery'),
             $container->get('activity_service_signup'),
             $container->get('activity_service_signupListQuery'),
             $container->get('activity_mapper_signup'),
-            $container->get('activity_service_acl'),
-            $container->get('translator'),
         );
     }
 }

--- a/module/Activity/src/Controller/Factory/AdminOptionControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminOptionControllerFactory.php
@@ -18,14 +18,14 @@ class AdminOptionControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AdminOptionController {
         return new AdminOptionController(
+            $container->get('activity_service_acl'),
+            $container->get('translator'),
             $container->get('activity_service_calendar'),
             $container->get('decision_service_organ'),
             $container->get('activity_mapper_period'),
-            $container->get('activity_service_acl'),
-            $container->get('translator'),
         );
     }
 }

--- a/module/Activity/src/Controller/Factory/AdminOptionControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/AdminOptionControllerFactory.php
@@ -11,14 +11,14 @@ class AdminOptionControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AdminOptionController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AdminOptionController {
         return new AdminOptionController(
             $container->get('activity_service_acl'),

--- a/module/Activity/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ApiControllerFactory.php
@@ -11,14 +11,14 @@ class ApiControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return ApiController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): ApiController {
         return new ApiController(
             $container->get('activity_service_acl'),

--- a/module/Activity/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/Activity/src/Controller/Factory/ApiControllerFactory.php
@@ -21,8 +21,8 @@ class ApiControllerFactory implements FactoryInterface
         array $options = null,
     ): ApiController {
         return new ApiController(
-            $container->get('activity_service_activityQuery'),
             $container->get('activity_service_acl'),
+            $container->get('activity_service_activityQuery'),
         );
     }
 }

--- a/module/Activity/src/Form/Activity.php
+++ b/module/Activity/src/Form/Activity.php
@@ -196,8 +196,11 @@ class Activity extends LocalisableForm implements InputFilterProviderInterface
      *
      * @return Activity
      */
-    public function setAllOptions(array $organs, array $companies, array $categories): self
-    {
+    public function setAllOptions(
+        array $organs,
+        array $companies,
+        array $categories,
+    ): self {
         $organOptions = $this->get('organ')->getValueOptions();
         foreach ($organs as $organ) {
             $organOptions[$organ->getId()] = $organ->getAbbr();
@@ -225,19 +228,21 @@ class Activity extends LocalisableForm implements InputFilterProviderInterface
     /**
      * Check if a certain date is before the end date of the activity.
      *
-     * @param DateTime $value
+     * @param string $value
      * @param array $context
      *
      * @return bool
      */
-    public static function beforeEndTime($value, $context = []): bool
-    {
+    public static function beforeEndTime(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
             $endTime = $context['endTime'];
             $endTime = isset($endTime) ? new DateTime($endTime) : new DateTime('now');
 
             return $value <= $endTime;
-        } catch (Exception $e) {
+        } catch (Exception) {
             // An exception is an indication that one of the times was not valid
             return false;
         }
@@ -246,18 +251,20 @@ class Activity extends LocalisableForm implements InputFilterProviderInterface
     /**
      * Checks if a certain date is before the begin date of the activity.
      *
-     * @param DateTime $value
+     * @param string $value
      * @param array $context
      *
      * @return bool
      */
-    public static function beforeBeginTime($value, $context = []): bool
-    {
+    public static function beforeBeginTime(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
             $beginTime = isset($context['beginTime']) ? new DateTime($context['beginTime']) : new DateTime('now');
 
             return $value <= $beginTime;
-        } catch (Exception $e) {
+        } catch (Exception) {
             // An exception is an indication that one of the DateTimes was not valid
             return false;
         }

--- a/module/Activity/src/Form/ActivityCalendarOption.php
+++ b/module/Activity/src/Form/ActivityCalendarOption.php
@@ -32,8 +32,10 @@ class ActivityCalendarOption extends Fieldset implements InputFilterProviderInte
      * @param Translator $translator
      * @param ActivityCalendarForm $calendarFormService
      */
-    public function __construct(Translator $translator, ActivityCalendarForm $calendarFormService)
-    {
+    public function __construct(
+        Translator $translator,
+        ActivityCalendarForm $calendarFormService,
+    ) {
         parent::__construct();
         $this->translator = $translator;
         $this->calendarFormService = $calendarFormService;
@@ -145,8 +147,10 @@ class ActivityCalendarOption extends Fieldset implements InputFilterProviderInte
      *
      * @return bool
      */
-    public function beforeEndTime($value, $context = []): bool
-    {
+    public function beforeEndTime(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
             $endTime = isset($context['endTime']) ? $this->calendarFormService->toDateTime($context['endTime']) : new DateTime('now');
 
@@ -164,13 +168,15 @@ class ActivityCalendarOption extends Fieldset implements InputFilterProviderInte
      *
      * @return bool
      */
-    public function isFutureTime($value, $context = []): bool
-    {
+    public function isFutureTime(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
             $today = new DateTime();
 
             return $this->calendarFormService->toDateTime($value) > $today;
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
     }
@@ -183,8 +189,10 @@ class ActivityCalendarOption extends Fieldset implements InputFilterProviderInte
      *
      * @return bool
      */
-    public function cannotPlanInPeriod($value, $context = []): bool
-    {
+    public function cannotPlanInPeriod(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
             $beginTime = $this->calendarFormService->toDateTime($value);
             $result = $this->calendarFormService->canCreateOption($beginTime);

--- a/module/Activity/src/Form/ActivityCalendarPeriod.php
+++ b/module/Activity/src/Form/ActivityCalendarPeriod.php
@@ -24,6 +24,9 @@ class ActivityCalendarPeriod extends Form implements InputFilterProviderInterfac
      */
     private Translator $translator;
 
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();
@@ -190,8 +193,11 @@ class ActivityCalendarPeriod extends Form implements InputFilterProviderInterfac
      *
      * @return bool
      */
-    public function afterOtherTime(string $value, array $context, string $option): bool
-    {
+    public function afterOtherTime(
+        string $value,
+        array $context,
+        string $option,
+    ): bool {
         try {
             $value = new DateTime($value);
             $time = isset($context[$option]) ? new DateTime($context[$option]) : new DateTime('now');

--- a/module/Activity/src/Form/ActivityCalendarProposal.php
+++ b/module/Activity/src/Form/ActivityCalendarProposal.php
@@ -192,7 +192,7 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
      */
     public function areGoodOptionDates(
         array $value,
-        $context = [],
+        array $context = [],
     ): bool {
         $final = true;
         foreach ($value as $option) {

--- a/module/Activity/src/Form/ActivityCalendarProposal.php
+++ b/module/Activity/src/Form/ActivityCalendarProposal.php
@@ -40,8 +40,11 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
      * @param ActivityCalendarForm $calendarFormService
      * @param bool $createAlways
      */
-    public function __construct(Translator $translator, ActivityCalendarForm $calendarFormService, bool $createAlways)
-    {
+    public function __construct(
+        Translator $translator,
+        ActivityCalendarForm $calendarFormService,
+        bool $createAlways,
+    ) {
         parent::__construct();
         $this->translator = $translator;
         $this->calendarFormService = $calendarFormService;
@@ -168,8 +171,10 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
      *
      * @return bool
      */
-    public function isGoodOptionCount($value, $context = []): bool
-    {
+    public function isGoodOptionCount(
+        array $value,
+        array $context = [],
+    ): bool {
         if (count($value) < 1 || count($value) > $this->maxOptions) {
             return false;
         }
@@ -185,8 +190,10 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
      *
      * @return bool
      */
-    public function areGoodOptionDates($value, $context = []): bool
-    {
+    public function areGoodOptionDates(
+        array $value,
+        $context = [],
+    ): bool {
         $final = true;
         foreach ($value as $option) {
             try {

--- a/module/Activity/src/Form/ActivityCategory.php
+++ b/module/Activity/src/Form/ActivityCategory.php
@@ -12,6 +12,9 @@ use Laminas\Mvc\I18n\Translator;
 
 class ActivityCategory extends LocalisableForm implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct($translator);

--- a/module/Activity/src/Form/ModifyRequest.php
+++ b/module/Activity/src/Form/ModifyRequest.php
@@ -16,8 +16,14 @@ use Laminas\InputFilter\InputFilterProviderInterface;
  */
 class ModifyRequest extends Form implements InputFilterProviderInterface
 {
-    public function __construct($name = null, $buttonvalue = 'submit')
-    {
+    /**
+     * @param string|null $name
+     * @param string $buttonvalue
+     */
+    public function __construct(
+        ?string $name = null,
+        string $buttonvalue = 'submit',
+    ) {
         parent::__construct($name);
         $this->setAttribute('method', 'post');
 

--- a/module/Activity/src/Form/SignupList.php
+++ b/module/Activity/src/Form/SignupList.php
@@ -2,6 +2,7 @@
 
 namespace Activity\Form;
 
+use Activity\Model\SignupList as SignupListModel;
 use DateTime;
 use Exception;
 use Laminas\Form\Element\{
@@ -18,13 +19,19 @@ use Laminas\Validator\Callback;
 
 class SignupList extends Fieldset implements InputFilterProviderInterface
 {
+    /**
+     * @var Translator
+     */
     private Translator $translator;
 
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct('signuplist');
         $this->setHydrator(new ClassMethodsHydrator(false))
-            ->setObject(new \Activity\Model\SignupList());
+            ->setObject(new SignupListModel());
 
         $this->add(
             [
@@ -115,8 +122,10 @@ class SignupList extends Fieldset implements InputFilterProviderInterface
      *
      * @return bool
      */
-    public static function beforeCloseDate($value, $context = []): bool
-    {
+    public static function beforeCloseDate(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
             $thisTime = new DateTime($value);
             $closeTime = isset($context['closeDate']) ? new DateTime($context['closeDate']) : new DateTime('now');

--- a/module/Activity/src/Form/SignupListField.php
+++ b/module/Activity/src/Form/SignupListField.php
@@ -2,7 +2,7 @@
 
 namespace Activity\Form;
 
-use Activity\Model\SignupField;
+use Activity\Model\SignupField as SignupFieldModel;
 use Laminas\Form\Element\{
     Number,
     Select,
@@ -24,12 +24,15 @@ class SignupListField extends Fieldset implements InputFilterProviderInterface
      */
     protected Translator $translator;
 
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct('signupfield');
         $this->translator = $translator;
         $this->setHydrator(new ClassMethodsHydrator(false))
-            ->setObject(new SignupField());
+            ->setObject(new SignupFieldModel());
 
         $this->add(
             [
@@ -215,8 +218,12 @@ class SignupListField extends Fieldset implements InputFilterProviderInterface
      *
      * @return bool
      */
-    protected function fieldDependantRequired($value, $context, $child, $testvalue): bool
-    {
+    protected function fieldDependantRequired(
+        string $value,
+        array $context,
+        string $child,
+        string $testvalue,
+    ): bool {
         if ($value === $testvalue) {
             return (new NotEmpty())->isValid($context[$child]);
         }

--- a/module/Activity/src/Mapper/ActivityOptionCreationPeriod.php
+++ b/module/Activity/src/Mapper/ActivityOptionCreationPeriod.php
@@ -18,14 +18,11 @@ class ActivityOptionCreationPeriod extends BaseMapper
      */
     public function getCurrentActivityOptionCreationPeriod(): ?ActivityOptionCreationPeriodModel
     {
-        $qb = $this->em->createQueryBuilder();
-        $today = new DateTime();
-        $qb->select('x')
-            ->from($this->getRepositoryName(), 'x')
-            ->andWhere('x.beginPlanningTime < :today')
-            ->andWhere('x.endPlanningTime > :today')
-            ->orderBy('x.beginPlanningTime', 'ASC')
-            ->setParameter('today', $today)
+        $qb = $this->getRepository()->createQueryBuilder('o');
+        $qb->where('o.beginPlanningTime < :today')
+            ->andWhere('o.endPlanningTime > :today')
+            ->orderBy('o.beginPlanningTime', 'ASC')
+            ->setParameter('today', new DateTime())
             ->setMaxResults(1);
 
         $res = $qb->getQuery()->getResult();
@@ -42,13 +39,10 @@ class ActivityOptionCreationPeriod extends BaseMapper
      */
     public function getUpcomingActivityOptionCreationPeriod(): ?ActivityOptionCreationPeriodModel
     {
-        $qb = $this->em->createQueryBuilder();
-        $today = new DateTime();
-        $qb->select('x')
-            ->from($this->getRepositoryName(), 'x')
-            ->where('x.beginPlanningTime > :today')
-            ->orderBy('x.beginPlanningTime', 'ASC')
-            ->setParameter('today', $today)
+        $qb = $this->getRepository()->createQueryBuilder('o');
+        $qb->where('o.beginPlanningTime > :today')
+            ->orderBy('o.beginPlanningTime', 'ASC')
+            ->setParameter('today', new DateTime())
             ->setMaxResults(1);
 
         return $qb->getQuery()->getOneOrNullResult();

--- a/module/Activity/src/Mapper/ActivityOptionProposal.php
+++ b/module/Activity/src/Mapper/ActivityOptionProposal.php
@@ -17,14 +17,15 @@ class ActivityOptionProposal extends BaseMapper
      *
      * @return array
      */
-    public function getNonClosedProposalsWithinPeriodAndOrgan($begin, $end, $organId)
-    {
-        $qb = $this->em->createQueryBuilder();
-        $qb->select('b')
-            ->from('Activity\Model\ActivityCalendarOption', 'a')
-            ->andWhere('a.modifiedBy IS NULL')
+    public function getNonClosedProposalsWithinPeriodAndOrgan(
+        DateTime $begin,
+        DateTime $end,
+        int $organId,
+    ): array {
+        $qb = $this->getRepository()->createQueryBuilder('b');
+        $qb->from('Activity\Model\ActivityCalendarOption', 'a')
+            ->where('a.modifiedBy IS NULL')
             ->orWhere("a.status = 'approved'")
-            ->from('Activity\Model\ActivityOptionProposal', 'b')
             ->andWhere('a.proposal = b.id')
             ->andWhere('a.beginTime > :begin')
             ->setParameter('begin', $begin)

--- a/module/Activity/src/Mapper/MaxActivities.php
+++ b/module/Activity/src/Mapper/MaxActivities.php
@@ -13,16 +13,16 @@ class MaxActivities extends BaseMapper
      * @param int $organId
      * @param int $periodId
      *
-     * @return MaxActivitiesModel
+     * @return MaxActivitiesModel|null
      */
-    public function getMaxActivityOptionsByOrganPeriod($organId, $periodId)
-    {
-        $qb = $this->em->createQueryBuilder();
-        $qb->select('x')
-            ->from('Activity\Model\MaxActivities', 'x')
-            ->andWhere('x.organ = :organ')
+    public function getMaxActivityOptionsByOrganPeriod(
+        int $organId,
+        int $periodId,
+    ): ?MaxActivitiesModel {
+        $qb = $this->getRepository()->createQueryBuilder('m');
+        $qb->where('m.organ = :organ')
             ->setParameter('organ', $organId)
-            ->andWhere('x.period = :period')
+            ->andWhere('m.period = :period')
             ->setParameter('period', $periodId)
             ->setMaxResults(1);
 

--- a/module/Activity/src/Mapper/Proposal.php
+++ b/module/Activity/src/Mapper/Proposal.php
@@ -2,7 +2,7 @@
 
 namespace Activity\Mapper;
 
-use Activity\Model\ActivityUpdateProposal;
+use Activity\Model\ActivityUpdateProposal as ActivityUpdateProposalModel;
 use Application\Mapper\BaseMapper;
 
 class Proposal extends BaseMapper
@@ -12,6 +12,6 @@ class Proposal extends BaseMapper
      */
     protected function getRepositoryName(): string
     {
-        return ActivityUpdateProposal::class;
+        return ActivityUpdateProposalModel::class;
     }
 }

--- a/module/Activity/src/Mapper/SignupFieldValue.php
+++ b/module/Activity/src/Mapper/SignupFieldValue.php
@@ -2,7 +2,10 @@
 
 namespace Activity\Mapper;
 
-use Activity\Model\SignupFieldValue as SignupFieldValueModel;
+use Activity\Model\{
+    Signup as SignupModel,
+    SignupFieldValue as SignupFieldValueModel,
+};
 use Application\Mapper\BaseMapper;
 
 class SignupFieldValue extends BaseMapper
@@ -12,7 +15,7 @@ class SignupFieldValue extends BaseMapper
      *
      * @return array of \Activity\Model\ActivityFieldValue
      */
-    public function getFieldValuesBySignup(\Activity\Model\Signup $signup)
+    public function getFieldValuesBySignup(SignupModel $signup): array
     {
         return $this->getRepository()->findBy(['signup' => $signup->getId()]);
     }

--- a/module/Activity/src/Mapper/SignupList.php
+++ b/module/Activity/src/Mapper/SignupList.php
@@ -13,29 +13,14 @@ class SignupList extends BaseMapper
      *
      * @return SignupListModel|null
      */
-    public function getSignupListByIdAndActivity($signupListId, $activityId)
-    {
-        $qb = $this->em->createQueryBuilder();
-        $qb->select('a')
-            ->from('Activity\Model\SignupList', 'a')
-            ->where('a.id = :signupList')
-            ->andWhere('a.activity = :activity')
-            ->setParameter('signupList', $signupListId)
-            ->setParameter('activity', $activityId);
-        $result = $qb->getQuery()->getResult();
-
-        return !empty($result) ? $result[0] : null;
-    }
-
-    public function getSignupListsOfActivity($activityId)
-    {
-        $qb = $this->em->createQueryBuilder();
-        $qb->select('a')
-            ->from('Activity\Model\SignupList', 'a')
-            ->where('a.activity = :activity')
-            ->setParameter('activity', $activityId);
-
-        return $qb->getQuery()->getResult();
+    public function getSignupListByIdAndActivity(
+        int $signupListId,
+        int $activityId,
+    ): ?SignupListModel {
+        return $this->findOneBy([
+            'id' => $signupListId,
+            'activity' => $activityId,
+        ]);
     }
 
     /**

--- a/module/Activity/src/Model/ActivityCalendarOption.php
+++ b/module/Activity/src/Model/ActivityCalendarOption.php
@@ -178,9 +178,9 @@ class ActivityCalendarOption
      * 2. The alternative for an organ, other organising parties
      * 3. The full name of the member who created the proposal.
      *
-     * @return mixed
+     * @return string
      */
-    public function getCreatorAlt()
+    public function getCreatorAlt(): string
     {
         return $this->getProposal()->getCreatorAlt();
     }

--- a/module/Activity/src/Service/AclService.php
+++ b/module/Activity/src/Service/AclService.php
@@ -6,9 +6,6 @@ use User\Permissions\Assertion\IsCreatorOrOrganMember;
 
 class AclService extends \User\Service\AclService
 {
-    /**
-     * @return void
-     */
     protected function createAcl(): void
     {
         parent::createAcl();

--- a/module/Activity/src/Service/AclService.php
+++ b/module/Activity/src/Service/AclService.php
@@ -6,7 +6,10 @@ use User\Permissions\Assertion\IsCreatorOrOrganMember;
 
 class AclService extends \User\Service\AclService
 {
-    protected function createAcl()
+    /**
+     * @return void
+     */
+    protected function createAcl(): void
     {
         parent::createAcl();
 

--- a/module/Activity/src/Service/Activity.php
+++ b/module/Activity/src/Service/Activity.php
@@ -544,7 +544,7 @@ class Activity
         unset($current['id']);
 
         // Convert all DateTimes in the original Activity to strings.
-        array_walk_recursive($current, function (&$v, $k) {
+        array_walk_recursive($current, function (&$v, $k): void {
             if ($v instanceof DateTime) {
                 $v = $v->format('Y/m/d H:i');
             }
@@ -562,13 +562,13 @@ class Activity
 
         // We do not need the ActivityCategory models, hence we replace it with the ids of each one. However, it is no
         // longer a model and requires array access to get the id.
-        array_walk($current['categories'], function (&$v, $k) {
+        array_walk($current['categories'], function (&$v, $k): void {
             $v = strval($v['id']);
         });
 
         // HTML forms do not know anything about booleans, hence we need to
         // convert the strings to something we can use.
-        array_walk_recursive($proposal, function (&$v, $k) {
+        array_walk_recursive($proposal, function (&$v, $k): void {
             if (in_array($k, ['isMyFuture', 'requireGEFLITST', 'onlyGEWIS', 'displaySubscribedNumber'], true)) {
                 $v = boolval($v);
             }

--- a/module/Activity/src/Service/Activity.php
+++ b/module/Activity/src/Service/Activity.php
@@ -21,7 +21,7 @@ use Decision\Service\Organ as OrganService;
 use Doctrine\ORM\{
     EntityManager,
     OptimisticLockException,
-    ORMException,
+    Exception\ORMException,
 };
 use Laminas\Mvc\I18n\Translator;
 use User\Model\User as UserModel;

--- a/module/Activity/src/Service/ActivityCalendar.php
+++ b/module/Activity/src/Service/ActivityCalendar.php
@@ -147,9 +147,6 @@ class ActivityCalendar
         );
     }
 
-    /**
-     * @return void
-     */
     public function sendOverdueNotifications(): void
     {
         $date = new DateTime();
@@ -237,8 +234,6 @@ class ActivityCalendar
 
     /**
      * @param int $id
-     *
-     * @return void
      */
     public function approveOption(int $id): void
     {
@@ -281,10 +276,8 @@ class ActivityCalendar
 
     /**
      * @param int $id
-     *
-     * @return void
      */
-    public function deleteOption(int $id)
+    public function deleteOption(int $id): void
     {
         $option = $this->calendarOptionMapper->find($id);
 

--- a/module/Activity/src/Service/ActivityCalendar.php
+++ b/module/Activity/src/Service/ActivityCalendar.php
@@ -3,7 +3,6 @@
 namespace Activity\Service;
 
 use Activity\Form\{
-    ActivityCalendarOption as ActivityCalendarOptionForm,
     ActivityCalendarPeriod as ActivityCalendarPeriodForm,
 };
 use Activity\Mapper\{

--- a/module/Activity/src/Service/ActivityCalendar.php
+++ b/module/Activity/src/Service/ActivityCalendar.php
@@ -3,21 +3,24 @@
 namespace Activity\Service;
 
 use Activity\Form\{
-    ActivityCalendarOption,
+    ActivityCalendarOption as ActivityCalendarOptionForm,
     ActivityCalendarPeriod as ActivityCalendarPeriodForm,
 };
-use Activity\Mapper\ActivityOptionCreationPeriod as ActivityOptionCreationPeriodMapper;
+use Activity\Mapper\{
+    ActivityCalendarOption as ActivityCalendarOptionMapper,
+    ActivityOptionCreationPeriod as ActivityOptionCreationPeriodMapper,
+};
 use Activity\Model\{
     ActivityCalendarOption as OptionModel,
+    ActivityCalendarOption as ActivityCalendarOptionModel,
     ActivityOptionCreationPeriod as ActivityOptionCreationPeriodModel,
     ActivityOptionProposal as ProposalModel,
-    MaxActivities as MaxActivitiesModel,
-};
-use Application\Service\Email;
+    MaxActivities as MaxActivitiesModel};
+use Application\Service\Email as EmailService;
 use DateInterval;
 use DateTime;
-use Decision\Mapper\Member;
-use Decision\Service\Organ;
+use Decision\Mapper\Member as MemberMapper;
+use Decision\Service\Organ as OrganService;
 use Doctrine\ORM\EntityManager;
 use Exception;
 use Laminas\Mvc\I18n\Translator;
@@ -26,33 +29,39 @@ use User\Permissions\NotAllowedException;
 class ActivityCalendar
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
      * @var Translator
      */
-    private $translator;
+    private Translator $translator;
+
     /**
      * @var EntityManager
      */
-    private $entityManager;
+    private EntityManager $entityManager;
+
     /**
-     * @var Organ
+     * @var OrganService
      */
-    private $organService;
+    private OrganService $organService;
+
     /**
-     * @var Email
+     * @var EmailService
      */
-    private $emailService;
+    private EmailService $emailService;
+
     /**
-     * @var \Activity\Mapper\ActivityCalendarOption
+     * @var ActivityCalendarOptionMapper
      */
-    private $calendarOptionMapper;
+    private ActivityCalendarOptionMapper $calendarOptionMapper;
+
     /**
-     * @var Member
+     * @var MemberMapper
      */
-    private $memberMapper;
-    /**
-     * @var ActivityCalendarOption
-     */
-    private $calendarOptionForm;
+    private MemberMapper $memberMapper;
 
     /**
      * @var ActivityCalendarPeriodForm
@@ -64,55 +73,73 @@ class ActivityCalendar
      */
     private ActivityOptionCreationPeriodMapper $calendarCreationPeriodMapper;
 
-    private AclService $aclService;
+    /**
+     * @var ActivityCalendarForm
+     */
     private ActivityCalendarForm $calendarFormService;
 
+    /**
+     * @param AclService $aclService
+     * @param Translator $translator
+     * @param EntityManager $entityManager
+     * @param OrganService $organService
+     * @param EmailService $emailService
+     * @param ActivityCalendarOptionMapper $calendarOptionMapper
+     * @param MemberMapper $memberMapper
+     * @param ActivityCalendarPeriodForm $calendarPeriodForm
+     * @param ActivityOptionCreationPeriodMapper $calendarCreationPeriodMapper
+     * @param ActivityCalendarForm $calendarFormService
+     */
     public function __construct(
+        AclService $aclService,
         Translator $translator,
         EntityManager $entityManager,
-        Organ $organService,
-        Email $emailService,
-        \Activity\Mapper\ActivityCalendarOption $calendarOptionMapper,
-        Member $memberMapper,
-        ActivityCalendarOption $calendarOptionForm,
+        OrganService $organService,
+        EmailService $emailService,
+        ActivityCalendarOptionMapper $calendarOptionMapper,
+        MemberMapper $memberMapper,
         ActivityCalendarPeriodForm $calendarPeriodForm,
         ActivityOptionCreationPeriodMapper $calendarCreationPeriodMapper,
-        AclService $aclService,
-        ActivityCalendarForm $calendarFormService
+        ActivityCalendarForm $calendarFormService,
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->entityManager = $entityManager;
         $this->organService = $organService;
         $this->emailService = $emailService;
         $this->calendarOptionMapper = $calendarOptionMapper;
         $this->memberMapper = $memberMapper;
-        $this->calendarOptionForm = $calendarOptionForm;
         $this->calendarPeriodForm = $calendarPeriodForm;
         $this->calendarCreationPeriodMapper = $calendarCreationPeriodMapper;
-        $this->aclService = $aclService;
         $this->calendarFormService = $calendarFormService;
     }
 
     /**
      * Gets all future options.
+     *
+     * @return array
      */
-    public function getUpcomingOptions()
+    public function getUpcomingOptions(): array
     {
         return $this->calendarOptionMapper->getUpcomingOptions(false);
     }
 
     /**
      * Gets all future options which the current user is allowed to edit/delete.
+     *
+     * @return array
      */
-    public function getEditableUpcomingOptions()
+    public function getEditableUpcomingOptions(): array
     {
         if (!$this->aclService->isAllowed('delete_own', 'activity_calendar_proposal')) {
             return [];
         }
+
         if ($this->aclService->isAllowed('delete_all', 'activity_calendar_proposal')) {
             // Return all
             return $this->calendarOptionMapper->getUpcomingOptions(true);
         }
+
         $user = $this->aclService->getIdentityOrThrowException();
 
         return $this->calendarOptionMapper->getUpcomingOptionsByOrgans(
@@ -120,7 +147,10 @@ class ActivityCalendar
         );
     }
 
-    public function sendOverdueNotifications()
+    /**
+     * @return void
+     */
+    public function sendOverdueNotifications(): void
     {
         $date = new DateTime();
         $date->sub(new DateInterval('P3W'));
@@ -133,20 +163,6 @@ class ActivityCalendar
                 ['options' => $oldOptions]
             );
         }
-    }
-
-    /**
-     * Retrieves the form for creating a new calendar activity option proposal.
-     *
-     * @return ActivityCalendarOption
-     */
-    public function getCreateOptionForm()
-    {
-        if (!$this->aclService->isAllowed('create', 'activity_calendar_proposal')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to create activity options.'));
-        }
-
-        return $this->calendarOptionForm;
     }
 
     /**
@@ -185,7 +201,7 @@ class ActivityCalendar
 
         $options = $data['options'];
         foreach ($options as $option) {
-            $this->createOption($option, $proposal);
+            $this->createOption($proposal, $option);
         }
 
         return $proposal;
@@ -199,8 +215,10 @@ class ActivityCalendar
      *
      * @throws Exception
      */
-    public function createOption($data, $proposal)
-    {
+    public function createOption(
+        ProposalModel $proposal,
+        array $data,
+    ): OptionModel {
         $option = new OptionModel();
 
         $em = $this->entityManager;
@@ -217,22 +235,29 @@ class ActivityCalendar
         return $option;
     }
 
-    public function approveOption($id)
+    /**
+     * @param int $id
+     *
+     * @return void
+     */
+    public function approveOption(int $id): void
     {
         if (!$this->canApproveOption()) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to approve this option'));
         }
 
-        $mapper = $this->calendarOptionMapper;
-        $option = $mapper->findOption($id);
+        $option = $this->calendarOptionMapper->find($id);
 
-        $em = $this->entityManager;
+        if (null === $option) {
+            return;
+        }
+
         $option->setModifiedBy($this->aclService->getIdentityOrThrowException());
         $option->setStatus('approved');
-        $em->flush();
+        $this->calendarOptionMapper->flush();
 
         $proposal = $option->getProposal();
-        $options = $mapper->findOptionsByProposal($proposal->getId());
+        $options = $this->calendarOptionMapper->findOptionsByProposal($proposal);
 
         foreach ($options as $option) {
             // Can't add two options at the same time
@@ -242,7 +267,10 @@ class ActivityCalendar
         }
     }
 
-    public function canApproveOption()
+    /**
+     * @return bool
+     */
+    public function canApproveOption(): bool
     {
         if ($this->aclService->isAllowed('approve_all', 'activity_calendar_proposal')) {
             return true;
@@ -251,21 +279,34 @@ class ActivityCalendar
         return false;
     }
 
-    public function deleteOption($id)
+    /**
+     * @param int $id
+     *
+     * @return void
+     */
+    public function deleteOption(int $id)
     {
-        $mapper = $this->calendarOptionMapper;
-        $option = $mapper->findOption($id);
+        $option = $this->calendarOptionMapper->find($id);
+
+        if (null === $option) {
+            return;
+        }
+
         if (!$this->canDeleteOption($option)) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete this option'));
         }
 
-        $em = $this->entityManager;
         $option->setModifiedBy($this->aclService->getIdentityOrThrowException());
         $option->setStatus('deleted');
-        $em->flush();
+        $this->calendarOptionMapper->flush();
     }
 
-    protected function canDeleteOption($option)
+    /**
+     * @param ActivityCalendarOptionModel $option
+     *
+     * @return bool
+     */
+    protected function canDeleteOption(ActivityCalendarOptionModel $option): bool
     {
         if ($this->aclService->isAllowed('delete_all', 'activity_calendar_proposal')) {
             return true;
@@ -297,7 +338,7 @@ class ActivityCalendar
      *
      * @throws Exception
      */
-    public function canCreateProposal()
+    public function canCreateProposal(): bool
     {
         $organs = $this->calendarFormService->getEditableOrgans();
 
@@ -305,23 +346,9 @@ class ActivityCalendar
     }
 
     /**
-     * Get the current ActivityOptionCreationPeriod.
-     *
-     * @param int $proposalId
-     * @param int $organId
-     *
-     * @return int
-     */
-    protected function getCurrentProposalOptionCount($proposalId, $organId)
-    {
-        $mapper = $this->calendarOptionMapper;
-        $options = $mapper->findOptionsByProposalAndOrgan($proposalId, $organId);
-
-        return count($options);
-    }
-
-    /**
      * @param array $data
+     *
+     * @return bool
      */
     public function createOptionPlanningPeriod(array $data): bool
     {
@@ -357,6 +384,12 @@ class ActivityCalendar
         return true;
     }
 
+    /**
+     * @param ActivityOptionCreationPeriodModel $activityOptionCreationPeriod
+     * @param array $data
+     *
+     * @return bool
+     */
     public function updateOptionPlanningPeriod(
         ActivityOptionCreationPeriodModel $activityOptionCreationPeriod,
         array $data,

--- a/module/Activity/src/Service/ActivityCategory.php
+++ b/module/Activity/src/Service/ActivityCategory.php
@@ -137,10 +137,8 @@ class ActivityCategory
 
     /**
      * @param ActivityCategoryModel $category
-     *
-     * @return void
      */
-    public function deleteCategory(ActivityCategoryModel $category)
+    public function deleteCategory(ActivityCategoryModel $category): void
     {
         if (!$this->aclService->isAllowed('deleteCategory', 'activity')) {
             throw new NotAllowedException(

--- a/module/Activity/src/Service/ActivityQuery.php
+++ b/module/Activity/src/Service/ActivityQuery.php
@@ -2,49 +2,69 @@
 
 namespace Activity\Service;
 
-use Activity\Mapper\Proposal;
-use Activity\Model\Activity as ActivityModel;
-use Activity\Model\ActivityUpdateProposal;
+use Activity\Mapper\{
+    Activity as ActivityMapper,
+    Proposal as ProposalMapper,
+};
+use Activity\Model\{
+    Activity as ActivityModel,
+    ActivityUpdateProposal as ActivityUpdateProposalModel,
+};
 use DateTime;
 use Decision\Model\AssociationYear as AssociationYear;
-use Decision\Model\Organ;
+use Decision\Model\Organ as OrganModel;
+use Decision\Service\Organ as OrganService;
 use DoctrineORMModule\Paginator\Adapter\DoctrinePaginator;
 use Laminas\Mvc\I18n\Translator;
-use User\Model\User;
+use User\Model\User as UserModel;
 use User\Permissions\NotAllowedException;
 
 class ActivityQuery
 {
     /**
-     * @var Translator
+     * @var AclService
      */
-    private $translator;
-    /**
-     * @var \Decision\Service\Organ
-     */
-    private $organService;
-    /**
-     * @var \Activity\Mapper\Activity
-     */
-    private $activityMapper;
-    /**
-     * @var Proposal
-     */
-    private $proposalMapper;
     private AclService $aclService;
 
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
+     * @var OrganService
+     */
+    private OrganService $organService;
+
+    /**
+     * @var ActivityMapper
+     */
+    private ActivityMapper $activityMapper;
+
+    /**
+     * @var ProposalMapper
+     */
+    private ProposalMapper $proposalMapper;
+
+    /**
+     * @param AclService $aclService
+     * @param Translator $translator
+     * @param OrganService $organService
+     * @param ActivityMapper $activityMapper
+     * @param ProposalMapper $proposalMapper
+     */
     public function __construct(
+        AclService $aclService,
         Translator $translator,
-        \Decision\Service\Organ $organService,
-        \Activity\Mapper\Activity $activityMapper,
-        Proposal $proposalMapper,
-        AclService $aclService
+        OrganService $organService,
+        ActivityMapper $activityMapper,
+        ProposalMapper $proposalMapper,
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->organService = $organService;
         $this->activityMapper = $activityMapper;
         $this->proposalMapper = $proposalMapper;
-        $this->aclService = $aclService;
     }
 
     /**
@@ -52,7 +72,7 @@ class ActivityQuery
      *
      * @return Translator
      */
-    public function getTranslator()
+    public function getTranslator(): Translator
     {
         return $this->translator;
     }
@@ -68,9 +88,9 @@ class ActivityQuery
      *
      * @param int $id The proposal id to be searched for
      *
-     * @return ActivityUpdateProposal|null or null if the proposal does not exist
+     * @return ActivityUpdateProposalModel|null or null if the proposal does not exist
      */
-    public function getProposal(int $id): ?ActivityUpdateProposal
+    public function getProposal(int $id): ?ActivityUpdateProposalModel
     {
         return $this->proposalMapper->find($id);
     }
@@ -78,7 +98,7 @@ class ActivityQuery
     /**
      * Retrieve all update proposals from the database.
      *
-     * @return array a Collection of \Activity\Model\ActivityUpdateProposal
+     * @return array a Collection of ActivityUpdateProposalModel
      */
     public function getAllProposals(): array
     {
@@ -93,7 +113,7 @@ class ActivityQuery
      *
      * @return array
      */
-    public function getAvailableLanguages($activity)
+    public function getAvailableLanguages(ActivityModel $activity): array
     {
         return [
             'nl' => !is_null($activity->getName()->getValueNL()),
@@ -130,7 +150,7 @@ class ActivityQuery
             throw new NotAllowedException($this->translator->translate('You are not allowed to view the activities'));
         }
 
-        return $this->activityMapper->getActivityById($id);
+        return $this->activityMapper->find($id);
     }
 
     /**
@@ -139,7 +159,7 @@ class ActivityQuery
      *
      * @return array Array of activities
      */
-    public function findAll()
+    public function findAll(): array
     {
         if (!$this->aclService->isAllowed('view', 'activity')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to view the activities'));
@@ -153,7 +173,7 @@ class ActivityQuery
      *
      * @return array Array of activities
      */
-    public function getUnapprovedActivities()
+    public function getUnapprovedActivities(): array
     {
         if (!$this->aclService->isAllowed('viewUnapproved', 'activity')) {
             throw new NotAllowedException(
@@ -169,7 +189,7 @@ class ActivityQuery
      *
      * @return array Array of activities
      */
-    public function getApprovedActivities()
+    public function getApprovedActivities(): array
     {
         if (!$this->aclService->isAllowed('view', 'activity')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to view activities'));
@@ -181,13 +201,15 @@ class ActivityQuery
     /**
      * Get upcoming activities organized by the given organ.
      *
-     * @param Organ $organ
-     * @param int $count
+     * @param OrganModel $organ
+     * @param int|null $count
      *
      * @return array
      */
-    public function getOrganActivities($organ, $count = null)
-    {
+    public function getOrganActivities(
+        OrganModel $organ,
+        ?int $count = null,
+    ): array {
         return $this->activityMapper->getUpcomingActivities($count, $organ);
     }
 
@@ -196,7 +218,7 @@ class ActivityQuery
      *
      * @return array Array of activities
      */
-    public function getDisapprovedActivities()
+    public function getDisapprovedActivities(): array
     {
         if (!$this->aclService->isAllowed('viewDisapproved', 'activity')) {
             throw new NotAllowedException(
@@ -210,11 +232,11 @@ class ActivityQuery
     /**
      * Get all activities that are approved by the board and which occur in the future.
      *
-     * @param string $category Type of activities requested
+     * @param string|null $category Type of activities requested
      *
      * @return array Array of activities
      */
-    public function getUpcomingActivities($category = null)
+    public function getUpcomingActivities(string $category = null): array
     {
         if (!$this->aclService->isAllowed('view', 'activity')) {
             throw new NotAllowedException(
@@ -235,18 +257,18 @@ class ActivityQuery
             return $this->activityMapper->getUpcomingActivitiesForMember($user);
         }
 
-        return $this->activityMapper->getUpcomingActivities(null, null, $category);
+        return $this->activityMapper->getUpcomingActivities(category: $category);
     }
 
     /**
      * Gets the upcoming activities created by this user or its organs.
      * Or, when the user is an admin, retrieve all upcoming activities.
      *
-     * @param User $user
+     * @param UserModel $user
      *
      * @return array
      */
-    public function getUpcomingCreatedActivities($user)
+    public function getUpcomingCreatedActivities(UserModel $user): array
     {
         if ($this->aclService->isAllowed('viewDetails', 'activity')) {
             //Only admins are allowed to unconditionally view activity details
@@ -254,18 +276,18 @@ class ActivityQuery
         }
         $organs = $this->organService->getEditableOrgans();
 
-        return $this->activityMapper->getAllUpcomingActivities($organs, $user->getLidnr());
+        return $this->activityMapper->getAllUpcomingActivities($organs, $user);
     }
 
     /**
      * Gets a paginator for the old activities created by this user or its organs.
      * Or, when the user is an admin, retrieve all old activities.
      *
-     * @param User $user
+     * @param UserModel $user
      *
      * @return DoctrinePaginator
      */
-    public function getOldCreatedActivitiesPaginator($user)
+    public function getOldCreatedActivitiesPaginator(UserModel $user): DoctrinePaginator
     {
         if ($this->aclService->isAllowed('viewDetails', 'activity')) {
             //Only admins are allowed to unconditionally view activity details
@@ -273,7 +295,7 @@ class ActivityQuery
         }
         $organs = $this->organService->getEditableOrgans();
 
-        return $this->activityMapper->getOldActivityPaginatorAdapterByOrganizer($organs, $user->getLidnr());
+        return $this->activityMapper->getOldActivityPaginatorAdapterByOrganizer($organs, $user);
     }
 
     /**
@@ -281,7 +303,7 @@ class ActivityQuery
      *
      * @return array
      */
-    public function getActivityArchiveYears()
+    public function getActivityArchiveYears(): array
     {
         $oldest = $this->activityMapper->getOldestActivity();
 
@@ -303,7 +325,7 @@ class ActivityQuery
      *
      * @return array
      */
-    public function getFinishedActivitiesByYear(int $year)
+    public function getFinishedActivitiesByYear(int $year): array
     {
         if (!$this->aclService->isAllowed('view', 'activity')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to view the activities'));

--- a/module/Activity/src/Service/ActivityQuery.php
+++ b/module/Activity/src/Service/ActivityQuery.php
@@ -78,12 +78,6 @@ class ActivityQuery
     }
 
     /**
-     * A GEWIS association year starts 01-07.
-     */
-    public const ASSOCIATION_YEAR_START_MONTH = 7;
-    public const ASSOCIATION_YEAR_START_DAY = 1;
-
-    /**
      * Get the information of one proposal from the database.
      *
      * @param int $id The proposal id to be searched for
@@ -151,21 +145,6 @@ class ActivityQuery
         }
 
         return $this->activityMapper->find($id);
-    }
-
-    /**
-     * Returns an array of all activities.
-     * NB: This method is currently unused. Should it be removed?
-     *
-     * @return array Array of activities
-     */
-    public function findAll(): array
-    {
-        if (!$this->aclService->isAllowed('view', 'activity')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view the activities'));
-        }
-
-        return $this->activityMapper->findAll();
     }
 
     /**

--- a/module/Activity/src/Service/Signup.php
+++ b/module/Activity/src/Service/Signup.php
@@ -354,8 +354,6 @@ class Signup
      *
      * @param SignupListModel $signupList
      * @param UserModel $user
-     *
-     * @return void
      */
     public function signOff(
         SignupListModel $signupList,
@@ -381,8 +379,6 @@ class Signup
     /**
      * @param SignupModel $signup
      *
-     * @return void
-     *
      * @throws ORMException
      * @throws OptimisticLockException
      */
@@ -403,8 +399,6 @@ class Signup
 
     /**
      * @param ExternalSignupModel $signup
-     *
-     * @return void
      *
      * @throws ORMException
      * @throws OptimisticLockException

--- a/module/Activity/src/Service/Signup.php
+++ b/module/Activity/src/Service/Signup.php
@@ -19,7 +19,7 @@ use DateTime;
 use Doctrine\ORM\{
     EntityManager,
     OptimisticLockException,
-    ORMException,
+    Exception\ORMException,
 };
 use Laminas\Mvc\I18n\Translator;
 use User\Model\User as UserModel;

--- a/module/Activity/src/Service/SignupListQuery.php
+++ b/module/Activity/src/Service/SignupListQuery.php
@@ -2,54 +2,57 @@
 
 namespace Activity\Service;
 
-use Activity\Mapper\SignupList;
+use Activity\Mapper\SignupList as SignupListMapper;
+use Activity\Model\SignupList as SignupListModel;
 use Laminas\Mvc\I18n\Translator;
 use User\Permissions\NotAllowedException;
 
 class SignupListQuery
 {
     /**
-     * @var Translator
+     * @var AclService
      */
-    private $translator;
-
-    /**
-     * @var SignupList
-     */
-    private $signupListMapper;
     private AclService $aclService;
 
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
+     * @var SignupListMapper
+     */
+    private SignupListMapper $signupListMapper;
+
+    /**
+     * @param Translator $translator
+     * @param SignupListMapper $signupListMapper
+     * @param AclService $aclService
+     */
     public function __construct(
+        AclService $aclService,
         Translator $translator,
-        SignupList $signupListMapper,
-        AclService $aclService
+        SignupListMapper $signupListMapper,
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->signupListMapper = $signupListMapper;
-        $this->aclService = $aclService;
     }
 
     /**
      * @param int $signupListId
      * @param int $activityId
      *
-     * @return \Activity\Model\SignupList|null
+     * @return SignupListModel|null
      */
-    public function getSignupListByActivity($signupListId, $activityId)
-    {
+    public function getSignupListByActivity(
+        int $signupListId,
+        int $activityId,
+    ): ?SignupListModel {
         if (!$this->aclService->isAllowed('view', 'signupList')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to view sign-up lists'));
         }
 
         return $this->signupListMapper->getSignupListByIdAndActivity($signupListId, $activityId);
-    }
-
-    public function getSignupListsOfActivity($activityId)
-    {
-        if (!$this->aclService->isAllowed('view', 'signupList')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view sign-up lists'));
-        }
-
-        return $this->signupListMapper->getSignupListsOfActivity($activityId);
     }
 }

--- a/module/Activity/test/ControllerTestTest.php
+++ b/module/Activity/test/ControllerTestTest.php
@@ -6,19 +6,19 @@ use ApplicationTest\BaseControllerTest;
 
 class ControllerTestTest extends BaseControllerTest
 {
-    public function testActivityActionCanBeAccessed()
+    public function testActivityActionCanBeAccessed(): void
     {
         $this->dispatch('/activity');
         $this->assertResponseStatusCode(200);
     }
 
-    public function testActivityArchiveActionCanBeAccessed()
+    public function testActivityArchiveActionCanBeAccessed(): void
     {
         $this->dispatch('/activity/archive');
         $this->assertResponseStatusCode(200);
     }
 
-    public function testActivityCareerActionCanBeAccessed()
+    public function testActivityCareerActionCanBeAccessed(): void
     {
         $this->dispatch('/activity/career');
         $this->assertResponseStatusCode(200);

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -13,7 +13,6 @@ use Application\View\Helper\{
 };
 use Doctrine\Common\Cache\MemcachedCache;
 use Interop\Container\ContainerInterface;
-use Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger;
 use Laminas\Router\Http\{
     Literal,
     Segment,

--- a/module/Application/src/Controller/Factory/IndexControllerFactory.php
+++ b/module/Application/src/Controller/Factory/IndexControllerFactory.php
@@ -11,14 +11,14 @@ class IndexControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return IndexController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): IndexController {
         return new IndexController();
     }

--- a/module/Application/src/Controller/Factory/IndexControllerFactory.php
+++ b/module/Application/src/Controller/Factory/IndexControllerFactory.php
@@ -18,7 +18,7 @@ class IndexControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): IndexController {
         return new IndexController();
     }

--- a/module/Application/src/Controller/IndexController.php
+++ b/module/Application/src/Controller/IndexController.php
@@ -2,6 +2,7 @@
 
 namespace Application\Controller;
 
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Session\Container as SessionContainer;
 
@@ -10,7 +11,7 @@ class IndexController extends AbstractActionController
     /**
      * Action to switch language.
      */
-    public function langAction()
+    public function langAction(): Response
     {
         $session = new SessionContainer('lang');
         $session->lang = $this->params()->fromRoute('lang');

--- a/module/Application/src/Controller/IndexController.php
+++ b/module/Application/src/Controller/IndexController.php
@@ -29,14 +29,14 @@ class IndexController extends AbstractActionController
     /**
      * Action called when loading pages from external templates.
      */
-    public function externalAction()
+    public function externalAction(): void
     {
     }
 
     /**
      * Throws a teapot error.
      */
-    public function teapotAction()
+    public function teapotAction(): void
     {
         $this->getResponse()->setStatusCode(418);
     }

--- a/module/Application/src/Extensions/Doctrine/Rand.php
+++ b/module/Application/src/Extensions/Doctrine/Rand.php
@@ -18,14 +18,24 @@ use Doctrine\ORM\Query\{
  */
 class Rand extends FunctionNode
 {
-    public function parse(Parser $parser)
+    /**
+     * @param Parser $parser
+     *
+     * @return void
+     */
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    /**
+     * @param SqlWalker $sqlWalker
+     *
+     * @return string
+     */
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'RAND()';
     }

--- a/module/Application/src/Extensions/Doctrine/Rand.php
+++ b/module/Application/src/Extensions/Doctrine/Rand.php
@@ -20,8 +20,6 @@ class Rand extends FunctionNode
 {
     /**
      * @param Parser $parser
-     *
-     * @return void
      */
     public function parse(Parser $parser): void
     {

--- a/module/Application/src/Form/Localisable.php
+++ b/module/Application/src/Form/Localisable.php
@@ -17,8 +17,14 @@ abstract class Localisable extends Form implements InputFilterProviderInterface
      */
     private Translator $translator;
 
-    public function __construct(Translator $translator, bool $addElements = true)
-    {
+    /**
+     * @param Translator $translator
+     * @param bool $addElements
+     */
+    public function __construct(
+        Translator $translator,
+        bool $addElements = true,
+    ) {
         parent::__construct();
         $this->translator = $translator;
 

--- a/module/Application/src/Mapper/BaseMapper.php
+++ b/module/Application/src/Mapper/BaseMapper.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\{
     EntityManager,
     EntityRepository,
     OptimisticLockException,
-    ORMException,
+    Exception\ORMException,
 };
 
 abstract class BaseMapper

--- a/module/Application/src/Mapper/BaseMapper.php
+++ b/module/Application/src/Mapper/BaseMapper.php
@@ -43,11 +43,12 @@ abstract class BaseMapper
      * @param array $entities
      * @throws ORMException
      */
-    public function persistMultiple(array $entities)
+    public function persistMultiple(array $entities): void
     {
         foreach ($entities as $entity) {
             $this->em->persist($entity);
         }
+
         $this->em->flush();
     }
 
@@ -67,11 +68,12 @@ abstract class BaseMapper
      * @param array $entities
      * @throws ORMException
      */
-    public function removeMultiple(array $entities)
+    public function removeMultiple(array $entities): void
     {
         foreach ($entities as $entity) {
             $this->em->remove($entity);
         }
+
         $this->em->flush();
     }
 

--- a/module/Application/src/Model/LocalisedText.php
+++ b/module/Application/src/Model/LocalisedText.php
@@ -47,8 +47,10 @@ abstract class LocalisedText
      * @param string|null $valueEN
      * @param string|null $valueNL
      */
-    public function __construct(?string $valueEN, ?string $valueNL)
-    {
+    public function __construct(
+        ?string $valueEN,
+        ?string $valueNL,
+    ) {
         $this->valueEN = $valueEN;
         $this->valueNL = $valueNL;
     }
@@ -81,8 +83,10 @@ abstract class LocalisedText
      * @param string|null $valueEN
      * @param string|null $valueNL
      */
-    public function updateValues(?string $valueEN, ?string $valueNL): void
-    {
+    public function updateValues(
+        ?string $valueEN,
+        ?string $valueNL,
+    ): void {
         $this->updateValueEN($valueEN);
         $this->updateValueNL($valueNL);
     }

--- a/module/Application/src/Module.php
+++ b/module/Application/src/Module.php
@@ -46,7 +46,12 @@ use User\Permissions\NotAllowedException;
 
 class Module
 {
-    public function onBootstrap(MvcEvent $e)
+    /**
+     * @param MvcEvent $e
+     *
+     * @return void
+     */
+    public function onBootstrap(MvcEvent $e): void
     {
         $eventManager = $e->getApplication()->getEventManager();
         $moduleRouteListener = new ModuleRouteListener();
@@ -70,7 +75,12 @@ class Module
         AbstractValidator::setDefaultTranslator($mvcTranslator, 'validate');
     }
 
-    public function logError(MvCEvent $e)
+    /**
+     * @param MvcEvent $e
+     *
+     * @return void
+     */
+    public function logError(MvCEvent $e): void
     {
         $container = $e->getApplication()->getServiceManager();
         $logger = $container->get('logger');
@@ -94,7 +104,12 @@ class Module
         $logger->error($e->getError());
     }
 
-    protected function determineLocale(MvcEvent $e)
+    /**
+     * @param MvcEvent $e
+     *
+     * @return string
+     */
+    protected function determineLocale(MvcEvent $e): string
     {
         $session = new SessionContainer('lang');
         if (!isset($session->lang)) {
@@ -115,7 +130,10 @@ class Module
         return include __DIR__ . '/../config/module.config.php';
     }
 
-    public function getServiceConfig()
+    /**
+     * @return array
+     */
+    public function getServiceConfig(): array
     {
         return [
             'factories' => [
@@ -188,7 +206,7 @@ class Module
      *
      * @return array
      */
-    public function getViewHelperConfig()
+    public function getViewHelperConfig(): array
     {
         return [
             'factories' => [

--- a/module/Application/src/Module.php
+++ b/module/Application/src/Module.php
@@ -48,8 +48,6 @@ class Module
 {
     /**
      * @param MvcEvent $e
-     *
-     * @return void
      */
     public function onBootstrap(MvcEvent $e): void
     {
@@ -77,8 +75,6 @@ class Module
 
     /**
      * @param MvcEvent $e
-     *
-     * @return void
      */
     public function logError(MvCEvent $e): void
     {

--- a/module/Application/src/Service/AbstractAclService.php
+++ b/module/Application/src/Service/AbstractAclService.php
@@ -20,7 +20,7 @@ abstract class AbstractAclService
      *
      * @return RoleInterface|string
      */
-    abstract protected function getRole();
+    abstract protected function getRole(): string|RoleInterface;
 
     /**
      * Check if a operation is allowed for the current role.
@@ -30,8 +30,10 @@ abstract class AbstractAclService
      *
      * @return bool
      */
-    public function isAllowed(string $operation, $resource): bool
-    {
+    public function isAllowed(
+        string $operation,
+        ResourceInterface|string $resource,
+    ): bool {
         return $this->getAcl()->isAllowed(
             $this->getRole(),
             $resource,

--- a/module/Application/src/Service/Email.php
+++ b/module/Application/src/Service/Email.php
@@ -56,8 +56,6 @@ class Email
      * @param String $view Template of the email
      * @param String $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
-     *
-     * @return void
      */
     public function sendEmail(
         string $type,
@@ -82,8 +80,6 @@ class Email
      * @param String $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
      * @param UserModel $user The user as which the email should be sent
-     *
-     * @return void
      */
     public function sendEmailAsUser(
         string $type,
@@ -110,8 +106,6 @@ class Email
      * @param String $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
      * @param MemberModel $user The user as which the email should be sent
-     *
-     * @return void
      */
     public function sendEmailAsUserToUser(
         MemberModel $recipient,
@@ -138,8 +132,6 @@ class Email
      * @param string $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
      * @param OrganInformationModel $organ The organ as which the email should be sent
-     *
-     * @return void
      */
     public function sendEmailAsOrgan(
         string $type,

--- a/module/Application/src/Service/Email.php
+++ b/module/Application/src/Service/Email.php
@@ -2,15 +2,17 @@
 
 namespace Application\Service;
 
-use Decision\Model\Member;
-use Decision\Model\OrganInformation;
+use Decision\Model\{
+    Member as MemberModel,
+    OrganInformation as OrganInformationModel,
+};
 use Laminas\Mail\Message;
 use Laminas\Mail\Transport\TransportInterface;
 use Laminas\Mime\Message as MimeMessage;
 use Laminas\Mime\Part as MimePart;
 use Laminas\View\Model\ViewModel;
 use Laminas\View\Renderer\PhpRenderer;
-use User\Model\User;
+use User\Model\User as UserModel;
 
 /**
  * This service is used for sending emails.
@@ -20,20 +22,28 @@ class Email
     /**
      * @var PhpRenderer
      */
-    private $renderer;
+    private PhpRenderer $renderer;
 
     /**
      * @var TransportInterface
      */
-    private $transport;
+    private TransportInterface $transport;
 
     /**
      * @var array
      */
-    private $emailConfig;
+    private array $emailConfig;
 
-    public function __construct(PhpRenderer $renderer, TransportInterface $transport, array $emailConfig)
-    {
+    /**
+     * @param PhpRenderer $renderer
+     * @param TransportInterface $transport
+     * @param array $emailConfig
+     */
+    public function __construct(
+        PhpRenderer $renderer,
+        TransportInterface $transport,
+        array $emailConfig,
+    ) {
         $this->renderer = $renderer;
         $this->transport = $transport;
         $this->emailConfig = $emailConfig;
@@ -46,9 +56,15 @@ class Email
      * @param String $view Template of the email
      * @param String $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
+     *
+     * @return void
      */
-    public function sendEmail($type, $view, $subject, $data)
-    {
+    public function sendEmail(
+        string $type,
+        string $view,
+        string $subject,
+        array $data,
+    ): void {
         $message = $this->createMessageFromView($view, $data);
 
         $message->addFrom($this->emailConfig['from']);
@@ -65,10 +81,17 @@ class Email
      * @param String $view Template of the email
      * @param String $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
-     * @param user $user The user as which the email should be sent
+     * @param UserModel $user The user as which the email should be sent
+     *
+     * @return void
      */
-    public function sendEmailAsUser($type, $view, $subject, $data, $user)
-    {
+    public function sendEmailAsUser(
+        string $type,
+        string $view,
+        string $subject,
+        array $data,
+        UserModel $user,
+    ): void {
         $message = $this->createMessageFromView($view, $data);
 
         $message->addFrom($this->emailConfig['from']);
@@ -82,14 +105,21 @@ class Email
     /**
      * Send an email as a given user. The user will be added as reply-to header to the email.
      *
-     * @param member $recipient The receiver of this email
+     * @param MemberModel $recipient The receiver of this email
      * @param String $view Template of the email
      * @param String $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
-     * @param member $user The user as which the email should be sent
+     * @param MemberModel $user The user as which the email should be sent
+     *
+     * @return void
      */
-    public function sendEmailAsUserToUser($recipient, $view, $subject, $data, $user)
-    {
+    public function sendEmailAsUserToUser(
+        MemberModel $recipient,
+        string $view,
+        string $subject,
+        array $data,
+        MemberModel $user,
+    ): void {
         $message = $this->createMessageFromView($view, $data);
 
         $message->addFrom($this->emailConfig['from']);
@@ -103,14 +133,21 @@ class Email
     /**
      * Send an email as a given user. The user will be added as reply-to header to the email.
      *
-     * @param String $type Type that this email belongs to. A key in the config file for email.
-     * @param String $view Template of the email
-     * @param String $subject Subject of the email
+     * @param string $type Type that this email belongs to. A key in the config file for email.
+     * @param string $view Template of the email
+     * @param string $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
-     * @param organInformation $organ The organ as which the email should be sent
+     * @param OrganInformationModel $organ The organ as which the email should be sent
+     *
+     * @return void
      */
-    public function sendEmailAsOrgan($type, $view, $subject, $data, $organ)
-    {
+    public function sendEmailAsOrgan(
+        string $type,
+        string $view,
+        string $subject,
+        array $data,
+        OrganInformationModel $organ,
+    ): void {
         $message = $this->createMessageFromView($view, $data);
 
         $message->addFrom($this->emailConfig['from']);
@@ -124,13 +161,15 @@ class Email
     /**
      * Constructs the Message instance for a given view with given variables.
      *
-     * @param String $view Template of the email
+     * @param string $view Template of the email
      * @param array $data Variables that you want to have available in the template
      *
      * @return Message the constructed instance containing the given view as HTML body
      */
-    private function createMessageFromView($view, $data)
-    {
+    private function createMessageFromView(
+        string $view,
+        array $data,
+    ): Message {
         $body = $this->render($view, $data);
 
         $html = new MimePart($body);
@@ -151,10 +190,12 @@ class Email
      * @param string $template
      * @param array $vars
      *
-     * @return string/
+     * @return string
      */
-    public function render($template, $vars)
-    {
+    public function render(
+        string $template,
+        array $vars,
+    ): string {
         $model = new ViewModel($vars);
         $model->setTemplate($template);
 

--- a/module/Application/src/Service/FileStorage.php
+++ b/module/Application/src/Service/FileStorage.php
@@ -17,19 +17,27 @@ class FileStorage
     /**
      * @var Translator
      */
-    private $translator;
+    private Translator $translator;
 
     /**
      * @var array
      */
-    private $storageConfig;
+    private array $storageConfig;
 
+    /**
+     * @var WatermarkService
+     */
     private WatermarkService $watermarkService;
 
+    /**
+     * @param Translator $translator
+     * @param array $storageConfig
+     * @param WatermarkService $watermarkService
+     */
     public function __construct(
         Translator $translator,
         array $storageConfig,
-        WatermarkService $watermarkService
+        WatermarkService $watermarkService,
     ) {
         $this->translator = $translator;
         $this->storageConfig = $storageConfig;
@@ -43,7 +51,7 @@ class FileStorage
      *
      * @return string the path at which the photo should be saved
      */
-    public function generateStoragePath($path)
+    public function generateStoragePath(string $path): string
     {
         $config = $this->storageConfig;
         $hash = sha1_file($path);
@@ -68,7 +76,7 @@ class FileStorage
      *
      * @throws Exception
      */
-    public function storeUploadedFile($file)
+    public function storeUploadedFile(array $file): string
     {
         $config = $this->storageConfig;
         if (0 !== $file['error']) {
@@ -100,8 +108,10 @@ class FileStorage
      *
      * @return string the path at which the file was stored
      */
-    public function storeFile($source, $move = true)
-    {
+    public function storeFile(
+        string $source,
+        bool $move = true,
+    ): string {
         $config = $this->storageConfig;
         $extension = pathinfo($source, PATHINFO_EXTENSION);
         $storagePath = $this->generateStoragePath($source) . '.' . $extension;
@@ -126,7 +136,7 @@ class FileStorage
      *
      * @return bool indicating if removing the file was successful
      */
-    public function removeFile($path)
+    public function removeFile(string $path): bool
     {
         $config = $this->storageConfig;
         $fullPath = $config['storage_dir'] . '/' . $path;
@@ -146,10 +156,14 @@ class FileStorage
      * @param string $path The CFS path of the file to download
      * @param string $fileName The file name to give the downloaded file
      * @param bool $watermarkPdf Parameter to require addition of a watermark to the pdf before download. False by default
+     *
      * @return Stream|null If the given file is not found, null is returned
      */
-    public function downloadFile($path, $fileName, $watermarkPdf = false)
-    {
+    public function downloadFile(
+        string $path,
+        string $fileName,
+        bool $watermarkPdf = false,
+    ): ?Stream {
         $config = $this->storageConfig;
 
         $file = $config['storage_dir'] . '/' . $path;

--- a/module/Application/src/Service/Infimum.php
+++ b/module/Application/src/Service/Infimum.php
@@ -29,6 +29,11 @@ class Infimum
      */
     private array $infimumConfig;
 
+    /**
+     * @param AbstractAdapter $infimumCache
+     * @param Translator $translator
+     * @param array $infimumConfig
+     */
     public function __construct(
         AbstractAdapter $infimumCache,
         Translator $translator,

--- a/module/Application/src/Service/Legacy.php
+++ b/module/Application/src/Service/Legacy.php
@@ -25,7 +25,7 @@ class Legacy
      *
      * @throws Exception
      */
-    public function checkPincode($user, $pincode)
+    public function checkPincode($user, $pincode): bool
     {
         throw new Exception('This operation is not supported.');
     }
@@ -41,7 +41,7 @@ class Legacy
      *
      * @throws Exception
      */
-    public function checkPassword($user, $password, $bcrypt)
+    public function checkPassword($user, $password, $bcrypt): bool
     {
         throw new Exception('This operation is not supported.');
     }

--- a/module/Application/src/Service/WatermarkService.php
+++ b/module/Application/src/Service/WatermarkService.php
@@ -20,12 +20,31 @@ class WatermarkService
     // The quality of the produced PDFs
     private const DPI = 150;
 
+    /**
+     * @var array
+     */
     private array $storageConfig;
+
+    /**
+     * @var AuthenticationService
+     */
     private AuthenticationService $authService;
+
+    /**
+     * @var string
+     */
     private string $remoteAddress;
 
-    public function __construct(array $storageConfig, AuthenticationService $authService, string $remoteAddress)
-    {
+    /**
+     * @param array $storageConfig
+     * @param AuthenticationService $authService
+     * @param string $remoteAddress
+     */
+    public function __construct(
+        array $storageConfig,
+        AuthenticationService $authService,
+        string $remoteAddress,
+    ) {
         $this->storageConfig = $storageConfig;
         $this->authService = $authService;
         $this->remoteAddress = $remoteAddress;
@@ -33,7 +52,9 @@ class WatermarkService
 
     /**
      * @param string $path The CFS path of the file to watermark
+     *
      * @return string The CFS path of the watermarked file
+     *
      * @throws ImagickException
      * @throws ImagickDrawException
      */

--- a/module/Application/src/View/Helper/Acl.php
+++ b/module/Application/src/View/Helper/Acl.php
@@ -28,10 +28,13 @@ class Acl extends AbstractHelper
      *
      * @param ResourceInterface|string $resource
      * @param string $operation
+     *
      * @return bool
      */
-    public function isAllowed($resource, string $operation)
-    {
+    public function isAllowed(
+        ResourceInterface|string $resource,
+        string $operation,
+    ): bool {
         return $this->acl->isAllowed($operation, $resource);
     }
 
@@ -42,9 +45,10 @@ class Acl extends AbstractHelper
      *
      * @return Acl
      */
-    public function __invoke(string $factory)
+    public function __invoke(string $factory): self
     {
         $this->acl = $this->getServiceLocator()->get($factory);
+
         if ($this->acl instanceof AbstractAclService) {
             return $this;
         } else {
@@ -57,7 +61,7 @@ class Acl extends AbstractHelper
      *
      * @return ContainerInterface
      */
-    protected function getServiceLocator()
+    protected function getServiceLocator(): ContainerInterface
     {
         return $this->locator;
     }
@@ -66,8 +70,10 @@ class Acl extends AbstractHelper
      * Set the service locator.
      *
      * @param ContainerInterface $locator
+     *
+     * @return void
      */
-    public function setServiceLocator(ContainerInterface $locator)
+    public function setServiceLocator(ContainerInterface $locator): void
     {
         $this->locator = $locator;
     }

--- a/module/Application/src/View/Helper/Acl.php
+++ b/module/Application/src/View/Helper/Acl.php
@@ -70,8 +70,6 @@ class Acl extends AbstractHelper
      * Set the service locator.
      *
      * @param ContainerInterface $locator
-     *
-     * @return void
      */
     public function setServiceLocator(ContainerInterface $locator): void
     {

--- a/module/Application/src/View/Helper/BootstrapElementError.php
+++ b/module/Application/src/View/Helper/BootstrapElementError.php
@@ -12,7 +12,7 @@ class BootstrapElementError extends AbstractHelper
      *
      * @return string A Bootstrap class
      */
-    public function __invoke(ElementInterface $element)
+    public function __invoke(ElementInterface $element): string
     {
         return count($element->getMessages()) > 0 ? 'has-error' : '';
     }

--- a/module/Application/src/View/Helper/FeaturedCompanyPackage.php
+++ b/module/Application/src/View/Helper/FeaturedCompanyPackage.php
@@ -2,18 +2,21 @@
 
 namespace Application\View\Helper;
 
-use Company\Model\CompanyFeaturedPackage;
-use Company\Service\Company;
+use Company\Model\CompanyFeaturedPackage as CompanyFeaturedPackageModel;
+use Company\Service\Company as CompanyService;
 use Laminas\View\Helper\AbstractHelper;
 
 class FeaturedCompanyPackage extends AbstractHelper
 {
     /**
-     * @var Company
+     * @var CompanyService
      */
-    private $companyService;
+    private CompanyService $companyService;
 
-    public function __construct(Company $companyService)
+    /**
+     * @param CompanyService $companyService
+     */
+    public function __construct(CompanyService $companyService)
     {
         $this->companyService = $companyService;
     }
@@ -21,9 +24,9 @@ class FeaturedCompanyPackage extends AbstractHelper
     /**
      * Returns currently active featurePackage.
      *
-     * @return CompanyFeaturedPackage
+     * @return CompanyFeaturedPackageModel|null
      */
-    public function __invoke()
+    public function __invoke(): ?CompanyFeaturedPackageModel
     {
         return $this->companyService->getFeaturedPackage();
     }

--- a/module/Application/src/View/Helper/FileUrl.php
+++ b/module/Application/src/View/Helper/FileUrl.php
@@ -12,7 +12,7 @@ class FileUrl extends AbstractHelper
      *
      * @var ContainerInterface
      */
-    protected $locator;
+    protected ContainerInterface $locator;
 
     /**
      * Get the file URL.
@@ -21,7 +21,7 @@ class FileUrl extends AbstractHelper
      *
      * @return string
      */
-    public function __invoke($path)
+    public function __invoke(string $path): string
     {
         $config = $this->getServiceLocator()->get('config');
         $basedir = $config['storage']['public_dir'];
@@ -34,7 +34,7 @@ class FileUrl extends AbstractHelper
      *
      * @return ContainerInterface
      */
-    protected function getServiceLocator()
+    protected function getServiceLocator(): ContainerInterface
     {
         return $this->locator;
     }
@@ -43,8 +43,10 @@ class FileUrl extends AbstractHelper
      * Set the service locator.
      *
      * @param ContainerInterface $locator
+     *
+     * @return void
      */
-    public function setServiceLocator($locator)
+    public function setServiceLocator(ContainerInterface $locator): void
     {
         $this->locator = $locator;
     }

--- a/module/Application/src/View/Helper/FileUrl.php
+++ b/module/Application/src/View/Helper/FileUrl.php
@@ -43,8 +43,6 @@ class FileUrl extends AbstractHelper
      * Set the service locator.
      *
      * @param ContainerInterface $locator
-     *
-     * @return void
      */
     public function setServiceLocator(ContainerInterface $locator): void
     {

--- a/module/Application/src/View/Helper/JobCategories.php
+++ b/module/Application/src/View/Helper/JobCategories.php
@@ -2,17 +2,20 @@
 
 namespace Application\View\Helper;
 
-use Company\Service\CompanyQuery;
+use Company\Service\CompanyQuery as CompanyQueryService;
 use Laminas\View\Helper\AbstractHelper;
 
 class JobCategories extends AbstractHelper
 {
     /**
-     * @var CompanyQuery
+     * @var CompanyQueryService
      */
-    private $companyQueryService;
+    private CompanyQueryService $companyQueryService;
 
-    public function __construct(CompanyQuery $companyQueryService)
+    /**
+     * @param CompanyQueryService $companyQueryService
+     */
+    public function __construct(CompanyQueryService $companyQueryService)
     {
         $this->companyQueryService = $companyQueryService;
     }
@@ -22,7 +25,7 @@ class JobCategories extends AbstractHelper
      *
      * @return array
      */
-    public function __invoke()
+    public function __invoke(): array
     {
         return $this->companyQueryService->getCategoryList(true);
     }

--- a/module/Application/src/View/Helper/ModuleIsActive.php
+++ b/module/Application/src/View/Helper/ModuleIsActive.php
@@ -65,8 +65,6 @@ class ModuleIsActive extends AbstractHelper
      * Set the service locator.
      *
      * @param ContainerInterface $locator
-     *
-     * @return void
      */
     public function setServiceLocator(ContainerInterface $locator): void
     {

--- a/module/Application/src/View/Helper/ModuleIsActive.php
+++ b/module/Application/src/View/Helper/ModuleIsActive.php
@@ -12,14 +12,16 @@ class ModuleIsActive extends AbstractHelper
      *
      * @var ContainerInterface
      */
-    protected $locator;
+    protected ContainerInterface $locator;
 
     /**
      * Get the active module.
      *
+     * @param array $condition
+     *
      * @return bool $condition
      */
-    public function __invoke($condition)
+    public function __invoke(array $condition): bool
     {
         $info = $this->getRouteInfo();
         foreach ($condition as $key => $cond) {
@@ -33,8 +35,10 @@ class ModuleIsActive extends AbstractHelper
 
     /**
      * Get the module.
+     *
+     * @return array
      */
-    public function getRouteInfo()
+    public function getRouteInfo(): array
     {
         $match = $this->getServiceLocator()->get('application')
             ->getMvcEvent()->getRouteMatch();
@@ -52,7 +56,7 @@ class ModuleIsActive extends AbstractHelper
      *
      * @return ContainerInterface
      */
-    protected function getServiceLocator()
+    protected function getServiceLocator(): ContainerInterface
     {
         return $this->locator;
     }
@@ -61,8 +65,10 @@ class ModuleIsActive extends AbstractHelper
      * Set the service locator.
      *
      * @param ContainerInterface $locator
+     *
+     * @return void
      */
-    public function setServiceLocator($locator)
+    public function setServiceLocator(ContainerInterface $locator): void
     {
         $this->locator = $locator;
     }

--- a/module/Application/src/View/Helper/ScriptUrl.php
+++ b/module/Application/src/View/Helper/ScriptUrl.php
@@ -15,12 +15,12 @@ class ScriptUrl extends AbstractHelper
      *
      * @var array
      */
-    protected $urls = [];
+    protected array $urls = [];
 
     /**
      * @return ScriptUrl
      */
-    public function __invoke()
+    public function __invoke(): self
     {
         return $this;
     }
@@ -33,8 +33,10 @@ class ScriptUrl extends AbstractHelper
      *
      * @return ScriptUrl
      */
-    public function requireUrl($name, $params = [])
-    {
+    public function requireUrl(
+        string $name,
+        array $params = [],
+    ): self {
         $scriptParams = [];
 
         foreach ($params as $param) {
@@ -56,8 +58,10 @@ class ScriptUrl extends AbstractHelper
      *
      * @return ScriptUrl
      */
-    public function requireUrls($names, $params)
-    {
+    public function requireUrls(
+        array $names,
+        array $params,
+    ): self {
         foreach ($names as $name) {
             $this->requireUrl($name, $params);
         }
@@ -70,7 +74,7 @@ class ScriptUrl extends AbstractHelper
      *
      * @return array
      */
-    public function getUrls()
+    public function getUrls(): array
     {
         return $this->urls;
     }

--- a/module/Application/src/View/Helper/Truncate.php
+++ b/module/Application/src/View/Helper/Truncate.php
@@ -15,11 +15,16 @@ class Truncate extends AbstractHelper
      *
      * @src http://www.codestance.com/tutorials-archive/zend-framework-truncate-view-helper-246
      */
-    public function __invoke($text, $length = 100, $options = [])
-    {
+    public function __invoke(
+        string $text,
+        int $length = 100,
+        array $options = [],
+    ): string {
         $default = [
-            'ending' => '...', 'exact' => false,
+            'ending' => '...',
+            'exact' => false,
         ];
+
         $options = array_merge($default, $options);
         $ending = $options['ending'];
         $exact = $options['exact'];

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -18,16 +18,6 @@ use User\Permissions\NotAllowedException;
 class AdminController extends AbstractActionController
 {
     /**
-     * @var CompanyService
-     */
-    private CompanyService $companyService;
-
-    /**
-     * @var CompanyQueryService
-     */
-    private CompanyQueryService $companyQueryService;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
@@ -38,23 +28,33 @@ class AdminController extends AbstractActionController
     private Translator $translator;
 
     /**
+     * @var CompanyService
+     */
+    private CompanyService $companyService;
+
+    /**
+     * @var CompanyQueryService
+     */
+    private CompanyQueryService $companyQueryService;
+
+    /**
      * AdminController constructor.
      *
-     * @param CompanyService $companyService
-     * @param CompanyQueryService $companyQueryService
      * @param AclService $aclService
      * @param Translator $translator
+     * @param CompanyService $companyService
+     * @param CompanyQueryService $companyQueryService
      */
     public function __construct(
-        CompanyService $companyService,
-        CompanyQueryService $companyQueryService,
         AclService $aclService,
         Translator $translator,
+        CompanyService $companyService,
+        CompanyQueryService $companyQueryService,
     ) {
-        $this->companyService = $companyService;
-        $this->companyQueryService = $companyQueryService;
         $this->aclService = $aclService;
         $this->translator = $translator;
+        $this->companyService = $companyService;
+        $this->companyQueryService = $companyQueryService;
     }
 
     /**

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -10,6 +10,7 @@ use Company\Service\{
 use Company\Model\CompanyJobPackage;
 use DateInterval;
 use DateTime;
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
@@ -60,7 +61,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that displays the main page.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('listAllLabels', 'company')) {
             throw new NotAllowedException(
@@ -86,7 +87,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that allows adding a company.
      */
-    public function addCompanyAction()
+    public function addCompanyAction(): Response|array
     {
         if (!$this->aclService->isAllowed('create', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to create companies'));
@@ -127,7 +128,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that displays a form for editing a company.
      */
-    public function editCompanyAction()
+    public function editCompanyAction(): Response|array|ViewModel
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit companies'));
@@ -191,7 +192,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that first asks for confirmation, and when given, deletes the company.
      */
-    public function deleteCompanyAction()
+    public function deleteCompanyAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('delete', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete companies'));
@@ -214,7 +215,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that allows adding a package.
      */
-    public function addPackageAction()
+    public function addPackageAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to create packages'));
@@ -281,7 +282,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that displays a form for editing a package.
      */
-    public function editPackageAction()
+    public function editPackageAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit packages'));
@@ -364,7 +365,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that first asks for confirmation, and when given, deletes the Package.
      */
-    public function deletePackageAction()
+    public function deletePackageAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('delete', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete packages'));
@@ -404,7 +405,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that allows adding a job.
      */
-    public function addJobAction()
+    public function addJobAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to create jobs'));
@@ -477,7 +478,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that displays a form for editing a job.
      */
-    public function editJobAction()
+    public function editJobAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit jobs'));
@@ -546,7 +547,7 @@ class AdminController extends AbstractActionController
     /**
      * Action to delete a job.
      */
-    public function deleteJobAction()
+    public function deleteJobAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('delete', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete jobs'));
@@ -586,7 +587,7 @@ class AdminController extends AbstractActionController
         );
     }
 
-    public function addCategoryAction()
+    public function addCategoryAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to create job categories'));
@@ -634,7 +635,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that displays a form for editing a category.
      */
-    public function editCategoryAction()
+    public function editCategoryAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit job categories'));
@@ -672,7 +673,7 @@ class AdminController extends AbstractActionController
         return new ViewModel(['form' => $categoryForm]);
     }
 
-    public function addLabelAction()
+    public function addLabelAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to create job labels'));
@@ -719,7 +720,7 @@ class AdminController extends AbstractActionController
     /**
      * Action that displays a form for editing a label.
      */
-    public function editLabelAction()
+    public function editLabelAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('edit', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit job labels'));

--- a/module/Company/src/Controller/CompanyController.php
+++ b/module/Company/src/Controller/CompanyController.php
@@ -7,7 +7,6 @@ use Company\Service\{
     CompanyQuery as CompanyQueryService,
 };
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
 
 class CompanyController extends AbstractActionController
@@ -39,7 +38,7 @@ class CompanyController extends AbstractActionController
     /**
      * Action to display a list of all non-hidden companies.
      */
-    public function listAction()
+    public function listAction(): ViewModel
     {
         $featuredPackage = $this->companyService->getFeaturedPackage();
 
@@ -60,7 +59,7 @@ class CompanyController extends AbstractActionController
         );
     }
 
-    public function showAction()
+    public function showAction(): ViewModel
     {
         $companyName = $this->params('companySlugName');
         $company = $this->companyService->getCompanyBySlugName($companyName);
@@ -81,7 +80,7 @@ class CompanyController extends AbstractActionController
     /**
      * Action that shows the 'company in the spotlight' and the article written by the company in the current language.
      */
-    public function spotlightAction()
+    public function spotlightAction(): ViewModel
     {
         $featuredPackage = $this->companyService->getFeaturedPackage();
 
@@ -104,7 +103,7 @@ class CompanyController extends AbstractActionController
      *
      * TODO: If the slug in the current locale is different from the slug parameter, redirect.
      */
-    public function jobListAction()
+    public function jobListAction(): ViewModel
     {
         $jobCategorySlug = $this->params('category');
         $jobCategory = $this->companyService->getJobCategoryBySlug($jobCategorySlug);
@@ -152,7 +151,7 @@ class CompanyController extends AbstractActionController
     /**
      * Action to list a single job of a certain company.
      */
-    public function jobsAction()
+    public function jobsAction(): ViewModel
     {
         $jobSlugName = $this->params('jobSlugName');
         $companySlugName = $this->params('companySlugName');

--- a/module/Company/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Company/src/Controller/Factory/AdminControllerFactory.php
@@ -21,10 +21,10 @@ class AdminControllerFactory implements FactoryInterface
         array $options = null,
     ): AdminController {
         return new AdminController(
-            $container->get('company_service_company'),
-            $container->get('company_service_companyquery'),
             $container->get('company_service_acl'),
             $container->get('translator'),
+            $container->get('company_service_company'),
+            $container->get('company_service_companyquery'),
         );
     }
 }

--- a/module/Company/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Company/src/Controller/Factory/AdminControllerFactory.php
@@ -11,14 +11,14 @@ class AdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AdminController {
         return new AdminController(
             $container->get('company_service_acl'),

--- a/module/Company/src/Controller/Factory/CompanyControllerFactory.php
+++ b/module/Company/src/Controller/Factory/CompanyControllerFactory.php
@@ -11,14 +11,14 @@ class CompanyControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return CompanyController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): CompanyController {
         return new CompanyController(
             $container->get('company_service_company'),

--- a/module/Company/src/Form/Company.php
+++ b/module/Company/src/Form/Company.php
@@ -41,8 +41,14 @@ class Company extends LocalisableForm implements InputFilterProviderInterface
      */
     private ?string $currentSlug = null;
 
-    public function __construct(CompanyMapper $mapper, Translator $translator)
-    {
+    /**
+     * @param CompanyMapper $mapper
+     * @param Translator $translator
+     */
+    public function __construct(
+        CompanyMapper $mapper,
+        Translator $translator,
+    ) {
         // we want to ignore the name passed
         parent::__construct($translator);
         $this->mapper = $mapper;

--- a/module/Company/src/Form/Job.php
+++ b/module/Company/src/Form/Job.php
@@ -48,8 +48,18 @@ class Job extends LocalisableForm implements InputFilterProviderInterface
      */
     private ?string $currentSlug = null;
 
-    public function __construct(JobMapper $mapper, Translator $translator, array $categories, array $labels)
-    {
+    /**
+     * @param JobMapper $mapper
+     * @param Translator $translator
+     * @param array $categories
+     * @param array $labels
+     */
+    public function __construct(
+        JobMapper $mapper,
+        Translator $translator,
+        array $categories,
+        array $labels,
+    ) {
         parent::__construct($translator);
         $this->mapper = $mapper;
 
@@ -490,8 +500,10 @@ class Job extends LocalisableForm implements InputFilterProviderInterface
      *
      * @return bool
      */
-    public function isSlugUnique(string $value, array $context): bool
-    {
+    public function isSlugUnique(
+        string $value,
+        array $context,
+    ): bool {
         $category = $context['category'];
 
         // Don't validate if the job category is empty. Note that this is an empty string, null only exists after

--- a/module/Company/src/Form/JobCategory.php
+++ b/module/Company/src/Form/JobCategory.php
@@ -47,8 +47,14 @@ class JobCategory extends Form implements InputFilterProviderInterface
      */
     private ?string $currentSlugEn = null;
 
-    public function __construct(CategoryMapper $mapper, Translator $translator)
-    {
+    /**
+     * @param CategoryMapper $mapper
+     * @param Translator $translator
+     */
+    public function __construct(
+        CategoryMapper $mapper,
+        Translator $translator,
+    ) {
         // we want to ignore the name passed
         parent::__construct();
         $this->mapper = $mapper;
@@ -256,8 +262,11 @@ class JobCategory extends Form implements InputFilterProviderInterface
      * @return bool
      * @throws NonUniqueResultException
      */
-    public function isSlugUnique(string $value, array $context, string $languageSuffix): bool
-    {
+    public function isSlugUnique(
+        string $value,
+        array $context,
+        string $languageSuffix,
+    ): bool {
         if ($this->{'currentSlug' . $languageSuffix} === $value) {
             return true;
         }

--- a/module/Company/src/Form/JobLabel.php
+++ b/module/Company/src/Form/JobLabel.php
@@ -17,6 +17,9 @@ use Laminas\Validator\StringLength;
 
 class JobLabel extends LocalisableForm implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         // we want to ignore the name passed

--- a/module/Company/src/Form/Package.php
+++ b/module/Company/src/Form/Package.php
@@ -28,8 +28,14 @@ class Package extends LocalisableForm implements InputFilterProviderInterface
      */
     private string $type;
 
-    public function __construct(Translator $translator, string $type)
-    {
+    /**
+     * @param Translator $translator
+     * @param string $type
+     */
+    public function __construct(
+        Translator $translator,
+        string $type,
+    ) {
         parent::__construct($translator, ('featured' === $type));
         $this->type = $type;
         $this->setAttribute('method', 'post');

--- a/module/Company/src/Mapper/BannerPackage.php
+++ b/module/Company/src/Mapper/BannerPackage.php
@@ -14,8 +14,10 @@ class BannerPackage extends Package
 {
     /**
      * Returns a random banner from the active banners.
+     *
+     * @return CompanyBannerPackageModel|null
      */
-    public function getBannerPackage()
+    public function getBannerPackage(): ?CompanyBannerPackageModel
     {
         $banners = $this->findVisiblePackages();
 

--- a/module/Company/src/Mapper/Category.php
+++ b/module/Company/src/Mapper/Category.php
@@ -13,24 +13,12 @@ use Doctrine\ORM\Query\Expr\Join;
 class Category extends BaseMapper
 {
     /**
-     * Finds the category with the given id.
-     *
-     * @param int $categorySlug
-     */
-    public function findCategory($categorySlug)
-    {
-        return $this->getRepository()->findOneBy(['slug' => $categorySlug]);
-    }
-
-    /**
      * @return array
      */
     public function findVisibleCategories(): array
     {
-        $objectRepository = $this->getRepository(); // From clause is integrated in this statement
-        $qb = $objectRepository->createQueryBuilder('c')
-            ->select('c')
-            ->where('c.hidden = :hidden')
+        $qb = $this->getRepository()->createQueryBuilder('c');
+        $qb->where('c.hidden = :hidden')
             ->setParameter('hidden', false);
 
         return $qb->getQuery()->getResult();
@@ -48,8 +36,7 @@ class Category extends BaseMapper
     public function findCategoryBySlug(string $value): ?JobCategoryModel
     {
         $qb = $this->getRepository()->createQueryBuilder('c');
-        $qb->select('c')
-            ->innerJoin(
+        $qb->innerJoin(
                 'c.slug',
                 'loc',
                 Join::WITH,

--- a/module/Company/src/Mapper/Category.php
+++ b/module/Company/src/Mapper/Category.php
@@ -37,14 +37,14 @@ class Category extends BaseMapper
     {
         $qb = $this->getRepository()->createQueryBuilder('c');
         $qb->innerJoin(
-                'c.slug',
-                'loc',
-                Join::WITH,
-                $qb->expr()->orX(
-                    'LOWER(loc.valueEN) = :value',
-                    'LOWER(loc.valueNL) = :value',
-                )
+            'c.slug',
+            'loc',
+            Join::WITH,
+            $qb->expr()->orX(
+                'LOWER(loc.valueEN) = :value',
+                'LOWER(loc.valueNL) = :value',
             )
+        )
             ->setParameter(':value', strtolower($value));
 
         return $qb->getQuery()->getOneOrNullResult();

--- a/module/Company/src/Mapper/Company.php
+++ b/module/Company/src/Mapper/Company.php
@@ -20,10 +20,8 @@ class Company extends BaseMapper
      */
     public function findAllPublic(): array
     {
-        $objectRepository = $this->getRepository(); // From clause is integrated in this statement
-        $qb = $objectRepository->createQueryBuilder('c');
-        $qb->select('c')
-            ->where('c.published = 1')
+        $qb = $this->getRepository()->createQueryBuilder('c');
+        $qb->where('c.published = 1')
             ->orderBy('c.name', 'ASC');
 
         return array_filter(
@@ -32,28 +30,6 @@ class Company extends BaseMapper
                 return $company->getNumberOfPackages() > $company->getNumberOfExpiredPackages();
             }
         );
-    }
-
-    /**
-     * Find a specific company by its id.
-     *
-     * @param int $id The id of the company
-     *
-     * @return CompanyModel|null
-     */
-    public function findById(int $id): ?CompanyModel
-    {
-        return $this->getRepository()->find($id);
-    }
-
-    /**
-     * Find all companies.
-     *
-     * @return array
-     */
-    public function findAll(): array
-    {
-        return $this->getRepository()->findAll();
     }
 
     /**

--- a/module/Company/src/Mapper/FeaturedPackage.php
+++ b/module/Company/src/Mapper/FeaturedPackage.php
@@ -15,8 +15,10 @@ class FeaturedPackage extends Package
     /**
      * Returns a random featured package from the active featured packages,
      * and null when there is no featured package.
+     *
+     * @return CompanyFeaturedPackageModel|null
      */
-    public function getFeaturedPackage()
+    public function getFeaturedPackage(): ?CompanyFeaturedPackageModel
     {
         $featuredPackages = $this->findVisiblePackages();
 

--- a/module/Company/src/Mapper/Job.php
+++ b/module/Company/src/Mapper/Job.php
@@ -23,8 +23,11 @@ class Job extends BaseMapper
      *
      * @return bool
      */
-    public function isSlugNameUnique(string $companySlugName, string $jobSlugName, int $jobCategoryId): bool
-    {
+    public function isSlugNameUnique(
+        string $companySlugName,
+        string $jobSlugName,
+        int $jobCategoryId,
+    ): bool {
         // A slug in unique if there is no other slug of the same category and same company.
         $jobs = $this->findJob(
             jobCategoryId: $jobCategoryId,
@@ -55,8 +58,7 @@ class Job extends BaseMapper
         string $companySlugName = null,
     ): array {
         $qb = $this->getRepository()->createQueryBuilder('j');
-        $qb->select('j')
-            ->join('j.package', 'p')
+        $qb->join('j.package', 'p')
             ->addSelect('p')
             ->join('p.company', 'c')
             ->addSelect('c');

--- a/module/Company/src/Mapper/Label.php
+++ b/module/Company/src/Mapper/Label.php
@@ -15,10 +15,8 @@ class Label extends BaseMapper
      */
     public function findVisibleLabels(): array
     {
-        $objectRepository = $this->getRepository(); // From clause is integrated in this statement
-        $qb = $objectRepository->createQueryBuilder('c')
-            ->select('c')
-            ->where('c.hidden = :hidden')
+        $qb = $this->getRepository()->createQueryBuilder('l');
+        $qb->where('l.hidden = :hidden')
             ->setParameter('hidden', false);
 
         return $qb->getQuery()->getResult();

--- a/module/Company/src/Mapper/Package.php
+++ b/module/Company/src/Mapper/Package.php
@@ -10,6 +10,7 @@ use Company\Model\{
     CompanyPackage as CompanyPackageModel,
 };
 use DateTime;
+use Doctrine\ORM\QueryBuilder;
 use Exception;
 
 /**
@@ -21,26 +22,16 @@ use Exception;
 class Package extends BaseMapper
 {
     /**
-     * Finds the package with the given id.
-     *
-     * @param int $packageId
-     */
-    public function findPackage($packageId)
-    {
-        return $this->getRepository()->findOneBy(['id' => $packageId]);
-    }
-
-    /**
      * Will return a list of published packages that will expire between now and $date.
      *
      * @param DateTime $date The date until where to search
+     *
+     * @return array
      */
-    public function findFuturePackageExpirationsBeforeDate($date)
+    public function findFuturePackageExpirationsBeforeDate(DateTime $date): array
     {
-        $objectRepository = $this->getRepository();
-        $qb = $objectRepository->createQueryBuilder('p');
-        $qb->select('p')
-            ->where('p.published=1')
+        $qb = $this->getRepository()->createQueryBuilder('p');
+        $qb->where('p.published=1')
             // All packages that will expire between today and then, ordered smallest first
             ->andWhere('p.expires>CURRENT_DATE()')
             ->andWhere('p.expires<=:date')
@@ -54,13 +45,13 @@ class Package extends BaseMapper
      * Will return a list of published packages that will expire between now and $date.
      *
      * @param DateTime $date The date until where to search
+     *
+     * @return array
      */
-    public function findFuturePackageStartsBeforeDate($date)
+    public function findFuturePackageStartsBeforeDate(DateTime $date): array
     {
-        $objectRepository = $this->getRepository();
-        $qb = $objectRepository->createQueryBuilder('p');
-        $qb->select('p')
-            ->where('p.published=1')
+        $qb = $this->getRepository()->createQueryBuilder('p');
+        $qb->where('p.published=1')
             // All packages that will start between today and then, ordered smallest first
             ->andWhere('p.starts>CURRENT_DATE()')
             ->andWhere('p.starts<=:date')
@@ -70,12 +61,13 @@ class Package extends BaseMapper
         return $qb->getQuery()->getResult();
     }
 
-    protected function getVisiblePackagesQueryBuilder()
+    /**
+     * @return QueryBuilder
+     */
+    protected function getVisiblePackagesQueryBuilder(): QueryBuilder
     {
-        $objectRepository = $this->getRepository(); // From clause is integrated in this statement
-        $qb = $objectRepository->createQueryBuilder('p');
-        $qb->select('p')
-            ->where('p.published=1')
+        $qb = $this->getRepository()->createQueryBuilder('p');
+        $qb->where('p.published=1')
             ->andWhere('p.starts<=CURRENT_DATE()')
             ->andWhere('p.expires>=CURRENT_DATE()');
 
@@ -87,7 +79,7 @@ class Package extends BaseMapper
      *
      * @return array
      */
-    public function findVisiblePackages()
+    public function findVisiblePackages(): array
     {
         $qb = $this->getVisiblePackagesQueryBuilder();
 
@@ -97,13 +89,14 @@ class Package extends BaseMapper
     /**
      * Find all packages, and returns an editable version of them.
      *
+     * @param int $packageId
+     *
      * @return CompanyPackageModel|null
      */
-    public function findEditablePackage($packageId)
+    public function findEditablePackage(int $packageId): ?CompanyPackageModel
     {
-        $objectRepository = $this->getRepository(); // From clause is integrated in this statement
-        $qb = $objectRepository->createQueryBuilder('p');
-        $qb->select('p')->where('p.id=:packageId')
+        $qb = $this->getRepository()->createQueryBuilder('p');
+        $qb->where('p.id=:packageId')
             ->setParameter('packageId', $packageId)
             ->setMaxResults(1);
 

--- a/module/Company/src/Model/Job.php
+++ b/module/Company/src/Model/Job.php
@@ -306,7 +306,7 @@ class Job
      *
      * @param CompanyLocalisedText $website
      */
-    public function setWebsite(CompanyLocalisedText $website)
+    public function setWebsite(CompanyLocalisedText $website): void
     {
         $this->website = $website;
     }

--- a/module/Company/src/Module.php
+++ b/module/Company/src/Module.php
@@ -152,10 +152,11 @@ class Module
      *
      * @return array Service configuration
      */
-    public function getServiceConfig()
+    public function getServiceConfig(): array
     {
         $serviceFactories = [
             'company_service_company' => function (ContainerInterface $container) {
+                $aclService = $container->get('company_service_acl');
                 $translator = $container->get('translator');
                 $storageService = $container->get('application_service_storage');
                 $companyMapper = $container->get('company_mapper_company');
@@ -172,9 +173,9 @@ class Module
                 $jobForm = $container->get('company_admin_job_form');
                 $jobCategoryForm = $container->get('company_admin_jobcategory_form');
                 $jobLabelForm = $container->get('company_admin_joblabel_form');
-                $aclService = $container->get('company_service_acl');
 
                 return new CompanySerivce(
+                    $aclService,
                     $translator,
                     $storageService,
                     $companyMapper,
@@ -191,22 +192,21 @@ class Module
                     $jobForm,
                     $jobCategoryForm,
                     $jobLabelForm,
-                    $aclService,
                 );
             },
             'company_service_companyquery' => function (ContainerInterface $container) {
+                $aclService = $container->get('company_service_acl');
                 $translator = $container->get('translator');
                 $jobMapper = $container->get('company_mapper_job');
                 $categoryMapper = $container->get('company_mapper_jobcategory');
                 $labelMapper = $container->get('company_mapper_joblabel');
-                $aclService = $container->get('company_service_acl');
 
                 return new CompanyQueryService(
+                    $aclService,
                     $translator,
                     $jobMapper,
                     $categoryMapper,
                     $labelMapper,
-                    $aclService,
                 );
             },
         ];

--- a/module/Company/src/Module.php
+++ b/module/Company/src/Module.php
@@ -24,7 +24,6 @@ use Company\Service\{
 };
 use Interop\Container\ContainerInterface;
 use User\Authorization\AclServiceFactory;
-use User\Permissions\NotAllowedException;
 
 class Module
 {

--- a/module/Company/src/Service/AclService.php
+++ b/module/Company/src/Service/AclService.php
@@ -4,9 +4,6 @@ namespace Company\Service;
 
 class AclService extends \User\Service\AclService
 {
-    /**
-     * @return void
-     */
     protected function createAcl(): void
     {
         parent::createAcl();

--- a/module/Company/src/Service/AclService.php
+++ b/module/Company/src/Service/AclService.php
@@ -4,7 +4,10 @@ namespace Company\Service;
 
 class AclService extends \User\Service\AclService
 {
-    protected function createAcl()
+    /**
+     * @return void
+     */
+    protected function createAcl(): void
     {
         parent::createAcl();
 

--- a/module/Company/src/Service/Company.php
+++ b/module/Company/src/Service/Company.php
@@ -368,8 +368,6 @@ class Company
     /**
      * @param JobCategoryModel $jobCategory The JobCategoryModel to update
      * @param array $data The (new) data to save
-     *
-     * @return void
      */
     public function updateJobCategory(
         JobCategoryModel $jobCategory,
@@ -407,8 +405,6 @@ class Company
      *
      * @param JobLabelModel $jobLabel
      * @param array $data The data to validate, and apply to the label
-     *
-     * @return void
      */
     public function updateJobLabel(
         JobLabelModel $jobLabel,
@@ -547,8 +543,6 @@ class Company
      * Saves the modified JobCategoryModel.
      *
      * @param JobCategoryModel $jobCategory
-     *
-     * @return void
      */
     public function persistJobCategory(JobCategoryModel $jobCategory): void
     {
@@ -559,8 +553,6 @@ class Company
      * Saves the modified JobLabelModel.
      *
      * @param JobLabelModel $jobLabel
-     *
-     * @return void
      */
     public function persistJobLabel(JobLabelModel $jobLabel): void
     {
@@ -572,8 +564,6 @@ class Company
      *
      * @param JobModel $job
      *
-     * @return void
-     *
      * @throws ORMException
      */
     public function persistJob(JobModel $job): void
@@ -583,8 +573,6 @@ class Company
 
     /**
      * @param CompanyModel $company
-     *
-     * @return void
      *
      * @throws ORMException
      */
@@ -597,8 +585,6 @@ class Company
      * Saves all modified packages.
      *
      * @param CompanyPackageModel $package
-     *
-     * @return void
      *
      * @throws ORMException
      */
@@ -801,8 +787,6 @@ class Company
      *
      * @param CompanyPackageModel $package
      *
-     * @return void
-     *
      * @throws ORMException
      */
     public function deletePackage(CompanyPackageModel $package): void
@@ -819,8 +803,6 @@ class Company
      *
      * @param JobModel $job
      *
-     * @return void
-     *
      * @throws ORMException
      */
     public function deleteJob($job): void
@@ -836,8 +818,6 @@ class Company
      * Deletes the company identified with $slug.
      *
      * @param string $slug
-     *
-     * @return void
      *
      * @throws ORMException
      */

--- a/module/Company/src/Service/Company.php
+++ b/module/Company/src/Service/Company.php
@@ -5,7 +5,7 @@ namespace Company\Service;
 use Application\Service\FileStorage;
 use Doctrine\ORM\{
     NonUniqueResultException,
-    ORMException,
+    Exception\ORMException,
 };
 use Company\Form\{
     JobCategory as EditCategoryForm,
@@ -805,7 +805,7 @@ class Company
      *
      * @throws ORMException
      */
-    public function deleteJob($job): void
+    public function deleteJob(JobModel $job): void
     {
         if (!$this->aclService->isAllowed('delete', 'company')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete jobs'));

--- a/module/Company/src/Service/CompanyQuery.php
+++ b/module/Company/src/Service/CompanyQuery.php
@@ -16,6 +16,11 @@ use User\Permissions\NotAllowedException;
 class CompanyQuery
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
      * @var Translator
      */
     private Translator $translator;
@@ -36,22 +41,24 @@ class CompanyQuery
     private LabelMapper $labelMapper;
 
     /**
-     * @var AclService
+     * @param AclService $aclService
+     * @param Translator $translator
+     * @param JobMapper $jobMapper
+     * @param CategoryMapper $categoryMapper
+     * @param LabelMapper $labelMapper
      */
-    private AclService $aclService;
-
     public function __construct(
+        AclService $aclService,
         Translator $translator,
         JobMapper $jobMapper,
         CategoryMapper $categoryMapper,
         LabelMapper $labelMapper,
-        AclService $aclService
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->jobMapper = $jobMapper;
         $this->categoryMapper = $categoryMapper;
         $this->labelMapper = $labelMapper;
-        $this->aclService = $aclService;
     }
 
     /**
@@ -130,7 +137,7 @@ class CompanyQuery
      *
      * @return array
      */
-    public function getCategoryList($visible)
+    public function getCategoryList(bool $visible): array
     {
         if (!$visible) {
             if (!$this->aclService->isAllowed('listAllCategories', 'company')) {

--- a/module/Company/test/ControllerTest.php
+++ b/module/Company/test/ControllerTest.php
@@ -6,7 +6,7 @@ use ApplicationTest\BaseControllerTest;
 
 class ControllerTest extends BaseControllerTest
 {
-    public function testCareerActionCanBeAccessed()
+    public function testCareerActionCanBeAccessed(): void
     {
         $this->dispatch('/career');
         $this->assertResponseStatusCode(200);

--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -28,7 +28,7 @@ class AdminController extends AbstractActionController
     /**
      * Notes upload action.
      */
-    public function notesAction()
+    public function notesAction(): ViewModel
     {
         $form = $this->decisionService->getNotesForm();
 
@@ -61,7 +61,7 @@ class AdminController extends AbstractActionController
     /**
      * Document upload action.
      */
-    public function documentAction()
+    public function documentAction(): ViewModel
     {
         $type = $this->params()->fromRoute('type');
         $number = $this->params()->fromRoute('number');
@@ -108,14 +108,14 @@ class AdminController extends AbstractActionController
     /**
      * TODO: Non-idempotent requests should be POST, not GET.
      */
-    public function deleteDocumentAction()
+    public function deleteDocumentAction(): Response
     {
         $this->decisionService->deleteDocument($this->getRequest()->getPost()->toArray());
 
         return $this->redirect()->toRoute('admin_decision/document');
     }
 
-    public function changePositionDocumentAction()
+    public function changePositionDocumentAction(): mixed
     {
         if (!$this->getRequest()->isPost()) {
             return $this->getResponse()->setStatusCode(Response::STATUS_CODE_405); // Method Not Allowed
@@ -140,7 +140,7 @@ class AdminController extends AbstractActionController
         return $this->getResponse()->setStatusCode(Response::STATUS_CODE_204); // No Content (OK)
     }
 
-    public function authorizationsAction()
+    public function authorizationsAction(): ViewModel
     {
         $meetings = $this->decisionService->getMeetingsByType('AV');
         $number = $this->params()->fromRoute('number');

--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -7,6 +7,7 @@ use Decision\Service\{
     AclService,
     Decision as DecisionService,
 };
+use Laminas\Http\Response\Stream;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
@@ -57,7 +58,7 @@ class DecisionController extends AbstractActionController
     /**
      * Index action, shows meetings.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         return new ViewModel(
             [
@@ -69,7 +70,7 @@ class DecisionController extends AbstractActionController
     /**
      * Download meeting notes.
      */
-    public function notesAction()
+    public function notesAction(): ViewModel|Stream
     {
         $type = $this->params()->fromRoute('type');
         $number = $this->params()->fromRoute('number');
@@ -86,7 +87,7 @@ class DecisionController extends AbstractActionController
         return $this->notFoundAction();
     }
 
-    public function documentAction()
+    public function documentAction(): ViewModel|Stream
     {
         $id = $this->params()->fromRoute('id');
 
@@ -105,7 +106,7 @@ class DecisionController extends AbstractActionController
     /**
      * View a meeting.
      */
-    public function viewAction()
+    public function viewAction(): ViewModel
     {
         $type = $this->params()->fromRoute('type');
         $number = $this->params()->fromRoute('number');
@@ -125,7 +126,7 @@ class DecisionController extends AbstractActionController
     /**
      * Search decisions.
      */
-    public function searchAction()
+    public function searchAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('search', 'decision')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to search decisions.'));
@@ -158,7 +159,7 @@ class DecisionController extends AbstractActionController
         );
     }
 
-    public function authorizationsAction()
+    public function authorizationsAction(): ViewModel
     {
         $meeting = $this->decisionService->getLatestAV();
         $authorization = null;
@@ -197,7 +198,7 @@ class DecisionController extends AbstractActionController
     /**
      * Browse/download files from the set FileReader.
      */
-    public function filesAction()
+    public function filesAction(): bool|ViewModel|Stream
     {
         if (!$this->decisionService->isAllowedToBrowseFiles()) {
             $translator = $this->decisionService->getTranslator();

--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -3,13 +3,27 @@
 namespace Decision\Controller;
 
 use Decision\Controller\FileBrowser\FileReader;
-use Decision\Service\Decision as DecisionService;
+use Decision\Service\{
+    AclService,
+    Decision as DecisionService,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
 use User\Permissions\NotAllowedException;
 
 class DecisionController extends AbstractActionController
 {
+    /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
     /**
      * @var DecisionService
      */
@@ -23,13 +37,19 @@ class DecisionController extends AbstractActionController
     /**
      * DecisionController constructor.
      *
+     * @param AclService $aclService
+     * @param Translator $translator
      * @param DecisionService $decisionService
      * @param FileReader $fileReader
      */
     public function __construct(
+        AclService $aclService,
+        Translator $translator,
         DecisionService $decisionService,
-        FileReader $fileReader
+        FileReader $fileReader,
     ) {
+        $this->aclService = $aclService;
+        $this->translator = $translator;
         $this->decisionService = $decisionService;
         $this->fileReader = $fileReader;
     }
@@ -107,24 +127,33 @@ class DecisionController extends AbstractActionController
      */
     public function searchAction()
     {
+        if (!$this->aclService->isAllowed('search', 'decision')) {
+            throw new NotAllowedException($this->translator->translate('You are not allowed to search decisions.'));
+        }
+
         $request = $this->getRequest();
+        $form = $this->decisionService->getSearchDecisionForm();
 
         if ($request->isPost()) {
-            $result = $this->decisionService->search($request->getPost());
+            $form->setData($request->getPost()->toArray());
 
-            if (null !== $result) {
-                return new ViewModel(
-                    [
-                        'result' => $result,
-                        'form' => $this->decisionService->getSearchDecisionForm(),
-                    ]
-                );
+            if ($form->isValid()) {
+                $result = $this->decisionService->search($form->getData());
+
+                if (null !== $result) {
+                    return new ViewModel(
+                        [
+                            'result' => $result,
+                            'form' => $form,
+                        ]
+                    );
+                }
             }
         }
 
         return new ViewModel(
             [
-                'form' => $this->decisionService->getSearchDecisionForm(),
+                'form' => $form,
             ]
         );
     }
@@ -135,7 +164,7 @@ class DecisionController extends AbstractActionController
         $authorization = null;
 
         if (null !== $meeting) {
-            $authorization = $this->decisionService->getUserAuthorization($meeting->getNumber());
+            $authorization = $this->decisionService->getUserAuthorization($meeting);
         }
 
         $form = $this->decisionService->getAuthorizationForm();

--- a/module/Decision/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/AdminControllerFactory.php
@@ -11,14 +11,14 @@ class AdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AdminController {
         return new AdminController(
             $container->get('decision_service_decision'),

--- a/module/Decision/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/AdminControllerFactory.php
@@ -18,7 +18,7 @@ class AdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AdminController {
         return new AdminController(
             $container->get('decision_service_decision'),

--- a/module/Decision/src/Controller/Factory/DecisionControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/DecisionControllerFactory.php
@@ -18,9 +18,11 @@ class DecisionControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): DecisionController {
         return new DecisionController(
+            $container->get('decision_service_acl'),
+            $container->get('translator'),
             $container->get('decision_service_decision'),
             $container->get('decision_fileReader'),
         );

--- a/module/Decision/src/Controller/Factory/DecisionControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/DecisionControllerFactory.php
@@ -11,14 +11,14 @@ class DecisionControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return DecisionController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): DecisionController {
         return new DecisionController(
             $container->get('decision_service_acl'),

--- a/module/Decision/src/Controller/Factory/MemberApiControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/MemberApiControllerFactory.php
@@ -11,14 +11,14 @@ class MemberApiControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return MemberApiController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): MemberApiController {
         return new MemberApiController(
             $container->get('decision_service_member'),

--- a/module/Decision/src/Controller/Factory/MemberApiControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/MemberApiControllerFactory.php
@@ -18,7 +18,7 @@ class MemberApiControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): MemberApiController {
         return new MemberApiController(
             $container->get('decision_service_member'),

--- a/module/Decision/src/Controller/Factory/MemberControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/MemberControllerFactory.php
@@ -11,14 +11,14 @@ class MemberControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return MemberController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): MemberController {
         return new MemberController(
             $container->get('decision_service_acl'),

--- a/module/Decision/src/Controller/Factory/MemberControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/MemberControllerFactory.php
@@ -18,14 +18,14 @@ class MemberControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): MemberController {
         return new MemberController(
+            $container->get('decision_service_acl'),
             $container->get('decision_service_member'),
             $container->get('decision_service_memberinfo'),
             $container->get('decision_service_decision'),
             $container->get('config')['regulations'],
-            $container->get('decision_service_acl'),
         );
     }
 }

--- a/module/Decision/src/Controller/Factory/OrganAdminControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/OrganAdminControllerFactory.php
@@ -11,14 +11,14 @@ class OrganAdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return OrganAdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): OrganAdminController {
         return new OrganAdminController(
             $container->get('decision_service_organ'),

--- a/module/Decision/src/Controller/Factory/OrganAdminControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/OrganAdminControllerFactory.php
@@ -18,7 +18,7 @@ class OrganAdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): OrganAdminController {
         return new OrganAdminController(
             $container->get('decision_service_organ'),

--- a/module/Decision/src/Controller/Factory/OrganControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/OrganControllerFactory.php
@@ -18,7 +18,7 @@ class OrganControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): OrganController {
         return new OrganController(
             $container->get('decision_service_organ'),

--- a/module/Decision/src/Controller/Factory/OrganControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/OrganControllerFactory.php
@@ -11,14 +11,14 @@ class OrganControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return OrganController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): OrganController {
         return new OrganController(
             $container->get('decision_service_organ'),

--- a/module/Decision/src/Controller/FileBrowser/FileNode.php
+++ b/module/Decision/src/Controller/FileBrowser/FileNode.php
@@ -75,8 +75,16 @@ class FileNode
         'fa-folder' => ['folder'],
     ];
 
-    public function __construct($kind, $fullPath, $name)
-    {
+    /**
+     * @param string $kind
+     * @param string $fullPath
+     * @param string $name
+     */
+    public function __construct(
+        string $kind,
+        string $fullPath,
+        string $name,
+    ) {
         if ('dir' !== $kind && 'file' !== $kind) {
             throw new RuntimeException('Kind is not supported.');
         }

--- a/module/Decision/src/Controller/FileBrowser/LocalFileReader.php
+++ b/module/Decision/src/Controller/FileBrowser/LocalFileReader.php
@@ -26,8 +26,14 @@ class LocalFileReader implements FileReader
      */
     private string $validFilepath;
 
-    public function __construct($root, $validFilepath)
-    {
+    /**
+     * @param string $root
+     * @param string $validFilepath
+     */
+    public function __construct(
+        string $root,
+        string $validFilepath,
+    ) {
         $this->root = $root;
         $this->validFilepath = $validFilepath;
     }
@@ -94,7 +100,7 @@ class LocalFileReader implements FileReader
             $files[] = new FileNode(
                 $kind,
                 $path . $delimiter . $dirContent,
-                $dirContent
+                $dirContent,
             );
         }
 
@@ -107,8 +113,10 @@ class LocalFileReader implements FileReader
      *
      * @return false|string
      */
-    protected function interpretDirContent(string $dirContent, string $fullPath): bool|string
-    {
+    protected function interpretDirContent(
+        string $dirContent,
+        string $fullPath,
+    ): bool|string {
         if ('.' === $dirContent[0] || !$this->isValidPathName($fullPath)) {
             return false;
         }

--- a/module/Decision/src/Controller/MemberApiController.php
+++ b/module/Decision/src/Controller/MemberApiController.php
@@ -23,7 +23,7 @@ class MemberApiController extends AbstractActionController
         $this->memberService = $memberService;
     }
 
-    public function lidnrAction()
+    public function lidnrAction(): JsonModel
     {
         $lidnr = $this->params()->fromRoute('lidnr');
 

--- a/module/Decision/src/Controller/MemberController.php
+++ b/module/Decision/src/Controller/MemberController.php
@@ -17,6 +17,11 @@ use Laminas\View\Model\{
 class MemberController extends AbstractActionController
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
      * @var MemberService
      */
     private MemberService $memberService;
@@ -37,31 +42,26 @@ class MemberController extends AbstractActionController
     private array $regulationsConfig;
 
     /**
-     * @var AclService
-     */
-    private AclService $aclService;
-
-    /**
      * MemberController constructor.
      *
+     * @param AclService $aclService
      * @param MemberService $memberService
      * @param MemberInfoService $memberInfoService
      * @param DecisionService $decisionService
      * @param array $regulationsConfig
-     * @param AclService $aclService
      */
     public function __construct(
+        AclService $aclService,
         MemberService $memberService,
         MemberInfoService $memberInfoService,
         DecisionService $decisionService,
         array $regulationsConfig,
-        AclService $aclService
     ) {
+        $this->aclService = $aclService;
         $this->memberService = $memberService;
         $this->memberInfoService = $memberInfoService;
         $this->decisionService = $decisionService;
         $this->regulationsConfig = $regulationsConfig;
-        $this->aclService = $aclService;
     }
 
     public function indexAction()

--- a/module/Decision/src/Controller/MemberController.php
+++ b/module/Decision/src/Controller/MemberController.php
@@ -8,6 +8,7 @@ use Decision\Service\{
     Member as MemberService,
     MemberInfo as MemberInfoService,
 };
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -64,7 +65,7 @@ class MemberController extends AbstractActionController
         $this->regulationsConfig = $regulationsConfig;
     }
 
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         // Get the latest 3 meetings of each type and flatten result
         $meetingsCollection = [
@@ -88,7 +89,7 @@ class MemberController extends AbstractActionController
     /**
      * Shown own information.
      */
-    public function selfAction()
+    public function selfAction(): ViewModel
     {
         return new ViewModel($this->memberInfoService->getMembershipInfo());
     }
@@ -96,7 +97,7 @@ class MemberController extends AbstractActionController
     /**
      * View information about a member.
      */
-    public function viewAction()
+    public function viewAction(): ViewModel
     {
         $info = $this->memberInfoService->getMembershipInfo($this->params()->fromRoute('lidnr'));
 
@@ -110,7 +111,7 @@ class MemberController extends AbstractActionController
     /**
      * Search action, allows searching for members.
      */
-    public function searchAction()
+    public function searchAction(): JsonModel|ViewModel
     {
         $name = $this->params()->fromQuery('q');
 
@@ -128,7 +129,7 @@ class MemberController extends AbstractActionController
     /**
      * Determinues whether a member can be authorized without additional confirmation.
      */
-    public function canAuthorizeAction()
+    public function canAuthorizeAction(): JsonModel|ViewModel
     {
         $lidnr = $this->params()->fromQuery('q');
         $meeting = $this->decisionService->getLatestAV();
@@ -158,7 +159,7 @@ class MemberController extends AbstractActionController
     /**
      * Show birthdays of members.
      */
-    public function birthdaysAction()
+    public function birthdaysAction(): ViewModel
     {
         return new ViewModel(
             [
@@ -170,7 +171,7 @@ class MemberController extends AbstractActionController
     /**
      * Action to download regulations.
      */
-    public function downloadRegulationAction()
+    public function downloadRegulationAction(): Response
     {
         $regulation = $this->params('regulation');
         if (isset($this->regulationsConfig['regulation'])) {

--- a/module/Decision/src/Controller/OrganAdminController.php
+++ b/module/Decision/src/Controller/OrganAdminController.php
@@ -4,6 +4,7 @@ namespace Decision\Controller;
 
 use Decision\Service\Organ as OrganService;
 use Laminas\Form\FormInterface;
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
@@ -27,7 +28,7 @@ class OrganAdminController extends AbstractActionController
     /**
      * Index action, shows all active organs.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         return new ViewModel(
             [
@@ -39,7 +40,7 @@ class OrganAdminController extends AbstractActionController
     /**
      * Show an organ.
      */
-    public function editAction()
+    public function editAction(): Response|ViewModel
     {
         $organId = $this->params()->fromRoute('organ_id');
         $organInformation = $this->organService->getEditableOrganInformation($organId);

--- a/module/Decision/src/Controller/OrganController.php
+++ b/module/Decision/src/Controller/OrganController.php
@@ -26,7 +26,7 @@ class OrganController extends AbstractActionController
     /**
      * Index action, shows all active organs.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         return new ViewModel(
             [
@@ -38,7 +38,7 @@ class OrganController extends AbstractActionController
     /**
      * Show an organ.
      */
-    public function showAction()
+    public function showAction(): ViewModel
     {
         $organId = $this->params()->fromRoute('organ');
         $organ = $this->organService->getOrgan($organId);

--- a/module/Decision/src/Form/Authorization.php
+++ b/module/Decision/src/Form/Authorization.php
@@ -13,6 +13,9 @@ use Laminas\InputFilter\InputFilterProviderInterface;
 
 class Authorization extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();
@@ -47,6 +50,8 @@ class Authorization extends Form implements InputFilterProviderInterface
 
     /**
      * Input filter specification.
+     *
+     * @return array
      */
     public function getInputFilterSpecification(): array
     {

--- a/module/Decision/src/Form/Document.php
+++ b/module/Decision/src/Form/Document.php
@@ -19,6 +19,9 @@ use Laminas\Validator\{
 
 class Document extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Decision/src/Form/Notes.php
+++ b/module/Decision/src/Form/Notes.php
@@ -24,6 +24,9 @@ class Notes extends Form implements InputFilterProviderInterface
      */
     protected Translator $translator;
 
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Decision/src/Form/OrganInformation.php
+++ b/module/Decision/src/Form/OrganInformation.php
@@ -22,6 +22,9 @@ use Laminas\Validator\{
 
 class OrganInformation extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Decision/src/Form/ReorderDocument.php
+++ b/module/Decision/src/Form/ReorderDocument.php
@@ -25,8 +25,14 @@ class ReorderDocument extends Form implements InputFilterProviderInterface
      */
     protected Translator $translator;
 
-    public function __construct($name = null, $options = [])
-    {
+    /**
+     * @param string|null $name
+     * @param array $options
+     */
+    public function __construct(
+        ?string $name = null,
+        array $options = [],
+    ) {
         parent::__construct($name, $options);
 
         $this->setAttribute('method', 'post');
@@ -124,8 +130,10 @@ class ReorderDocument extends Form implements InputFilterProviderInterface
      *
      * @return string
      */
-    private static function generateIcon($className, $title): string
-    {
+    private static function generateIcon(
+        string $className,
+        string $title,
+    ): string {
         return "<span class=\"fa {$className}\" title=\"{$title}\"></span>";
     }
 }

--- a/module/Decision/src/Form/SearchDecision.php
+++ b/module/Decision/src/Form/SearchDecision.php
@@ -13,6 +13,9 @@ use Laminas\Validator\NotEmpty;
 
 class SearchDecision extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();

--- a/module/Decision/src/Mapper/Authorization.php
+++ b/module/Decision/src/Mapper/Authorization.php
@@ -3,7 +3,11 @@
 namespace Decision\Mapper;
 
 use Application\Mapper\BaseMapper;
-use Decision\Model\Authorization as AuthorizationModel;
+use Decision\Model\{
+    Authorization as AuthorizationModel,
+    Meeting as MeetingModel,
+    Member as MemberModel,
+};
 
 /**
  * Mappers for authorizations.
@@ -17,26 +21,30 @@ class Authorization extends BaseMapper
      *
      * @return array
      */
-    public function findNotRevoked($meetingNumber)
+    public function findNotRevoked(int $meetingNumber): array
     {
-        return $this->getRepository()->findBy(['meetingNumber' => $meetingNumber, 'revoked' => false]);
+        return $this->getRepository()->findBy(
+            [
+                'meetingNumber' => $meetingNumber,
+                'revoked' => false,
+            ]
+        );
     }
 
     /**
      * Find non-revoked authorizations for a meeting for a user.
      *
      * @param int $meetingNumber
-     * @param int $authorizer
+     * @param MemberModel $authorizer
      *
      * @return AuthorizationModel|null
      */
-    public function findUserAuthorization($meetingNumber, $authorizer)
-    {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('a')
-            ->from($this->getRepositoryName(), 'a')
-            ->where('a.meetingNumber = :meetingNumber')
+    public function findUserAuthorization(
+        int $meetingNumber,
+        MemberModel $authorizer,
+    ): ?AuthorizationModel {
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.meetingNumber = :meetingNumber')
             ->andWhere('a.authorizer = :authorizer')
             ->andWhere('a.revoked = 0')
             ->setParameter('meetingNumber', $meetingNumber)
@@ -49,17 +57,16 @@ class Authorization extends BaseMapper
      * Find non-revoked authorizations for a meeting for a recipient.
      *
      * @param int $meetingNumber
-     * @param int $recipient
+     * @param MemberModel $recipient
      *
      * @return array
      */
-    public function findRecipientAuthorization($meetingNumber, $recipient)
-    {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('a')
-            ->from($this->getRepositoryName(), 'a')
-            ->where('a.meetingNumber = :meetingNumber')
+    public function findRecipientAuthorization(
+        int $meetingNumber,
+        MemberModel $recipient,
+    ): array {
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.meetingNumber = :meetingNumber')
             ->andWhere('a.recipient = :recipient')
             ->andWhere('a.revoked = 0')
             ->setParameter('meetingNumber', $meetingNumber)

--- a/module/Decision/src/Mapper/Authorization.php
+++ b/module/Decision/src/Mapper/Authorization.php
@@ -5,7 +5,6 @@ namespace Decision\Mapper;
 use Application\Mapper\BaseMapper;
 use Decision\Model\{
     Authorization as AuthorizationModel,
-    Meeting as MeetingModel,
     Member as MemberModel,
 };
 

--- a/module/Decision/src/Mapper/Decision.php
+++ b/module/Decision/src/Mapper/Decision.php
@@ -14,10 +14,9 @@ class Decision extends BaseMapper
      *
      * @return array
      */
-    public function search($query)
+    public function search(string $query): array
     {
         $qb = $this->getRepository()->createQueryBuilder('d');
-
         $qb->select('d, m')
             ->where('d.content LIKE :query')
             ->join('d.meeting', 'm')

--- a/module/Decision/src/Mapper/Meeting.php
+++ b/module/Decision/src/Mapper/Meeting.php
@@ -12,7 +12,7 @@ use Decision\Model\{
 use Doctrine\ORM\{
     NonUniqueResultException,
     NoResultException,
-    ORMException,
+    Exception\ORMException,
 };
 use InvalidArgumentException;
 

--- a/module/Decision/src/Mapper/Member.php
+++ b/module/Decision/src/Mapper/Member.php
@@ -40,7 +40,7 @@ class Member extends BaseMapper
         string $name,
         int $maxResults = 32,
         string $orderColumn = 'generation',
-        string $orderDirection = 'DESC'
+        string $orderDirection = 'DESC',
     ): array {
         $rsm = new ResultSetMapping();
         $rsm->addScalarResult('lidnr', 'lidnr', 'integer')
@@ -100,7 +100,6 @@ class Member extends BaseMapper
     public function findOrgans(MemberModel $member): array
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
-
         $qb->select('DISTINCT o')
             ->from(OrganModel::class, 'o')
             ->join('o.members', 'om')

--- a/module/Decision/src/Mapper/Organ.php
+++ b/module/Decision/src/Mapper/Organ.php
@@ -20,15 +20,16 @@ class Organ extends BaseMapper
     /**
      * Find all active organs.
      *
-     * @param string $type
+     * @param string|null $type
      *
      * @return array
      */
-    public function findActive($type = null)
+    public function findActive(?string $type = null): array
     {
         $criteria = [
             'abrogationDate' => null,
         ];
+
         if (!is_null($type)) {
             $criteria['type'] = $type;
         }
@@ -45,27 +46,26 @@ class Organ extends BaseMapper
      */
     public function findActiveById(int $id): ?OrganModel
     {
-        $criteria = [
-            'id' => $id,
-            'abrogationDate' => null,
-        ];
-
-        return $this->getRepository()->findOneBy($criteria);
+        return $this->getRepository()->findOneBy(
+            [
+                'id' => $id,
+                'abrogationDate' => null,
+            ]
+        );
     }
 
     /**
      * Find all abrogated organs.
      *
-     * @param string $type
+     * @param string|null $type
      *
      * @return array
      */
-    public function findAbrogated($type = null)
+    public function findAbrogated(?string $type = null): array
     {
         $qb = $this->getRepository()->createQueryBuilder('o');
+        $qb->where('o.abrogationDate IS NOT NULL');
 
-        $qb->select('o')
-            ->where('o.abrogationDate IS NOT NULL');
         if (!is_null($type)) {
             $qb->andWhere('o.type = :type')
                 ->setParameter('type', $type);
@@ -80,13 +80,13 @@ class Organ extends BaseMapper
      * @param int $id
      *
      * @return OrganModel
+     *
      * @throws NoResultException
      * @throws NonUniqueResultException
      */
-    public function findOrgan($id)
+    public function findOrgan(int $id): OrganModel
     {
         $qb = $this->getRepository()->createQueryBuilder('o');
-
         $qb->select('o, om, m')
             ->leftJoin('o.members', 'om')
             ->leftJoin('om.member', 'm')
@@ -108,14 +108,16 @@ class Organ extends BaseMapper
      * @param bool $latest Whether to retrieve the latest occurrence of an organ or not
      * @param string|null $type
      *
-     * @return OrganModel
+     * @return OrganModel|null
      * @throws NoResultException
      * @throws NonUniqueResultException
      */
-    public function findByAbbr(string $abbr, bool $latest, ?string $type = null): OrganModel
-    {
+    public function findByAbbr(
+        string $abbr,
+        bool $latest,
+        ?string $type = null,
+    ): ?OrganModel {
         $qb = $this->getRepository()->createQueryBuilder('o');
-
         $qb->select('o, om, m')
             ->leftJoin('o.members', 'om')
             ->leftJoin('om.member', 'm')
@@ -133,7 +135,7 @@ class Organ extends BaseMapper
 
             if (empty($queryResult)) {
                 // the query did not return any records
-                throw new NoResultException();
+                return null;
             }
 
             // the query returned at least 1 record, use first (= latest) record

--- a/module/Decision/src/Model/Decision.php
+++ b/module/Decision/src/Model/Decision.php
@@ -105,7 +105,7 @@ class Decision
      *
      * @param Meeting $meeting
      */
-    public function setMeeting(Meeting $meeting)
+    public function setMeeting(Meeting $meeting): void
     {
         $meeting->addDecision($this);
         $this->meeting_type = $meeting->getType();

--- a/module/Decision/src/Model/Meeting.php
+++ b/module/Decision/src/Model/Meeting.php
@@ -33,20 +33,20 @@ class Meeting
      */
     #[Id]
     #[Column(type: "string")]
-    protected $type;
+    protected string $type;
 
     /**
      * Meeting number.
      */
     #[Id]
     #[Column(type: "integer")]
-    protected $number;
+    protected int $number;
 
     /**
      * Meeting date.
      */
     #[Column(type: "date")]
-    protected $date;
+    protected DateTime $date;
 
     /**
      * Decisions.

--- a/module/Decision/src/Model/Organ.php
+++ b/module/Decision/src/Model/Organ.php
@@ -66,8 +66,8 @@ class Organ
      * Reference to foundation of organ.
      */
     #[OneToOne(
-        targetEntity: Foundation::class,
         inversedBy: "organ",
+        targetEntity: Foundation::class,
     )]
     #[JoinColumn(
         name: "r_meeting_type",
@@ -110,8 +110,8 @@ class Organ
      * Reference to members.
      */
     #[OneToMany(
-        targetEntity: OrganMember::class,
         mappedBy: "organ",
+        targetEntity: OrganMember::class,
     )]
     protected Collection $members;
 
@@ -156,8 +156,8 @@ class Organ
      * All organInformation for this organ.
      */
     #[OneToMany(
-        targetEntity: OrganInformation::class,
         mappedBy: "organ",
+        targetEntity: OrganInformation::class,
         cascade: ["persist", "remove"],
     )]
     protected Collection $organInformation;
@@ -361,7 +361,7 @@ class Organ
      *
      * @return array subdecisions[0]->getDate < subdecision[1]->getDate
      */
-    public function getOrderedSubdecisions()
+    public function getOrderedSubdecisions(): array
     {
         $array = $this->subdecisions->toArray();
         usort($array, function ($dA, $dB) {

--- a/module/Decision/src/Service/AclService.php
+++ b/module/Decision/src/Service/AclService.php
@@ -4,7 +4,10 @@ namespace Decision\Service;
 
 class AclService extends \User\Service\AclService
 {
-    protected function createAcl()
+    /**
+     * @return void
+     */
+    protected function createAcl(): void
     {
         parent::createAcl();
 

--- a/module/Decision/src/Service/AclService.php
+++ b/module/Decision/src/Service/AclService.php
@@ -4,9 +4,6 @@ namespace Decision\Service;
 
 class AclService extends \User\Service\AclService
 {
-    /**
-     * @return void
-     */
     protected function createAcl(): void
     {
         parent::createAcl();

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -438,7 +438,7 @@ class Decision
         $ordering->set($newPosition, $id);
 
         // Persist new positions
-        $documents->map(function (MeetingDocumentModel $document) use ($ordering) {
+        $documents->map(function (MeetingDocumentModel $document) use ($ordering): void {
             $position = $ordering->indexOf($document->getId());
 
             $document->setDisplayPosition($position);

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -27,7 +27,7 @@ use Decision\Model\{
 };
 use Doctrine\ORM\{
     NonUniqueResultException,
-    ORMException,
+    Exception\ORMException,
     PersistentCollection,
 };
 use Exception;

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -401,8 +401,6 @@ class Decision
      * @param int $id Document ID
      * @param bool $moveDown If the document should be moved down in the ordering, defaults to TRUE
      *
-     * @return void
-     *
      * @throws NotAllowedException
      * @throws InvalidArgumentException If the document doesn't exist
      */

--- a/module/Decision/src/Service/MemberInfo.php
+++ b/module/Decision/src/Service/MemberInfo.php
@@ -15,6 +15,11 @@ use User\Permissions\NotAllowedException;
 class MemberInfo
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
      * @var Translator
      */
     private Translator $translator;
@@ -30,26 +35,28 @@ class MemberInfo
     private MemberMapper $memberMapper;
 
     /**
-     * @var AclService
-     */
-    private AclService $aclService;
-
-    /**
      * @var array
      */
     private array $photoConfig;
 
+    /**
+     * @param AclService $aclService
+     * @param Translator $translator
+     * @param PhotoService $photoService
+     * @param MemberMapper $memberMapper
+     * @param array $photoConfig
+     */
     public function __construct(
+        AclService $aclService,
         Translator $translator,
         PhotoService $photoService,
         MemberMapper $memberMapper,
-        AclService $aclService,
         array $photoConfig,
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->photoService = $photoService;
         $this->memberMapper = $memberMapper;
-        $this->aclService = $aclService;
         $this->photoConfig = $photoConfig;
     }
 
@@ -59,6 +66,7 @@ class MemberInfo
      * @param int|null $lidnr
      *
      * @return array|null
+     *
      * @throws Exception
      */
     public function getMembershipInfo(?int $lidnr = null): ?array

--- a/module/Decision/src/Service/Organ.php
+++ b/module/Decision/src/Service/Organ.php
@@ -344,7 +344,7 @@ class Organ
         $image->setimageformat('jpg');
 
         //Tempfile is used such that the file storage service can generate a filename
-        $tempFileName = sys_get_temp_dir() . '/ThumbImage' . rand() . '.jpg';
+        $tempFileName = sys_get_temp_dir() . '/ThumbImage' . random_int(0, getrandmax()) . '.jpg';
         $image->writeImage($tempFileName);
 
         return $this->storageService->storeFile($tempFileName);

--- a/module/Decision/src/Service/Organ.php
+++ b/module/Decision/src/Service/Organ.php
@@ -6,7 +6,7 @@ use ImagickException;
 use Doctrine\ORM\{
     NonUniqueResultException,
     NoResultException,
-    ORMException,
+    Exception\ORMException,
     EntityManager,
 };
 use Application\Service\{

--- a/module/Education/src/Controller/AdminController.php
+++ b/module/Education/src/Controller/AdminController.php
@@ -148,12 +148,10 @@ class AdminController extends AbstractActionController
             );
         }
 
-        $config = $this->educationTempConfig;
-
         return new ViewModel(
             [
                 'form' => $this->examService->getBulkExamForm(),
-                'config' => $config,
+                'config' => $this->educationTempConfig,
             ]
         );
     }

--- a/module/Education/src/Controller/AdminController.php
+++ b/module/Education/src/Controller/AdminController.php
@@ -35,12 +35,12 @@ class AdminController extends AbstractActionController
         $this->educationTempConfig = $educationTempConfig;
     }
 
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         return new ViewModel();
     }
 
-    public function addCourseAction()
+    public function addCourseAction(): ViewModel
     {
         $request = $this->getRequest();
 
@@ -73,7 +73,7 @@ class AdminController extends AbstractActionController
         );
     }
 
-    public function bulkExamAction()
+    public function bulkExamAction(): ViewModel
     {
         $request = $this->getRequest();
 
@@ -103,7 +103,7 @@ class AdminController extends AbstractActionController
         );
     }
 
-    public function bulkSummaryAction()
+    public function bulkSummaryAction(): ViewModel
     {
         $request = $this->getRequest();
 
@@ -136,7 +136,7 @@ class AdminController extends AbstractActionController
     /**
      * Edit several exams in bulk.
      */
-    public function editExamAction()
+    public function editExamAction(): ViewModel
     {
         $request = $this->getRequest();
 
@@ -159,7 +159,7 @@ class AdminController extends AbstractActionController
     /**
      * Edit summaries in bulk.
      */
-    public function editSummaryAction()
+    public function editSummaryAction(): ViewModel
     {
         $request = $this->getRequest();
 
@@ -181,7 +181,7 @@ class AdminController extends AbstractActionController
         );
     }
 
-    public function deleteTempAction()
+    public function deleteTempAction(): JsonModel|ViewModel
     {
         $request = $this->getRequest();
         if ($request->isPost()) {

--- a/module/Education/src/Controller/EducationController.php
+++ b/module/Education/src/Controller/EducationController.php
@@ -35,26 +35,29 @@ class EducationController extends AbstractActionController
 
     public function indexAction()
     {
-        $request = $this->getRequest();
-
-        $query = $request->getQuery();
+        $query = $this->getRequest()->getQuery();
+        $form = $this->searchCourseForm;
 
         if (isset($query['query'])) {
-            $courses = $this->examService->searchCourse($query->toArray());
+            $form->setData($query->toArray());
 
-            if (null !== $courses) {
-                return new ViewModel(
-                    [
-                        'form' => $this->searchCourseForm,
-                        'courses' => $courses,
-                    ]
-                );
+            if ($form->isValid()) {
+                $courses = $this->examService->searchCourse($form->getData());
+
+                if (null !== $courses) {
+                    return new ViewModel(
+                        [
+                            'form' => $form,
+                            'courses' => $courses,
+                        ]
+                    );
+                }
             }
         }
 
         return new ViewModel(
             [
-                'form' => $this->searchCourseForm,
+                'form' => $form,
             ]
         );
     }

--- a/module/Education/src/Controller/EducationController.php
+++ b/module/Education/src/Controller/EducationController.php
@@ -4,6 +4,8 @@ namespace Education\Controller;
 
 use Education\Form\SearchCourse as SearchCourseForm;
 use Education\Service\Exam as ExamService;
+use Laminas\Http\Response;
+use Laminas\Http\Response\Stream;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
@@ -33,7 +35,7 @@ class EducationController extends AbstractActionController
         $this->searchCourseForm = $searchCourseForm;
     }
 
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $query = $this->getRequest()->getQuery();
         $form = $this->searchCourseForm;
@@ -62,7 +64,7 @@ class EducationController extends AbstractActionController
         );
     }
 
-    public function courseAction()
+    public function courseAction(): Response|ViewModel
     {
         $code = $this->params()->fromRoute('code');
         $course = $this->examService->getCourse($code);
@@ -92,7 +94,7 @@ class EducationController extends AbstractActionController
     /**
      * Download an exam.
      */
-    public function downloadAction()
+    public function downloadAction(): ?Stream
     {
         $id = $this->params()->fromRoute('id');
 

--- a/module/Education/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Education/src/Controller/Factory/AdminControllerFactory.php
@@ -11,14 +11,14 @@ class AdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AdminController {
         return new AdminController(
             $container->get('education_service_exam'),

--- a/module/Education/src/Controller/Factory/EducationControllerFactory.php
+++ b/module/Education/src/Controller/Factory/EducationControllerFactory.php
@@ -18,7 +18,7 @@ class EducationControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): EducationController {
         return new EducationController(
             $container->get('education_service_exam'),

--- a/module/Education/src/Controller/Factory/EducationControllerFactory.php
+++ b/module/Education/src/Controller/Factory/EducationControllerFactory.php
@@ -11,14 +11,14 @@ class EducationControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return EducationController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): EducationController {
         return new EducationController(
             $container->get('education_service_exam'),

--- a/module/Education/src/Form/AddCourse.php
+++ b/module/Education/src/Form/AddCourse.php
@@ -17,6 +17,9 @@ use Laminas\Validator\StringLength;
 
 class AddCourse extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         $qOptions = [

--- a/module/Education/src/Form/Bulk.php
+++ b/module/Education/src/Form/Bulk.php
@@ -15,8 +15,14 @@ use Laminas\InputFilter\InputFilterProviderInterface;
 
 class Bulk extends Form implements InputFilterProviderInterface
 {
-    public function __construct(Translator $translator, Fieldset $exam)
-    {
+    /**
+     * @param Translator $translator
+     * @param Fieldset $exam
+     */
+    public function __construct(
+        Translator $translator,
+        Fieldset $exam,
+    ) {
         parent::__construct();
 
         $this->add(

--- a/module/Education/src/Form/Fieldset/Exam.php
+++ b/module/Education/src/Form/Fieldset/Exam.php
@@ -24,8 +24,14 @@ use Laminas\Validator\{
 
 class Exam extends Fieldset implements InputFilterProviderInterface
 {
-    protected $config;
+    /**
+     * @var array
+     */
+    protected array $config;
 
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct('exam');
@@ -94,7 +100,7 @@ class Exam extends Fieldset implements InputFilterProviderInterface
      *
      * @param array $config
      */
-    public function setConfig($config): void
+    public function setConfig(array $config): void
     {
         $this->config = $config['education_temp'];
     }

--- a/module/Education/src/Form/Fieldset/Summary.php
+++ b/module/Education/src/Form/Fieldset/Summary.php
@@ -24,8 +24,14 @@ use Laminas\Validator\{
 
 class Summary extends Fieldset implements InputFilterProviderInterface
 {
-    protected $config;
+    /**
+     * @var array
+     */
+    protected array $config;
 
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct('exam');
@@ -88,7 +94,7 @@ class Summary extends Fieldset implements InputFilterProviderInterface
      *
      * @param array $config
      */
-    public function setConfig($config): void
+    public function setConfig(array $config): void
     {
         $this->config = $config['education_temp'];
     }

--- a/module/Education/src/Form/SearchCourse.php
+++ b/module/Education/src/Form/SearchCourse.php
@@ -3,12 +3,15 @@
 namespace Education\Form;
 
 use Laminas\Form\Form;
+use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Mvc\I18n\Translator;
-use Laminas\InputFilter\InputFilter;
 use Laminas\Validator\NotEmpty;
 
-class SearchCourse extends Form
+class SearchCourse extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();
@@ -22,26 +25,22 @@ class SearchCourse extends Form
                 ],
             ]
         );
-
-        $this->initFilters();
     }
 
-    protected function initFilters()
+    /**
+     * @return array
+     */
+    public function getInputFilterSpecification(): array
     {
-        $filter = new InputFilter();
-
-        $filter->add(
-            [
-                'name' => 'query',
+        return [
+            'query' => [
                 'required' => true,
                 'validators' => [
                     [
                         'name' => NotEmpty::class,
                     ],
                 ],
-            ]
-        );
-
-        $this->setInputFilter($filter);
+            ],
+        ];
     }
 }

--- a/module/Education/src/Form/SummaryUpload.php
+++ b/module/Education/src/Form/SummaryUpload.php
@@ -27,6 +27,9 @@ use Laminas\Validator\{
  */
 class SummaryUpload extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Education/src/Form/TempUpload.php
+++ b/module/Education/src/Form/TempUpload.php
@@ -13,6 +13,9 @@ use Laminas\Validator\File\{
 
 class TempUpload extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();
@@ -29,7 +32,7 @@ class TempUpload extends Form implements InputFilterProviderInterface
     }
 
     /**
-     * @return array[]
+     * @return array
      */
     public function getInputFilterSpecification(): array
     {

--- a/module/Education/src/Mapper/Course.php
+++ b/module/Education/src/Mapper/Course.php
@@ -48,11 +48,9 @@ class Course extends BaseMapper
     public function search(string $query): array
     {
         $query = '%' . $query . '%';
-        $qb = $this->em->createQueryBuilder();
+        $qb = $this->getRepository()->createQueryBuilder('c');
 
-        $qb->select('c')
-            ->from($this->getRepositoryName(), 'c')
-            ->where('c.code LIKE ?1')
+        $qb->where('c.code LIKE ?1')
             ->orWhere('c.name LIKE ?1');
         $qb->setParameter(1, $query);
 

--- a/module/Education/src/Mapper/Exam.php
+++ b/module/Education/src/Mapper/Exam.php
@@ -16,8 +16,12 @@ class Exam extends BaseMapper
      *
      * Instead of the EntityManager, this inserts this Mapper into the
      * function.
+     *
+     * @param Closure $func
+     *
+     * @return mixed
      */
-    public function transactional(Closure $func)
+    public function transactional(Closure $func): mixed
     {
         return $this->em->transactional(
             function ($em) use ($func) {

--- a/module/Education/src/Mapper/Study.php
+++ b/module/Education/src/Mapper/Study.php
@@ -8,7 +8,7 @@ use Education\Model\Study as StudyModel;
 /**
  * Mappers for Study.
  *
- * NOTE: Organs will be modified externally by a script. Modifycations will be
+ * NOTE: Organs will be modified externally by a script. Modifications will be
  * overwritten.
  */
 class Study extends BaseMapper

--- a/module/Education/src/Module.php
+++ b/module/Education/src/Module.php
@@ -6,6 +6,8 @@ use Doctrine\Laminas\Hydrator\DoctrineObject;
 use Education\Form\{
     AddCourse as AddCourseForm,
     Bulk as BulkForm,
+    Fieldset\Exam as ExamFieldset,
+    Fieldset\Summary as SummaryFieldset,
     SearchCourse as SearchCourseForm,
     SummaryUpload as SummaryUploadForm,
     TempUpload as TempUploadForm,
@@ -46,30 +48,28 @@ class Module
         return [
             'factories' => [
                 'education_service_exam' => function (ContainerInterface $container) {
+                    $aclService = $container->get('education_service_acl');
                     $translator = $container->get('translator');
                     $storageService = $container->get('application_service_storage');
                     $courseMapper = $container->get('education_mapper_course');
                     $examMapper = $container->get('education_mapper_exam');
                     $addCourseForm = $container->get('education_form_add_course');
-                    $searchCourseForm = $container->get('education_form_searchcourse');
                     $tempUploadForm = $container->get('education_form_tempupload');
                     $bulkSummaryForm = $container->get('education_form_bulk_summary');
                     $bulkExamForm = $container->get('education_form_bulk_exam');
                     $config = $container->get('config');
-                    $aclService = $container->get('education_service_acl');
 
                     return new ExamService(
+                        $aclService,
                         $translator,
                         $storageService,
                         $courseMapper,
                         $examMapper,
                         $addCourseForm,
-                        $searchCourseForm,
                         $tempUploadForm,
                         $bulkSummaryForm,
                         $bulkExamForm,
                         $config,
-                        $aclService
                     );
                 },
                 'education_form_tempupload' => function (ContainerInterface $container) {
@@ -108,7 +108,7 @@ class Module
                     );
                 },
                 'education_form_fieldset_exam' => function (ContainerInterface $container) {
-                    $fieldset = new Form\Fieldset\Exam(
+                    $fieldset = new ExamFieldset(
                         $container->get('translator')
                     );
                     $fieldset->setConfig($container->get('config'));
@@ -118,7 +118,7 @@ class Module
                     return $fieldset;
                 },
                 'education_form_fieldset_summary' => function (ContainerInterface $container) {
-                    $fieldset = new Form\Fieldset\Summary(
+                    $fieldset = new SummaryFieldset(
                         $container->get('translator')
                     );
                     $fieldset->setConfig($container->get('config'));

--- a/module/Education/src/Service/AclService.php
+++ b/module/Education/src/Service/AclService.php
@@ -4,7 +4,10 @@ namespace Education\Service;
 
 class AclService extends \User\Service\AclService
 {
-    protected function createAcl()
+    /**
+     * @return void
+     */
+    protected function createAcl(): void
     {
         parent::createAcl();
 

--- a/module/Education/src/Service/AclService.php
+++ b/module/Education/src/Service/AclService.php
@@ -4,9 +4,6 @@ namespace Education\Service;
 
 class AclService extends \User\Service\AclService
 {
-    /**
-     * @return void
-     */
     protected function createAcl(): void
     {
         parent::createAcl();

--- a/module/Education/src/Service/Exam.php
+++ b/module/Education/src/Service/Exam.php
@@ -210,7 +210,7 @@ class Exam
          * exam, which we need in the upload process.
          */
         $storage = $this->storageService;
-        $this->examMapper->transactional(function ($mapper) use ($data, $type, $temporaryEducationConfig, $storage) {
+        $this->examMapper->transactional(function ($mapper) use ($data, $type, $temporaryEducationConfig, $storage): void {
             foreach ($data['exams'] as $examData) {
                 // finalize exam upload
                 $exam = new ExamModel();

--- a/module/Education/src/Service/Exam.php
+++ b/module/Education/src/Service/Exam.php
@@ -8,10 +8,9 @@ use DirectoryIterator;
 use Education\Form\{
     AddCourse as AddCourseForm,
     Bulk as BulkForm,
-    SearchCourse as SearchCourseForm,
     TempUpload as TempUploadForm,
 };
-use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Exception\ORMException;
 use Education\Mapper\{
     Exam as ExamMapper,
     Course as CourseMapper,
@@ -498,7 +497,7 @@ class Exam
         $filename = str_replace($month, '', $filename);
         $day = preg_match_all('/[0123]\d/', $filename, $matches) ? $matches[0][0] : $today->format('d');
 
-        $language = strstr($filename, 'nl') ? 'nl' : 'en';
+        $language = str_contains($filename, 'nl') ? 'nl' : 'en';
 
         return [
             'course' => $course,

--- a/module/Education/src/View/Helper/ExamUrl.php
+++ b/module/Education/src/View/Helper/ExamUrl.php
@@ -9,25 +9,27 @@ use Laminas\View\Helper\AbstractHelper;
 class ExamUrl extends AbstractHelper
 {
     /**
-     * Exam service..
+     * Exam service.
      *
      * @var ExamService
      */
-    protected $examService;
+    protected ExamService $examService;
 
     /**
      * Education data dir.
      *
      * @var string
      */
-    protected $dir;
+    protected string $dir;
 
     /**
      * Get the exam URL.
      *
+     * @param Exam $exam
+     *
      * @return string
      */
-    public function __invoke(Exam $exam)
+    public function __invoke(Exam $exam): string
     {
         return $this->getView()->basePath() . '/' . $this->getDir() . '/' . $this->examService->examToFilename($exam);
     }
@@ -37,7 +39,7 @@ class ExamUrl extends AbstractHelper
      *
      * @return string
      */
-    public function getDir()
+    public function getDir(): string
     {
         return $this->dir;
     }
@@ -47,7 +49,7 @@ class ExamUrl extends AbstractHelper
      *
      * @param string $dir
      */
-    public function setDir($dir)
+    public function setDir(string $dir): void
     {
         $this->dir = $dir;
     }
@@ -57,15 +59,17 @@ class ExamUrl extends AbstractHelper
      *
      * @return ExamService
      */
-    public function getExamService()
+    public function getExamService(): ExamService
     {
         return $this->examService;
     }
 
     /**
      * Set the authentication service.
+     *
+     * @param ExamService $examService
      */
-    public function setExamService(ExamService $examService)
+    public function setExamService(ExamService $examService): void
     {
         $this->examService = $examService;
     }

--- a/module/Education/test/ControllerTest.php
+++ b/module/Education/test/ControllerTest.php
@@ -6,7 +6,7 @@ use ApplicationTest\BaseControllerTest;
 
 class ControllerTest extends BaseControllerTest
 {
-    public function testEducationActionCanBeAccessed()
+    public function testEducationActionCanBeAccessed(): void
     {
         $this->dispatch('/education');
         $this->assertResponseStatusCode(200);

--- a/module/Frontpage/src/Controller/AdminController.php
+++ b/module/Frontpage/src/Controller/AdminController.php
@@ -7,7 +7,7 @@ use Laminas\View\Model\ViewModel;
 
 class AdminController extends AbstractActionController
 {
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         return new ViewModel();
     }

--- a/module/Frontpage/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/AdminControllerFactory.php
@@ -11,14 +11,14 @@ class AdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AdminController {
         return new AdminController();
     }

--- a/module/Frontpage/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/AdminControllerFactory.php
@@ -18,7 +18,7 @@ class AdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AdminController {
         return new AdminController();
     }

--- a/module/Frontpage/src/Controller/Factory/FrontpageControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/FrontpageControllerFactory.php
@@ -18,7 +18,7 @@ class FrontpageControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): FrontpageController {
         return new FrontpageController(
             $container->get('frontpage_service_frontpage'),

--- a/module/Frontpage/src/Controller/Factory/FrontpageControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/FrontpageControllerFactory.php
@@ -11,14 +11,14 @@ class FrontpageControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return FrontpageController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): FrontpageController {
         return new FrontpageController(
             $container->get('frontpage_service_frontpage'),

--- a/module/Frontpage/src/Controller/Factory/InfimumControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/InfimumControllerFactory.php
@@ -11,14 +11,14 @@ class InfimumControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return InfimumController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): InfimumController {
         return new InfimumController(
             $container->get('frontpage_service_acl'),

--- a/module/Frontpage/src/Controller/Factory/InfimumControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/InfimumControllerFactory.php
@@ -18,12 +18,12 @@ class InfimumControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): InfimumController {
         return new InfimumController(
-            $container->get('application_service_infimum'),
             $container->get('frontpage_service_acl'),
             $container->get('translator'),
+            $container->get('application_service_infimum'),
         );
     }
 }

--- a/module/Frontpage/src/Controller/Factory/NewsAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/NewsAdminControllerFactory.php
@@ -18,12 +18,12 @@ class NewsAdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): NewsAdminController {
         return new NewsAdminController(
-            $container->get('frontpage_service_news'),
             $container->get('frontpage_service_acl'),
             $container->get('translator'),
+            $container->get('frontpage_service_news'),
         );
     }
 }

--- a/module/Frontpage/src/Controller/Factory/NewsAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/NewsAdminControllerFactory.php
@@ -11,14 +11,14 @@ class NewsAdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return NewsAdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): NewsAdminController {
         return new NewsAdminController(
             $container->get('frontpage_service_acl'),

--- a/module/Frontpage/src/Controller/Factory/OrganControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/OrganControllerFactory.php
@@ -11,14 +11,14 @@ class OrganControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return OrganController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): OrganController {
         return new OrganController(
             $container->get('activity_service_activityQuery'),

--- a/module/Frontpage/src/Controller/Factory/OrganControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/OrganControllerFactory.php
@@ -18,7 +18,7 @@ class OrganControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): OrganController {
         return new OrganController(
             $container->get('activity_service_activityQuery'),

--- a/module/Frontpage/src/Controller/Factory/PageAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PageAdminControllerFactory.php
@@ -18,7 +18,7 @@ class PageAdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): PageAdminController {
         return new PageAdminController(
             $container->get('frontpage_service_page'),

--- a/module/Frontpage/src/Controller/Factory/PageAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PageAdminControllerFactory.php
@@ -11,14 +11,14 @@ class PageAdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return PageAdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): PageAdminController {
         return new PageAdminController(
             $container->get('frontpage_service_page'),

--- a/module/Frontpage/src/Controller/Factory/PageControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PageControllerFactory.php
@@ -18,7 +18,7 @@ class PageControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): PageController {
         return new PageController(
             $container->get('frontpage_service_page'),

--- a/module/Frontpage/src/Controller/Factory/PageControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PageControllerFactory.php
@@ -11,14 +11,14 @@ class PageControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return PageController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): PageController {
         return new PageController(
             $container->get('frontpage_service_page'),

--- a/module/Frontpage/src/Controller/Factory/PollAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PollAdminControllerFactory.php
@@ -11,14 +11,14 @@ class PollAdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return PollAdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): PollAdminController {
         return new PollAdminController(
             $container->get('frontpage_service_poll'),

--- a/module/Frontpage/src/Controller/Factory/PollAdminControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PollAdminControllerFactory.php
@@ -18,7 +18,7 @@ class PollAdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): PollAdminController {
         return new PollAdminController(
             $container->get('frontpage_service_poll'),

--- a/module/Frontpage/src/Controller/Factory/PollControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PollControllerFactory.php
@@ -11,14 +11,14 @@ class PollControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return PollController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): PollController {
         return new PollController(
             $container->get('frontpage_service_acl'),

--- a/module/Frontpage/src/Controller/Factory/PollControllerFactory.php
+++ b/module/Frontpage/src/Controller/Factory/PollControllerFactory.php
@@ -18,13 +18,13 @@ class PollControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): PollController {
         return new PollController(
-            $container->get('frontpage_form_poll_comment'),
-            $container->get('frontpage_service_poll'),
             $container->get('frontpage_service_acl'),
             $container->get('translator'),
+            $container->get('frontpage_form_poll_comment'),
+            $container->get('frontpage_service_poll'),
         );
     }
 }

--- a/module/Frontpage/src/Controller/FrontpageController.php
+++ b/module/Frontpage/src/Controller/FrontpageController.php
@@ -23,7 +23,7 @@ class FrontpageController extends AbstractActionController
         $this->frontpageService = $frontpageService;
     }
 
-    public function homeAction()
+    public function homeAction(): ViewModel
     {
         $homePageData = $this->frontpageService->getHomepageData();
 

--- a/module/Frontpage/src/Controller/InfimumController.php
+++ b/module/Frontpage/src/Controller/InfimumController.php
@@ -43,7 +43,7 @@ class InfimumController extends AbstractActionController
         $this->infimumService = $infimumService;
     }
 
-    public function showAction()
+    public function showAction(): JsonModel
     {
         if (!$this->aclService->isAllowed('view', 'infimum')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to view infima'));

--- a/module/Frontpage/src/Controller/InfimumController.php
+++ b/module/Frontpage/src/Controller/InfimumController.php
@@ -12,11 +12,6 @@ use User\Permissions\NotAllowedException;
 class InfimumController extends AbstractActionController
 {
     /**
-     * @var InfimumService
-     */
-    private InfimumService $infimumService;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
@@ -27,20 +22,25 @@ class InfimumController extends AbstractActionController
     private Translator $translator;
 
     /**
+     * @var InfimumService
+     */
+    private InfimumService $infimumService;
+
+    /**
      * FrontpageController constructor.
      *
-     * @param InfimumService $infimumService
      * @param AclService $aclService
      * @param Translator $translator
+     * @param InfimumService $infimumService
      */
     public function __construct(
-        InfimumService $infimumService,
         AclService $aclService,
         Translator $translator,
+        InfimumService $infimumService,
     ) {
-        $this->infimumService = $infimumService;
         $this->aclService = $aclService;
         $this->translator = $translator;
+        $this->infimumService = $infimumService;
     }
 
     public function showAction()

--- a/module/Frontpage/src/Controller/NewsAdminController.php
+++ b/module/Frontpage/src/Controller/NewsAdminController.php
@@ -15,11 +15,6 @@ use User\Permissions\NotAllowedException;
 class NewsAdminController extends AbstractActionController
 {
     /**
-     * @var NewsService
-     */
-    private NewsService $newsService;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
@@ -30,18 +25,25 @@ class NewsAdminController extends AbstractActionController
     private Translator $translator;
 
     /**
+     * @var NewsService
+     */
+    private NewsService $newsService;
+
+    /**
      * NewsAdminController constructor.
      *
+     * @param AclService $aclService
+     * @param Translator $translator
      * @param NewsService $newsService
      */
     public function __construct(
-        NewsService $newsService,
         AclService $aclService,
         Translator $translator,
+        NewsService $newsService,
     ) {
-        $this->newsService = $newsService;
         $this->aclService = $aclService;
         $this->translator = $translator;
+        $this->newsService = $newsService;
     }
 
     public function listAction()

--- a/module/Frontpage/src/Controller/NewsAdminController.php
+++ b/module/Frontpage/src/Controller/NewsAdminController.php
@@ -6,6 +6,7 @@ use Frontpage\Service\{
     AclService,
     News as NewsService,
 };
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Paginator\Paginator;
@@ -46,7 +47,7 @@ class NewsAdminController extends AbstractActionController
         $this->newsService = $newsService;
     }
 
-    public function listAction()
+    public function listAction(): ViewModel
     {
         $adapter = $this->newsService->getPaginatorAdapter();
         $paginator = new Paginator($adapter);
@@ -68,7 +69,7 @@ class NewsAdminController extends AbstractActionController
     /**
      * Create a news item.
      */
-    public function createAction()
+    public function createAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'news_item')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to create news items'));
@@ -103,7 +104,7 @@ class NewsAdminController extends AbstractActionController
     /**
      * Edit a news item.
      */
-    public function editAction()
+    public function editAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('edit', 'news_item')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit news items'));
@@ -146,7 +147,7 @@ class NewsAdminController extends AbstractActionController
      *
      * TODO: Non-idempotent requests should be done via POST, not GET.
      */
-    public function deleteAction()
+    public function deleteAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('delete', 'news_item')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete news items'));
@@ -160,6 +161,6 @@ class NewsAdminController extends AbstractActionController
         }
 
         $this->newsService->deleteNewsItem($newsItem);
-        $this->redirect()->toUrl($this->url()->fromRoute('admin_news'));
+        return $this->redirect()->toUrl($this->url()->fromRoute('admin_news'));
     }
 }

--- a/module/Frontpage/src/Controller/OrganController.php
+++ b/module/Frontpage/src/Controller/OrganController.php
@@ -34,7 +34,7 @@ class OrganController extends AbstractActionController
         $this->organService = $organService;
     }
 
-    public function committeeListAction()
+    public function committeeListAction(): ViewModel
     {
         $committees = $this->organService->findActiveOrgansByType(Organ::ORGAN_TYPE_COMMITTEE);
 
@@ -45,7 +45,7 @@ class OrganController extends AbstractActionController
         );
     }
 
-    public function fraternityListAction()
+    public function fraternityListAction(): ViewModel
     {
         $activeFraternities = $this->organService->findActiveOrgansByType(Organ::ORGAN_TYPE_FRATERNITY);
         $abrogatedFraternities = $this->organService->findAbrogatedOrgansByType(Organ::ORGAN_TYPE_FRATERNITY);
@@ -58,7 +58,7 @@ class OrganController extends AbstractActionController
         );
     }
 
-    public function organAction()
+    public function organAction(): ViewModel
     {
         $type = $this->params()->fromRoute('type');
         $abbr = $this->params()->fromRoute('abbr');

--- a/module/Frontpage/src/Controller/OrganController.php
+++ b/module/Frontpage/src/Controller/OrganController.php
@@ -28,7 +28,7 @@ class OrganController extends AbstractActionController
      */
     public function __construct(
         ActivityQueryService $activityQueryService,
-        OrganService $organService
+        OrganService $organService,
     ) {
         $this->activityQueryService = $activityQueryService;
         $this->organService = $organService;
@@ -63,8 +63,12 @@ class OrganController extends AbstractActionController
         $type = $this->params()->fromRoute('type');
         $abbr = $this->params()->fromRoute('abbr');
         $organ = $this->organService->findOrganByAbbr($abbr, $type, true);
-        $organMemberInformation = $this->organService->getOrganMemberInformation($organ);
 
+        if (null === $organ) {
+            return $this->notFoundAction();
+        }
+
+        $organMemberInformation = $this->organService->getOrganMemberInformation($organ);
         $activities = $this->activityQueryService->getOrganActivities($organ, 3);
 
         return new ViewModel(

--- a/module/Frontpage/src/Controller/PageAdminController.php
+++ b/module/Frontpage/src/Controller/PageAdminController.php
@@ -27,7 +27,7 @@ class PageAdminController extends AbstractActionController
         $this->pageService = $pageService;
     }
 
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $pages = $this->pageService->getPages();
 
@@ -38,7 +38,7 @@ class PageAdminController extends AbstractActionController
         );
     }
 
-    public function createAction()
+    public function createAction(): ViewModel
     {
         $request = $this->getRequest();
 
@@ -63,7 +63,7 @@ class PageAdminController extends AbstractActionController
         return $view;
     }
 
-    public function editAction()
+    public function editAction(): ViewModel
     {
         $pageId = $this->params()->fromRoute('page_id');
         $request = $this->getRequest();
@@ -92,7 +92,7 @@ class PageAdminController extends AbstractActionController
         $this->redirect()->toUrl($this->url()->fromRoute('admin_page'));
     }
 
-    public function uploadAction()
+    public function uploadAction(): JsonModel
     {
         $request = $this->getRequest();
         $result = [];

--- a/module/Frontpage/src/Controller/PageAdminController.php
+++ b/module/Frontpage/src/Controller/PageAdminController.php
@@ -85,7 +85,7 @@ class PageAdminController extends AbstractActionController
         );
     }
 
-    public function deleteAction()
+    public function deleteAction(): void
     {
         $pageId = $this->params()->fromRoute('page_id');
         $this->pageService->deletePage($pageId);

--- a/module/Frontpage/src/Controller/PageController.php
+++ b/module/Frontpage/src/Controller/PageController.php
@@ -23,7 +23,7 @@ class PageController extends AbstractActionController
         $this->pageService = $pageService;
     }
 
-    public function pageAction()
+    public function pageAction(): ViewModel
     {
         $category = $this->params()->fromRoute('category');
         $subCategory = $this->params()->fromRoute('sub_category');

--- a/module/Frontpage/src/Controller/PollAdminController.php
+++ b/module/Frontpage/src/Controller/PollAdminController.php
@@ -3,9 +3,11 @@
 namespace Frontpage\Controller;
 
 use Frontpage\Service\Poll as PollService;
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Paginator\Paginator;
 use Laminas\View\Model\ViewModel;
+use User\Permissions\NotAllowedException;
 
 class PollAdminController extends AbstractActionController
 {
@@ -27,7 +29,7 @@ class PollAdminController extends AbstractActionController
     /**
      * List all approved and unapproved polls.
      */
-    public function listAction()
+    public function listAction(): ViewModel
     {
         $adapter = $this->pollService->getPaginatorAdapter();
         $paginator = new Paginator($adapter);
@@ -55,7 +57,7 @@ class PollAdminController extends AbstractActionController
     /**
      * Approve a poll.
      */
-    public function approveAction()
+    public function approveAction(): Response
     {
         if ($this->getRequest()->isPost()) {
             $pollId = $this->params()->fromRoute('poll_id');
@@ -64,12 +66,13 @@ class PollAdminController extends AbstractActionController
 
             return $this->redirect()->toRoute('admin_poll');
         }
+        throw new NotAllowedException();
     }
 
     /**
      * Delete a poll.
      */
-    public function deleteAction()
+    public function deleteAction(): Response
     {
         if ($this->getRequest()->isPost()) {
             $pollId = $this->params()->fromRoute('poll_id');
@@ -78,5 +81,6 @@ class PollAdminController extends AbstractActionController
 
             return $this->redirect()->toRoute('admin_poll');
         }
+        throw new NotAllowedException();
     }
 }

--- a/module/Frontpage/src/Controller/PollController.php
+++ b/module/Frontpage/src/Controller/PollController.php
@@ -8,9 +8,11 @@ use Frontpage\Service\{
     AclService,
     Poll as PollService,
 };
+use Laminas\Http\PhpEnvironment\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Paginator\Paginator;
+use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\ViewModel;
 use User\Permissions\NotAllowedException;
 
@@ -59,7 +61,7 @@ class PollController extends AbstractActionController
     /**
      * Displays the currently active poll.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $poll = $this->obtainPoll();
 
@@ -85,7 +87,7 @@ class PollController extends AbstractActionController
      *
      * @return PollModel|null
      */
-    public function obtainPoll()
+    public function obtainPoll(): ?PollModel
     {
         $pollId = $this->params()->fromRoute('poll_id');
 
@@ -99,7 +101,7 @@ class PollController extends AbstractActionController
     /**
      * Submits a poll vote.
      */
-    public function voteAction()
+    public function voteAction(): Response|ResponseInterface
     {
         $pollId = (int)$this->params('poll_id');
         $request = $this->getRequest();
@@ -119,7 +121,7 @@ class PollController extends AbstractActionController
     /**
      * Submits a comment.
      */
-    public function commentAction()
+    public function commentAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'poll_comment')) {
             throw new NotAllowedException(
@@ -155,7 +157,7 @@ class PollController extends AbstractActionController
     /**
      * View all previous polls.
      */
-    public function historyAction()
+    public function historyAction(): ViewModel
     {
         $adapter = $this->pollService->getPaginatorAdapter();
         $paginator = new Paginator($adapter);
@@ -176,7 +178,7 @@ class PollController extends AbstractActionController
     /**
      * Request a poll.
      */
-    public function requestAction()
+    public function requestAction(): ViewModel
     {
         $form = $this->pollService->getPollForm();
 

--- a/module/Frontpage/src/Controller/PollController.php
+++ b/module/Frontpage/src/Controller/PollController.php
@@ -17,16 +17,6 @@ use User\Permissions\NotAllowedException;
 class PollController extends AbstractActionController
 {
     /**
-     * @var PollCommentForm
-     */
-    private PollCommentForm $pollCommentForm;
-
-    /**
-     * @var PollService
-     */
-    private PollService $pollService;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
@@ -37,23 +27,33 @@ class PollController extends AbstractActionController
     private Translator $translator;
 
     /**
+     * @var PollCommentForm
+     */
+    private PollCommentForm $pollCommentForm;
+
+    /**
+     * @var PollService
+     */
+    private PollService $pollService;
+
+    /**
      * PollController constructor.
      *
-     * @param PollCommentForm $pollCommentForm
-     * @param PollService $pollService
      * @param AclService $aclService
      * @param Translator $translator
+     * @param PollCommentForm $pollCommentForm
+     * @param PollService $pollService
      */
     public function __construct(
-        PollCommentForm $pollCommentForm,
-        PollService $pollService,
         AclService $aclService,
         Translator $translator,
+        PollCommentForm $pollCommentForm,
+        PollService $pollService,
     ) {
-        $this->pollCommentForm = $pollCommentForm;
-        $this->pollService = $pollService;
         $this->aclService = $aclService;
         $this->translator = $translator;
+        $this->pollCommentForm = $pollCommentForm;
+        $this->pollService = $pollService;
     }
 
     /**

--- a/module/Frontpage/src/Form/NewsItem.php
+++ b/module/Frontpage/src/Form/NewsItem.php
@@ -15,6 +15,9 @@ use Laminas\Validator\StringLength;
 
 class NewsItem extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Frontpage/src/Form/Page.php
+++ b/module/Frontpage/src/Form/Page.php
@@ -18,6 +18,9 @@ use Laminas\Validator\StringLength;
 
 class Page extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Frontpage/src/Form/Poll.php
+++ b/module/Frontpage/src/Form/Poll.php
@@ -15,6 +15,9 @@ use Laminas\Validator\StringLength;
 
 class Poll extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Frontpage/src/Form/PollApproval.php
+++ b/module/Frontpage/src/Form/PollApproval.php
@@ -13,6 +13,9 @@ use Laminas\Validator\Date as DateValidator;
 
 class PollApproval extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Frontpage/src/Form/PollComment.php
+++ b/module/Frontpage/src/Form/PollComment.php
@@ -14,6 +14,9 @@ use Laminas\Validator\StringLength;
 
 class PollComment extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/Frontpage/src/Mapper/NewsItem.php
+++ b/module/Frontpage/src/Mapper/NewsItem.php
@@ -19,7 +19,7 @@ class NewsItem extends BaseMapper
      *
      * @return array
      */
-    public function getLatestNewsItems($count)
+    public function getLatestNewsItems(int $count): array
     {
         $qb = $this->getRepository()->createQueryBuilder('newsItem');
         $qb->addOrderBy('newsItem.pinned', 'DESC')
@@ -34,7 +34,7 @@ class NewsItem extends BaseMapper
      *
      * @return DoctrineAdapter
      */
-    public function getPaginatorAdapter()
+    public function getPaginatorAdapter(): DoctrineAdapter
     {
         $qb = $this->getRepository()->createQueryBuilder('newsItem');
         $qb->orderBy('newsItem.date', 'DESC');

--- a/module/Frontpage/src/Mapper/Page.php
+++ b/module/Frontpage/src/Mapper/Page.php
@@ -19,8 +19,11 @@ class Page extends BaseMapper
      *
      * @return PageModel|null
      */
-    public function findPage(string $category, ?string $subCategory = null, ?string $name = null): ?PageModel
-    {
+    public function findPage(
+        string $category,
+        ?string $subCategory = null,
+        ?string $name = null,
+    ): ?PageModel {
         return $this->getRepository()->findOneBy(
             [
                 'category' => $category,

--- a/module/Frontpage/src/Mapper/Poll.php
+++ b/module/Frontpage/src/Mapper/Poll.php
@@ -3,7 +3,6 @@
 namespace Frontpage\Mapper;
 
 use Application\Mapper\BaseMapper;
-use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use DoctrineORMModule\Paginator\Adapter\DoctrinePaginator as DoctrineAdapter;
 use Frontpage\Model\{
@@ -23,12 +22,10 @@ class Poll extends BaseMapper
      * @param int $optionId
      *
      * @return PollOptionModel|null
-     *
-     * @throws ORMException
      */
     public function findPollOptionById(int $optionId): ?PollOptionModel
     {
-        return $this->em->find(PollOptionModel::class, $optionId);
+        return $this->em->getRepository(PollOptionModel::class)->find($optionId);
     }
 
     /**
@@ -39,8 +36,10 @@ class Poll extends BaseMapper
      *
      * @return PollVoteModel|null
      */
-    public function findVote(int $pollId, int $lidnr): ?PollVoteModel
-    {
+    public function findVote(
+        int $pollId,
+        int $lidnr,
+    ): ?PollVoteModel {
         return $this->em->getRepository(PollVoteModel::class)->findOneBy(
             [
                 'poll' => $pollId,
@@ -49,10 +48,12 @@ class Poll extends BaseMapper
         );
     }
 
-    public function getUnapprovedPolls()
+    /**
+     * @return array
+     */
+    public function getUnapprovedPolls(): array
     {
         $qb = $this->getRepository()->createQueryBuilder('p');
-
         $qb->where('p.approver IS NULL')
             ->orderBy('p.expiryDate', 'DESC');
 
@@ -68,7 +69,6 @@ class Poll extends BaseMapper
     public function getNewestPoll(): ?PollModel
     {
         $qb = $this->getRepository()->createQueryBuilder('p');
-
         $qb->where('p.approver IS NOT NULL')
             ->andWhere('p.expiryDate > CURRENT_DATE()')
             ->setMaxResults(1)
@@ -87,7 +87,6 @@ class Poll extends BaseMapper
     public function getPaginatorAdapter(): DoctrineAdapter
     {
         $qb = $this->getRepository()->createQueryBuilder('p');
-
         $qb->where('p.approver IS NOT NULL')
             ->orderBy('p.expiryDate', 'DESC');
 

--- a/module/Frontpage/src/Module.php
+++ b/module/Frontpage/src/Module.php
@@ -4,16 +4,23 @@ namespace Frontpage;
 
 use Doctrine\Laminas\Hydrator\DoctrineObject;
 use Frontpage\Form\{
-    NewsItem,
-    Page,
-    Poll,
-    PollApproval,
-    PollComment,
+    NewsItem as NewsItemForm,
+    Page as PageForm,
+    Poll as PollForm,
+    PollApproval as PollApprovalForm,
+    PollComment as PollCommentForm,
+};
+use Frontpage\Mapper\{
+    NewsItem as NewsItemMapper,
+    Page as PageMapper,
+    Poll as PollMapper,
 };
 use Frontpage\Service\{
     AclService,
-    Frontpage,
-    News,
+    Frontpage as FrontpageService,
+    News as NewsService,
+    Page as PageService,
+    Poll as PollService,
 };
 use Interop\Container\ContainerInterface;
 use RuntimeException;
@@ -36,7 +43,7 @@ class Module
      *
      * @return array Service configuration
      */
-    public function getServiceConfig()
+    public function getServiceConfig(): array
     {
         return [
             'factories' => [
@@ -52,7 +59,7 @@ class Module
                     $frontpageConfig = $container->get('config')['frontpage'];
                     $photoConfig = $container->get('config')['photo'];
 
-                    return new Frontpage(
+                    return new FrontpageService(
                         $translator,
                         $pollService,
                         $newsService,
@@ -66,49 +73,54 @@ class Module
                     );
                 },
                 'frontpage_service_page' => function (ContainerInterface $container) {
+                    $aclService = $container->get('frontpage_service_acl');
                     $translator = $container->get('translator');
                     $storageService = $container->get('application_service_storage');
                     $pageMapper = $container->get('frontpage_mapper_page');
                     $pageForm = $container->get('frontpage_form_page');
                     $storageConfig = $container->get('config')['storage'];
-                    $aclService = $container->get('frontpage_service_acl');
 
-                    return new Service\Page(
+                    return new PageService(
+                        $aclService,
                         $translator,
                         $storageService,
                         $pageMapper,
                         $pageForm,
                         $storageConfig,
-                        $aclService
                     );
                 },
                 'frontpage_service_poll' => function (ContainerInterface $container) {
+                    $aclService = $container->get('frontpage_service_acl');
                     $translator = $container->get('translator');
                     $emailService = $container->get('application_service_email');
                     $pollMapper = $container->get('frontpage_mapper_poll');
                     $pollForm = $container->get('frontpage_form_poll');
                     $pollApprovalForm = $container->get('frontpage_form_poll_approval');
-                    $aclService = $container->get('frontpage_service_acl');
 
-                    return new Service\Poll(
+                    return new PollService(
+                        $aclService,
                         $translator,
                         $emailService,
                         $pollMapper,
                         $pollForm,
                         $pollApprovalForm,
-                        $aclService,
                     );
                 },
                 'frontpage_service_news' => function (ContainerInterface $container) {
+                    $aclService = $container->get('frontpage_service_acl');
                     $translator = $container->get('translator');
                     $newsItemMapper = $container->get('frontpage_mapper_news_item');
                     $newsItemForm = $container->get('frontpage_form_news_item');
-                    $aclService = $container->get('frontpage_service_acl');
 
-                    return new News($newsItemMapper, $newsItemForm, $aclService, $translator);
+                    return new NewsService(
+                        $aclService,
+                        $translator,
+                        $newsItemMapper,
+                        $newsItemForm,
+                    );
                 },
                 'frontpage_form_page' => function (ContainerInterface $container) {
-                    $form = new Page(
+                    $form = new PageForm(
                         $container->get('translator')
                     );
                     $form->setHydrator($container->get('frontpage_hydrator'));
@@ -116,7 +128,7 @@ class Module
                     return $form;
                 },
                 'frontpage_form_poll' => function (ContainerInterface $container) {
-                    $form = new Poll(
+                    $form = new PollForm(
                         $container->get('translator')
                     );
                     $form->setHydrator($container->get('frontpage_hydrator'));
@@ -124,7 +136,7 @@ class Module
                     return $form;
                 },
                 'frontpage_form_poll_comment' => function (ContainerInterface $container) {
-                    $form = new PollComment(
+                    $form = new PollCommentForm(
                         $container->get('translator')
                     );
                     $form->setHydrator($container->get('frontpage_hydrator'));
@@ -132,7 +144,7 @@ class Module
                     return $form;
                 },
                 'frontpage_form_poll_approval' => function (ContainerInterface $container) {
-                    $form = new PollApproval(
+                    $form = new PollApprovalForm(
                         $container->get('translator')
                     );
                     $form->setHydrator($container->get('frontpage_hydrator'));
@@ -140,7 +152,7 @@ class Module
                     return $form;
                 },
                 'frontpage_form_news_item' => function (ContainerInterface $container) {
-                    $form = new NewsItem(
+                    $form = new NewsItemForm(
                         $container->get('translator')
                     );
                     $form->setHydrator($container->get('frontpage_hydrator'));
@@ -153,17 +165,17 @@ class Module
                     );
                 },
                 'frontpage_mapper_page' => function (ContainerInterface $container) {
-                    return new Mapper\Page(
+                    return new PageMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },
                 'frontpage_mapper_poll' => function (ContainerInterface $container) {
-                    return new Mapper\Poll(
+                    return new PollMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },
                 'frontpage_mapper_news_item' => function (ContainerInterface $container) {
-                    return new Mapper\NewsItem(
+                    return new NewsItemMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },

--- a/module/Frontpage/src/Service/AclService.php
+++ b/module/Frontpage/src/Service/AclService.php
@@ -4,7 +4,12 @@ namespace Frontpage\Service;
 
 class AclService extends \User\Service\AclService
 {
-    public function setPages(array $pages)
+    /**
+     * @param array $pages
+     *
+     * @return void
+     */
+    public function setPages(array $pages): void
     {
         foreach ($pages as $page) {
             $requiredRole = $page->getRequiredRole();
@@ -13,7 +18,10 @@ class AclService extends \User\Service\AclService
         }
     }
 
-    protected function createAcl()
+    /**
+     * @return void
+     */
+    protected function createAcl(): void
     {
         parent::createAcl();
 

--- a/module/Frontpage/src/Service/AclService.php
+++ b/module/Frontpage/src/Service/AclService.php
@@ -6,8 +6,6 @@ class AclService extends \User\Service\AclService
 {
     /**
      * @param array $pages
-     *
-     * @return void
      */
     public function setPages(array $pages): void
     {
@@ -18,9 +16,6 @@ class AclService extends \User\Service\AclService
         }
     }
 
-    /**
-     * @return void
-     */
     protected function createAcl(): void
     {
         parent::createAcl();

--- a/module/Frontpage/src/Service/News.php
+++ b/module/Frontpage/src/Service/News.php
@@ -17,6 +17,16 @@ use User\Service\AclService;
 class News
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
      * @var NewsItemMapper
      */
     private NewsItemMapper $newsItemMapper;
@@ -27,25 +37,21 @@ class News
     private NewsItemForm $newsItemForm;
 
     /**
-     * @var AclService
+     * @param AclService $aclService
+     * @param Translator $translator
+     * @param NewsItemMapper $newsItemMapper
+     * @param NewsItemForm $newsItemForm
      */
-    private AclService $aclService;
-
-    /**
-     * @var Translator
-     */
-    private Translator $translator;
-
     public function __construct(
-        NewsItemMapper $newsItemMapper,
-        NewsItemForm $newsItemForm,
         AclService $aclService,
         Translator $translator,
+        NewsItemMapper $newsItemMapper,
+        NewsItemForm $newsItemForm,
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->newsItemMapper = $newsItemMapper;
         $this->newsItemForm = $newsItemForm;
-        $this->aclService = $aclService;
     }
 
     /**
@@ -109,8 +115,10 @@ class News
      *
      * @return bool
      */
-    public function updateNewsItem(NewsItemModel $newsItem, array $data): bool
-    {
+    public function updateNewsItem(
+        NewsItemModel $newsItem,
+        array $data,
+    ): bool {
         $newsItem->setEnglishContent($data['englishContent']);
         $newsItem->setEnglishTitle($data['englishTitle']);
         $newsItem->setDutchContent($data['dutchContent']);
@@ -118,7 +126,6 @@ class News
         $newsItem->setPinned($data['pinned']);
 
         $this->newsItemMapper->persist($newsItem);
-        $this->newsItemMapper->flush();
 
         return true;
     }
@@ -131,7 +138,6 @@ class News
     public function deleteNewsItem(NewsItemModel $newsItem): void
     {
         $this->newsItemMapper->remove($newsItem);
-        $this->newsItemMapper->flush();
     }
 
     /**

--- a/module/Frontpage/src/Service/Page.php
+++ b/module/Frontpage/src/Service/Page.php
@@ -3,7 +3,7 @@
 namespace Frontpage\Service;
 
 use Application\Service\FileStorage;
-use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Exception\ORMException;
 use Exception;
 use Frontpage\Form\Page as PageForm;
 use Frontpage\Mapper\Page as PageMapper;

--- a/module/Frontpage/src/Service/Page.php
+++ b/module/Frontpage/src/Service/Page.php
@@ -23,6 +23,11 @@ use User\Permissions\NotAllowedException;
 class Page
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
      * @var Translator
      */
     private Translator $translator;
@@ -48,24 +53,27 @@ class Page
     private array $storageConfig;
 
     /**
-     * @var AclService
+     * @param AclService $aclService
+     * @param Translator $translator
+     * @param FileStorage $storageService
+     * @param PageMapper $pageMapper
+     * @param PageForm $pageForm
+     * @param array $storageConfig
      */
-    private AclService $aclService;
-
     public function __construct(
+        AclService $aclService,
         Translator $translator,
         FileStorage $storageService,
         PageMapper $pageMapper,
         PageForm $pageForm,
         array $storageConfig,
-        AclService $aclService
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->storageService = $storageService;
         $this->pageMapper = $pageMapper;
         $this->pageForm = $pageForm;
         $this->storageConfig = $storageConfig;
-        $this->aclService = $aclService;
     }
 
     /**
@@ -87,8 +95,11 @@ class Page
      *
      * @return PageModel|null
      */
-    public function getPage(string $category, ?string $subCategory = null, ?string $name = null): ?PageModel
-    {
+    public function getPage(
+        string $category,
+        ?string $subCategory = null,
+        ?string $name = null,
+    ): ?PageModel {
         $page = $this->pageMapper->findPage($category, $subCategory, $name);
 
         if (null !== $page && !$this->aclService->isAllowed('view', $page)) {
@@ -181,6 +192,7 @@ class Page
      */
     public function createPage(Parameters $data): bool
     {
+        // TODO: Move form checks to the controller.
         $form = $this->getPageForm();
         $form->setData($data);
 
@@ -226,8 +238,10 @@ class Page
      *
      * @throws ORMException
      */
-    public function updatePage(int $pageId, Parameters $data): bool
-    {
+    public function updatePage(
+        int $pageId,
+        Parameters $data,
+    ): bool {
         if (!$this->aclService->isAllowed('edit', 'page')) {
             throw new NotAllowedException($this->translator->translate('You are not allowed to edit pages.'));
         }
@@ -253,10 +267,7 @@ class Page
      */
     public function deletePage(int $pageId): void
     {
-        $page = $this->getPageById($pageId);
-
-        $this->pageMapper->remove($page);
-        $this->pageMapper->flush();
+        $this->pageMapper->remove($this->getPageById($pageId));
     }
 
     /**
@@ -301,7 +312,7 @@ class Page
      *
      * @return PageForm
      */
-    public function getPageForm(int $pageId = null): PageForm
+    public function getPageForm(?int $pageId = null): PageForm
     {
         if (!$this->aclService->isAllowed('create', 'page')) {
             throw new NotAllowedException(

--- a/module/Frontpage/src/Service/Poll.php
+++ b/module/Frontpage/src/Service/Poll.php
@@ -30,6 +30,11 @@ use User\Permissions\NotAllowedException;
 class Poll
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
      * @var Translator
      */
     private Translator $translator;
@@ -54,25 +59,20 @@ class Poll
      */
     private PollApprovalForm $pollApprovalForm;
 
-    /**
-     * @var AclService
-     */
-    private AclService $aclService;
-
     public function __construct(
+        AclService $aclService,
         Translator $translator,
         EmailService $emailService,
         PollMapper $pollMapper,
         PollForm $pollForm,
         PollApprovalForm $pollApprovalForm,
-        AclService $aclService,
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->emailService = $emailService;
         $this->pollMapper = $pollMapper;
         $this->pollForm = $pollForm;
         $this->pollApprovalForm = $pollApprovalForm;
-        $this->aclService = $aclService;
     }
 
     /**
@@ -248,8 +248,10 @@ class Poll
      *
      * @throws ORMException
      */
-    public function createComment(PollModel $poll, array $data): bool
-    {
+    public function createComment(
+        PollModel $poll,
+        array $data,
+    ): bool {
         $user = $this->aclService->getIdentity();
         $comment = $this->saveCommentData($data, $poll, $user);
 
@@ -272,8 +274,11 @@ class Poll
      *
      * @throws ORMException
      */
-    public function saveCommentData(array $data, PollModel $poll, UserModel $user): PollCommentModel
-    {
+    public function saveCommentData(
+        array $data,
+        PollModel $poll,
+        UserModel $user,
+    ): PollCommentModel {
         $comment = new PollCommentModel();
 
         $comment->setPoll($poll);
@@ -330,8 +335,10 @@ class Poll
      *
      * @throws ORMException
      */
-    public function savePollData(array $data, UserModel $user): PollModel
-    {
+    public function savePollData(
+        array $data,
+        UserModel $user,
+    ): PollModel {
         $poll = new PollModel();
         $poll->setDutchQuestion($data['dutchQuestion']);
         $poll->setEnglishQuestion($data['englishQuestion']);
@@ -353,8 +360,10 @@ class Poll
      *
      * @return PollOptionModel
      */
-    public function createPollOption(array $data, PollModel $poll): PollOption
-    {
+    public function createPollOption(
+        array $data,
+        PollModel $poll,
+    ): PollOption {
         $pollOption = new PollOptionModel();
         $pollOption->setDutchText($data['dutchText']);
         $pollOption->setEnglishText($data['englishText']);
@@ -412,8 +421,10 @@ class Poll
      *
      * @throws ORMException
      */
-    public function approvePoll(PollModel $poll, Parameters $data): bool
-    {
+    public function approvePoll(
+        PollModel $poll,
+        Parameters $data,
+    ): bool {
         $approvalForm = $this->getPollApprovalForm();
         $approvalForm->bind($poll);
         $approvalForm->setData($data);

--- a/module/Frontpage/src/Service/Poll.php
+++ b/module/Frontpage/src/Service/Poll.php
@@ -4,7 +4,7 @@ namespace Frontpage\Service;
 
 use Application\Service\Email as EmailService;
 use DateTime;
-use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Exception\ORMException;
 use DoctrineORMModule\Paginator\Adapter\DoctrinePaginator;
 use Laminas\Stdlib\Parameters;
 use Frontpage\Form\{

--- a/module/Frontpage/test/ControllerTest.php
+++ b/module/Frontpage/test/ControllerTest.php
@@ -6,31 +6,31 @@ use ApplicationTest\BaseControllerTest;
 
 class ControllerTest extends BaseControllerTest
 {
-    public function testIndexActionCanBeAccessed()
+    public function testIndexActionCanBeAccessed(): void
     {
         $this->dispatch('/');
         $this->assertResponseStatusCode(200);
     }
 
-    public function testLangEnDoesRedirect()
+    public function testLangEnDoesRedirect(): void
     {
         $this->dispatch('/lang/en/');
         $this->assertResponseStatusCode(302);
     }
 
-    public function testLangNlDoesRedirect()
+    public function testLangNlDoesRedirect(): void
     {
         $this->dispatch('/lang/nl/');
         $this->assertResponseStatusCode(302);
     }
 
-    public function testPollHistoryActionCanBeAccessed()
+    public function testPollHistoryActionCanBeAccessed(): void
     {
         $this->dispatch('/poll/history');
         $this->assertResponseStatusCode(200);
     }
 
-    public function testPollRequestActionIsForbidden()
+    public function testPollRequestActionIsForbidden(): void
     {
         $this->dispatch('/poll/request');
         $this->assertResponseStatusCode(403);

--- a/module/Photo/src/Command/WeeklyPhoto.php
+++ b/module/Photo/src/Command/WeeklyPhoto.php
@@ -9,10 +9,21 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WeeklyPhoto extends Command
 {
+    /**
+     * @var Photo
+     */
     private Photo $photoService;
 
-    public function execute(InputInterface $input, OutputInterface $output)
-    {
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    public function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
         $weeklyPhoto = $this->photoService->generatePhotoOfTheWeek();
 
         if (is_null($weeklyPhoto)) {

--- a/module/Photo/src/Controller/AlbumAdminController.php
+++ b/module/Photo/src/Controller/AlbumAdminController.php
@@ -33,7 +33,7 @@ class AlbumAdminController extends AbstractActionController
      */
     public function __construct(
         AdminService $adminService,
-        AlbumService $albumService
+        AlbumService $albumService,
     ) {
         $this->adminService = $adminService;
         $this->albumService = $albumService;
@@ -158,7 +158,7 @@ class AlbumAdminController extends AbstractActionController
             $album = $this->albumService->getAlbum($albumId);
 
             try {
-                $this->adminService->upload($request->getFiles(), $album);
+                $this->adminService->upload($request->getFiles()->toArray(), $album);
                 $result['success'] = true;
             } catch (Exception $e) {
                 $this->getResponse()->setStatusCode(500);

--- a/module/Photo/src/Controller/AlbumAdminController.php
+++ b/module/Photo/src/Controller/AlbumAdminController.php
@@ -3,6 +3,7 @@
 namespace Photo\Controller;
 
 use Exception;
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -42,7 +43,7 @@ class AlbumAdminController extends AbstractActionController
     /**
      * Retrieves the main photo admin index page.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $years = $this->albumService->getAlbumYears();
         $albumsByYear = [];
@@ -63,7 +64,7 @@ class AlbumAdminController extends AbstractActionController
     /**
      * Retrieves the album creation form and saves data if needed.
      */
-    public function createAction()
+    public function createAction(): Response|ViewModel
     {
         $form = $this->albumService->getCreateAlbumForm();
 
@@ -89,7 +90,7 @@ class AlbumAdminController extends AbstractActionController
     /**
      * Retrieves photos on a certain page.
      */
-    public function pageAction()
+    public function pageAction(): JsonModel|ViewModel
     {
         $albumId = $this->params()->fromRoute('album_id');
         $activePage = (int) $this->params()->fromRoute('page');
@@ -108,7 +109,7 @@ class AlbumAdminController extends AbstractActionController
     /**
      * Retrieves the album editing form and saves changes.
      */
-    public function editAction()
+    public function editAction(): Response|ViewModel
     {
         $albumId = $this->params()->fromRoute('album_id');
         $form = $this->albumService->getEditAlbumForm($albumId);
@@ -131,7 +132,7 @@ class AlbumAdminController extends AbstractActionController
         );
     }
 
-    public function addAction()
+    public function addAction(): ViewModel
     {
         $this->adminService->checkUploadAllowed();
 
@@ -148,7 +149,7 @@ class AlbumAdminController extends AbstractActionController
     /**
      * Uploads an image file and adds it to an album.
      */
-    public function uploadAction()
+    public function uploadAction(): JsonModel
     {
         $request = $this->getRequest();
         $result = [];
@@ -172,7 +173,7 @@ class AlbumAdminController extends AbstractActionController
     /**
      * Moves the album by setting the parent album to another album.
      */
-    public function moveAction()
+    public function moveAction(): JsonModel
     {
         $request = $this->getRequest();
         $result = [];
@@ -193,7 +194,7 @@ class AlbumAdminController extends AbstractActionController
     /**
      * Deletes the album.
      */
-    public function deleteAction()
+    public function deleteAction(): JsonModel
     {
         $request = $this->getRequest();
         $albumId = $this->params()->fromRoute('album_id');
@@ -207,7 +208,7 @@ class AlbumAdminController extends AbstractActionController
     /**
      * Regenerates the cover photo for the album.
      */
-    public function coverAction()
+    public function coverAction(): JsonModel
     {
         if ($this->getRequest()->isPost()) {
             $albumId = $this->params()->fromRoute('album_id');

--- a/module/Photo/src/Controller/AlbumController.php
+++ b/module/Photo/src/Controller/AlbumController.php
@@ -30,6 +30,7 @@ class AlbumController extends AbstractActionController
      * AlbumController constructor.
      *
      * @param AlbumService $albumService
+     * @param PhotoService $photoService
      * @param array $photoConfig
      */
     public function __construct(

--- a/module/Photo/src/Controller/AlbumController.php
+++ b/module/Photo/src/Controller/AlbumController.php
@@ -49,7 +49,7 @@ class AlbumController extends AbstractActionController
      *
      * @return ViewModel
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $albumId = $this->params()->fromRoute('album_id');
         $albumType = $this->params()->fromRoute('album_type');

--- a/module/Photo/src/Controller/ApiController.php
+++ b/module/Photo/src/Controller/ApiController.php
@@ -4,6 +4,7 @@ namespace Photo\Controller;
 
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
+use Laminas\View\Model\ViewModel;
 
 class ApiController extends AbstractActionController
 {
@@ -13,7 +14,7 @@ class ApiController extends AbstractActionController
      * This API call is intended for external scripts. Like the AViCo TV screen
      * that needs a list of all photo's.
      */
-    public function listAction()
+    public function listAction(): JsonModel|ViewModel
     {
         $albumId = $this->params()->fromRoute('album_id');
         $album = $this->plugin('AlbumPlugin')->getAlbumAsArray($albumId);

--- a/module/Photo/src/Controller/Factory/AlbumAdminControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/AlbumAdminControllerFactory.php
@@ -18,7 +18,7 @@ class AlbumAdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AlbumAdminController {
         return new AlbumAdminController(
             $container->get('photo_service_admin'),

--- a/module/Photo/src/Controller/Factory/AlbumAdminControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/AlbumAdminControllerFactory.php
@@ -11,14 +11,14 @@ class AlbumAdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AlbumAdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AlbumAdminController {
         return new AlbumAdminController(
             $container->get('photo_service_admin'),

--- a/module/Photo/src/Controller/Factory/AlbumControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/AlbumControllerFactory.php
@@ -11,14 +11,14 @@ class AlbumControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AlbumController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AlbumController {
         return new AlbumController(
             $container->get('photo_service_album'),

--- a/module/Photo/src/Controller/Factory/AlbumControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/AlbumControllerFactory.php
@@ -18,7 +18,7 @@ class AlbumControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AlbumController {
         return new AlbumController(
             $container->get('photo_service_album'),

--- a/module/Photo/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/ApiControllerFactory.php
@@ -18,7 +18,7 @@ class ApiControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): ApiController {
         return new ApiController();
     }

--- a/module/Photo/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/ApiControllerFactory.php
@@ -11,14 +11,14 @@ class ApiControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return ApiController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): ApiController {
         return new ApiController();
     }

--- a/module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php
@@ -18,7 +18,7 @@ class PhotoAdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): PhotoAdminController {
         return new PhotoAdminController(
             $container->get('photo_service_album'),

--- a/module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php
@@ -11,14 +11,14 @@ class PhotoAdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return PhotoAdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): PhotoAdminController {
         return new PhotoAdminController(
             $container->get('photo_service_album'),

--- a/module/Photo/src/Controller/Factory/PhotoControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/PhotoControllerFactory.php
@@ -18,7 +18,7 @@ class PhotoControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): PhotoController {
         return new PhotoController(
             $container->get('photo_service_album'),

--- a/module/Photo/src/Controller/Factory/PhotoControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/PhotoControllerFactory.php
@@ -11,14 +11,14 @@ class PhotoControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return PhotoController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): PhotoController {
         return new PhotoController(
             $container->get('photo_service_album'),

--- a/module/Photo/src/Controller/Factory/Plugin/AlbumPluginFactory.php
+++ b/module/Photo/src/Controller/Factory/Plugin/AlbumPluginFactory.php
@@ -11,14 +11,14 @@ class AlbumPluginFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return AlbumPlugin
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): AlbumPlugin {
         return new AlbumPlugin(
             $container->get('photo_service_album'),

--- a/module/Photo/src/Controller/Factory/Plugin/AlbumPluginFactory.php
+++ b/module/Photo/src/Controller/Factory/Plugin/AlbumPluginFactory.php
@@ -18,7 +18,7 @@ class AlbumPluginFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): AlbumPlugin {
         return new AlbumPlugin(
             $container->get('photo_service_album'),

--- a/module/Photo/src/Controller/Factory/TagControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/TagControllerFactory.php
@@ -11,14 +11,14 @@ class TagControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return TagController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): TagController {
         return new TagController(
             $container->get('photo_service_photo'),

--- a/module/Photo/src/Controller/Factory/TagControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/TagControllerFactory.php
@@ -18,7 +18,7 @@ class TagControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): TagController {
         return new TagController(
             $container->get('photo_service_photo'),

--- a/module/Photo/src/Controller/PhotoAdminController.php
+++ b/module/Photo/src/Controller/PhotoAdminController.php
@@ -2,7 +2,6 @@
 
 namespace Photo\Controller;
 
-use Doctrine\ORM\EntityManager;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -44,7 +43,7 @@ class PhotoAdminController extends AbstractActionController
      *
      * TODO: Potentially remove, as the admin interface can already move/delete images from the global view.
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         $photoId = $this->params()->fromRoute('photo_id');
         $data = $this->photoService->getPhotoData($photoId);
@@ -66,7 +65,7 @@ class PhotoAdminController extends AbstractActionController
     /**
      * Places a photo in another album.
      */
-    public function moveAction()
+    public function moveAction(): JsonModel
     {
         $request = $this->getRequest();
         $result = [];
@@ -82,7 +81,7 @@ class PhotoAdminController extends AbstractActionController
     /**
      * Removes a photo from an album and deletes it.
      */
-    public function deleteAction()
+    public function deleteAction(): JsonModel
     {
         $request = $this->getRequest();
         $result = [];

--- a/module/Photo/src/Controller/PhotoController.php
+++ b/module/Photo/src/Controller/PhotoController.php
@@ -2,6 +2,8 @@
 
 namespace Photo\Controller;
 
+use Laminas\Http\Response;
+use Laminas\Http\Response\Stream;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -38,7 +40,7 @@ class PhotoController extends AbstractActionController
         $this->albumService = $albumService;
     }
 
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         //add any other special behavior which is required for the main photo page here later
         $years = $this->albumService->getAlbumYears();
@@ -65,7 +67,7 @@ class PhotoController extends AbstractActionController
         );
     }
 
-    public function downloadAction()
+    public function downloadAction(): ?Stream
     {
         $photoId = $this->params()->fromRoute('photo_id');
 
@@ -75,7 +77,7 @@ class PhotoController extends AbstractActionController
     /**
      * Display the page containing previous pictures of the week.
      */
-    public function weeklyAction()
+    public function weeklyAction(): ViewModel
     {
         $weeklyPhotos = $this->photoService->getPhotosOfTheWeek();
 
@@ -89,7 +91,7 @@ class PhotoController extends AbstractActionController
     /**
      * For setting a profile picture.
      */
-    public function setProfilePhotoAction()
+    public function setProfilePhotoAction(): Response
     {
         $photoId = $this->params()->fromRoute('photo_id');
         $this->photoService->setProfilePhoto($photoId);
@@ -105,7 +107,7 @@ class PhotoController extends AbstractActionController
     /**
      * For removing a profile picture.
      */
-    public function removeProfilePhotoAction()
+    public function removeProfilePhotoAction(): Response
     {
         $photoId = $this->params()->fromRoute('photo_id');
         $this->photoService->removeProfilePhoto();
@@ -125,7 +127,7 @@ class PhotoController extends AbstractActionController
     /**
      * Store a vote for a photo.
      */
-    public function voteAction()
+    public function voteAction(): JsonModel|ViewModel
     {
         $request = $this->getRequest();
 

--- a/module/Photo/src/Controller/PhotoController.php
+++ b/module/Photo/src/Controller/PhotoController.php
@@ -32,7 +32,7 @@ class PhotoController extends AbstractActionController
      */
     public function __construct(
         AlbumService $albumService,
-        PhotoService $photoService
+        PhotoService $photoService,
     ) {
         $this->photoService = $photoService;
         $this->albumService = $albumService;

--- a/module/Photo/src/Controller/Plugin/AlbumPaginatorAdapter.php
+++ b/module/Photo/src/Controller/Plugin/AlbumPaginatorAdapter.php
@@ -3,9 +3,10 @@
 namespace Photo\Controller\Plugin;
 
 use Laminas\Paginator\Adapter\AdapterInterface;
+use Photo\Model\Album as AlbumModel;
 use Photo\Service\{
-    Album,
-    Photo,
+    Album as AlbumService,
+    Photo as PhotoService,
 };
 
 /**
@@ -16,34 +17,39 @@ class AlbumPaginatorAdapter implements AdapterInterface
     /**
      * Album.
      *
-     * @var \Photo\Model\Album
+     * @var AlbumModel|null
      */
-    protected $album = null;
+    protected ?AlbumModel $album = null;
 
     /**
      * Item count.
      *
-     * @var int
+     * @var int|null
      */
-    protected $count = null;
+    protected ?int $count = null;
 
     /**
-     * @var Photo
+     * @var PhotoService
      */
-    private $photoService;
+    private PhotoService $photoService;
 
     /**
-     * @var Album
+     * @var AlbumService
      */
-    private $albumService;
+    private AlbumService $albumService;
 
     /**
      * Constructor.
      *
-     * @param \Photo\Model\Album $album Album to paginate
+     * @param AlbumModel $album Album to paginate
+     * @param PhotoService $photoService
+     * @param AlbumService $albumService
      */
-    public function __construct(\Photo\Model\Album $album, Photo $photoService, Album $albumService)
-    {
+    public function __construct(
+        AlbumModel $album,
+        PhotoService $photoService,
+        AlbumService $albumService,
+    ) {
         $this->album = $album;
         $this->photoService = $photoService;
         $this->albumService = $albumService;
@@ -59,8 +65,10 @@ class AlbumPaginatorAdapter implements AdapterInterface
      *
      * @return array
      */
-    public function getItems($offset, $itemCountPerPage)
-    {
+    public function getItems(
+        $offset,
+        $itemCountPerPage,
+    ): array {
         $albums = $this->albumService->getAlbums(
             $this->album,
             $offset,

--- a/module/Photo/src/Controller/Plugin/AlbumPlugin.php
+++ b/module/Photo/src/Controller/Plugin/AlbumPlugin.php
@@ -40,7 +40,7 @@ class AlbumPlugin extends AbstractPlugin
     public function __construct(
         AlbumService $albumService,
         PhotoService $photoService,
-        array $photoConfig
+        array $photoConfig,
     ) {
         $this->photoService = $photoService;
         $this->albumService = $albumService;
@@ -90,8 +90,10 @@ class AlbumPlugin extends AbstractPlugin
      *
      * @throws Exception
      */
-    public function getAlbumPageAsArray(int $albumId, int $activePage): ?array
-    {
+    public function getAlbumPageAsArray(
+        int $albumId,
+        int $activePage,
+    ): ?array {
         $page = $this->getAlbumPage($albumId, $activePage);
 
         if (null === $page) {
@@ -130,8 +132,11 @@ class AlbumPlugin extends AbstractPlugin
      *
      * @throws Exception
      */
-    public function getAlbumPage(int $albumId, int $activePage, string $type = 'album'): ?array
-    {
+    public function getAlbumPage(
+        int $albumId,
+        int $activePage,
+        string $type = 'album',
+    ): ?array {
         $album = $this->albumService->getAlbum($albumId, $type);
 
         if (null === $album) {

--- a/module/Photo/src/Controller/TagController.php
+++ b/module/Photo/src/Controller/TagController.php
@@ -23,7 +23,7 @@ class TagController extends AbstractActionController
         $this->photoService = $photoService;
     }
 
-    public function addAction()
+    public function addAction(): JsonModel
     {
         $request = $this->getRequest();
         $result = [];
@@ -42,7 +42,7 @@ class TagController extends AbstractActionController
         return new JsonModel($result);
     }
 
-    public function removeAction()
+    public function removeAction(): JsonModel
     {
         $request = $this->getRequest();
         $result = [];

--- a/module/Photo/src/Form/CreateAlbum.php
+++ b/module/Photo/src/Form/CreateAlbum.php
@@ -2,17 +2,20 @@
 
 namespace Photo\Form;
 
+use Laminas\InputFilter\InputProviderInterface;
 use Laminas\Form\Element\{
     Submit,
     Text,
 };
 use Laminas\Form\Form;
-use Laminas\InputFilter\InputFilter;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Validator\StringLength;
 
-class CreateAlbum extends Form
+class CreateAlbum extends Form implements InputProviderInterface
 {
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();
@@ -36,17 +39,15 @@ class CreateAlbum extends Form
                 ],
             ]
         );
-
-        $this->initFilters();
     }
 
-    protected function initFilters()
+    /**
+     * @return array
+     */
+    public function getInputSpecification(): array
     {
-        $filter = new InputFilter();
-
-        $filter->add(
-            [
-                'name' => 'name',
+        return [
+            'name' => [
                 'required' => true,
                 'validators' => [
                     [
@@ -58,9 +59,7 @@ class CreateAlbum extends Form
                         ],
                     ],
                 ],
-            ]
-        );
-
-        $this->setInputFilter($filter);
+            ],
+        ];
     }
 }

--- a/module/Photo/src/Form/EditAlbum.php
+++ b/module/Photo/src/Form/EditAlbum.php
@@ -8,12 +8,16 @@ use Laminas\Form\Element\{
     Text,
 };
 use Laminas\Form\Form;
-use Laminas\InputFilter\InputFilter;
+use Laminas\I18n\Validator\Alnum;
+use Laminas\InputFilter\InputProviderInterface;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Validator\NotEmpty;
 
-class EditAlbum extends Form
+class EditAlbum extends Form implements InputProviderInterface
 {
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();
@@ -59,30 +63,28 @@ class EditAlbum extends Form
                 ],
             ]
         );
-
-        $this->initFilters();
     }
 
-    protected function initFilters()
+    /**
+     * @return array
+     */
+    public function getInputSpecification(): array
     {
-        $filter = new InputFilter();
-
-        $filter->add(
-            [
-                'name' => 'name',
+        return [
+            'name' => [
                 'required' => true,
                 'validators' => [
-                    ['name' => NotEmpty::class],
                     [
-                        'name' => 'alnum',
+                        'name' => NotEmpty::class,
+                    ],
+                    [
+                        'name' => Alnum::class,
                         'options' => [
                             'allowWhiteSpace' => true,
                         ],
                     ],
                 ],
-            ]
-        );
-
-        $this->setInputFilter($filter);
+            ],
+        ];
     }
 }

--- a/module/Photo/src/Listener/Remove.php
+++ b/module/Photo/src/Listener/Remove.php
@@ -2,9 +2,14 @@
 
 namespace Photo\Listener;
 
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Photo\Model\{
-    Album,
-    Photo,
+    Album as AlbumModel,
+    Photo as PhotoModel,
+};
+use Photo\Service\{
+    Album as AlbumService,
+    Photo as PhotoService,
 };
 
 /**
@@ -14,37 +19,53 @@ use Photo\Model\{
 class Remove
 {
     /**
-     * @var \Photo\Service\Photo
+     * @var PhotoService
      */
-    private $photoService;
+    private PhotoService $photoService;
 
     /**
-     * @var \Photo\Service\Album
+     * @var AlbumService
      */
-    private $albumService;
+    private AlbumService $albumService;
 
-    public function __construct(\Photo\Service\Photo $photoService, \Photo\Service\Album $albumService)
-    {
+    /**
+     * @param PhotoService $photoService
+     * @param AlbumService $albumService
+     */
+    public function __construct(
+        PhotoService $photoService,
+        AlbumService $albumService,
+    ) {
         $this->photoService = $photoService;
         $this->albumService = $albumService;
     }
 
-    public function preRemove($eventArgs)
+    /**
+     * @param LifecycleEventArgs $eventArgs
+     */
+    public function preRemove(LifecycleEventArgs $eventArgs): void
     {
         $entity = $eventArgs->getEntity();
-        if ($entity instanceof Album) {
+
+        if ($entity instanceof AlbumModel) {
             $this->albumRemoved($entity);
-        } elseif ($entity instanceof Photo) {
+        } elseif ($entity instanceof PhotoModel) {
             $this->photoRemoved($entity);
         }
     }
 
-    protected function photoRemoved($photo)
+    /**
+     * @param PhotoModel $photo
+     */
+    protected function photoRemoved(PhotoModel $photo): void
     {
         $this->photoService->deletePhotoFiles($photo);
     }
 
-    protected function albumRemoved($album)
+    /**
+     * @param AlbumModel $album
+     */
+    protected function albumRemoved(AlbumModel $album): void
     {
         $this->albumService->deleteAlbumCover($album);
     }

--- a/module/Photo/src/Mapper/Album.php
+++ b/module/Photo/src/Mapper/Album.php
@@ -14,24 +14,23 @@ class Album extends BaseMapper
     /**
      * Returns all the subalbums of a given album.
      *
-     * @param AlbumModel $parent the parent album to retrieve the
-     *                               subalbum from
+     * @param AlbumModel $parent the parent album to retrieve the subalbum from
      * @param int $start the result to start at
-     * @param int $maxResults max amount of results to return,
-     *                               null for infinite
+     * @param int|null $maxResults max amount of results to return, null for infinite
      *
      * @return array of subalbums or null if there are none
      */
-    public function getSubAlbums($parent, $start = 0, $maxResults = null)
-    {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('a')
-            ->from($this->getRepositoryName(), 'a')
-            ->where('a.parent = ?1')
+    public function getSubAlbums(
+        AlbumModel $parent,
+        int $start = 0,
+        ?int $maxResults = null,
+    ): array {
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.parent = ?1')
             ->setParameter(1, $parent)
             ->setFirstResult($start)
             ->orderBy('a.startDateTime', 'ASC');
+
         if (!is_null($maxResults)) {
             $qb->setMaxResults($maxResults);
         }
@@ -42,15 +41,12 @@ class Album extends BaseMapper
     /**
      * return all the sub-albums without a parent.
      *
-     * @return array of \Photo\Model\Album
+     * @return array
      */
-    public function getRootAlbums()
+    public function getRootAlbums(): array
     {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('a')
-            ->from($this->getRepositoryName(), 'a')
-            ->where('a.parent IS NULL')
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.parent IS NULL')
             ->orderBy('a.startDateTime', 'DESC');
 
         return $qb->getQuery()->getResult();
@@ -62,15 +58,14 @@ class Album extends BaseMapper
      * @param DateTime $start start date and time
      * @param DateTime $end   end date and time
      *
-     * @return array of \Photo\Model\Album
+     * @return array
      */
-    public function getAlbumsInDateRange($start, $end)
-    {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('a')
-            ->from($this->getRepositoryName(), 'a')
-            ->where('a.parent IS NULL')
+    public function getAlbumsInDateRange(
+        DateTime $start,
+        DateTime $end,
+    ): array {
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.parent IS NULL')
             ->andWhere('a.startDateTime BETWEEN ?1 AND ?2')
             ->setParameter(1, $start)
             ->setParameter(2, $end)
@@ -85,13 +80,10 @@ class Album extends BaseMapper
      *
      * @return array
      */
-    public function getAlbumsWithoutDate()
+    public function getAlbumsWithoutDate(): array
     {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('a')
-            ->from($this->getRepositoryName(), 'a')
-            ->where('a.parent IS NULL')
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.parent IS NULL')
             ->andWhere('a.startDateTime IS NULL');
 
         return $qb->getQuery()->getResult();
@@ -104,11 +96,8 @@ class Album extends BaseMapper
      */
     public function getNewestAlbum(): ?AlbumModel
     {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('a')
-            ->from($this->getRepositoryName(), 'a')
-            ->where('a.parent IS NULL')
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.parent IS NULL')
             ->andWhere('a.startDateTime IS NOT NULL')
             ->setMaxResults(1)
             ->orderBy('a.startDateTime', 'DESC');
@@ -125,11 +114,8 @@ class Album extends BaseMapper
      */
     public function getOldestAlbum(): ?AlbumModel
     {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('a')
-            ->from($this->getRepositoryName(), 'a')
-            ->where('a.parent IS NULL')
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.parent IS NULL')
             ->andWhere('a.startDateTime IS NOT NULL')
             ->setMaxResults(1)
             ->orderBy('a.startDateTime', 'ASC');

--- a/module/Photo/src/Mapper/ProfilePhoto.php
+++ b/module/Photo/src/Mapper/ProfilePhoto.php
@@ -21,7 +21,7 @@ class ProfilePhoto extends BaseMapper
      *
      * @throws Exception
      */
-    public function getProfilePhotoByLidnr($lidnr)
+    public function getProfilePhotoByLidnr(int $lidnr): ?ProfilePhotoModel
     {
         return $this->getRepository()->findOneBy(
             [

--- a/module/Photo/src/Mapper/Tag.php
+++ b/module/Photo/src/Mapper/Tag.php
@@ -13,8 +13,16 @@ use Photo\Model\{
  */
 class Tag extends BaseMapper
 {
-    public function findTag($photoId, $lidnr)
-    {
+    /**
+     * @param int $photoId
+     * @param int $lidnr
+     *
+     * @return TagModel|null
+     */
+    public function findTag(
+        int $photoId,
+        int $lidnr,
+    ): ?TagModel {
         return $this->getRepository()->findOneBy(
             [
                 'photo' => $photoId,
@@ -23,7 +31,11 @@ class Tag extends BaseMapper
         );
     }
 
-    public function getTagsByLidnr($lidnr)
+    /**
+     * @param int $lidnr
+     * @return array
+     */
+    public function getTagsByLidnr(int $lidnr): array
     {
         return $this->getRepository()->findBy(
             [
@@ -39,7 +51,7 @@ class Tag extends BaseMapper
      *
      * @return TagModel|null
      */
-    public function getMostActiveMemberTag($members)
+    public function getMostActiveMemberTag(array $members): ?TagModel
     {
         $qb = $this->em->createQueryBuilder();
 
@@ -61,10 +73,8 @@ class Tag extends BaseMapper
         $lidnr = $res[0][1];
 
         // Retrieve the most recent tag of a member
-        $qb2 = $this->em->createQueryBuilder();
-        $qb2->select('t')
-            ->from($this->getRepositoryName(), 't')
-            ->join(PhotoModel::class, 'p', 'WITH', 'p.id = t.photo')
+        $qb2 = $this->getRepository()->createQueryBuilder('t');
+        $qb2->join(PhotoModel::class, 'p', 'WITH', 'p.id = t.photo')
             ->where('t.member = ?1')
             ->setParameter(1, $lidnr)
             ->setMaxResults(1)

--- a/module/Photo/src/Mapper/Vote.php
+++ b/module/Photo/src/Mapper/Vote.php
@@ -18,10 +18,13 @@ class Vote extends BaseMapper
      *
      * @param DateTime $startDate
      * @param DateTime $endDate
+     *
      * @return array of array of string
      */
-    public function getVotesInRange($startDate, $endDate)
-    {
+    public function getVotesInRange(
+        DateTime $startDate,
+        DateTime $endDate,
+    ): array {
         $qb = $this->em->createQueryBuilder();
 
         $qb->select('IDENTITY(vote.photo)', 'Count(vote.photo)')
@@ -42,8 +45,10 @@ class Vote extends BaseMapper
      *
      * @return VoteModel|null
      */
-    public function findVote(int $photoId, int $lidnr): ?VoteModel
-    {
+    public function findVote(
+        int $photoId,
+        int $lidnr,
+    ): ?VoteModel {
         return $this->getRepository()->findOneBy(
             [
                 'photo' => $photoId,
@@ -56,6 +61,7 @@ class Vote extends BaseMapper
      * Checks if a member has recently voted.
      *
      * @param int $lidnr
+     *
      * @return bool
      */
     public function hasRecentVote(int $lidnr): bool

--- a/module/Photo/src/Mapper/WeeklyPhoto.php
+++ b/module/Photo/src/Mapper/WeeklyPhoto.php
@@ -3,7 +3,10 @@
 namespace Photo\Mapper;
 
 use Application\Mapper\BaseMapper;
-use Photo\Model\WeeklyPhoto as WeeklyPhotoModel;
+use Photo\Model\{
+    Photo as PhotoModel,
+    WeeklyPhoto as WeeklyPhotoModel,
+};
 
 /**
  * Mappers for WeeklyPhoto.
@@ -13,11 +16,11 @@ class WeeklyPhoto extends BaseMapper
     /**
      * Check whether the given photo has been a photo of the week.
      *
-     * @param \Photo\Model\Photo $photo
+     * @param PhotoModel $photo
      *
      * @return bool
      */
-    public function hasBeenPhotoOfTheWeek($photo)
+    public function hasBeenPhotoOfTheWeek(PhotoModel $photo): bool
     {
         return !is_null($this->getRepository()->findOneBy(['photo' => $photo]));
     }
@@ -27,11 +30,8 @@ class WeeklyPhoto extends BaseMapper
      */
     public function getCurrentPhotoOfTheWeek(): ?WeeklyPhotoModel
     {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('w')
-            ->from($this->getRepositoryName(), 'w')
-            ->setMaxResults(1)
+        $qb = $this->getRepository()->createQueryBuilder('w');
+        $qb->setMaxResults(1)
             ->orderBy('w.week', 'DESC');
 
         $res = $qb->getQuery()->getResult();
@@ -44,13 +44,10 @@ class WeeklyPhoto extends BaseMapper
      *
      * @return array
      */
-    public function getPhotosOfTheWeek()
+    public function getPhotosOfTheWeek(): array
     {
-        $qb = $this->em->createQueryBuilder();
-
-        $qb->select('w')
-            ->from($this->getRepositoryName(), 'w')
-            ->orderBy('w.week', 'DESC');
+        $qb = $this->getRepository()->createQueryBuilder('w');
+        $qb->orderBy('w.week', 'DESC');
 
         return $qb->getQuery()->getResult();
     }

--- a/module/Photo/src/Model/MemberAlbum.php
+++ b/module/Photo/src/Model/MemberAlbum.php
@@ -24,8 +24,10 @@ class MemberAlbum extends VirtualAlbum
      * @param int $id it is best to use the member lidnr here
      * @param MemberModel $member
      */
-    public function __construct(int $id, MemberModel $member)
-    {
+    public function __construct(
+        int $id,
+        MemberModel $member,
+    ) {
         parent::__construct($id);
         $this->member = $member;
     }

--- a/module/Photo/src/Model/ProfilePhoto.php
+++ b/module/Photo/src/Model/ProfilePhoto.php
@@ -109,7 +109,7 @@ class ProfilePhoto implements ResourceInterface
     /**
      * @param int $id
      */
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -117,7 +117,7 @@ class ProfilePhoto implements ResourceInterface
     /**
      * @param Photo $photo
      */
-    public function setPhoto(Photo $photo)
+    public function setPhoto(Photo $photo): void
     {
         $this->photo = $photo;
     }
@@ -125,7 +125,7 @@ class ProfilePhoto implements ResourceInterface
     /**
      * @param MemberModel $member
      */
-    public function setMember(MemberModel $member)
+    public function setMember(MemberModel $member): void
     {
         $this->member = $member;
     }
@@ -133,7 +133,7 @@ class ProfilePhoto implements ResourceInterface
     /**
      * @param DateTime $dateTime
      */
-    public function setDateTime(DateTime $dateTime)
+    public function setDateTime(DateTime $dateTime): void
     {
         $this->dateTime = $dateTime;
     }
@@ -141,7 +141,7 @@ class ProfilePhoto implements ResourceInterface
     /**
      * @param bool $explicit
      */
-    public function setExplicit(bool $explicit)
+    public function setExplicit(bool $explicit): void
     {
         $this->explicit = $explicit;
     }

--- a/module/Photo/src/Model/VirtualAlbum.php
+++ b/module/Photo/src/Model/VirtualAlbum.php
@@ -14,7 +14,10 @@ use Exception;
  */
 class VirtualAlbum extends Album
 {
-    public function __construct($id)
+    /**
+     * @param int $id
+     */
+    public function __construct(int $id)
     {
         parent::__construct();
         $this->id = $id;

--- a/module/Photo/src/Model/Vote.php
+++ b/module/Photo/src/Model/Vote.php
@@ -67,8 +67,10 @@ class Vote implements ResourceInterface
      * @param Photo $photo
      * @param UserModel $voter The member who voted
      */
-    public function __construct(Photo $photo, UserModel $voter)
-    {
+    public function __construct(
+        Photo $photo,
+        UserModel $voter,
+    ) {
         $this->dateTime = new DateTime();
         $this->voter = $voter;
         $this->photo = $photo;

--- a/module/Photo/src/Module.php
+++ b/module/Photo/src/Module.php
@@ -17,6 +17,14 @@ use Photo\Listener\{
     AlbumDate as AlbumDateListener,
     Remove as RemoveListener,
 };
+use Photo\Mapper\{
+    Album as AlbumMapper,
+    Photo as PhotoMapper,
+    ProfilePhoto as ProfilePhotoMapper,
+    Tag as TagMapper,
+    Vote as VoteMapper,
+    WeeklyPhoto as WeeklyPhotoMapper,
+};
 use Photo\Service\{
     Admin as AdminService,
     Album as AlbumService,
@@ -32,7 +40,10 @@ use User\Authorization\AclServiceFactory;
 
 class Module
 {
-    public function onBootstrap(MvcEvent $e)
+    /**
+     * @param MvcEvent $e
+     */
+    public function onBootstrap(MvcEvent $e): void
     {
         $container = $e->getApplication()->getServiceManager();
         $em = $container->get('doctrine.entitymanager.orm_default');
@@ -63,6 +74,8 @@ class Module
         return [
             'factories' => [
                 'photo_service_album' => function (ContainerInterface $container) {
+                    $aclService = $container->get('photo_service_acl');
+                    $translator = $container->get('translator');
                     $photoService = $container->get('photo_service_photo');
                     $albumCoverService = $container->get('photo_service_album_cover');
                     $memberService = $container->get('decision_service_member');
@@ -70,10 +83,10 @@ class Module
                     $albumMapper = $container->get('photo_mapper_album');
                     $createAlbumForm = $container->get('photo_form_album_create');
                     $editAlbumForm = $container->get('photo_form_album_edit');
-                    $aclService = $container->get('photo_service_acl');
-                    $translator = $container->get('translator');
 
                     return new AlbumService(
+                        $aclService,
+                        $translator,
                         $photoService,
                         $albumCoverService,
                         $memberService,
@@ -81,14 +94,13 @@ class Module
                         $albumMapper,
                         $createAlbumForm,
                         $editAlbumForm,
-                        $aclService,
-                        $translator,
                     );
                 },
                 'photo_service_metadata' => function () {
                     return new MetadataService();
                 },
                 'photo_service_photo' => function (ContainerInterface $container) {
+                    $aclService = $container->get('photo_service_acl');
                     $translator = $container->get('translator');
                     $memberService = $container->get('decision_service_member');
                     $storageService = $container->get('application_service_storage');
@@ -98,9 +110,9 @@ class Module
                     $weeklyPhotoMapper = $container->get('photo_mapper_weekly_photo');
                     $profilePhotoMapper = $container->get('photo_mapper_profile_photo');
                     $photoConfig = $container->get('config')['photo'];
-                    $aclService = $container->get('photo_service_acl');
 
                     return new PhotoService(
+                        $aclService,
                         $translator,
                         $memberService,
                         $storageService,
@@ -110,7 +122,6 @@ class Module
                         $weeklyPhotoMapper,
                         $profilePhotoMapper,
                         $photoConfig,
-                        $aclService
                     );
                 },
                 'photo_service_album_cover' => function (ContainerInterface $container) {
@@ -129,22 +140,22 @@ class Module
                     );
                 },
                 'photo_service_admin' => function (ContainerInterface $container) {
+                    $aclService = $container->get('photo_service_acl');
                     $translator = $container->get('translator');
                     $photoService = $container->get('photo_service_photo');
                     $metadataService = $container->get('photo_service_metadata');
                     $storageService = $container->get('application_service_storage');
                     $photoMapper = $container->get('photo_mapper_photo');
                     $photoConfig = $container->get('config')['photo'];
-                    $aclService = $container->get('photo_service_acl');
 
                     return new AdminService(
+                        $aclService,
                         $translator,
                         $photoService,
                         $metadataService,
                         $storageService,
                         $photoMapper,
                         $photoConfig,
-                        $aclService,
                     );
                 },
                 'photo_form_album_edit' => function (ContainerInterface $container) {
@@ -169,37 +180,36 @@ class Module
                     );
                 },
                 'photo_mapper_album' => function (ContainerInterface $container) {
-                    return new Mapper\Album(
+                    return new AlbumMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },
                 'photo_mapper_photo' => function (ContainerInterface $container) {
-                    return new Mapper\Photo(
+                    return new PhotoMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },
                 'photo_mapper_profile_photo' => function (ContainerInterface $container) {
-                    return new Mapper\ProfilePhoto(
+                    return new ProfilePhotoMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },
                 'photo_mapper_tag' => function (ContainerInterface $container) {
-                    return new Mapper\Tag(
+                    return new TagMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },
                 'photo_mapper_weekly_photo' => function (ContainerInterface $container) {
-                    return new Mapper\WeeklyPhoto(
+                    return new WeeklyPhotoMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },
                 'photo_mapper_vote' => function (ContainerInterface $container) {
-                    return new Mapper\Vote(
+                    return new VoteMapper(
                         $container->get('doctrine.entitymanager.orm_default')
                     );
                 },
                 'photo_service_acl' => AclServiceFactory::class,
-                'activity_service_acl' => AclServiceFactory::class,
                 WeeklyPhoto::class => function (ContainerInterface $container) {
                     $weeklyPhoto = new WeeklyPhoto();
                     $photoService = $container->get('photo_service_photo');

--- a/module/Photo/src/Service/AclService.php
+++ b/module/Photo/src/Service/AclService.php
@@ -4,7 +4,10 @@ namespace Photo\Service;
 
 class AclService extends \User\Service\AclService
 {
-    protected function createAcl()
+    /**
+     * @return void
+     */
+    protected function createAcl(): void
     {
         parent::createAcl();
 

--- a/module/Photo/src/Service/AclService.php
+++ b/module/Photo/src/Service/AclService.php
@@ -4,9 +4,6 @@ namespace Photo\Service;
 
 class AclService extends \User\Service\AclService
 {
-    /**
-     * @return void
-     */
     protected function createAcl(): void
     {
         parent::createAcl();

--- a/module/Photo/src/Service/Admin.php
+++ b/module/Photo/src/Service/Admin.php
@@ -166,7 +166,7 @@ class Admin
         $image->thumbnailImage($width, $height, true);
         $image->setimageformat('png');
         //Tempfile is used to generate sha1, not sure this is the best method
-        $tempFileName = sys_get_temp_dir() . '/ThumbImage' . rand() . '.png';
+        $tempFileName = sys_get_temp_dir() . '/ThumbImage' . random_int(0, getrandmax()) . '.png';
         $image->writeImage($tempFileName);
 
         return $this->storageService->storeFile($tempFileName);

--- a/module/Photo/src/Service/Album.php
+++ b/module/Photo/src/Service/Album.php
@@ -30,6 +30,16 @@ use User\Permissions\NotAllowedException;
 class Album
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
      * @var PhotoService
      */
     private PhotoService $photoService;
@@ -64,17 +74,9 @@ class Album
      */
     private EditAlbumForm $editAlbumForm;
 
-    /**
-     * @var AclService
-     */
-    private AclService $aclService;
-
-    /**
-     * @var Translator
-     */
-    private Translator $translator;
-
     public function __construct(
+        AclService $aclService,
+        Translator $translator,
         PhotoService $photoService,
         AlbumCoverService $albumCoverService,
         MemberService $memberService,
@@ -82,9 +84,9 @@ class Album
         AlbumMapper $albumMapper,
         CreateAlbumForm $createAlbumForm,
         EditAlbumForm $editAlbumForm,
-        AclService $aclService,
-        Translator $translator,
     ) {
+        $this->aclService = $aclService;
+        $this->translator = $translator;
         $this->photoService = $photoService;
         $this->albumCoverService = $albumCoverService;
         $this->memberService = $memberService;
@@ -92,8 +94,6 @@ class Album
         $this->albumMapper = $albumMapper;
         $this->createAlbumForm = $createAlbumForm;
         $this->editAlbumForm = $editAlbumForm;
-        $this->aclService = $aclService;
-        $this->translator = $translator;
     }
 
     /**
@@ -106,14 +106,17 @@ class Album
      * Retrieves all the albums in the root directory or in the specified
      * album.
      *
+     * @param AlbumModel|null $album The album to retrieve sub-albums of
      * @param int $start the result to start at
      * @param int|null $maxResults max amount of results to return, null for infinite
-     * @param AlbumModel|null $album The album to retrieve sub-albums of
      *
      * @return array
      */
-    public function getAlbums(AlbumModel $album = null, int $start = 0, int $maxResults = null): array
-    {
+    public function getAlbums(
+        ?AlbumModel $album = null,
+        int $start = 0,
+        ?int $maxResults = null,
+    ): array {
         if (!$this->aclService->isAllowed('view', 'album')) {
             throw new NotAllowedException($this->translator->translate('Not allowed to view albums'));
         }
@@ -234,8 +237,10 @@ class Album
      *
      * @throws Exception
      */
-    public function createAlbum(?int $parentId, array $data): AlbumModel
-    {
+    public function createAlbum(
+        ?int $parentId,
+        array $data,
+    ): AlbumModel {
         if (!$this->aclService->isAllowed('create', 'album')) {
             throw new NotAllowedException($this->translator->translate('Not allowed to create albums'));
         }
@@ -277,8 +282,10 @@ class Album
      *
      * @throws Exception If there are not sufficient permissions
      */
-    public function getAlbum(int $albumId, string $type = 'album'): MemberAlbumModel|AlbumModel|null
-    {
+    public function getAlbum(
+        int $albumId,
+        string $type = 'album',
+    ): MemberAlbumModel|AlbumModel|null {
         if (!$this->aclService->isAllowed('view', 'album')) {
             throw new NotAllowedException($this->translator->translate('Not allowed to view albums'));
         }
@@ -360,8 +367,10 @@ class Album
      *
      * @throws Exception
      */
-    public function moveAlbum(int $albumId, ?int $parentId): bool
-    {
+    public function moveAlbum(
+        int $albumId,
+        ?int $parentId,
+    ): bool {
         if (!$this->aclService->isAllowed('move', 'album')) {
             throw new NotAllowedException($this->translator->translate('Not allowed to move albums'));
         }
@@ -438,7 +447,7 @@ class Album
      *
      * @param AlbumModel $album
      */
-    public function deleteAlbumCover(AlbumModel $album)
+    public function deleteAlbumCover(AlbumModel $album): void
     {
         $this->photoService->deletePhotoFile($album->getCoverPath());
     }
@@ -453,8 +462,10 @@ class Album
      *
      * @throws Exception
      */
-    public function movePhoto(int $photoId, int $albumId): bool
-    {
+    public function movePhoto(
+        int $photoId,
+        int $albumId,
+    ): bool {
         if (!$this->aclService->isAllowed('move', 'album')) {
             throw new NotAllowedException($this->translator->translate('Not allowed to move photos'));
         }

--- a/module/Photo/src/Service/AlbumCover.php
+++ b/module/Photo/src/Service/AlbumCover.php
@@ -72,7 +72,7 @@ class AlbumCover
     public function createCover(AlbumModel $album): string
     {
         $cover = $this->generateCover($album);
-        $tempFileName = sys_get_temp_dir() . '/CoverImage' . rand() . '.png';
+        $tempFileName = sys_get_temp_dir() . '/CoverImage' . random_int(0, getrandmax()) . '.png';
         $cover->writeImage($tempFileName);
 
         return $this->storage->storeFile($tempFileName, false);

--- a/module/Photo/src/Service/Metadata.php
+++ b/module/Photo/src/Service/Metadata.php
@@ -103,7 +103,7 @@ class Metadata
     private function exifGetShutter(string $shutterSpeed): ?string
     {
         $apex = $this->frac2dec($shutterSpeed);
-        $shutter = pow(2, -$apex);
+        $shutter = 2 ** ( -$apex);
         if (0 == $shutter) {
             return null;
         }
@@ -124,7 +124,7 @@ class Metadata
     private function exifGetFstop(string $apertureValue): ?string
     {
         $apex = $this->frac2dec($apertureValue);
-        $fstop = pow(2, $apex / 2);
+        $fstop = 2 ** ( $apex / 2);
         if (0 == $fstop) {
             return null;
         }

--- a/module/Photo/src/Service/Photo.php
+++ b/module/Photo/src/Service/Photo.php
@@ -639,7 +639,7 @@ class Photo
         $votes = $photo->getVoteCount();
         $tags = $photo->getTagCount();
 
-        $baseRating = $votes / pow($tags, 1.25);
+        $baseRating = $votes / $tags ** 1.25;
         // Prevent division by zero.
         if ($age < 14) {
             return $baseRating * (14 - $age);

--- a/module/Photo/src/Service/Photo.php
+++ b/module/Photo/src/Service/Photo.php
@@ -7,7 +7,7 @@ use DateInterval;
 use DateTime;
 use Decision\Model\Member as MemberModel;
 use Decision\Service\Member as MemberService;
-use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Exception\ORMException;
 use Exception;
 use Laminas\Http\Response\Stream;
 use Laminas\I18n\Filter\Alnum;

--- a/module/Photo/src/View/Helper/GlideUrl.php
+++ b/module/Photo/src/View/Helper/GlideUrl.php
@@ -7,16 +7,19 @@ use League\Glide\Urls\UrlBuilder;
 
 /**
  * Url view helper for generating (signed) glide url's
- * Usage: $this->scriptUrl()->requireUrl('/url/route');.
+ * Usage: $this->glideUrl()->getUrl('path to image', ['parameters']);.
  */
 class GlideUrl extends AbstractHelper
 {
-    protected $urlBuilder;
+    /**
+     * @var UrlBuilder
+     */
+    protected UrlBuilder $urlBuilder;
 
     /**
      * @return GlideUrl
      */
-    public function __invoke()
+    public function __invoke(): self
     {
         return $this;
     }
@@ -29,8 +32,10 @@ class GlideUrl extends AbstractHelper
      *
      * @return string
      */
-    public function getUrl($imagePath, $params)
-    {
+    public function getUrl(
+        string $imagePath,
+        array $params,
+    ): string {
         return $this->urlBuilder->getUrl($imagePath, $params);
     }
 
@@ -39,7 +44,7 @@ class GlideUrl extends AbstractHelper
      *
      * @param UrlBuilder $urlBuilder
      */
-    public function setUrlBuilder($urlBuilder)
+    public function setUrlBuilder(UrlBuilder $urlBuilder): void
     {
         $this->urlBuilder = $urlBuilder;
     }

--- a/module/Photo/src/View/Helper/HasVoted.php
+++ b/module/Photo/src/View/Helper/HasVoted.php
@@ -15,6 +15,9 @@ class HasVoted extends AbstractHelper
      */
     private VoteMapper $voteMapper;
 
+    /**
+     * @param VoteMapper $voteMapper
+     */
     public function __construct(VoteMapper $voteMapper)
     {
         $this->voteMapper = $voteMapper;
@@ -26,8 +29,10 @@ class HasVoted extends AbstractHelper
      *
      * @return bool
      */
-    public function __invoke(int $photoId, int $lidnr): bool
-    {
+    public function __invoke(
+        int $photoId,
+        int $lidnr,
+    ): bool {
         return null !== $this->voteMapper->findVote($photoId, $lidnr);
     }
 }

--- a/module/Photo/test/ControllerTest.php
+++ b/module/Photo/test/ControllerTest.php
@@ -6,7 +6,7 @@ use ApplicationTest\BaseControllerTest;
 
 class ControllerTest extends BaseControllerTest
 {
-    public function testIndexActionIsForbidden()
+    public function testIndexActionIsForbidden(): void
     {
         $this->dispatch('/photo');
         $this->assertResponseStatusCode(403);

--- a/module/Photo/view/photo/album/index.phtml
+++ b/module/Photo/view/photo/album/index.phtml
@@ -166,7 +166,7 @@ $this->scriptUrl()->requireUrl('member/search')
 
     const leftArrowSVGString = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 50 30" width="50" height="30"><use href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#chevron-left"></use></svg>';
     const closeSVGString = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 32 32" width="32" height="32"><use href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#times"></use></svg>';
-    const zoomSVGString = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 32 32" width="32" height="32"><use class="pswp__icn-zoom-plus" href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#search-plus"></use><use class="pswp__icn-zoom-minus" href="<?php $this->basePath() ?>/sprites/fontawesome/solid.svg#search-minus"></use></svg>';
+    const zoomSVGString = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 32 32" width="32" height="32"><use class="pswp__icn-zoom-plus" href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#search-plus"></use><use class="pswp__icn-zoom-minus" href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#search-minus"></use></svg>';
 
     const lightbox = new PhotoSwipeLightbox({
         gallery: '.pswp-gallery',

--- a/module/Photo/view/photo/album/index.phtml
+++ b/module/Photo/view/photo/album/index.phtml
@@ -166,7 +166,7 @@ $this->scriptUrl()->requireUrl('member/search')
 
     const leftArrowSVGString = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 50 30" width="50" height="30"><use href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#chevron-left"></use></svg>';
     const closeSVGString = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 32 32" width="32" height="32"><use href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#times"></use></svg>';
-    const zoomSVGString = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 32 32" width="32" height="32"><use class="pswp__icn-zoom-plus" href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#search-plus"></use><use class="pswp__icn-zoom-minus" href="<? $this->basePath() ?>/sprites/fontawesome/solid.svg#search-minus"></use></svg>';
+    const zoomSVGString = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 32 32" width="32" height="32"><use class="pswp__icn-zoom-plus" href="<?= $this->basePath() ?>/sprites/fontawesome/solid.svg#search-plus"></use><use class="pswp__icn-zoom-minus" href="<?php $this->basePath() ?>/sprites/fontawesome/solid.svg#search-minus"></use></svg>';
 
     const lightbox = new PhotoSwipeLightbox({
         gallery: '.pswp-gallery',

--- a/module/User/src/Authentication/Adapter/ApiMapper.php
+++ b/module/User/src/Authentication/Adapter/ApiMapper.php
@@ -15,6 +15,9 @@ class ApiMapper implements AdapterInterface
      */
     protected ApiUserMapper $mapper;
 
+    /**
+     * @var string
+     */
     private string $token;
 
     /**
@@ -49,9 +52,8 @@ class ApiMapper implements AdapterInterface
      * Sets the credentials used to authenticate.
      *
      * @param string $token
-     * @return void
      */
-    public function setCredentials(string $token)
+    public function setCredentials(string $token): void
     {
         $this->token = $token;
     }

--- a/module/User/src/Authentication/Adapter/Mapper.php
+++ b/module/User/src/Authentication/Adapter/Mapper.php
@@ -127,8 +127,6 @@ class Mapper implements AdapterInterface
      *
      * @param string $login
      * @param string $password
-     *
-     * @return void
      */
     public function setCredentials(
         string $login,

--- a/module/User/src/Authentication/Adapter/Mapper.php
+++ b/module/User/src/Authentication/Adapter/Mapper.php
@@ -7,7 +7,7 @@ use Laminas\Authentication\Result;
 use Laminas\Crypt\Password\Bcrypt;
 use RuntimeException;
 use User\Mapper\User as UserMapper;
-use User\Model\LoginAttempt;
+use User\Model\LoginAttempt as LoginAttemptModel;
 use User\Authentication\Service\LoginAttempt as LoginAttemptService;
 
 class Mapper implements AdapterInterface
@@ -18,6 +18,11 @@ class Mapper implements AdapterInterface
      * @var UserMapper
      */
     protected UserMapper $mapper;
+
+    /**
+     * @var string
+     */
+    private string $login;
 
     /**
      * Password.
@@ -42,18 +47,16 @@ class Mapper implements AdapterInterface
     protected LoginAttemptService $loginAttemptService;
 
     /**
-     * @var mixed
-     */
-    private $login;
-
-    /**
      * Constructor.
      * @param Bcrypt $bcrypt
      * @param LoginAttemptService $loginAttemptService
      * @param UserMapper $mapper
      */
-    public function __construct(Bcrypt $bcrypt, loginAttemptService $loginAttemptService, UserMapper $mapper)
-    {
+    public function __construct(
+        Bcrypt $bcrypt,
+        LoginAttemptService $loginAttemptService,
+        UserMapper $mapper,
+    ) {
         $this->bcrypt = $bcrypt;
         $this->loginAttemptService = $loginAttemptService;
         $this->mapper = $mapper;
@@ -77,7 +80,7 @@ class Mapper implements AdapterInterface
 
         $this->mapper->detach($user);
 
-        if ($this->loginAttemptService->loginAttemptsExceeded(LoginAttempt::TYPE_NORMAL, $user)) {
+        if ($this->loginAttemptService->loginAttemptsExceeded($user, LoginAttemptModel::TYPE_NORMAL)) {
             return new Result(
                 Result::FAILURE,
                 null,
@@ -85,7 +88,7 @@ class Mapper implements AdapterInterface
         }
 
         if (!$this->verifyPassword($this->password, $user->getPassword())) {
-            $this->loginAttemptService->logFailedLogin($user, LoginAttempt::TYPE_NORMAL);
+            $this->loginAttemptService->logFailedLogin($user, LoginAttemptModel::TYPE_NORMAL);
 
             return new Result(
                 Result::FAILURE_CREDENTIAL_INVALID,
@@ -104,8 +107,10 @@ class Mapper implements AdapterInterface
      *
      * @return bool
      */
-    public function verifyPassword($password, $hash)
-    {
+    public function verifyPassword(
+        string $password,
+        string $hash,
+    ): bool {
         if (0 === strlen($hash)) {
             throw new RuntimeException("Legacy service is not available for Mapper Auth.");
         }
@@ -120,13 +125,15 @@ class Mapper implements AdapterInterface
     /**
      * Sets the credentials used to authenticate.
      *
-     * @param mixed $login
+     * @param string $login
      * @param string $password
      *
      * @return void
      */
-    public function setCredentials($login, $password)
-    {
+    public function setCredentials(
+        string $login,
+        string $password,
+    ): void {
         $this->login = $login;
         $this->password = $password;
     }

--- a/module/User/src/Authentication/Adapter/PinMapper.php
+++ b/module/User/src/Authentication/Adapter/PinMapper.php
@@ -45,8 +45,10 @@ class PinMapper implements AdapterInterface
      * @param LoginAttemptService $loginAttemptService
      * @param UserMapper $mapper
      */
-    public function __construct(loginAttemptService $loginAttemptService, UserMapper $mapper)
-    {
+    public function __construct(
+        LoginAttemptService $loginAttemptService,
+        UserMapper $mapper,
+    ) {
         $this->loginAttemptService = $loginAttemptService;
         $this->mapper = $mapper;
     }
@@ -66,11 +68,11 @@ class PinMapper implements AdapterInterface
      *
      * @param string $lidnr
      * @param string $pincode
-     *
-     * @return void
      */
-    public function setCredentials($lidnr, $pincode)
-    {
+    public function setCredentials(
+        string $lidnr,
+        string $pincode,
+    ): void {
         $this->lidnr = $lidnr;
         $this->pincode = $pincode;
     }

--- a/module/User/src/Authentication/ApiAuthenticationService.php
+++ b/module/User/src/Authentication/ApiAuthenticationService.php
@@ -44,7 +44,7 @@ class ApiAuthenticationService implements AuthenticationServiceInterface
      *
      * @return ApiMapper
      */
-    public function getAdapter()
+    public function getAdapter(): ApiMapper
     {
         return $this->adapter;
     }
@@ -56,10 +56,11 @@ class ApiAuthenticationService implements AuthenticationServiceInterface
      *
      * @return self Provides a fluent interface
      */
-    public function setAdapter(AdapterInterface $adapter)
+    public function setAdapter(AdapterInterface $adapter): self
     {
         if ($adapter instanceof ApiMapper) {
             $this->adapter = $adapter;
+
             return $this;
         }
 
@@ -70,22 +71,25 @@ class ApiAuthenticationService implements AuthenticationServiceInterface
 
     /**
      * @param string|null $token
+     *
      * @return Result
      */
-    public function authenticate(string $token = null)
+    public function authenticate(?string $token = null): Result
     {
         $this->getAdapter()->setCredentials($token);
         $result = $this->getAdapter()->authenticate();
+
         if ($result->isValid()) {
             $this->identity = $result->getIdentity();
         }
+
         return $result;
     }
 
     /**
      * @return bool
      */
-    public function hasIdentity()
+    public function hasIdentity(): bool
     {
         return !is_null($this->identity);
     }
@@ -93,12 +97,12 @@ class ApiAuthenticationService implements AuthenticationServiceInterface
     /**
      * @return ApiUser|null
      */
-    public function getIdentity()
+    public function getIdentity(): ?ApiUser
     {
         return $this->identity;
     }
 
-    public function clearIdentity()
+    public function clearIdentity(): void
     {
         $this->identity = null;
     }

--- a/module/User/src/Authentication/AuthenticationService.php
+++ b/module/User/src/Authentication/AuthenticationService.php
@@ -39,8 +39,10 @@ class AuthenticationService implements AuthenticationServiceInterface
      * @param AdapterInterface $adapter
      *
      */
-    public function __construct(StorageInterface $storage, AdapterInterface $adapter)
-    {
+    public function __construct(
+        StorageInterface $storage,
+        AdapterInterface $adapter,
+    ) {
         $this->setStorage($storage);
         $this->setAdapter($adapter);
     }
@@ -112,15 +114,17 @@ class AuthenticationService implements AuthenticationServiceInterface
      * Authenticates against the authentication adapter. The default values must be `null` to be compatible with the
      * `AuthenticationServiceInterface`. We can safely assume they are provided, but if not throw a `RuntimeException`.
      *
-     * @param mixed|null $login
+     * @param string|null $login
      * @param string|null $securityCode
      *
      * @return Result
      *
      * @throws RuntimeException
      */
-    public function authenticate(mixed $login = null, string $securityCode = null): Result
-    {
+    public function authenticate(
+        ?string $login = null,
+        ?string $securityCode = null,
+    ): Result {
         if (
             is_null($login)
             || is_null($securityCode)

--- a/module/User/src/Authentication/AuthenticationService.php
+++ b/module/User/src/Authentication/AuthenticationService.php
@@ -178,8 +178,6 @@ class AuthenticationService implements AuthenticationServiceInterface
 
     /**
      * Clears the identity from persistent storage
-     *
-     * @return void
      */
     public function clearIdentity(): void
     {
@@ -190,8 +188,6 @@ class AuthenticationService implements AuthenticationServiceInterface
      * Set whether we should remember this session or not.
      *
      * @param bool $rememberMe
-     *
-     * @return void
      */
     public function setRememberMe(bool $rememberMe): void
     {

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -165,8 +165,6 @@ class Session extends SessionStorage
 
     /**
      * Defined by Laminas\Authentication\Storage\StorageInterface.
-     *
-     * @return void
      */
     public function clear(): void
     {
@@ -181,8 +179,6 @@ class Session extends SessionStorage
      * Store the session token as a cookie.
      *
      * @param string $jwt The session token to store
-     *
-     * @return void
      */
     protected function saveCookie(string $jwt): void
     {
@@ -194,8 +190,6 @@ class Session extends SessionStorage
 
     /**
      * Destroy the cookie holding the stored session.
-     *
-     * @return void
      */
     protected function clearCookie(): void
     {

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -11,7 +11,6 @@ use Laminas\Http\{
     Response,
 };
 use UnexpectedValueException;
-use User\Model\User as UserModel;
 
 class Session extends SessionStorage
 {

--- a/module/User/src/Authentication/Storage/Session.php
+++ b/module/User/src/Authentication/Storage/Session.php
@@ -35,6 +35,11 @@ class Session extends SessionStorage
      */
     private array $config;
 
+    /**
+     * @param Request $request
+     * @param Response $response
+     * @param array $config
+     */
     public function __construct(
         Request $request,
         Response $response,
@@ -121,8 +126,6 @@ class Session extends SessionStorage
      * Defined by Laminas\Authentication\Storage\StorageInterface.
      *
      * @param int $contents
-     *
-     * @return void
      */
     public function write($contents): void
     {
@@ -137,8 +140,6 @@ class Session extends SessionStorage
      * Store the current session.
      *
      * @param int $lidnr the lidnr of the logged in user
-     *
-     * @return void
      */
     protected function saveSession(int $lidnr): void
     {

--- a/module/User/src/Authorization/AclServiceFactory.php
+++ b/module/User/src/Authorization/AclServiceFactory.php
@@ -2,42 +2,93 @@
 
 namespace User\Authorization;
 
+use Activity\Service\AclService as ActivityAclService;
+use Company\Service\AclService as CompanyAclService;
+use Decision\Service\AclService as DecisionAclService;
+use Education\Service\AclService as EducationAclService;
+use Frontpage\Service\AclService as FrontpageAclService;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\Exception\InvalidArgumentException;
-use User\Service\AclService;
+use Photo\Service\AclService as PhotoAclService;
+use User\Service\AclService as UserAclService;
 
 class AclServiceFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): GenericAclService
-    {
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param array|null $options
+     *
+     * @return GenericAclService
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): GenericAclService {
         $translator = $container->get('translator');
         $authService = $container->get('user_auth_service');
         $apiAuthService = $container->get('user_apiauth_service');
         $remoteAddress = $container->get('user_remoteaddress');
         $tueRange = $container->get('config')['tue_range'];
-        switch ($requestedName) {
-            case 'user_service_acl':
-                return new AclService($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
-            case 'activity_service_acl':
-                return new \Activity\Service\AclService($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
-            case 'company_service_acl':
-                return new \Company\Service\AclService($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
-            case 'decision_service_acl':
-                return new \Decision\Service\AclService($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
-            case 'education_service_acl':
-                return new \Education\Service\AclService($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
-            case 'frontpage_service_acl':
-                return new \Frontpage\Service\AclService($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
-            case 'photo_service_acl':
-                return new \Photo\Service\AclService($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
-            default:
-                throw new InvalidArgumentException(
-                    sprintf(
-                        "The service with name %s could not be found and was therefore not created.",
-                        $requestedName
-                    )
-                );
-        }
+
+        return match ($requestedName) {
+            'activity_service_acl' => new ActivityAclService(
+                $translator,
+                $authService,
+                $apiAuthService,
+                $remoteAddress,
+                $tueRange,
+            ),
+            'company_service_acl' => new CompanyAclService(
+                $translator,
+                $authService,
+                $apiAuthService,
+                $remoteAddress,
+                $tueRange,
+            ),
+            'decision_service_acl' => new DecisionAclService(
+                $translator,
+                $authService,
+                $apiAuthService,
+                $remoteAddress,
+                $tueRange,
+            ),
+            'education_service_acl' => new EducationAclService(
+                $translator,
+                $authService,
+                $apiAuthService,
+                $remoteAddress,
+                $tueRange,
+            ),
+            'frontpage_service_acl' => new FrontpageAclService(
+                $translator,
+                $authService,
+                $apiAuthService,
+                $remoteAddress,
+                $tueRange,
+            ),
+            'photo_service_acl' => new PhotoAclService(
+                $translator,
+                $authService,
+                $apiAuthService,
+                $remoteAddress,
+                $tueRange,
+            ),
+            'user_service_acl' => new UserAclService(
+                $translator,
+                $authService,
+                $apiAuthService,
+                $remoteAddress,
+                $tueRange,
+            ),
+            default => throw new InvalidArgumentException(
+                sprintf(
+                    "The service with name %s could not be found and was therefore not created.",
+                    $requestedName,
+                )
+            ),
+        };
     }
 }

--- a/module/User/src/Authorization/GenericAclService.php
+++ b/module/User/src/Authorization/GenericAclService.php
@@ -80,10 +80,9 @@ abstract class GenericAclService extends AbstractAclService
     /**
      * Gets the user identity, or gives a 403 if the user is not logged in
      *
-     * @return User the current logged in user
-     * @throws NotAllowedException if no user is logged in
+     * @return User|null the current logged in user
      */
-    public function getIdentityOrThrowException()
+    public function getIdentityOrThrowException(): ?User
     {
         if (!$this->hasIdentity()) {
             throw new NotAllowedException(

--- a/module/User/src/Authorization/GenericAclService.php
+++ b/module/User/src/Authorization/GenericAclService.php
@@ -3,28 +3,48 @@
 namespace User\Authorization;
 
 use Application\Service\AbstractAclService;
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Mvc\I18n\Translator;
 use User\Authentication\{
     ApiAuthenticationService,
     AuthenticationService,
 };
+use Laminas\Permissions\Acl\Role\RoleInterface;
 use User\Model\User;
 use User\Permissions\NotAllowedException;
 
 abstract class GenericAclService extends AbstractAclService
 {
-    private TranslatorInterface $translator;
+    /**
+     * @var Translator
+     */
+    private Translator $translator;
+
+    /**
+     * @var AuthenticationService
+     */
     private AuthenticationService $authService;
+
+    /**
+     * @var ApiAuthenticationService
+     */
     private ApiAuthenticationService $apiAuthService;
+
+    /**
+     * @var string
+     */
     private string $remoteAddress;
+
+    /**
+     * @var string
+     */
     private string $tueRange;
 
     public function __construct(
-        TranslatorInterface $translator,
+        Translator $translator,
         AuthenticationService $authService,
         ApiAuthenticationService $apiAuthService,
         string $remoteAddress,
-        string $tueRange
+        string $tueRange,
     ) {
         $this->translator = $translator;
         $this->authService = $authService;
@@ -39,7 +59,7 @@ abstract class GenericAclService extends AbstractAclService
      * The role that should take precedence should be returned first.
      * This is because of the behaviour of {@link \Laminas\Permissions\Acl\Role\Registry}.
      */
-    protected function getRole()
+    protected function getRole(): RoleInterface|string
     {
         if ($this->authService->hasIdentity()) {
             return $this->authService->getIdentity();

--- a/module/User/src/Controller/ApiAdminController.php
+++ b/module/User/src/Controller/ApiAdminController.php
@@ -2,6 +2,7 @@
 
 namespace User\Controller;
 
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use User\Service\ApiUser as ApiUserService;
@@ -28,7 +29,7 @@ class ApiAdminController extends AbstractActionController
      *
      * Show all API tokens
      */
-    public function indexAction()
+    public function indexAction(): ViewModel
     {
         return new ViewModel(
             [
@@ -40,7 +41,7 @@ class ApiAdminController extends AbstractActionController
     /**
      * Add an API token.
      */
-    public function addAction()
+    public function addAction(): ViewModel
     {
         $form = $this->apiUserService->getApiTokenForm();
 
@@ -71,7 +72,7 @@ class ApiAdminController extends AbstractActionController
     /**
      * Remove an API token.
      */
-    public function removeAction()
+    public function removeAction(): Response|ViewModel
     {
         $id = $this->params()->fromRoute('id');
         $service = $this->apiUserService;

--- a/module/User/src/Controller/ApiAuthenticationController.php
+++ b/module/User/src/Controller/ApiAuthenticationController.php
@@ -13,27 +13,27 @@ use User\Service\{
 class ApiAuthenticationController extends AbstractActionController
 {
     /**
-     * @var ApiAppService
-     */
-    protected ApiAppService $apiAppService;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
 
     /**
+     * @var ApiAppService
+     */
+    protected ApiAppService $apiAppService;
+
+    /**
      * ApiAuthenticationController constructor.
      *
-     * @param ApiAppService $apiAppService
      * @param AclService $aclService
+     * @param ApiAppService $apiAppService
      */
     public function __construct(
+        AclService $aclService,
         ApiAppService $apiAppService,
-        AclService $aclService
     ) {
-        $this->apiAppService = $apiAppService;
         $this->aclService = $aclService;
+        $this->apiAppService = $apiAppService;
     }
 
     public function tokenAction()

--- a/module/User/src/Controller/ApiAuthenticationController.php
+++ b/module/User/src/Controller/ApiAuthenticationController.php
@@ -2,6 +2,7 @@
 
 namespace User\Controller;
 
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use User\Model\User;
 use User\Permissions\NotAllowedException;
@@ -36,7 +37,7 @@ class ApiAuthenticationController extends AbstractActionController
         $this->apiAppService = $apiAppService;
     }
 
-    public function tokenAction()
+    public function tokenAction(): Response
     {
         $appId = $this->params()->fromRoute('appId');
         $identity = $this->aclService->getIdentity();

--- a/module/User/src/Controller/ApiController.php
+++ b/module/User/src/Controller/ApiController.php
@@ -3,7 +3,9 @@
 namespace User\Controller;
 
 use Decision\Service\MemberInfo as MemberInfoService;
+use Laminas\Http\PhpEnvironment\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\Stdlib\ResponseInterface;
 use User\Service\AclService;
 
 class ApiController extends AbstractActionController
@@ -32,7 +34,7 @@ class ApiController extends AbstractActionController
         $this->memberInfoService = $memberInfoService;
     }
 
-    public function validateAction()
+    public function validateAction(): Response|ResponseInterface
     {
         if ($this->aclService->hasIdentity()) {
             $identity = $this->aclService->getIdentity();

--- a/module/User/src/Controller/ApiController.php
+++ b/module/User/src/Controller/ApiController.php
@@ -9,27 +9,27 @@ use User\Service\AclService;
 class ApiController extends AbstractActionController
 {
     /**
-     * @var MemberInfoService
-     */
-    private MemberInfoService $memberInfoService;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
 
     /**
+     * @var MemberInfoService
+     */
+    private MemberInfoService $memberInfoService;
+
+    /**
      * ApiController constructor.
      *
-     * @param MemberInfoService $memberInfoService
      * @param AclService $aclService
+     * @param MemberInfoService $memberInfoService
      */
     public function __construct(
+        AclService $aclService,
         MemberInfoService $memberInfoService,
-        AclService $aclService
     ) {
-        $this->memberInfoService = $memberInfoService;
         $this->aclService = $aclService;
+        $this->memberInfoService = $memberInfoService;
     }
 
     public function validateAction()

--- a/module/User/src/Controller/Factory/ApiAdminControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiAdminControllerFactory.php
@@ -11,14 +11,14 @@ class ApiAdminControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return ApiAdminController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): ApiAdminController {
         return new ApiAdminController(
             $container->get('user_service_apiuser'),

--- a/module/User/src/Controller/Factory/ApiAdminControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiAdminControllerFactory.php
@@ -18,10 +18,10 @@ class ApiAdminControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): ApiAdminController {
         return new ApiAdminController(
-            $container->get('user_service_apiuser')
+            $container->get('user_service_apiuser'),
         );
     }
 }

--- a/module/User/src/Controller/Factory/ApiAuthenticationControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiAuthenticationControllerFactory.php
@@ -12,14 +12,14 @@ class ApiAuthenticationControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return ApiAuthenticationController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): ApiAuthenticationController {
         return new ApiAuthenticationController(
             $container->get('user_service_acl'),

--- a/module/User/src/Controller/Factory/ApiAuthenticationControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiAuthenticationControllerFactory.php
@@ -19,11 +19,11 @@ class ApiAuthenticationControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): ApiAuthenticationController {
         return new ApiAuthenticationController(
+            $container->get('user_service_acl'),
             $container->get(ApiAppService::class),
-            $container->get('user_service_acl')
         );
     }
 }

--- a/module/User/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiControllerFactory.php
@@ -11,14 +11,14 @@ class ApiControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return ApiController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): ApiController {
         return new ApiController(
             $container->get('user_service_acl'),

--- a/module/User/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiControllerFactory.php
@@ -18,11 +18,11 @@ class ApiControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): ApiController {
         return new ApiController(
+            $container->get('user_service_acl'),
             $container->get('decision_service_memberinfo'),
-            $container->get('user_service_acl')
         );
     }
 }

--- a/module/User/src/Controller/Factory/UserControllerFactory.php
+++ b/module/User/src/Controller/Factory/UserControllerFactory.php
@@ -18,10 +18,10 @@ class UserControllerFactory implements FactoryInterface
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null
+        array $options = null,
     ): UserController {
         return new UserController(
-            $container->get('user_service_user')
+            $container->get('user_service_user'),
         );
     }
 }

--- a/module/User/src/Controller/Factory/UserControllerFactory.php
+++ b/module/User/src/Controller/Factory/UserControllerFactory.php
@@ -11,14 +11,14 @@ class UserControllerFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param null|array $options
+     * @param array|null $options
      *
      * @return UserController
      */
     public function __invoke(
         ContainerInterface $container,
         $requestedName,
-        array $options = null,
+        ?array $options = null,
     ): UserController {
         return new UserController(
             $container->get('user_service_user'),

--- a/module/User/src/Controller/UserController.php
+++ b/module/User/src/Controller/UserController.php
@@ -2,6 +2,7 @@
 
 namespace User\Controller;
 
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -30,7 +31,7 @@ class UserController extends AbstractActionController
     /**
      * User login action.
      */
-    public function indexAction()
+    public function indexAction(): Response|ViewModel
     {
         $referer = $this->getRequest()->getServer('HTTP_REFERER');
 
@@ -61,7 +62,7 @@ class UserController extends AbstractActionController
      *
      * @return LoginForm
      */
-    private function handleRedirect(?string $referer)
+    private function handleRedirect(?string $referer): LoginForm
     {
         $form = $this->userService->getLoginForm();
         if (is_null($form->get('redirect')->getValue())) {
@@ -85,7 +86,7 @@ class UserController extends AbstractActionController
         return $form;
     }
 
-    public function pinLoginAction()
+    public function pinLoginAction(): JsonModel
     {
         if ($this->getRequest()->isPost()) {
             $data = $this->getRequest()->getPost();
@@ -112,7 +113,7 @@ class UserController extends AbstractActionController
     /**
      * User logout action.
      */
-    public function logoutAction()
+    public function logoutAction(): Response
     {
         $this->userService->logout();
 
@@ -126,7 +127,7 @@ class UserController extends AbstractActionController
     /**
      * User register action.
      */
-    public function registerAction()
+    public function registerAction(): ViewModel
     {
         if ($this->getRequest()->isPost()) {
             $newUser = $this->userService->register($this->getRequest()->getPost());
@@ -151,7 +152,7 @@ class UserController extends AbstractActionController
     /**
      * Action to change password.
      */
-    public function passwordAction()
+    public function passwordAction(): ViewModel
     {
         $request = $this->getRequest();
 
@@ -173,7 +174,7 @@ class UserController extends AbstractActionController
     /**
      * Action to reset password.
      */
-    public function resetAction()
+    public function resetAction(): ViewModel
     {
         $request = $this->getRequest();
 
@@ -199,7 +200,7 @@ class UserController extends AbstractActionController
     /**
      * User activation action.
      */
-    public function activateAction()
+    public function activateAction(): Response|ViewModel
     {
         $code = $this->params()->fromRoute('code');
 

--- a/module/User/src/Controller/UserController.php
+++ b/module/User/src/Controller/UserController.php
@@ -7,7 +7,7 @@ use Laminas\View\Model\{
     JsonModel,
     ViewModel,
 };
-use Laminas\View\View;
+use User\Form\Login as LoginForm;
 use User\Service\User as UserService;
 
 class UserController extends AbstractActionController
@@ -56,21 +56,29 @@ class UserController extends AbstractActionController
         );
     }
 
-    private function handleRedirect($referer)
+    /**
+     * @param string|null $referer
+     *
+     * @return LoginForm
+     */
+    private function handleRedirect(?string $referer)
     {
         $form = $this->userService->getLoginForm();
         if (is_null($form->get('redirect')->getValue())) {
             $redirect = $this->getRequest()->getQuery('redirect');
+
             if (isset($redirect)) {
                 $form->get('redirect')->setValue($redirect);
 
                 return $form;
             }
-            if (isset($referer)) {
+
+            if (null !== $referer) {
                 $form->get('redirect')->setValue($referer);
 
                 return $form;
             }
+
             $form->get('redirect')->setValue($this->url()->fromRoute('home'));
         }
 

--- a/module/User/src/Form/Activate.php
+++ b/module/User/src/Form/Activate.php
@@ -17,6 +17,9 @@ use Laminas\Validator\{
 
 class Activate extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();

--- a/module/User/src/Form/ApiToken.php
+++ b/module/User/src/Form/ApiToken.php
@@ -13,6 +13,9 @@ use Laminas\Validator\StringLength;
 
 class ApiToken extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translator
+     */
     public function __construct(Translator $translator)
     {
         parent::__construct();

--- a/module/User/src/Form/Login.php
+++ b/module/User/src/Form/Login.php
@@ -12,20 +12,23 @@ use Laminas\Form\Element\{
     Text,
 };
 use Laminas\Form\Form;
+use Laminas\InputFilter\InputProviderInterface;
 use Laminas\Mvc\I18n\Translator;
-use Laminas\InputFilter\InputFilter;
 use Laminas\Validator\{
     NotEmpty,
     StringLength,
 };
 
-class Login extends Form
+class Login extends Form implements InputProviderInterface
 {
     /**
      * @var Translator
      */
     protected Translator $translate;
 
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();
@@ -87,14 +90,14 @@ class Login extends Form
                 'type' => Csrf::class,
             ]
         );
-
-        $this->initFilters();
     }
 
     /**
      * Set authentication result.
+     *
+     * @param Result $result
      */
-    public function setResult(Result $result)
+    public function setResult(Result $result): void
     {
         if (!$result->isValid()) {
             switch ($result->getCode()) {
@@ -129,25 +132,21 @@ class Login extends Form
         }
     }
 
-    protected function initFilters()
+    /**
+     * @return array
+     */
+    public function getInputSpecification(): array
     {
-        $filter = new InputFilter();
-
-        $filter->add(
-            [
-                'name' => 'login',
+        return [
+            'login' => [
                 'required' => true,
                 'validators' => [
                     [
                         'name' => NotEmpty::class,
                     ],
                 ],
-            ]
-        );
-
-        $filter->add(
-            [
-                'name' => 'password',
+            ],
+            'password' => [
                 'required' => true,
                 'validators' => [
                     [
@@ -160,9 +159,7 @@ class Login extends Form
                         ],
                     ],
                 ],
-            ]
-        );
-
-        $this->setInputFilter($filter);
+            ],
+        ];
     }
 }

--- a/module/User/src/Form/Password.php
+++ b/module/User/src/Form/Password.php
@@ -17,6 +17,9 @@ use Laminas\Validator\{
 
 class Password extends Form implements InputFilterProviderInterface
 {
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();

--- a/module/User/src/Form/Register.php
+++ b/module/User/src/Form/Register.php
@@ -8,15 +8,15 @@ use Laminas\Form\Element\{
     Submit,
 };
 use Laminas\Form\Form;
+use Laminas\InputFilter\InputProviderInterface;
 use Laminas\Mvc\I18n\Translator;
-use Laminas\InputFilter\InputFilter;
 use Laminas\Validator\{
     Digits,
     EmailAddress,
     NotEmpty,
 };
 
-class Register extends Form
+class Register extends Form implements InputProviderInterface
 {
     public const ERROR_WRONG_EMAIL = 'wrong_email';
     public const ERROR_MEMBER_NOT_EXISTS = 'member_not_exists';
@@ -28,6 +28,9 @@ class Register extends Form
      */
     protected Translator $translate;
 
+    /**
+     * @param Translator $translate
+     */
     public function __construct(Translator $translate)
     {
         parent::__construct();
@@ -62,8 +65,6 @@ class Register extends Form
                 ],
             ]
         );
-
-        $this->initFilters();
     }
 
     /**
@@ -71,7 +72,7 @@ class Register extends Form
      *
      * @param string $error
      */
-    public function setError($error)
+    public function setError(string $error): void
     {
         switch ($error) {
             case self::ERROR_WRONG_EMAIL:
@@ -113,13 +114,13 @@ class Register extends Form
         }
     }
 
-    protected function initFilters()
+    /**
+     * @return array
+     */
+    public function getInputSpecification(): array
     {
-        $filter = new InputFilter();
-
-        $filter->add(
-            [
-                'name' => 'lidnr',
+        return [
+            'lidnr' => [
                 'required' => true,
                 'validators' => [
                     [
@@ -129,12 +130,8 @@ class Register extends Form
                         'name' => Digits::class,
                     ],
                 ],
-            ]
-        );
-
-        $filter->add(
-            [
-                'name' => 'email',
+            ],
+            'email' => [
                 'required' => true,
                 'validators' => [
                     [
@@ -144,9 +141,7 @@ class Register extends Form
                         'name' => EmailAddress::class,
                     ],
                 ],
-            ]
-        );
-
-        $this->setInputFilter($filter);
+            ],
+        ];
     }
 }

--- a/module/User/src/Mapper/ApiUser.php
+++ b/module/User/src/Mapper/ApiUser.php
@@ -14,9 +14,13 @@ class ApiUser extends BaseMapper
      *
      * @return ApiUserModel|null
      */
-    public function findByToken($token): ?ApiUserModel
+    public function findByToken(string $token): ?ApiUserModel
     {
-        return $this->getRepository()->findOneBy(['token' => $token]);
+        return $this->getRepository()->findOneBy(
+            [
+                'token' => $token,
+            ]
+        );
     }
 
     /**

--- a/module/User/src/Mapper/Factory/ApiAppFactory.php
+++ b/module/User/src/Mapper/Factory/ApiAppFactory.php
@@ -9,10 +9,19 @@ use User\Mapper\ApiApp;
 class ApiAppFactory implements FactoryInterface
 {
     /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param array|null $options
+     *
      * @return ApiApp
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
-    {
-        return new ApiApp($container->get('doctrine.entitymanager.orm_default'));
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): ApiApp {
+        return new ApiApp(
+            $container->get('doctrine.entitymanager.orm_default'),
+        );
     }
 }

--- a/module/User/src/Mapper/LoginAttempt.php
+++ b/module/User/src/Mapper/LoginAttempt.php
@@ -3,12 +3,28 @@
 namespace User\Mapper;
 
 use Application\Mapper\BaseMapper;
-use User\Model\LoginAttempt as LoginAttemptModel;
+use DateTime;
+use User\Model\{
+    LoginAttempt as LoginAttemptModel,
+    User as UserModel,
+};
 
 class LoginAttempt extends BaseMapper
 {
-    public function getFailedAttemptCount($since, $type, $ip, $user = null)
-    {
+    /**
+     * @param DateTime $since
+     * @param string $type
+     * @param string $ip
+     * @param UserModel|null $user
+     *
+     * @return int|string
+     */
+    public function getFailedAttemptCount(
+        DateTime $since,
+        string $type,
+        string $ip,
+        ?UserModel $user = null,
+    ): int|string {
         $qb = $this->em->createQueryBuilder();
         $qb->select('count(a)')
             ->from($this->getRepositoryName(), 'a')

--- a/module/User/src/Mapper/NewUser.php
+++ b/module/User/src/Mapper/NewUser.php
@@ -3,7 +3,7 @@
 namespace User\Mapper;
 
 use Application\Mapper\BaseMapper;
-use Decision\Model\Member;
+use Decision\Model\Member as MemberModel;
 use User\Model\NewUser as NewUserModel;
 
 class NewUser extends BaseMapper
@@ -15,7 +15,7 @@ class NewUser extends BaseMapper
      *
      * @return NewUserModel|null
      */
-    public function getByLidnr($lidnr): ?NewUserModel
+    public function getByLidnr(int $lidnr): ?NewUserModel
     {
         $qb = $this->em->createQueryBuilder();
         $qb->select('u, m')
@@ -37,7 +37,7 @@ class NewUser extends BaseMapper
      *
      * @return NewUserModel|null
      */
-    public function getByCode($code): ?NewUserModel
+    public function getByCode(string $code): ?NewUserModel
     {
         $qb = $this->em->createQueryBuilder();
         $qb->select('u, m')
@@ -55,9 +55,11 @@ class NewUser extends BaseMapper
     /**
      * Delete the existing activation code for a member.
      *
-     * @return array
+     * @param MemberModel $member
+     *
+     * @return int
      */
-    public function deleteByMember(Member $member)
+    public function deleteByMember(MemberModel $member): int
     {
         $qb = $this->em->createQueryBuilder();
         $qb->delete($this->getRepositoryName(), 'u');

--- a/module/User/src/Mapper/User.php
+++ b/module/User/src/Mapper/User.php
@@ -27,7 +27,7 @@ class User extends BaseMapper
      *
      * @return UserModel|null
      */
-    public function findByLogin($login): ?UserModel
+    public function findByLogin(string $login): ?UserModel
     {
         // create query for user
         $qb = $this->em->createQueryBuilder();
@@ -60,8 +60,10 @@ class User extends BaseMapper
      * @param UserModel $user User to create
      * @param NewUserModel $newUser NewUser to destroy
      */
-    public function createUser(UserModel $user, NewUserModel $newUser)
-    {
+    public function createUser(
+        UserModel $user,
+        NewUserModel $newUser,
+    ): void {
         $this->em->persist($user);
         $this->em->remove($newUser);
         $this->em->flush();

--- a/module/User/src/Module.php
+++ b/module/User/src/Module.php
@@ -71,7 +71,7 @@ class Module
         // there is a NotAllowedException
         $em->attach(
             MvcEvent::EVENT_DISPATCH_ERROR,
-            function ($e) {
+            function ($e): void {
                 if (
                     'error-exception' == $e->getError()
                     && null != $e->getParam('exception', null)

--- a/module/User/src/Module.php
+++ b/module/User/src/Module.php
@@ -3,31 +3,44 @@
 namespace User;
 
 use Doctrine\Laminas\Hydrator\DoctrineObject;
+use Laminas\Authentication\AuthenticationService as LaminasAuthenticationService;
 use Laminas\Crypt\Password\Bcrypt;
 use Laminas\Http\PhpEnvironment\RemoteAddress;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\MvcEvent;
 use Interop\Container\ContainerInterface;
-use User\Authentication\Adapter\ApiMapper;
-use User\Authentication\Adapter\Mapper;
-use User\Authentication\Adapter\PinMapper;
-use User\Authentication\ApiAuthenticationService;
+use User\Authentication\{
+    Adapter\ApiMapper,
+    Adapter\Mapper,
+    Adapter\PinMapper,
+    ApiAuthenticationService,
+    AuthenticationService,
+    Service\LoginAttempt as LoginAttemptService,
+};
 use User\Authorization\AclServiceFactory;
-use User\Mapper\User;
-use User\Mapper\Factory\ApiAppFactory as ApiAppMapperFactory;
-use User\Service\Factory\ApiAppFactory as ApiAppServiceFactory;
-use User\Form\Activate;
-use User\Form\ApiToken;
-use User\Form\Login;
-use User\Form\Password;
-use User\Form\Register;
-use User\Mapper\ApiUser;
-use User\Mapper\LoginAttempt;
-use User\Mapper\NewUser;
+use User\Mapper\{
+    User as UserMapper,
+    Factory\ApiAppFactory as ApiAppMapperFactory,
+    ApiUser as ApiUserMapper,
+    LoginAttempt as LoginAttemptMapper,
+    NewUser as NewUserMapper,
+    ApiApp as ApiAppMapper,
+};
+use User\Form\{
+    Activate as ActivateForm,
+    ApiToken as ApiTokenForm,
+    Login as LoginForm,
+    Password as PasswordForm,
+    Register as RegisterForm,
+};
 use User\Permissions\NotAllowedException;
-use User\Mapper\ApiApp as ApiAppMapper;
-use User\Service\ApiApp as ApiAppService;
-use User\Service\Email;
+use User\Service\{
+    ApiApp as ApiAppService,
+    ApiUser as ApiUserService,
+    Factory\ApiAppFactory as ApiAppServiceFactory,
+    Email as EmailService,
+    User as UserService,
+};
 
 class Module
 {
@@ -36,7 +49,7 @@ class Module
      *
      * @param MvcEvent $e
      */
-    public function onBootstrap(MvcEvent $e)
+    public function onBootstrap(MvcEvent $e): void
     {
         $em = $e->getApplication()->getEventManager();
 
@@ -89,14 +102,15 @@ class Module
      *
      * @return array Service configuration
      */
-    public function getServiceConfig()
+    public function getServiceConfig(): array
     {
         return [
             'aliases' => [
-                'Laminas\Authentication\AuthenticationService' => 'user_auth_service',
+                LaminasAuthenticationService::class => 'user_auth_service',
             ],
             'factories' => [
                 'user_service_user' => function (ContainerInterface $container) {
+                    $aclService = $container->get('user_service_acl');
                     $translator = $container->get('translator');
                     $bcrypt = $container->get('user_bcrypt');
                     $authService = $container->get('user_auth_service');
@@ -109,9 +123,9 @@ class Module
                     $activateForm = $container->get('user_form_activate');
                     $loginForm = $container->get('user_form_login');
                     $passwordForm = $container->get('user_form_password');
-                    $aclService = $container->get('user_service_acl');
 
-                    return new Service\User(
+                    return new UserService(
+                        $aclService,
                         $translator,
                         $bcrypt,
                         $authService,
@@ -124,7 +138,6 @@ class Module
                         $activateForm,
                         $loginForm,
                         $passwordForm,
-                        $aclService
                     );
                 },
                 'user_service_loginattempt' => function (ContainerInterface $container) {
@@ -134,21 +147,26 @@ class Module
                     $userMapper = $container->get('user_mapper_user');
                     $rateLimitConfig = $container->get('config')['login_rate_limits'];
 
-                    return new Authentication\Service\LoginAttempt(
+                    return new LoginAttemptService(
                         $remoteAddress,
                         $entityManager,
                         $loginAttemptMapper,
                         $userMapper,
-                        $rateLimitConfig
+                        $rateLimitConfig,
                     );
                 },
                 'user_service_apiuser' => function (ContainerInterface $container) {
-                    $apiUserMapper = $container->get('user_mapper_apiuser');
-                    $apiTokenForm = $container->get('user_form_apitoken');
                     $aclService = $container->get('user_service_acl');
                     $translator = $container->get('translator');
+                    $apiUserMapper = $container->get('user_mapper_apiuser');
+                    $apiTokenForm = $container->get('user_form_apitoken');
 
-                    return new Service\ApiUser($apiUserMapper, $apiTokenForm, $aclService, $translator);
+                    return new ApiUserService(
+                        $aclService,
+                        $translator,
+                        $apiUserMapper,
+                        $apiTokenForm,
+                    );
                 },
                 'user_service_email' => function (ContainerInterface $container) {
                     $translator = $container->get('translator');
@@ -156,7 +174,12 @@ class Module
                     $transport = $container->get('user_mail_transport');
                     $emailConfig = $container->get('config')['email'];
 
-                    return new Email($translator, $renderer, $transport, $emailConfig);
+                    return new EmailService(
+                        $translator,
+                        $renderer,
+                        $transport,
+                        $emailConfig,
+                    );
                 },
                 ApiAppMapper::class => ApiAppMapperFactory::class,
                 ApiAppService::class => ApiAppServiceFactory::class,
@@ -168,7 +191,7 @@ class Module
                     return new Authentication\Storage\Session(
                         $request,
                         $response,
-                        $config
+                        $config,
                     );
                 },
                 'user_bcrypt' => function (ContainerInterface $container) {
@@ -181,36 +204,36 @@ class Module
 
                 'user_hydrator' => function (ContainerInterface $container) {
                     return new DoctrineObject(
-                        $container->get('doctrine.entitymanager.orm_default')
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'user_form_activate' => function (ContainerInterface $container) {
-                    return new Activate(
-                        $container->get('translator')
+                    return new ActivateForm(
+                        $container->get('translator'),
                     );
                 },
                 'user_form_register' => function (ContainerInterface $container) {
-                    return new Register(
-                        $container->get('translator')
+                    return new RegisterForm(
+                        $container->get('translator'),
                     );
                 },
                 'user_form_login' => function (ContainerInterface $container) {
-                    return new Login(
-                        $container->get('translator')
+                    return new LoginForm(
+                        $container->get('translator'),
                     );
                 },
                 'user_form_password' => function (ContainerInterface $container) {
-                    return new Password(
-                        $container->get('translator')
+                    return new PasswordForm(
+                        $container->get('translator'),
                     );
                 },
                 'user_form_passwordactivate' => function (ContainerInterface $container) {
-                    return new Activate(
-                        $container->get('translator')
+                    return new ActivateForm(
+                        $container->get('translator'),
                     );
                 },
                 'user_form_apitoken' => function (ContainerInterface $container) {
-                    $form = new ApiToken(
+                    $form = new ApiTokenForm(
                         $container->get('translator')
                     );
                     $form->setHydrator($container->get('user_hydrator'));
@@ -219,23 +242,23 @@ class Module
                 },
 
                 'user_mapper_user' => function (ContainerInterface $container) {
-                    return new User(
-                        $container->get('doctrine.entitymanager.orm_default')
+                    return new UserMapper(
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'user_mapper_newuser' => function (ContainerInterface $container) {
-                    return new NewUser(
-                        $container->get('doctrine.entitymanager.orm_default')
+                    return new NewUserMapper(
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'user_mapper_apiuser' => function (ContainerInterface $container) {
-                    return new ApiUser(
-                        $container->get('doctrine.entitymanager.orm_default')
+                    return new ApiUserMapper(
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
                 'user_mapper_loginattempt' => function (ContainerInterface $container) {
-                    return new LoginAttempt(
-                        $container->get('doctrine.entitymanager.orm_default')
+                    return new LoginAttemptMapper(
+                        $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },
 
@@ -253,35 +276,35 @@ class Module
                     return new Mapper(
                         $container->get('user_bcrypt'),
                         $container->get('user_service_loginattempt'),
-                        $container->get('user_mapper_user')
+                        $container->get('user_mapper_user'),
                     );
                 },
                 'user_apiauth_adapter' => function (ContainerInterface $container) {
                     return new ApiMapper(
-                        $container->get('user_mapper_apiuser')
+                        $container->get('user_mapper_apiuser'),
                     );
                 },
                 'user_pin_auth_adapter' => function (ContainerInterface $container) {
                     return new PinMapper(
                         $container->get('user_service_loginattempt'),
-                        $container->get('user_mapper_user')
+                        $container->get('user_mapper_user'),
                     );
                 },
                 'user_auth_service' => function (ContainerInterface $container) {
-                    return new Authentication\AuthenticationService(
+                    return new AuthenticationService(
                         $container->get('user_auth_storage'),
-                        $container->get('user_auth_adapter')
+                        $container->get('user_auth_adapter'),
                     );
                 },
                 'user_apiauth_service' => function (ContainerInterface $container) {
-                    return new Authentication\ApiAuthenticationService(
-                        $container->get('user_apiauth_adapter')
+                    return new ApiAuthenticationService(
+                        $container->get('user_apiauth_adapter'),
                     );
                 },
                 'user_pin_auth_service' => function (ContainerInterface $container) {
-                    return new Authentication\AuthenticationService(
+                    return new AuthenticationService(
                         $container->get('user_auth_storage'),
-                        $container->get('user_pin_auth_adapter')
+                        $container->get('user_pin_auth_adapter'),
                     );
                 },
                 'user_remoteaddress' => function (ContainerInterface $container) {

--- a/module/User/src/Permissions/Assertion/IsCreator.php
+++ b/module/User/src/Permissions/Assertion/IsCreator.php
@@ -24,13 +24,20 @@ class IsCreator implements AssertionInterface
      * @param Acl $acl
      * @param RoleInterface|null $role
      * @param ResourceInterface|null $resource
-     * @param string $privilege
+     * @param string|null $privilege
      *
      * @return bool
      */
-    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null): bool
-    {
-        if (!$role instanceof User || !$resource instanceof CreatorResourceInterface) {
+    public function assert(
+        Acl $acl,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
+        $privilege = null,
+    ): bool {
+        if (
+            !$role instanceof User
+            || !$resource instanceof CreatorResourceInterface
+        ) {
             return false;
         }
 

--- a/module/User/src/Permissions/Assertion/IsCreatorOrOrganMember.php
+++ b/module/User/src/Permissions/Assertion/IsCreatorOrOrganMember.php
@@ -23,12 +23,16 @@ class IsCreatorOrOrganMember implements AssertionInterface
      * @param Acl $acl
      * @param RoleInterface|null $role
      * @param ResourceInterface|null $resource
-     * @param string $privilege
+     * @param string|null $privilege
      *
      * @return bool
      */
-    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null): bool
-    {
+    public function assert(
+        Acl $acl,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
+        $privilege = null,
+    ): bool {
         $isCreator = new IsCreator();
         $isOrganMember = new IsOrganMember();
 

--- a/module/User/src/Permissions/Assertion/IsOrganMember.php
+++ b/module/User/src/Permissions/Assertion/IsOrganMember.php
@@ -29,13 +29,20 @@ class IsOrganMember implements AssertionInterface
      * @param Acl $acl
      * @param RoleInterface|null $role
      * @param ResourceInterface|null $resource
-     * @param string $privilege
+     * @param string|null $privilege
      *
      * @return bool
      */
-    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null): bool
-    {
-        if (!$role instanceof User || !$resource instanceof OrganResourceInterface) {
+    public function assert(
+        Acl $acl,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
+        $privilege = null,
+    ): bool {
+        if (
+            !$role instanceof User
+            || !$resource instanceof OrganResourceInterface
+        ) {
             return false;
         }
 
@@ -61,9 +68,11 @@ class IsOrganMember implements AssertionInterface
     /**
      * Check if this is a current organ member.
      *
+     * @param OrganMember $organMember
+     *
      * @return bool
      */
-    protected function isCurrentMember(OrganMember $organMember)
+    protected function isCurrentMember(OrganMember $organMember): bool
     {
         $now = new DateTime();
 

--- a/module/User/src/Permissions/Resource/CreatorResourceInterface.php
+++ b/module/User/src/Permissions/Resource/CreatorResourceInterface.php
@@ -12,5 +12,5 @@ interface CreatorResourceInterface extends ResourceInterface
      *
      * @return User
      */
-    public function getResourceCreator();
+    public function getResourceCreator(): User;
 }

--- a/module/User/src/Permissions/Resource/OrganResourceInterface.php
+++ b/module/User/src/Permissions/Resource/OrganResourceInterface.php
@@ -10,7 +10,7 @@ interface OrganResourceInterface extends ResourceInterface
     /**
      * Get the organ of this resource.
      *
-     * @return Organ
+     * @return ?Organ
      */
-    public function getResourceOrgan();
+    public function getResourceOrgan(): ?Organ;
 }

--- a/module/User/src/Service/AclService.php
+++ b/module/User/src/Service/AclService.php
@@ -38,9 +38,6 @@ class AclService extends GenericAclService
         return $this->acl;
     }
 
-    /**
-     * @return void
-     */
     protected function createAcl(): void
     {
         // initialize the ACL

--- a/module/User/src/Service/AclService.php
+++ b/module/User/src/Service/AclService.php
@@ -2,7 +2,7 @@
 
 namespace User\Service;
 
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Mvc\I18n\Translator;
 use Laminas\Permissions\Acl\Acl;
 use Laminas\Permissions\Acl\Resource\GenericResource as Resource;
 use Laminas\Permissions\Acl\Role\GenericRole as Role;
@@ -14,25 +14,34 @@ use User\Authorization\GenericAclService;
 
 class AclService extends GenericAclService
 {
+    /**
+     * @var Acl
+     */
     protected Acl $acl;
 
     public function __construct(
-        TranslatorInterface $translator,
+        Translator $translator,
         AuthenticationService $authService,
         ApiAuthenticationService $apiAuthService,
         string $remoteAddress,
-        string $tueRange
+        string $tueRange,
     ) {
         parent::__construct($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
         $this->createAcl();
     }
 
+    /**
+     * @return Acl
+     */
     protected function getAcl(): Acl
     {
         return $this->acl;
     }
 
-    protected function createAcl()
+    /**
+     * @return void
+     */
+    protected function createAcl(): void
     {
         // initialize the ACL
         $this->acl = new Acl();

--- a/module/User/src/Service/ApiApp.php
+++ b/module/User/src/Service/ApiApp.php
@@ -28,7 +28,7 @@ class ApiApp
      * Get a callback from an appId and a user identity.
      *
      * @param string $appId
-     *
+     * @param UserModel $user
      * @return string
      */
     public function callbackWithToken(

--- a/module/User/src/Service/ApiApp.php
+++ b/module/User/src/Service/ApiApp.php
@@ -12,10 +12,12 @@ class ApiApp
     /**
      * @var ApiAppMapper
      */
-    protected $mapper;
+    protected ApiAppMapper $mapper;
 
     /**
      * Constructor.
+     *
+     * @param ApiAppMapper $mapper
      */
     public function __construct(ApiAppMapper $mapper)
     {
@@ -29,8 +31,10 @@ class ApiApp
      *
      * @return string
      */
-    public function callbackWithToken($appId, UserModel $user)
-    {
+    public function callbackWithToken(
+        string $appId,
+        UserModel $user,
+    ): string {
         $app = $this->getMapper()->findByAppId($appId);
 
         $token = [
@@ -47,7 +51,7 @@ class ApiApp
     /**
      * @return ApiAppMapper
      */
-    public function getMapper()
+    public function getMapper(): ApiAppMapper
     {
         return $this->mapper;
     }

--- a/module/User/src/Service/ApiUser.php
+++ b/module/User/src/Service/ApiUser.php
@@ -15,16 +15,6 @@ use User\Permissions\NotAllowedException;
 class ApiUser
 {
     /**
-     * @var ApiUserMapper
-     */
-    private ApiUserMapper $apiUserMapper;
-
-    /**
-     * @var ApiTokenForm
-     */
-    private ApiTokenForm $apiTokenForm;
-
-    /**
      * @var AclService
      */
     private AclService $aclService;
@@ -35,23 +25,38 @@ class ApiUser
     private Translator $translator;
 
     /**
+     * @var ApiUserMapper
+     */
+    private ApiUserMapper $apiUserMapper;
+
+    /**
+     * @var ApiTokenForm
+     */
+    private ApiTokenForm $apiTokenForm;
+
+    /**
      * Identity storage.
      *
      * @var ApiUserModel
      */
     protected ApiUserModel $identity;
 
-
+    /**
+     * @param AclService $aclService
+     * @param Translator $translator
+     * @param ApiUserMapper $apiUserMapper
+     * @param ApiTokenForm $apiTokenForm
+     */
     public function __construct(
-        ApiUserMapper $apiUserMapper,
-        ApiTokenForm $apiTokenForm,
         AclService $aclService,
         Translator $translator,
+        ApiUserMapper $apiUserMapper,
+        ApiTokenForm $apiTokenForm,
     ) {
-        $this->apiUserMapper = $apiUserMapper;
-        $this->apiTokenForm = $apiTokenForm;
         $this->aclService = $aclService;
         $this->translator = $translator;
+        $this->apiUserMapper = $apiUserMapper;
+        $this->apiTokenForm = $apiTokenForm;
     }
 
     /**

--- a/module/User/src/Service/ApiUser.php
+++ b/module/User/src/Service/ApiUser.php
@@ -2,7 +2,7 @@
 
 namespace User\Service;
 
-use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Exception\ORMException;
 use Laminas\Mvc\I18n\Translator;
 use User\Form\ApiToken as ApiTokenForm;
 use User\Mapper\ApiUser as ApiUserMapper;

--- a/module/User/src/Service/ApiUser.php
+++ b/module/User/src/Service/ApiUser.php
@@ -35,13 +35,6 @@ class ApiUser
     private ApiTokenForm $apiTokenForm;
 
     /**
-     * Identity storage.
-     *
-     * @var ApiUserModel
-     */
-    protected ApiUserModel $identity;
-
-    /**
      * @param AclService $aclService
      * @param Translator $translator
      * @param ApiUserMapper $apiUserMapper

--- a/module/User/src/Service/Email.php
+++ b/module/User/src/Service/Email.php
@@ -15,28 +15,34 @@ class Email
     /**
      * @var Translator
      */
-    private $translator;
+    private Translator $translator;
 
     /**
      * @var PhpRenderer
      */
-    private $renderer;
+    private PhpRenderer $renderer;
 
     /**
      * @var TransportInterface
      */
-    private $transport;
+    private TransportInterface $transport;
 
     /**
      * @var array
      */
-    private $emailConfig;
+    private array $emailConfig;
 
+    /**
+     * @param Translator $translator
+     * @param PhpRenderer $renderer
+     * @param TransportInterface $transport
+     * @param array $emailConfig
+     */
     public function __construct(
         Translator $translator,
         PhpRenderer $renderer,
         TransportInterface $transport,
-        array $emailConfig
+        array $emailConfig,
     ) {
         $this->translator = $translator;
         $this->renderer = $renderer;
@@ -46,9 +52,14 @@ class Email
 
     /**
      * Send registration email.
+     *
+     * @param NewUserModel $newUser
+     * @param MemberModel $member
      */
-    public function sendRegisterEmail(NewUserModel $newUser, MemberModel $member)
-    {
+    public function sendRegisterEmail(
+        NewUserModel $newUser,
+        MemberModel $member,
+    ): void {
         $body = $this->render(
             'user/email/register',
             [
@@ -73,8 +84,10 @@ class Email
      * @param NewUserModel $newUser
      * @param MemberModel $member
      */
-    public function sendPasswordLostMail(NewUserModel $newUser, MemberModel $member)
-    {
+    public function sendPasswordLostMail(
+        NewUserModel $newUser,
+        MemberModel $member,
+    ): void {
         $body = $this->render(
             'user/email/reset',
             [
@@ -99,10 +112,12 @@ class Email
      * @param string $template
      * @param array $vars
      *
-     * @return string/
+     * @return string
      */
-    public function render($template, $vars)
-    {
+    public function render(
+        string $template,
+        array $vars,
+    ): string {
         $model = new ViewModel($vars);
         $model->setTemplate($template);
 

--- a/module/User/src/Service/Factory/ApiAppFactory.php
+++ b/module/User/src/Service/Factory/ApiAppFactory.php
@@ -4,15 +4,25 @@ namespace User\Service\Factory;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use User\Mapper\ApiApp as ApiAppMapper;
 use User\Service\ApiApp;
 
 class ApiAppFactory implements FactoryInterface
 {
     /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param array|null $options
+     *
      * @return ApiApp
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
-    {
-        return new ApiApp($container->get(\User\Mapper\ApiApp::class));
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): ApiApp {
+        return new ApiApp(
+            $container->get(ApiAppMapper::class),
+        );
     }
 }

--- a/module/User/src/Service/User.php
+++ b/module/User/src/Service/User.php
@@ -440,7 +440,7 @@ class User
         $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
         for ($i = 0; $i < $length; ++$i) {
-            $ret .= $alphabet[rand(0, strlen($alphabet) - 1)];
+            $ret .= $alphabet[random_int(0, strlen($alphabet) - 1)];
         }
 
         return $ret;

--- a/module/User/src/Service/User.php
+++ b/module/User/src/Service/User.php
@@ -33,6 +33,11 @@ use User\Permissions\NotAllowedException;
 class User
 {
     /**
+     * @var AclService
+     */
+    private AclService $aclService;
+
+    /**
      * @var Translator
      */
     private Translator $translator;
@@ -95,11 +100,22 @@ class User
     private PasswordForm $passwordForm;
 
     /**
-     * @var AclService
+     * @param AclService $aclService
+     * @param Translator $translator
+     * @param Bcrypt $bcrypt
+     * @param AuthenticationService $authService
+     * @param AuthenticationService $pinAuthService
+     * @param Email $emailService
+     * @param UserMapper $userMapper
+     * @param NewUserMapper $newUserMapper
+     * @param MemberMapper $memberMapper
+     * @param RegisterForm $registerForm
+     * @param ActivateForm $activateForm
+     * @param LoginForm $loginForm
+     * @param PasswordForm $passwordForm
      */
-    private AclService $aclService;
-
     public function __construct(
+        AclService $aclService,
         Translator $translator,
         Bcrypt $bcrypt,
         AuthenticationService $authService,
@@ -112,8 +128,8 @@ class User
         ActivateForm $activateForm,
         LoginForm $loginForm,
         PasswordForm $passwordForm,
-        AclService $aclService,
     ) {
+        $this->aclService = $aclService;
         $this->translator = $translator;
         $this->bcrypt = $bcrypt;
         $this->authService = $authService;
@@ -126,7 +142,6 @@ class User
         $this->activateForm = $activateForm;
         $this->loginForm = $loginForm;
         $this->passwordForm = $passwordForm;
-        $this->aclService = $aclService;
     }
 
     /**
@@ -137,12 +152,14 @@ class User
      *
      * @return bool
      */
-    public function activate(Parameters $data, NewUserModel $newUser): bool
-    {
+    public function activate(
+        Parameters $data,
+        NewUserModel $newUser,
+    ): bool {
         $form = $this->activateForm;
 
         $form->setData($data);
-
+        // TODO: Move form validation to controller.
         if (!$form->isValid()) {
             return false;
         }
@@ -177,7 +194,7 @@ class User
     {
         $form = $this->registerForm;
         $form->setData($data);
-
+        // TODO: Move form validation to controller.
         if (!$form->isValid()) {
             return null;
         }
@@ -244,7 +261,7 @@ class User
     {
         $form = $this->registerForm;
         $form->setData($data);
-
+        // TODO: Move form validation to controller.
         if (!$form->isValid()) {
             return null;
         }
@@ -295,7 +312,7 @@ class User
         $form = $this->getPasswordForm();
 
         $form->setData($data);
-
+        // TODO: Move form validation to controller.
         if (!$form->isValid()) {
             return false;
         }
@@ -344,7 +361,7 @@ class User
     {
         $form = $this->getLoginForm();
         $form->setData($data);
-
+        // TODO: Move form validation to controller.
         if (!$form->isValid()) {
             return null;
         }

--- a/module/User/test/ControllerTest.php
+++ b/module/User/test/ControllerTest.php
@@ -6,25 +6,25 @@ use ApplicationTest\BaseControllerTest;
 
 class ControllerTest extends BaseControllerTest
 {
-    public function testUserActionCanBeAccessed()
+    public function testUserActionCanBeAccessed(): void
     {
         $this->dispatch('/user');
         $this->assertResponseStatusCode(200);
     }
 
-    public function testUserRegisterActionCanBeAccessed()
+    public function testUserRegisterActionCanBeAccessed(): void
     {
         $this->dispatch('/user/register');
         $this->assertResponseStatusCode(200);
     }
 
-    public function testUserResetActionCanBeAccessed()
+    public function testUserResetActionCanBeAccessed(): void
     {
         $this->dispatch('/user/reset');
         $this->assertResponseStatusCode(200);
     }
 
-    public function testUserLogoutActionDoesRedirect()
+    public function testUserLogoutActionDoesRedirect(): void
     {
         $this->dispatch('/user/logout');
         $this->assertResponseStatusCode(302);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,11 @@ includes:
     - phpstan/phpstan-baseline-pr.neon
 
 parameters:
-    level: 5
-    treatPhpDocTypesAsCertain: false
+    level: 6
+    treatPhpDocTypesAsCertain: true
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false
+    reportUnmatchedIgnoredErrors: false
     bootstrapFiles:
         - bootstrap.php
     laminasframework:
@@ -23,5 +26,4 @@ parameters:
         - module/Photo/src
         - module/User/src
         - public/index.php
-    reportUnmatchedIgnoredErrors: false
     tmpDir: data/cache/phpstan

--- a/phpstan/phpstan-baseline.neon
+++ b/phpstan/phpstan-baseline.neon
@@ -11,3 +11,7 @@ parameters:
         - '#Property [a-zA-Z0-9\\_]+\:\:\$[a-zA-Z0-9_]+ type mapping mismatch\: property can contain Doctrine\\Common\\Collections\\Collection but database expects Doctrine\\Common\\Collections\\Collection\&iterable\<[a-zA-Z0-9\\_]+\>\.$#'
         - '#Property [a-zA-Z0-9\\_]+\:\:\$[a-zA-Z0-9_]+ type mapping mismatch\: database can contain [a-zA-Z0-9\\_]+\|null but property expects [a-zA-Z0-9\\_]+\.$#'
         - '#Call to an undefined method Laminas\\Form\\ElementInterface\:\:(count|getFieldSets|getValueOptions|populateValues|setCount|setValueOptions)\(\).$#'
+        -
+            message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ORM\\\\EntityManager\\:\\:getRepository\\(\\)$#"
+            count: 1
+            path: ../module/Application/src/Mapper/BaseMapper.php


### PR DESCRIPTION
This PR is based on #1309 and should be rebased once that is merged. Fixes (almost) all typing issues which are currently present in the code.

To accomplish this, I have locally changed my PHPStan configuration to be like this:

```yml
level: 6
treatPhpDocTypesAsCertain: true
checkMissingIterableValueType: false
checkGenericClassInNonGenericObjectType: false
```

The last two are necessary at the moment, because I do not have the time and motivation to determine all correct types for `arrays`, `Collection`s, etc.

**Modules:**
- [X] Activity
- [x] Application
- [x] Company
- [x] Decision
- [x] Education
- [x] Frontpage
- [x] Photo
- [x] User

This closes #1126.