### PR TITLE
Add infrastructure for automatic documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Docs
+
+# Only run this action when pushing to master.
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    phpunit:
+        name: PHPUnit
+        runs-on: ubuntu-latest
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+
+            -   name: Install PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.1'
+                    tools: phpdoc
+
+            -   name: Clone the target branch
+                run: |
+                    REMOTE_BRANCH="${REMOTE_BRANCH:-gh-pages}"
+                    REMOTE_REPO="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+                    echo "Publishing to ${GITHUB_REPOSITORY} on branch ${REMOTE_BRANCH}"
+                    rm -rf docs/_site/
+                    git clone --depth=1 --branch="${REMOTE_BRANCH}" --single-branch --no-checkout "${REMOTE_REPO}" docs/_site/
+
+            -   name: Build site
+                run: phpdoc
+
+            -   name: Deploy to GitHub Pages
+                run: |
+                    SOURCE_COMMIT="$(git log -1 --pretty="%an: %B" "$GITHUB_SHA")"
+                    pushd docs/_site &>/dev/null
+                    : > .nojekyll
+                    git add --all
+                    git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+                        commit --quiet \
+                        --message "Deploy docs from ${GITHUB_SHA}" \
+                        --message "$SOURCE_COMMIT" \
+                        --message "Co-authored-by: ${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
+                    git push
+                    popd &>/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ config/bash.env
 .idea/sonarlint-state.xml
 phpstan/phpstan-baseline-temp.neon
 phpstan/phpstan-baseline-pr.neon
+docs/_site/

--- a/phpdoc.xml
+++ b/phpdoc.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+        configVersion="3.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://www.phpdoc.org"
+        xsi:noNamespaceSchemaLocation="https://docs.phpdoc.org/latest/phpdoc.xsd"
+>
+    <paths>
+        <output>docs/_site</output>
+        <cache>docs/_site/cache</cache>
+    </paths>
+    <version number="latest">
+        <api format="php">
+            <source dsn=".">
+                <path>module</path>
+            </source>
+            <extensions>
+                <extension>php</extension>
+            </extensions>
+            <default-package-name>gewisweb</default-package-name>
+        </api>
+    </version>
+</phpdocumentor>


### PR DESCRIPTION
This supersedes #1246 and adds automatic generation (and deployment) of the documentation based on our PHP files.

I have moved the generated items to a separate branch `gh-pages`, this branch is an orphan and has no knowledge about any other commits/files. I have created the initial version of `gh-pages` myself, you can find it live at https://gewis.github.io/gewisweb/.

The GitHub Action borrows heavily from the Jekyll equivalent. It will automatically commit when the documentation has been updated, commit is authored (and committed) by the GitHub Actions bot, original commit author is added as a co-author.