### PR TITLE
Automatically calculate aspect ratio on persist

### DIFF
--- a/module/Photo/src/Model/Photo.php
+++ b/module/Photo/src/Model/Photo.php
@@ -5,7 +5,6 @@ namespace Photo\Model;
 use DateTime;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\{
-    ClassMetadataInfo,
     Column,
     Entity,
     GeneratedValue,
@@ -15,6 +14,7 @@ use Doctrine\ORM\Mapping\{
     ManyToOne,
     OneToMany,
     OneToOne,
+    PrePersist,
 };
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
@@ -400,11 +400,17 @@ class Photo implements ResourceInterface
     public function getAspectRatio(): ?float
     {
         if (null === $this->aspectRatio) {
-            [$width, $height, $type, $attr] = getimagesize('public/data/' . $this->getSmallThumbPath());
-            $this->aspectRatio = $height / $width;
+            $this->calculateAspectRatio();
         }
 
         return $this->aspectRatio;
+    }
+
+    #[PrePersist]
+    public function calculateAspectRatio(): void
+    {
+        [$width, $height, $type, $attr] = getimagesize('public/data/' . $this->getSmallThumbPath());
+        $this->aspectRatio = $height / $width;
     }
 
     /**

--- a/module/Photo/src/Module.php
+++ b/module/Photo/src/Module.php
@@ -32,10 +32,7 @@ use Photo\Service\{
     Metadata as MetadataService,
     Photo as PhotoService,
 };
-use Photo\View\Helper\{
-    GlideUrl,
-    HasVoted,
-};
+use Photo\View\Helper\GlideUrl;
 use User\Authorization\AclServiceFactory;
 
 class Module


### PR DESCRIPTION
This automatically calculates the aspect ratio of a `Photo` when the entity is persisted (only on the first persist). There is no other way to do this without involving the EntityManager, as Doctrine is strictly follows the data mapper pattern and not the active record pattern. Hence, updating the aspect ratio from within the entity is not possible.

This does still require the manual calculation of the aspect ratios of all old photos.

Fixes #1449.