### PR TITLE
Add more claims to the `ApiApp` JWT

### DIFF
--- a/module/User/src/Service/ApiApp.php
+++ b/module/User/src/Service/ApiApp.php
@@ -36,10 +36,15 @@ class ApiApp
         UserModel $user,
     ): string {
         $app = $this->getMapper()->findByAppId($appId);
+        $member = $user->getMember();
 
         $token = [
             'iss' => 'https://gewis.nl/',
-            'lidnr' => $user->getLidnr(),
+            'lidnr' => $member->getLidnr(),
+            'given_name' => $member->getFirstName(),
+            'family_name' => $member->getLastName(),
+            'email' => $member->getEmail(),
+            'membership_type' => $member->getType(),
             'exp' => (new DateTime('+5 min'))->getTimestamp(),
             'iat' => (new DateTime())->getTimestamp(),
             'nonce' => bin2hex(openssl_random_pseudo_bytes(16)),


### PR DESCRIPTION
This adds more claims to the JWT that were requested for SudoSOS, they should also provide some more functionality to other `ApiApp`s.

The claims added:
- `given_name`      => given name or first name
- `family_name`     => given surname or last name
- `email`           => email address
- `membership_type` => type of membership

This closes #1403.

**This is a draft pending a discussion with the IO/privacy responsibles regarding the implementation and its implications.**