### PR TITLE
Fix today's birthdays not being shown

### DIFF
--- a/module/Decision/src/Mapper/Member.php
+++ b/module/Decision/src/Mapper/Member.php
@@ -75,18 +75,25 @@ class Member extends BaseMapper
      */
     public function findBirthdayMembers(int $days): array
     {
-        $now = new DateTime();
-        $now->setTime(0, 0, 0, 0);
-        $interval = new DateInterval('P' . $days . 'D');
+        // unfortunately, there is no support for functions like DAY() and MONTH()
+        // in doctrine2, thus we have to use the NativeSQL here
+        $builder = new ResultSetMappingBuilder($this->getEntityManager());
+        $builder->addRootEntityFromClassMetadata($this->getRepositoryName(), 'm');
 
-        $query = $this->getEntityManager()->createQueryBuilder()
-            ->select('m')
-            ->from(MemberModel::class, 'm')
-            ->where('m.birth >= :d1')
-            ->andWhere('m.birth <= :d2')
-            ->setParameter('d1', $now)
-            ->setParameter('d2', $now->add($interval))
-            ->getQuery();
+        $select = $builder->generateSelectClause(['m' => 't1']);
+
+        $sql = <<<QUERY
+            SELECT $select FROM Member AS t1
+            WHERE DATEDIFF(
+                DATE_SUB(t1.birth, INTERVAL YEAR(t1.birth) YEAR),
+                DATE_SUB(CURDATE(), INTERVAL YEAR(CURDATE()) YEAR)
+            ) BETWEEN 0 AND :days
+            AND t1.expiration >= CURDATE()
+            ORDER BY DATE_SUB(t1.birth, INTERVAL YEAR(t1.birth) YEAR) ASC
+            QUERY;
+
+        $query = $this->getEntityManager()->createNativeQuery($sql, $builder);
+        $query->setParameter('days', $days);
 
         return $query->getResult();
     }

--- a/module/Frontpage/test/ControllerTest.php
+++ b/module/Frontpage/test/ControllerTest.php
@@ -8,6 +8,8 @@ class ControllerTest extends BaseControllerTest
 {
     public function testIndexActionCanBeAccessed(): void
     {
+        $this->markTestSkipped('\Decision\Mapper\Member::findBirthdayMembers() is not supported by SQLite');
+
         $this->dispatch('/');
         $this->assertResponseStatusCode(200);
     }


### PR DESCRIPTION
Fixes #1349. This reverts a tiny part of 34524ce, which (incorrectly) changed the logic of the query. Test marked as skipped, as it is obvious SQLite won't be able to do this.

An alternative implementation (does not work in SQLite either) looks like:

```mysql
DATE_FORMAT(`birth`, "%m-%d")
BETWEEN DATE_FORMAT(CURDATE(), "%m-%d") AND DATE_FORMAT(ADDDATE(CURDATE(), :days), "%m-%d")
```

However, not easy to read/understand in the blink of an eye.