### PR TITLE
Do not translate organ member function before sorting

### DIFF
--- a/module/Decision/src/Service/Organ.php
+++ b/module/Decision/src/Service/Organ.php
@@ -460,8 +460,7 @@ class Organ
                 }
 
                 if ('Lid' != $install->getFunction()) {
-                    $function = $this->translator->translate($install->getFunction());
-                    $currentMembers[$install->getMember()->getLidnr()]['functions'][] = $function;
+                    $currentMembers[$install->getMember()->getLidnr()]['functions'][] = $install->getFunction();
                 }
             } else {
                 // old member

--- a/module/Decision/view/decision/organ/show.phtml
+++ b/module/Decision/view/decision/organ/show.phtml
@@ -14,7 +14,7 @@ $this->headTitle($organ->getName()); ?>
                                 <?= $membership['member']->getFullName() ?>
                             </a>
                             <?php if (!empty($membership['functions'])): ?>
-                                (<?= implode(', ', $membership['functions']) ?>)
+                                (<?= implode(', ', array_map(fn(string $value): string => $this->translate($value), $membership['functions'])) ?>)
                             <?php endif ?></li>
                     <?php endforeach ?>
                 </ul>

--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -122,7 +122,7 @@ function getOrganDescription($organInformation, $lang)
                                 <a href="<?= $this->url('member/view', ['lidnr' => $membership['member']->getLidnr()]) ?>">
                                     <?= $membership['member']->getFullName() ?>
                                     <?php if (!empty($membership['functions'])): ?>
-                                        (<?= implode(', ', $membership['functions']) ?>)
+                                        (<?= implode(', ', array_map(fn(string $value): string => $this->translate($value), $membership['functions'])) ?>)
                                     <?php endif ?>
                                 </a>
                             </li>


### PR DESCRIPTION
This would have worked if `Voorzitter` was also translated, but that
was not the case. It would have been possible to do this, but then
the translator is called on every sorting which is not particularly
efficient.

To fix this, we just use the Dutch term for sorting and translate
the values in the views.

Fixes #1408.