### PR TITLE
Add GitHub Actions for analysis of pull requests

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,26 @@
+name: PHP Coding Standards
+
+# Only run this action when pushing to master or on pull requests (creation, synchronisation, and reopening).
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+
+jobs:
+    php-codesniffer:
+        name: PHP_CodeSniffer
+        runs-on: ubuntu-latest
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+
+            -   name: Install PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.1'
+                    tools: cs2pr, phpcs
+
+            -   name: Run PHPCS
+                run: phpcs --standard=PSR1,PSR12 --extensions=php,dist --report=checkstyle -q module config | cs2pr --graceful-warnings

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,102 @@
+name: PHP Static Analysis
+
+# Only run this action on pull requests (creation, synchronisation, and reopening).
+on: [pull_request]
+
+jobs:
+    phpstan:
+        name: PHPStan
+        runs-on: ubuntu-latest
+
+        # Create a MySQL service.
+        services:
+            mysql:
+                image: mariadb
+                env:
+                    MYSQL_ROOT_PASSWORD: gewis
+                    MYSQL_DATABASE: gewis
+                    MYSQL_USER: gewis
+                    MYSQL_PASSWORD: gewis
+                ports:
+                    - 3306:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+        steps:
+            -   name: Checkout head branch
+                uses: actions/checkout@v2
+
+            -   name: Install PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.1'
+                    extensions: calendar, curl, exif, gd, intl, opcache, pgsql, pdo_mysql, pdo_pgsql, soap, zip, imagick, memcached, xdebug
+                    tools: cs2pr
+
+            -   name: Get Composer cache directory
+                id: composer-cache-head
+                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            -   name: Cache dependencies
+                uses: actions/cache@v2
+                with:
+                    path: ${{ steps.composer-cache-head.outputs.dir }}
+                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: ${{ runner.os }}-composer-
+
+            -   name: Extract configuration files
+                run: |
+                    cp config/autoload/doctrine.local.development.php.dist config/autoload/doctrine.local.php
+                    cp config/autoload/laminas-developer-tools.local.php.dist config/autoload/laminas-developer-tools.local.php
+                    cp config/autoload/local.development.php.dist config/autoload/local.php
+
+            -   name: Check out master
+                run: |
+                    git fetch --all
+                    git update-ref refs/heads/temp-phpstanpr refs/remotes/origin/master
+                    git checkout --detach temp-phpstanpr
+
+            -   name: Install dependencies
+                run: composer install --no-interaction
+
+            -   name: Load environment variables
+                uses: c-py/action-dotenv-to-setenv@v3
+                with:
+                    env-file: .env.dist
+
+            -   name: Create database
+                env:
+                    DOCKER_DB_HOST: 127.0.0.1
+                run: ./orm orm:schema-tool:update --force
+
+            -   name: Generate PHPStan Baseline
+                env:
+                    DOCKER_DB_HOST: 127.0.0.1
+                run: |
+                    echo "" > phpstan/phpstan-baseline.neon
+                    echo "" > phpstan/phpstan-baseline-pr.neon
+                    vendor/bin/phpstan analyse -c phpstan.neon --generate-baseline phpstan/phpstan-baseline-temp.neon --memory-limit 1G --no-progress
+
+            -   name: Check out new branch
+                run: |
+                    git checkout -
+                    git checkout -- phpstan/phpstan-baseline.neon
+
+            -   name: Install dependencies
+                run: composer install --no-interaction
+
+            -   name: Load environment variables
+                uses: c-py/action-dotenv-to-setenv@v3
+                with:
+                    env-file: .env.dist
+
+            -   name: Create database
+                env:
+                    DOCKER_DB_HOST: 127.0.0.1
+                run: ./orm orm:schema-tool:update --force
+
+            -   name: Run PHPStan
+                env:
+                    DOCKER_DB_HOST: 127.0.0.1
+                run: |
+                    cp phpstan/phpstan-baseline-temp.neon phpstan/phpstan-baseline-pr.neon
+                    vendor/bin/phpstan analyse -c phpstan.neon --memory-limit 1G --no-progress --error-format=checkstyle | cs2pr

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,76 @@
+name: PHP Unit Tests
+
+# Only run this action when pushing to master or on pull requests (creation, synchronisation, and reopening).
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+
+jobs:
+    phpunit:
+        name: PHPUnit
+        runs-on: ubuntu-latest
+
+        # Create a MySQL service.
+        services:
+            mysql:
+                image: mariadb
+                env:
+                    MYSQL_ROOT_PASSWORD: gewis
+                    MYSQL_DATABASE: gewis
+                    MYSQL_USER: gewis
+                    MYSQL_PASSWORD: gewis
+                ports:
+                    - 3306:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+
+            -   name: Install PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.1'
+                    extensions: calendar, curl, exif, gd, intl, opcache, pgsql, pdo_mysql, pdo_pgsql, soap, zip, imagick, memcached, xdebug
+
+            -   name: Setup problem matchers for PHPUnit
+                run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Get Composer cache directory
+                id: composer-cache
+                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            -   name: Cache dependencies
+                uses: actions/cache@v2
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: ${{ runner.os }}-composer-
+
+            -   name: Install dependencies
+                run: composer install --no-interaction
+
+            -   name: Extract configuration files
+                run: |
+                    cp config/autoload/doctrine.local.development.php.dist config/autoload/doctrine.local.php
+                    cp config/autoload/laminas-developer-tools.local.php.dist config/autoload/laminas-developer-tools.local.php
+                    cp config/autoload/local.development.php.dist config/autoload/local.php
+
+            -   name: Load environment variables
+                uses: c-py/action-dotenv-to-setenv@v3
+                with:
+                    env-file: .env.dist
+
+            -   name: Create database
+                # GitHub Actions do not support custom hostnames like in Docker, hence we need to overwrite this value.
+                # Furthermore, we cannot declare it above, as it will be overwritten by the previous step.
+                env:
+                    DOCKER_DB_HOST: 127.0.0.1
+                run: ./orm orm:schema-tool:update --force
+
+            -   name: Run PHPUnit
+                env:
+                    DOCKER_DB_HOST: 127.0.0.1
+                run: vendor/phpunit/phpunit/phpunit --bootstrap bootstrap.php --configuration phpunit.xml


### PR DESCRIPTION
This supersedes #1297 and #1308 .
Actions are run as in #1308 , so without too much usage of Docker and thus ensuring fast actions.
Issues raised in #1308 are addressed however. Most notably. A baseline is automatically generated from the master branch and the PR verifies that no new issues are introduced. So, this does not necessarily require resolving all issues of a certain level in case we desire to raise the level at some point.

For an example, refer to https://github.com/Koen1999/gewisweb/pull/7
Currently PHPStan somehow is not able to add all errors to the baseline, thus raising one error. But this should be resolved after #1309 .