### PR TITLE
Fixed automatic controller tests

### DIFF
--- a/docker/web/development/php.ini
+++ b/docker/web/development/php.ini
@@ -1,6 +1,6 @@
 date.timezone = Europe/Amsterdam
 
-memory_limit = 256M
+memory_limit = -1
 max_input_time = 600
 max_execution_time = 300
 
@@ -11,9 +11,10 @@ post_max_size = 192M
 
 max_input_vars = 15000
 
-error_reporting = E_ALL & ~E_NOTICE
+error_reporting = -1
 display_errors = On
 display_startup_errors = On
+log_errors_max_len = 0
 
 report_memleaks = On
 
@@ -30,6 +31,12 @@ engine = Off
 output_buffering = 4096
 
 cli_server.color = On
+
+[assert]
+assert.exception = 1
+
+[zend]
+zend.assertions = 1
 
 [opcache]
 opcache.enable = 1
@@ -68,3 +75,4 @@ xdebug.client_port = 9003
 xdebug.idekey = "PHPSTORM"
 xdebug.start_upon_error = yes
 xdebug.start_with_request = no
+xdebug.show_exception_trace = 0

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
     xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="./bootstrap.php"
     colors="true">
-    <coverage processUncoveredFiles="true">
+    <coverage processUncoveredFiles="true" pathCoverage="true">
         <include>
             <directory suffix=".php">./module/Activity/src</directory>
             <directory suffix=".php">./module/Application/src</directory>


### PR DESCRIPTION
Now it performs 355 assertions corresponding to approximately 150+ routes.

parsePart did not perform assertions as expected.

Still not all routes are being tested, however.