### PR TITLE
Add null check on organ mutation page

### DIFF
--- a/module/Decision/src/Controller/OrganController.php
+++ b/module/Decision/src/Controller/OrganController.php
@@ -42,6 +42,11 @@ class OrganController extends AbstractActionController
     {
         $organId = $this->params()->fromRoute('organ');
         $organ = $this->organService->getOrgan($organId);
+
+        if (null === $organ) {
+            return $this->notFoundAction();
+        }
+
         $organMemberInformation = $this->organService->getOrganMemberInformation($organ);
 
         return new ViewModel(

--- a/module/Decision/src/Mapper/Organ.php
+++ b/module/Decision/src/Mapper/Organ.php
@@ -79,12 +79,11 @@ class Organ extends BaseMapper
      *
      * @param int $id
      *
-     * @return OrganModel
+     * @return OrganModel|null
      *
-     * @throws NoResultException
      * @throws NonUniqueResultException
      */
-    public function findOrgan(int $id): OrganModel
+    public function findOrgan(int $id): ?OrganModel
     {
         $qb = $this->getRepository()->createQueryBuilder('o');
         $qb->select('o, om, m')
@@ -94,7 +93,7 @@ class Organ extends BaseMapper
 
         $qb->setParameter('id', $id);
 
-        return $qb->getQuery()->getSingleResult();
+        return $qb->getQuery()->getOneOrNullResult();
     }
 
     /**


### PR DESCRIPTION
The `Organ` mapper did not have the correct return type due to the usage of `getSingleResult()`, that prevented the static type checking from picking up this issue.

This fixes #1422.