### PR TITLE
Fix being unable to sign off external participant

### DIFF
--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -389,10 +389,10 @@ class AdminController extends AbstractActionController
         );
     }
 
-    public function externalSignoffAction(): \Laminas\Http\PhpEnvironment\Response|ResponseInterface|ViewModel
+    public function externalSignoffAction(): Response|ViewModel
     {
         $signupId = (int) $this->params('id');
-        $signup = $this->signupMapper->find($signupId);
+        $signup = $this->signupMapper->getExternalSignUp($signupId);
 
         if (null === $signup) {
             return $this->notFoundAction();

--- a/module/Activity/src/Mapper/Signup.php
+++ b/module/Activity/src/Mapper/Signup.php
@@ -3,6 +3,7 @@
 namespace Activity\Mapper;
 
 use Activity\Model\{
+    ExternalSignup as ExternalSignupModel,
     SignupList as SignupListModel,
     UserSignup as UserSignupModel,
 };
@@ -50,6 +51,11 @@ class Signup extends BaseMapper
         $result = $qb->getQuery()->getResult();
 
         return $result[0] ?? null;
+    }
+
+    public function getExternalSignUp(int $signupId): ?ExternalSignupModel
+    {
+        return $this->getEntityManager()->getRepository(ExternalSignupModel::class)->find($signupId);
     }
 
     /**


### PR DESCRIPTION
I changed the default repository of the `Signup` mapper at some point to `UserSignup`, but did not account for `ExternalSignup`. Hence, when trying to sign off an external participant from an activity, the `Signup` cannot be found.

Fixes #1416.