### PR TITLE
Fix 500 errors when company or job slug is not provided

### DIFF
--- a/module/Company/config/module.config.php
+++ b/module/Company/config/module.config.php
@@ -80,11 +80,9 @@ return [
                             // company/apple/jobs should be list of jobs of apple
                             // company/apple/jobs/ceo should be the page of ceo job
                             // company should give frontpage of company part
-                            // company/list should give a list of companies
-                            // company/index should give the frontpage
                             'route' => '/company/:companySlugName',
                             'constraints' => [
-                                'companySlugName' => '[a-zA-Z0-9_\-\.]*',
+                                'companySlugName' => '[a-zA-Z0-9_\-\.]+',
                             ],
                         ],
                         'may_terminate' => true,

--- a/module/Company/config/module.config.php
+++ b/module/Company/config/module.config.php
@@ -38,7 +38,7 @@ return [
                         'options' => [
                             'route' => '/:category',
                             'constraints' => [
-                                'category' => '[a-zA-Z0-9_\-\.]*',
+                                'category' => '[a-zA-Z0-9_\-\.]+',
                             ],
                             'defaults' => [
                                 'action' => 'jobList',

--- a/module/Company/src/Form/Company.php
+++ b/module/Company/src/Form/Company.php
@@ -256,7 +256,7 @@ class Company extends LocalisableForm implements InputFilterProviderInterface
                     [
                         'name' => Regex::class,
                         'options' => [
-                            'pattern' => '/^[0-9a-zA-Z_\-\.]*$/',
+                            'pattern' => '/^[0-9a-zA-Z_\-\.]+$/',
                             'messages' => [
                                 Regex::ERROROUS => $this->getTranslator()->translate('This slug contains invalid characters'),
                             ],

--- a/module/Company/src/Form/Job.php
+++ b/module/Company/src/Form/Job.php
@@ -302,7 +302,7 @@ class Job extends LocalisableForm implements InputFilterProviderInterface
                     [
                         'name' => Regex::class,
                         'options' => [
-                            'pattern' => '/^[0-9a-zA-Z_\-\.]*$/',
+                            'pattern' => '/^[0-9a-zA-Z_\-\.]+$/',
                             'messages' => [
                                 Regex::ERROROUS => $this->getTranslator()->translate('This slug contains invalid characters'),
                             ],


### PR DESCRIPTION
Improved validation of company and job slugs. They must now be at least 1 of the defined characters. This was not really an issue in the forms, as it would still scream about a missing field. However, such enforcement does not take place in the router.

Fixes #1385.