### PR TITLE
Disable strict host key verification for sFTP

### DIFF
--- a/publicarchive.sh
+++ b/publicarchive.sh
@@ -3,7 +3,7 @@
 rm -rf /code/public/publicarchive/*
 
 # Download the new files
-sshpass -p "${SSH_PASSWORD}" sftp "${SSH_USERNAME}"@"${SSH_REMOTE}" <<!
+sshpass -p "${SSH_PASSWORD}" sftp -o StrictHostKeyChecking=no "${SSH_USERNAME}"@"${SSH_REMOTE}" <<!
 cd "/datas/Public Archive/"
 mget -r * /code/public/publicarchive/
 quit


### PR DESCRIPTION
Fixes an issue where synchronisation of the public archive failed after deploying fresh images.