### PR TITLE
Fixed toggling nested trees

### DIFF
--- a/module/Photo/view/photo/album-admin/index.phtml
+++ b/module/Photo/view/photo/album-admin/index.phtml
@@ -1,7 +1,8 @@
 <?php
 $this->headScript()
     ->appendFile($this->basePath() . '/js/photo.js')
-    ->appendFile($this->basePath() . '/js/photo-admin.js');
+    ->appendFile($this->basePath() . '/js/photo-admin.js')
+    ->appendFile($this->basePath() . '/js/tree.js');
 $this->headLink()
     ->appendStylesheet($this->basePath() . '/css/tree.css');
 
@@ -38,22 +39,27 @@ $this->scriptUrl()->requireUrl('admin_photo/album_page', ['album_id', 'page'])
                     <?php
                     function showAlbumTree($albums, $context)
                     {
-                        foreach ($albums as $album): ?>
-                            <li><a
-                                    id="<?= $album->getId() ?>"
-                                    href="<?= $context->url('admin_photo/album_index',
-                                        ['album_id' => $album->getId()]) ?>">
-                                    <?= $context->escapeHtml($album->getName()) ?>
-                                </a>
-
-                                <?php $children = $album->getChildren() ?>
-                                <?php if (!empty($children)): ?>
-                                    <ul>
-                                        <?php showAlbumTree($children, $context); ?>
-                                    </ul>
-                                <?php endif; ?>
-                            </li>
-                        <?php
+                        foreach ($albums as $album):
+                    ?>
+                        <li>
+                            <a
+                                id="<?= $album->getId() ?>"
+                                href="<?= $context->url('admin_photo/album_index',
+                                    ['album_id' => $album->getId()]) ?>">
+                                <?= $context->escapeHtml($album->getName()) ?>
+                            </a>
+                            <?php
+                            $children = $album->getChildren();
+                            if (!$children->isEmpty()):
+                            ?>
+                                <ul>
+                                    <?php showAlbumTree($children, $context); ?>
+                                </ul>
+                            <?php
+                            endif;
+                            ?>
+                        </li>
+                    <?php
                         endforeach;
                     }
 

--- a/public/js/photo-admin.js
+++ b/public/js/photo-admin.js
@@ -203,6 +203,9 @@ Photo.Admin.init = function () {
     $("#multipleDeleteButton").on('click', Photo.Admin.deleteMultiple);
     $("#multipleMoveButton").on('click', Photo.Admin.moveMultiple);
     $("#moveAlbumButton").on('click', Photo.Admin.moveAlbum);
+    $('.tree .branch a').each(function () {
+        $(this).on('click', Photo.Admin.albumClicked);
+    });
     //auto load album on hash
     if (location.hash !== "") {
         $(location.hash).click();
@@ -266,6 +269,7 @@ Photo.Admin.updateBreadCrumb = function (target) {
 }
 Photo.Admin.albumClicked = function (e) {
     e.preventDefault();
+    $(this).closest('li').click();
     //workaround for preventing page from jumping when changing hash
     if (history.pushState) {
         history.pushState(null, null, '#' + $(this).attr('id'));
@@ -280,39 +284,3 @@ Photo.Admin.albumClicked = function (e) {
     Photo.Admin.loadPage(e.target.href);
 
 }
-
-$.fn.extend({
-    treed: function () {
-        //initialize each of the top levels
-        var tree = $(this);
-        tree.addClass("tree");
-        tree.find('li').has("ul").each(function () {
-            var branch = $(this); //li with children ul
-            branch.prepend("<i class='fas fa-plus-circle'></i>");
-            branch.addClass('branch');
-            branch.on('click', function (e) {
-                if (this == e.target) {
-                    var icon = $(this).children('i:first');
-                    icon.toggleClass("fa-plus-circle fa-minus-circle");
-                    $(this).children().children().toggle();
-                }
-            })
-            branch.children().children().toggle();
-        });
-        //fire event from the dynamically added icon
-        $('.branch .indicator').on('click', function () {
-            $(this).closest('li').click();
-        });
-        //fire event to open branch if the li contains an anchor instead of text
-        $('.branch>a').each(function () {
-            $(this).on('click', function (e) {
-                $(this).closest('li').click();
-                e.preventDefault();
-                // Photo.Admin.loadPage(e.target.href);
-            });
-        });
-        tree.find("a").each(function () {
-            $(this).on('click', Photo.Admin.albumClicked);
-        });
-    }
-});

--- a/public/js/tree.js
+++ b/public/js/tree.js
@@ -2,25 +2,23 @@ $.fn.extend({
     treed: function () {
         //initialize each of the top levels
         var tree = $(this);
-        tree.addClass("tree");
-        tree.find('li').has("ul").each(function () {
-            var branch = $(this); //li with children ul
-            branch.prepend("<i class='fas fa-plus-circle toggleicon'></i>");
+        tree.addClass('tree');
+        tree.find('li').has('ul').each(function () {
+            let branch = $(this); //li with children ul
+            branch.prepend('<i class="fas fa-folder-plus indicator"></i>');
             branch.addClass('branch');
             branch.on('click', function (e) {
                 if (this == e.target) {
-                    var icon = $(this).children('i:first');
-                      icon.toggleClass("fa-plus-circle fa-minus-circle");
+                    let icon = $(this).children('i:first');
+                    icon.toggleClass('fa-folder-plus fa-folder-minus');
                     $(this).children().children().toggle();
                 }
             });
             branch.children().children().toggle();
         });
         //fire event from the dynamically added icon
-        $('.branch .toggleicon').on('click', function () {
+        $('.branch .indicator').on('click', function () {
             $(this).closest('li').click();
         });
-        //fire event to open branch if the li contains an anchor instead of text
-
     }
 });

--- a/public/js/tree.js
+++ b/public/js/tree.js
@@ -5,17 +5,19 @@ $.fn.extend({
         tree.addClass("tree");
         tree.find('li').has("ul").each(function () {
             var branch = $(this); //li with children ul
-            branch.prepend("<i class='fas fa-plus-circle'></i>");
+            branch.prepend("<i class='fas fa-plus-circle toggleicon'></i>");
             branch.addClass('branch');
             branch.on('click', function (e) {
-                var icon = $(this).children('i:first');
-                  icon.toggleClass("fa-plus-circle fa-minus-circle");
-                $(this).children().children().toggle();
+                if (this == e.target) {
+                    var icon = $(this).children('i:first');
+                      icon.toggleClass("fa-plus-circle fa-minus-circle");
+                    $(this).children().children().toggle();
+                }
             });
             branch.children().children().toggle();
         });
         //fire event from the dynamically added icon
-        $('.branch .indicator').on('click', function () {
+        $('.branch .toggleicon').on('click', function () {
             $(this).closest('li').click();
         });
         //fire event to open branch if the li contains an anchor instead of text


### PR DESCRIPTION
Third tiny pull request from me. Fixes clicking on nested trees.

Current behaviour: unfolding 2nd-level tree will fold 1st level tree back