### PR TITLE
Fix missing anonymous votes on polls

### DIFF
--- a/module/Frontpage/src/Model/PollOption.php
+++ b/module/Frontpage/src/Model/PollOption.php
@@ -68,9 +68,9 @@ class PollOption implements ResourceInterface
 
     #[Column(
         type: "integer",
-        nullable: true,
+        options: ["default" => 0],
     )]
-    protected ?int $anonymousVotes = null;
+    protected int $anonymousVotes = 0;
 
     /**
      * @return int|null
@@ -146,21 +146,15 @@ class PollOption implements ResourceInterface
      */
     public function getVotesCount(): int
     {
-        $votes = $this->votes->count();
-
-        if (null !== ($anonymousVotes = $this->getAnonymousVotes())) {
-            $votes += $anonymousVotes;
-        }
-
-        return $votes;
+        return $this->votes->count() + $this->getAnonymousVotes();
     }
 
-    public function getAnonymousVotes(): ?int
+    public function getAnonymousVotes(): int
     {
         return $this->anonymousVotes;
     }
 
-    public function setAnonymousVotes(?int $anonymousVotes): void
+    public function setAnonymousVotes(int $anonymousVotes): void
     {
         $this->anonymousVotes = $anonymousVotes;
     }

--- a/module/Frontpage/src/Model/PollOption.php
+++ b/module/Frontpage/src/Model/PollOption.php
@@ -66,6 +66,12 @@ class PollOption implements ResourceInterface
     )]
     protected Collection $votes;
 
+    #[Column(
+        type: "integer",
+        nullable: true,
+    )]
+    protected ?int $anonymousVotes = null;
+
     /**
      * @return int|null
      */
@@ -140,7 +146,23 @@ class PollOption implements ResourceInterface
      */
     public function getVotesCount(): int
     {
-        return $this->votes->count();
+        $votes = $this->votes->count();
+
+        if (null !== ($anonymousVotes = $this->getAnonymousVotes())) {
+            $votes += $anonymousVotes;
+        }
+
+        return $votes;
+    }
+
+    public function getAnonymousVotes(): ?int
+    {
+        return $this->anonymousVotes;
+    }
+
+    public function setAnonymousVotes(?int $anonymousVotes): void
+    {
+        $this->anonymousVotes = $anonymousVotes;
     }
 
     /**


### PR DESCRIPTION
Fixes #1414. We only need the actual anonymous from the old database, but I can arrange that.