### PR TITLE
Replace deprecated `transactional` with `wrapInTransaction`

### DIFF
--- a/module/Application/src/Mapper/BaseMapper.php
+++ b/module/Application/src/Mapper/BaseMapper.php
@@ -2,6 +2,7 @@
 
 namespace Application\Mapper;
 
+use Closure;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\{
     EntityManager,
@@ -188,6 +189,25 @@ abstract class BaseMapper
     public function count(mixed $criteria): int
     {
         return $this->getRepository()->count($criteria);
+    }
+
+    /**
+     * Transactional Doctrine wrapper.
+     *
+     * Instead of the EntityManager, this inserts this Mapper into the
+     * function.
+     *
+     * @param Closure $func
+     *
+     * @return mixed
+     */
+    public function transactional(Closure $func): mixed
+    {
+        return $this->getEntityManager()->wrapInTransaction(
+            function ($em) use ($func) {
+                return $func($this);
+            }
+        );
     }
 
     /**

--- a/module/Education/src/Mapper/Exam.php
+++ b/module/Education/src/Mapper/Exam.php
@@ -12,25 +12,6 @@ use Education\Model\Exam as ExamModel;
 class Exam extends BaseMapper
 {
     /**
-     * Transactional Doctrine wrapper.
-     *
-     * Instead of the EntityManager, this inserts this Mapper into the
-     * function.
-     *
-     * @param Closure $func
-     *
-     * @return mixed
-     */
-    public function transactional(Closure $func): mixed
-    {
-        return $this->em->transactional(
-            function ($em) use ($func) {
-                return $func($this);
-            }
-        );
-    }
-
-    /**
      * @inheritDoc
      */
     protected function getRepositoryName(): string


### PR DESCRIPTION
Fixes #1312. Also moves the `transactional` from the `ExamMapper` to `BaseMapper`.