### PR TITLE
Fix ordering of activity archive

### DIFF
--- a/module/Activity/src/Controller/ActivityController.php
+++ b/module/Activity/src/Controller/ActivityController.php
@@ -507,7 +507,7 @@ class ActivityController extends AbstractActionController
 
         // If no year is supplied, use the latest year.
         if (null === $year) {
-            if (empty($years)) {
+            if (0 === count($years)) {
                 $year = (int) date('Y');
             } else {
                 $year = max($years);
@@ -518,7 +518,6 @@ class ActivityController extends AbstractActionController
 
         return new ViewModel(
             [
-                'activeYear' => $year,
                 'years' => $years,
                 'activities' => $this->activityQueryService->getFinishedActivitiesByYear($year),
             ]

--- a/module/Activity/src/Mapper/Activity.php
+++ b/module/Activity/src/Mapper/Activity.php
@@ -291,7 +291,7 @@ class Activity extends BaseMapper
             ->setParameter('end', $end)
             ->andWhere('a.status = :status')
             ->setParameter('status', ActivityModel::STATUS_APPROVED)
-            ->orderBy('a.beginTime', 'ASC');
+            ->orderBy('a.beginTime', 'DESC');
 
         return $qb->getQuery()->getResult();
     }

--- a/module/Activity/view/activity/activity/archive.phtml
+++ b/module/Activity/view/activity/activity/archive.phtml
@@ -37,7 +37,7 @@
         <?php if (0 !== count($activities)): ?>
             <?= $this->partial('activity/activity/list.phtml', ['activities' => $activities]) ?>
         <?php else: ?>
-            <p><?= $this->translate('There are no activities the archive.') ?></p>
+            <p><?= $this->translate('There are no activities in the archive.') ?></p>
         <?php endif; ?>
     </div>
 </div>

--- a/module/Activity/view/activity/activity/archive.phtml
+++ b/module/Activity/view/activity/activity/archive.phtml
@@ -2,36 +2,42 @@
     <section class="section">
         <div class="container">
             <ul class="nav nav-pills head-menu">
-                <li role="presentation" class="dropdown">
-                    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true"
-                       aria-expanded="false">
-                        <?= $this->translate('Older') ?> <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu">
-                        <?php for ($i = 0; $i < max(0, count($years) - 5); $i++): ?>
-                            <li>
-                                <a href="<?= $this->url('activity/year', ['year' => $years[$i]]); ?>">
-                                    <?= $years[$i] ?>/<?= $years[$i] + 1 ?>
-                                </a>
-                            </li>
-                        <?php endfor ?>
-                    </ul>
-                </li>
-                <?php for ($i = max(0, count($years) - 5); $i < count($years); $i++): ?>
+                <?php for ($i = count($years) - 1; $i >= max(0, count($years) - 5); $i--): ?>
                     <li>
                         <a href="<?= $this->url('activity/year', ['year' => $years[$i]]); ?>">
-                            <?= $years[$i] ?>/<?= $years[$i] + 1 ?>
+                            <?= $years[$i] ?>-<?= $years[$i] + 1 ?>
                         </a>
                     </li>
                 <?php endfor; ?>
+                <?php if (7 <= count($years)): ?>
+                    <li role="presentation" class="dropdown">
+                        <a class="dropdown-toggle"
+                           data-toggle="dropdown"
+                           href="#"
+                           role="button"
+                           aria-haspopup="true"
+                           aria-expanded="false">
+                            <?= $this->translate('Older') ?> <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            <?php for ($i = max(0, count($years) - 6); $i > 0; $i--): ?>
+                                <li>
+                                    <a href="<?= $this->url('activity/year', ['year' => $years[$i]]); ?>">
+                                        <?= $years[$i] ?>-<?= $years[$i] + 1 ?>
+                                    </a>
+                                </li>
+                            <?php endfor ?>
+                        </ul>
+                    </li>
+                <?php endif; ?>
             </ul>
         </div>
     </section>
     <div class="container">
-        <?php
-        echo $this->partial('activity/activity/list.phtml', [
-            'activities' => $activities,
-        ]);
-        ?>
+        <?php if (0 !== count($activities)): ?>
+            <?= $this->partial('activity/activity/list.phtml', ['activities' => $activities]) ?>
+        <?php else: ?>
+            <p><?= $this->translate('There are no activities the archive.') ?></p>
+        <?php endif; ?>
     </div>
 </div>

--- a/module/Activity/view/activity/activity/list.phtml
+++ b/module/Activity/view/activity/activity/list.phtml
@@ -1,4 +1,5 @@
 <ul class="list-group">
+    <?php if (0 !== count($activities)): ?>
     <?php foreach ($activities as $activity): ?>
         <li class="list-group-item agenda-item">
             <div class="row">
@@ -50,6 +51,9 @@
             </div>
         </li>
     <?php endforeach; ?>
+    <?php else: ?>
+        <ul><?= $this->translate('There are no activities.') ?></ul>
+    <?php endif; ?>
 </ul>
 
 <script type="application/javascript">

--- a/module/Photo/src/Controller/PhotoController.php
+++ b/module/Photo/src/Controller/PhotoController.php
@@ -42,27 +42,24 @@ class PhotoController extends AbstractActionController
 
     public function indexAction(): ViewModel
     {
-        //add any other special behavior which is required for the main photo page here later
         $years = $this->albumService->getAlbumYears();
         $year = $this->params()->fromRoute('year');
+
         // If no year is supplied, use the latest year.
-        if (is_null($year)) {
-            if (empty($years)) {
+        if (null === $year) {
+            if (0 === count($years)) {
                 $year = (int) date('Y');
             } else {
                 $year = max($years);
             }
         } else {
-            $year = (int)$year;
+            $year = (int) $year;
         }
-
-        $albums = $this->albumService->getAlbumsByYear($year);
 
         return new ViewModel(
             [
-                'activeYear' => $year,
                 'years' => $years,
-                'albums' => $albums,
+                'albums' => $this->albumService->getAlbumsByYear($year),
             ]
         );
     }

--- a/module/Photo/view/photo/photo/index.phtml
+++ b/module/Photo/view/photo/photo/index.phtml
@@ -12,32 +12,35 @@ $this->headTitle($this->translate('Photos')); ?>
                         </a>
                     </li>
                 <?php endfor; ?>
-                <li role="presentation" class="dropdown">
-                    <a class="dropdown-toggle"
-                       data-toggle="dropdown"
-                       href="#"
-                       role="button"
-                       aria-haspopup="true"
-                       aria-expanded="false">
-                        <?= $this->translate('Older') ?> <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu">
-                        <?php for ($i = max(0, count($years) - 6); $i > 0; $i--): ?>
-                            <li>
-                                <a href="<?= $this->url('photo/year', ['year' => $years[$i]]); ?>">
-                                    <?= $years[$i] ?>-<?= $years[$i] + 1 ?>
-                                </a>
-                            </li>
-                        <?php endfor ?>
-                    </ul>
-                </li>
+                <?php if (7 <= count($years)): ?>
+                    <li role="presentation" class="dropdown">
+                        <a class="dropdown-toggle"
+                           data-toggle="dropdown"
+                           href="#"
+                           role="button"
+                           aria-haspopup="true"
+                           aria-expanded="false">
+                            <?= $this->translate('Older') ?> <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            <?php var_dump($years) ?>
+                            <?php for ($i = max(0, count($years) - 6); $i > 0; $i--): ?>
+                                <li>
+                                    <a href="<?= $this->url('photo/year', ['year' => $years[$i]]); ?>">
+                                        <?= $years[$i] ?>-<?= $years[$i] + 1 ?>
+                                    </a>
+                                </li>
+                            <?php endfor ?>
+                        </ul>
+                    </li>
+                <?php endif; ?>
             </ul>
         </div>
     </section>
-    <?php if (!empty($albums)): ?>
-        <section class="section">
-            <div class="container">
-                <div class="row">
+    <section class="section">
+        <div class="container">
+            <div class="row">
+                <?php if (0 !== count($albums)): ?>
                     <?php foreach ($albums as $album): ?>
                         <?php if ($album->getPhotoCount() > 0): ?>
                             <div class="col-lg-3 col-md-4 col-xs-6 thumb">
@@ -53,9 +56,11 @@ $this->headTitle($this->translate('Photos')); ?>
                             </div>
                         <?php endif; ?>
                     <?php endforeach; ?>
-                </div>
+                <?php else: ?>
+                    <p><?= $this->translate('There are no photos in this year.') ?></p>
+                <?php endif; ?>
             </div>
-        </section>
-    <?php endif; ?>
+        </div>
+    </section>
 </div>
 


### PR DESCRIPTION
Order of the navpills is not the same as in the photo module, which is more logical (decreasing order). Also displays the activities in reverse order (most recent is first).

Also some small quality of life improvements, consisting of small messages if there are no activities/albums in a particular year.

Fixes #1378.