### PR TITLE
Fix authorization issues

### DIFF
--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -175,7 +175,7 @@ class DecisionController extends AbstractActionController
             $form->setData($request->getPost()->toArray());
 
             if ($form->isValid()) {
-                if ($this->decisionService->createAuthorization($form->getData())) {
+                if (false !== ($authorization = $this->decisionService->createAuthorization($form->getData()))) {
                     return new ViewModel(
                         [
                             'meeting' => $meeting,

--- a/module/Decision/src/Form/Authorization.php
+++ b/module/Decision/src/Form/Authorization.php
@@ -4,6 +4,7 @@ namespace Decision\Form;
 
 use Laminas\Form\Element\{
     Checkbox,
+    Csrf,
     Hidden,
     Submit,
 };
@@ -34,6 +35,13 @@ class Authorization extends Form implements InputFilterProviderInterface
                 'options' => [
                     'use_hidden_element' => false,
                 ],
+            ]
+        );
+
+        $this->add(
+            [
+                'name' => 'csrf_token',
+                'type' => Csrf::class,
             ]
         );
 

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -503,11 +503,9 @@ class Decision
      */
     public function createAuthorization(array $data): AuthorizationModel|bool
     {
-        $authorization = new AuthorizationModel();
-        $user = $this->aclService->getIdentityOrThrowException();
-        $authorizer = $user->getMember();
-
+        $authorizer = $this->aclService->getIdentityOrThrowException()->getMember();
         $recipient = $this->memberMapper->findByLidnr($data['recipient']);
+
         if (
             null === $recipient
             || $recipient->getLidnr() === $authorizer->getLidnr()
@@ -519,6 +517,13 @@ class Decision
         if (null === $meeting) {
             return false;
         }
+
+        // You cannot authorize more than one person.
+        if (null !== $this->getUserAuthorization($meeting)) {
+            return false;
+        }
+
+        $authorization = new AuthorizationModel();
 
         $authorization->setAuthorizer($authorizer);
         $authorization->setRecipient($recipient);

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -518,9 +518,10 @@ class Decision
             return false;
         }
 
-        // You cannot authorize more than one person.
-        if (null !== $this->getUserAuthorization($meeting)) {
-            return false;
+        // You cannot authorize more than one person, actually return the existing authorization model to ensure the
+        // form is not shown again on a refresh.
+        if (null !== ($previousAuthorization = $this->getUserAuthorization($meeting))) {
+            return $previousAuthorization;
         }
 
         $authorization = new AuthorizationModel();

--- a/module/Decision/view/decision/decision/authorizations.phtml
+++ b/module/Decision/view/decision/decision/authorizations.phtml
@@ -67,6 +67,7 @@ You may still be able to authorize someone or revoke an authorization by contact
             $submit = $form->get('submit');
             $submit->setLabel($this->translate('Authorize'));
             $submit->setAttribute('class', 'btn btn-primary pull-right');
+            echo $this->formHidden($form->get('csrf_token'));
             ?>
             <div class='form-group'>
                 <button type='button' class='btn btn-primary pull-right' id='initialSubmit'>


### PR DESCRIPTION
This fixes #1369 (and as a result also fixes #1302).

Technically there is still a race-condition where you can authorize two (or more) different members. Changing the unique columns in the table is not really helpful, if you remove `recipient` you cannot have a revoked and actual authorization. If you add `revoked` (with `recipient` removed) you can revoke only one authorization.

The latter would work if `$revoked = true` is `NULL` in the database (`NULL` does not care about uniqueness). So we'd probably want to change it to `$isValid = true` (by default) and then set it to `null` when it is no longer valid.

@Koen1999 Let me know what you think about the proposed solution for the race-condition. Though it will not be possible to do it at this point in time, as we have a duplicate record in the database (so we need to discuss with the board what we can do).