### PR TITLE
Fix Psalm and other minor issues

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "brick/varexporter",
-            "version": "0.3.5",
+            "version": "0.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/varexporter.git",
-                "reference": "05241f28dfcba2b51b11e2d750e296316ebbe518"
+                "reference": "3361a8a30e807c0841a7ca98e5c72b6bffc73463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/varexporter/zipball/05241f28dfcba2b51b11e2d750e296316ebbe518",
-                "reference": "05241f28dfcba2b51b11e2d750e296316ebbe518",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/3361a8a30e807c0841a7ca98e5c72b6bffc73463",
+                "reference": "3361a8a30e807c0841a7ca98e5c72b6bffc73463",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +27,7 @@
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
                 "phpunit/phpunit": "^8.5 || ^9.0",
-                "vimeo/psalm": "4.4.1"
+                "vimeo/psalm": "4.23.0"
             },
             "type": "library",
             "autoload": {
@@ -45,9 +45,15 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/varexporter/issues",
-                "source": "https://github.com/brick/varexporter/tree/0.3.5"
+                "source": "https://github.com/brick/varexporter/tree/0.3.6"
             },
-            "time": "2021-02-10T13:53:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-06-15T23:51:29+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -504,16 +510,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.3.6",
+            "version": "3.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "9e7f76dd1cde81c62574fdffa5a9c655c847ad21"
+                "reference": "9f79d4650430b582f4598fe0954ef4d52fbc0a8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9e7f76dd1cde81c62574fdffa5a9c655c847ad21",
-                "reference": "9e7f76dd1cde81c62574fdffa5a9c655c847ad21",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9f79d4650430b582f4598fe0954ef4d52fbc0a8a",
+                "reference": "9f79d4650430b582f4598fe0954ef4d52fbc0a8a",
                 "shasum": ""
             },
             "require": {
@@ -528,11 +534,11 @@
             "require-dev": {
                 "doctrine/coding-standard": "9.0.0",
                 "jetbrains/phpstorm-stubs": "2022.1",
-                "phpstan/phpstan": "1.6.3",
+                "phpstan/phpstan": "1.7.13",
                 "phpstan/phpstan-strict-rules": "^1.2",
                 "phpunit/phpunit": "9.5.20",
                 "psalm/plugin-phpunit": "0.16.1",
-                "squizlabs/php_codesniffer": "3.6.2",
+                "squizlabs/php_codesniffer": "3.7.0",
                 "symfony/cache": "^5.2|^6.0",
                 "symfony/console": "^2.7|^3.0|^4.0|^5.0|^6.0",
                 "vimeo/psalm": "4.23.0"
@@ -595,7 +601,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.3.6"
+                "source": "https://github.com/doctrine/dbal/tree/3.3.7"
             },
             "funding": [
                 {
@@ -611,7 +617,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-02T17:21:01+00:00"
+            "time": "2022-06-13T21:43:03+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -1316,16 +1322,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.12.2",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "8291a7f09b12d14783ed6537b4586583d155869e"
+                "reference": "c05e1709e9ffb9abe8d37260a78975cc816ee385"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/8291a7f09b12d14783ed6537b4586583d155869e",
-                "reference": "8291a7f09b12d14783ed6537b4586583d155869e",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/c05e1709e9ffb9abe8d37260a78975cc816ee385",
+                "reference": "c05e1709e9ffb9abe8d37260a78975cc816ee385",
                 "shasum": ""
             },
             "require": {
@@ -1354,10 +1360,10 @@
                 "doctrine/annotations": "^1.13",
                 "doctrine/coding-standard": "^9.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "~1.4.10 || 1.6.3",
+                "phpstan/phpstan": "~1.4.10 || 1.7.13",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
                 "psr/log": "^1 || ^2 || ^3",
-                "squizlabs/php_codesniffer": "3.6.2",
+                "squizlabs/php_codesniffer": "3.7.0",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
                 "vimeo/psalm": "4.23.0"
@@ -1409,9 +1415,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.12.2"
+                "source": "https://github.com/doctrine/orm/tree/2.12.3"
             },
-            "time": "2022-05-02T19:10:07+00:00"
+            "time": "2022-06-16T13:42:23+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -1725,16 +1731,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "83260bb50b8fc753c72d14dc1621a2dac31877ee"
+                "reference": "13388f00956b1503577598873fffb5ae994b5737"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/83260bb50b8fc753c72d14dc1621a2dac31877ee",
-                "reference": "83260bb50b8fc753c72d14dc1621a2dac31877ee",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/13388f00956b1503577598873fffb5ae994b5737",
+                "reference": "13388f00956b1503577598873fffb5ae994b5737",
                 "shasum": ""
             },
             "require": {
@@ -1758,7 +1764,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -1820,7 +1826,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.3.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.0"
             },
             "funding": [
                 {
@@ -1836,7 +1842,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T08:26:02+00:00"
+            "time": "2022-06-20T21:43:11+00:00"
         },
         {
             "name": "intervention/image",
@@ -1924,16 +1930,16 @@
         },
         {
             "name": "laminas/laminas-authentication",
-            "version": "2.10.1",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-authentication.git",
-                "reference": "7308db03e11147fbf567b5004ac428bdaba267f9"
+                "reference": "51815691d862b82b749a4aa9c4f6ec078d579f74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-authentication/zipball/7308db03e11147fbf567b5004ac428bdaba267f9",
-                "reference": "7308db03e11147fbf567b5004ac428bdaba267f9",
+                "url": "https://api.github.com/repos/laminas/laminas-authentication/zipball/51815691d862b82b749a4aa9c4f6ec078d579f74",
+                "reference": "51815691d862b82b749a4aa9c4f6ec078d579f74",
                 "shasum": ""
             },
             "require": {
@@ -1944,7 +1950,7 @@
                 "zendframework/zend-authentication": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "laminas/laminas-crypt": "^2.6 || ^3.2.1",
                 "laminas/laminas-db": "^2.13",
                 "laminas/laminas-http": "^2.15.0",
@@ -1996,7 +2002,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-03-09T23:07:57+00:00"
+            "time": "2022-06-23T10:41:36+00:00"
         },
         {
             "name": "laminas/laminas-cache",
@@ -2886,22 +2892,22 @@
         },
         {
             "name": "laminas/laminas-form",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-form.git",
-                "reference": "43005a3ec4c2292d4f825273768d9b884acbca37"
+                "reference": "c1a8474dc459672a30b5817716a797da7a5026a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-form/zipball/43005a3ec4c2292d4f825273768d9b884acbca37",
-                "reference": "43005a3ec4c2292d4f825273768d9b884acbca37",
+                "url": "https://api.github.com/repos/laminas/laminas-form/zipball/c1a8474dc459672a30b5817716a797da7a5026a9",
+                "reference": "c1a8474dc459672a30b5817716a797da7a5026a9",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-hydrator": "^4.3.0",
+                "laminas/laminas-hydrator": "^4.3.1",
                 "laminas/laminas-inputfilter": "^2.13.0",
-                "laminas/laminas-stdlib": "^3.6.1",
+                "laminas/laminas-stdlib": "^3.7.1",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
@@ -2914,26 +2920,26 @@
                 "laminas/laminas-view": "<2.14.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.12.0",
+                "doctrine/annotations": "^1.13.2",
                 "ext-intl": "*",
                 "laminas/laminas-captcha": "^2.11.0",
                 "laminas/laminas-coding-standard": "^2.3.0",
                 "laminas/laminas-db": "^2.13.4",
                 "laminas/laminas-escaper": "^2.9.0",
                 "laminas/laminas-eventmanager": "^3.4.0",
-                "laminas/laminas-filter": "^2.13.0",
-                "laminas/laminas-i18n": "^2.12.0",
+                "laminas/laminas-filter": "^2.14.0",
+                "laminas/laminas-i18n": "^2.14.0",
                 "laminas/laminas-modulemanager": "^2.11.0",
                 "laminas/laminas-recaptcha": "^3.4.0",
                 "laminas/laminas-servicemanager": "^3.10.0",
-                "laminas/laminas-session": "^2.12.0",
+                "laminas/laminas-session": "^2.12.1",
                 "laminas/laminas-text": "^2.9.0",
-                "laminas/laminas-validator": "^2.15.1",
-                "laminas/laminas-view": "^2.14.0",
+                "laminas/laminas-validator": "^2.16.0",
+                "laminas/laminas-view": "^2.19.1",
                 "phpspec/prophecy-phpunit": "^2.0.1",
-                "phpunit/phpunit": "^9.5.10",
+                "phpunit/phpunit": "^9.5.14",
                 "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.13.1"
+                "vimeo/psalm": "^4.21.0"
             },
             "suggest": {
                 "doctrine/annotations": "^1.12, required to use laminas-form annotations support",
@@ -2980,7 +2986,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-28T15:58:45+00:00"
+            "time": "2022-06-16T10:13:15+00:00"
         },
         {
             "name": "laminas/laminas-http",
@@ -3271,16 +3277,16 @@
         },
         {
             "name": "laminas/laminas-inputfilter",
-            "version": "2.17.0",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-inputfilter.git",
-                "reference": "a6e8bc751c321bae1b3f8e235eeb4871256a6009"
+                "reference": "8c663d35926f8276b4bf1a2c571310eb285f80cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-inputfilter/zipball/a6e8bc751c321bae1b3f8e235eeb4871256a6009",
-                "reference": "a6e8bc751c321bae1b3f8e235eeb4871256a6009",
+                "url": "https://api.github.com/repos/laminas/laminas-inputfilter/zipball/8c663d35926f8276b4bf1a2c571310eb285f80cb",
+                "reference": "8c663d35926f8276b4bf1a2c571310eb285f80cb",
                 "shasum": ""
             },
             "require": {
@@ -3342,7 +3348,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-13T16:43:33+00:00"
+            "time": "2022-06-15T11:40:14+00:00"
         },
         {
             "name": "laminas/laminas-json",
@@ -4666,22 +4672,22 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.19.0",
+            "version": "2.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df"
+                "reference": "ba665f5a52763dda5a747c4ad826d2adf1510486"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/4875d4e58b6f728981bb767a60530540f82ee1df",
-                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/ba665f5a52763dda5a747c4ad826d2adf1510486",
+                "reference": "ba665f5a52763dda5a747c4ad826d2adf1510486",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-servicemanager": "^3.12.0",
                 "laminas/laminas-stdlib": "^3.10",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
@@ -4690,27 +4696,24 @@
                 "laminas/laminas-cache": "^2.6.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-db": "^2.7",
-                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-filter": "^2.14.0",
                 "laminas/laminas-http": "^2.14.2",
-                "laminas/laminas-i18n": "^2.6",
-                "laminas/laminas-math": "^2.6",
-                "laminas/laminas-servicemanager": "^2.7.11 || ^3.0.3",
-                "laminas/laminas-session": "^2.8",
-                "laminas/laminas-uri": "^2.7",
+                "laminas/laminas-i18n": "^2.15.0",
+                "laminas/laminas-session": "^2.12.1",
+                "laminas/laminas-uri": "^2.9.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
                 "psalm/plugin-phpunit": "^0.15.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0",
-                "vimeo/psalm": "^4.3"
+                "vimeo/psalm": "^4.23"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
                 "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
                 "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
                 "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
                 "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
@@ -4752,7 +4755,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-09T21:49:40+00:00"
+            "time": "2022-06-14T12:31:18+00:00"
         },
         {
             "name": "laminas/laminas-view",
@@ -6145,16 +6148,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6187424023fbffcd757789aeb517c9161b1eabee"
+                "reference": "7a86c1c42fbcb69b59768504c7bca1d3767760b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6187424023fbffcd757789aeb517c9161b1eabee",
-                "reference": "6187424023fbffcd757789aeb517c9161b1eabee",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7a86c1c42fbcb69b59768504c7bca1d3767760b7",
+                "reference": "7a86c1c42fbcb69b59768504c7bca1d3767760b7",
                 "shasum": ""
             },
             "require": {
@@ -6221,7 +6224,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.1.1"
+                "source": "https://github.com/symfony/console/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -6237,7 +6240,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-08T14:02:09+00:00"
+            "time": "2022-06-26T13:01:30+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -7129,16 +7132,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.1.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d3edc75baf9f1d4f94879764dda2e1ac33499529"
+                "reference": "1903f2879875280c5af944625e8246d81c2f0604"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d3edc75baf9f1d4f94879764dda2e1ac33499529",
-                "reference": "d3edc75baf9f1d4f94879764dda2e1ac33499529",
+                "url": "https://api.github.com/repos/symfony/string/zipball/1903f2879875280c5af944625e8246d81c2f0604",
+                "reference": "1903f2879875280c5af944625e8246d81c2f0604",
                 "shasum": ""
             },
             "require": {
@@ -7194,7 +7197,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.1.0"
+                "source": "https://github.com/symfony/string/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -7210,7 +7213,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-22T08:18:23+00:00"
+            "time": "2022-06-26T16:35:04+00:00"
         },
         {
             "name": "twbs/bootstrap-sass",
@@ -9543,16 +9546,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.7.13",
+            "version": "1.7.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "86ffc063bfd8f264c9eba568e84b0225a6090d09"
+                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/86ffc063bfd8f264c9eba568e84b0225a6090d09",
-                "reference": "86ffc063bfd8f264c9eba568e84b0225a6090d09",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
+                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
                 "shasum": ""
             },
             "require": {
@@ -9578,7 +9581,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.7.13"
+                "source": "https://github.com/phpstan/phpstan/tree/1.7.15"
             },
             "funding": [
                 {
@@ -9598,7 +9601,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-13T15:15:39+00:00"
+            "time": "2022-06-20T08:29:01+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
@@ -10040,16 +10043,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -10083,7 +10086,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -10127,7 +10129,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -10139,7 +10141,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -11342,16 +11344,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -11394,7 +11396,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-13T06:31:38+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/config",
@@ -11540,16 +11542,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.1.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "fc1fcd2b153f585934e80055bb3254913def2a6e"
+                "reference": "5635ff016a814d7984b1c4644ad28e7df546077b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/fc1fcd2b153f585934e80055bb3254913def2a6e",
-                "reference": "fc1fcd2b153f585934e80055bb3254913def2a6e",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5635ff016a814d7984b1c4644ad28e7df546077b",
+                "reference": "5635ff016a814d7984b1c4644ad28e7df546077b",
                 "shasum": ""
             },
             "require": {
@@ -11607,7 +11609,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.1.0"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -11623,7 +11625,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-27T06:40:20+00:00"
+            "time": "2022-06-26T13:01:30+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -12031,16 +12033,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "96a4db91d2655a85d631af451ab906ccdc711a15"
+                "reference": "1634ac09337990f1a4489263be090a40b0acd985"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/96a4db91d2655a85d631af451ab906ccdc711a15",
-                "reference": "96a4db91d2655a85d631af451ab906ccdc711a15",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/1634ac09337990f1a4489263be090a40b0acd985",
+                "reference": "1634ac09337990f1a4489263be090a40b0acd985",
                 "shasum": ""
             },
             "require": {
@@ -12112,7 +12114,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.1.1"
+                "source": "https://github.com/symfony/serializer/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -12128,7 +12130,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-06T19:15:01+00:00"
+            "time": "2022-06-26T16:35:04+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/docker/glide/composer.lock
+++ b/docker/glide/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "83260bb50b8fc753c72d14dc1621a2dac31877ee"
+                "reference": "13388f00956b1503577598873fffb5ae994b5737"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/83260bb50b8fc753c72d14dc1621a2dac31877ee",
-                "reference": "83260bb50b8fc753c72d14dc1621a2dac31877ee",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/13388f00956b1503577598873fffb5ae994b5737",
+                "reference": "13388f00956b1503577598873fffb5ae994b5737",
                 "shasum": ""
             },
             "require": {
@@ -41,7 +41,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -103,7 +103,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.3.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.0"
             },
             "funding": [
                 {
@@ -119,7 +119,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T08:26:02+00:00"
+            "time": "2022-06-20T21:43:11+00:00"
         },
         {
             "name": "intervention/image",
@@ -207,16 +207,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.0.20",
+            "version": "3.0.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "42a2f47dcf39944e2aee1b660ee55ab6ef69b535"
+                "reference": "8f1fcf9d2304ff77a006aa36dd2cb5f236999b12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/42a2f47dcf39944e2aee1b660ee55ab6ef69b535",
-                "reference": "42a2f47dcf39944e2aee1b660ee55ab6ef69b535",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/8f1fcf9d2304ff77a006aa36dd2cb5f236999b12",
+                "reference": "8f1fcf9d2304ff77a006aa36dd2cb5f236999b12",
                 "shasum": ""
             },
             "require": {
@@ -277,7 +277,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.0.20"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.0.21"
             },
             "funding": [
                 {
@@ -293,7 +293,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-25T19:18:39+00:00"
+            "time": "2022-06-12T17:54:28+00:00"
         },
         {
             "name": "league/glide",

--- a/module/Activity/src/Controller/ActivityCalendarController.php
+++ b/module/Activity/src/Controller/ActivityCalendarController.php
@@ -8,7 +8,10 @@ use Activity\Service\{
     ActivityCalendar as ActivityCalendarService,
     ActivityCalendarForm as ActivityCalendarFormService,
 };
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use User\Permissions\NotAllowedException;
@@ -82,7 +85,7 @@ class ActivityCalendarController extends AbstractActionController
                 'editableOptions' => $this->calendarService->getEditableUpcomingOptions(),
                 'APIKey' => $config['google_api_key'],
                 'calendarKey' => $config['google_calendar_key'],
-                'success' => $this->getRequest()->getQuery('success', false),
+                'success' => (bool) $this->params()->fromQuery('success', false),
                 'canCreate' => $this->calendarService->canCreateProposal(),
                 'canApprove' => $this->calendarService->canApproveOption(),
             ]
@@ -91,6 +94,7 @@ class ActivityCalendarController extends AbstractActionController
 
     public function deleteAction(): Response|ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -103,6 +107,7 @@ class ActivityCalendarController extends AbstractActionController
 
     public function approveAction(): Response|ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -121,7 +126,9 @@ class ActivityCalendarController extends AbstractActionController
             );
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $this->calendarProposalForm->setData($request->getPost()->toArray());
 

--- a/module/Activity/src/Controller/ActivityController.php
+++ b/module/Activity/src/Controller/ActivityController.php
@@ -2,7 +2,6 @@
 
 namespace Activity\Controller;
 
-use Laminas\Stdlib\ParametersInterface;
 use Activity\Form\{
     ModifyRequest as RequestForm,
     Signup as SignupForm,
@@ -20,11 +19,17 @@ use Activity\Service\{
 };
 use DateTime;
 use Laminas\Form\FormInterface;
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Session\Container as SessionContainer;
-use Laminas\Stdlib\Parameters;
+use Laminas\Stdlib\{
+    Parameters,
+    ParametersInterface,
+};
 use Laminas\View\Model\ViewModel;
 
 class ActivityController extends AbstractActionController
@@ -250,6 +255,7 @@ class ActivityController extends AbstractActionController
     public function createAction(): ViewModel
     {
         $form = $this->activityService->getActivityForm();
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -275,7 +281,7 @@ class ActivityController extends AbstractActionController
     }
 
     /**
-     * Signup for a activity.
+     * Signup for an activity.
      */
     public function signupAction(): Response|ViewModel
     {
@@ -287,6 +293,7 @@ class ActivityController extends AbstractActionController
             return $this->notFoundAction();
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -383,6 +390,7 @@ class ActivityController extends AbstractActionController
             return $this->notFoundAction();
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -446,11 +454,12 @@ class ActivityController extends AbstractActionController
             return $this->notFoundAction();
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
             $form = new RequestForm('activitysignoff');
-            $form->setData($this->getRequest()->getPost());
+            $form->setData($request->getPost());
 
             // Check if the form is valid
             if (!$form->isValid()) {

--- a/module/Activity/src/Controller/AdminApprovalController.php
+++ b/module/Activity/src/Controller/AdminApprovalController.php
@@ -9,7 +9,10 @@ use Activity\Service\{
     ActivityQuery as ActivityQueryService,
 };
 use InvalidArgumentException;
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
@@ -106,8 +109,11 @@ class AdminApprovalController extends AbstractActionController
      */
     protected function setApprovalStatus(string $status): Response|ViewModel
     {
-        //Assure the form is used
-        if (!$this->getRequest()->isPost()) {
+        /** @var Request $request */
+        $request = $this->getRequest();
+
+        // Assure the form is used
+        if (!$request->isPost()) {
             return $this->notFoundAction();
         }
 
@@ -119,7 +125,7 @@ class AdminApprovalController extends AbstractActionController
         }
 
         $form = new RequestForm('updateApprovalStatus');
-        $form->setData($this->getRequest()->getPost());
+        $form->setData($request->getPost()->toArray());
 
         //Assure the form is valid
         if (!$form->isValid()) {
@@ -186,15 +192,17 @@ class AdminApprovalController extends AbstractActionController
      */
     public function applyProposalAction(): Response|ViewModel
     {
-        $id = (int)$this->params('id');
+        $id = (int) $this->params('id');
+        /** @var Request $request */
+        $request = $this->getRequest();
 
         //Assure the form is used
-        if (!$this->getRequest()->isPost()) {
+        if (!$request->isPost()) {
             return $this->notFoundAction();
         }
         $form = new RequestForm('proposalApply');
 
-        $form->setData($this->getRequest()->getPost());
+        $form->setData($request->getPost()->toArray());
 
         //Assure the form is valid
         if (!$form->isValid()) {
@@ -221,14 +229,17 @@ class AdminApprovalController extends AbstractActionController
      */
     public function revokeProposalAction(): Response|ViewModel
     {
-        $id = (int)$this->params('id');
+        $id = (int) $this->params('id');
+        /** @var Request $request */
+        $request = $this->getRequest();
+
         //Assure the form is used
-        if (!$this->getRequest()->isPost()) {
+        if (!$request->isPost()) {
             return $this->notFoundAction();
         }
         $form = new RequestForm('proposalRevoke');
 
-        $form->setData($this->getRequest()->getPost());
+        $form->setData($request->getPost()->toArray());
 
         //Assure the form is valid
         if (!$form->isValid()) {

--- a/module/Activity/src/Controller/AdminCategoryController.php
+++ b/module/Activity/src/Controller/AdminCategoryController.php
@@ -6,7 +6,10 @@ use Activity\Service\{
     AclService,
     ActivityCategory as ActivityCategoryService,
 };
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
@@ -71,6 +74,7 @@ class AdminCategoryController extends AbstractActionController
             );
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
         $form = $this->categoryService->getCategoryForm();
 
@@ -118,6 +122,7 @@ class AdminCategoryController extends AbstractActionController
      */
     public function deleteAction(): Response|ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -155,6 +160,7 @@ class AdminCategoryController extends AbstractActionController
         }
 
         $form = $this->categoryService->getCategoryForm();
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {

--- a/module/Activity/src/Controller/AdminOptionController.php
+++ b/module/Activity/src/Controller/AdminOptionController.php
@@ -9,7 +9,10 @@ use Activity\Service\{
 use Activity\Mapper\ActivityOptionCreationPeriod as ActivityOptionCreationPeriodMapper;
 use DateTime;
 use Decision\Service\Organ as OrganService;
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
@@ -86,6 +89,7 @@ class AdminOptionController extends AbstractActionController
         $form = $this->activityCalendarService->getCalendarPeriodForm();
         $organs = $this->organService->getEditableOrgans();
         $organCount = count($organs);
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -123,17 +127,25 @@ class AdminOptionController extends AbstractActionController
     public function deleteAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('delete', 'activity_calendar_period')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to delete option calendar periods'));
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to delete option calendar periods'),
+            );
         }
 
-        if ($this->getRequest()->isPost()) {
+        /** @var Request $request */
+        $request = $this->getRequest();
+
+        if ($request->isPost()) {
             $optionCreationPeriodId = $this->params('id');
             $optionCreationPeriod = $this->activityCalendarService->getOptionCreationPeriod($optionCreationPeriodId);
 
             if (null !== $optionCreationPeriod) {
                 $this->activityCalendarService->deleteOptionCreationPeriod($optionCreationPeriod);
 
-                return $this->redirectWithMessage(true, $this->translator->translate('Option planning period removed.'));
+                return $this->redirectWithMessage(
+                    true,
+                    $this->translator->translate('Option planning period removed.'),
+                );
             }
         }
 
@@ -159,6 +171,7 @@ class AdminOptionController extends AbstractActionController
 
         $form = $this->activityCalendarService->getCalendarPeriodForm();
         $organCount = $optionCreationPeriod->getMaxActivities()->count();
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {

--- a/module/Application/src/Controller/IndexController.php
+++ b/module/Application/src/Controller/IndexController.php
@@ -2,7 +2,11 @@
 
 namespace Application\Controller;
 
-use Laminas\Http\Response;
+use Laminas\View\Model\ViewModel;
+use Laminas\Http\{
+    PhpEnvironment\Response as EnvironmentResponse,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Session\Container as SessionContainer;
 
@@ -42,8 +46,12 @@ class IndexController extends AbstractActionController
     /**
      * Throws a teapot error.
      */
-    public function teapotAction(): void
+    public function teapotAction(): ViewModel
     {
-        $this->getResponse()->setStatusCode(418);
+        /** @var EnvironmentResponse $response */
+        $response = $this->getResponse();
+        $response->setStatusCode(418);
+
+        return new ViewModel();
     }
 }

--- a/module/Application/test/AutomaticControllerTest.php
+++ b/module/Application/test/AutomaticControllerTest.php
@@ -7,6 +7,7 @@ use Iterator;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Http\{
     Literal,
+    Method,
     Part,
     Regex,
     Segment,
@@ -14,7 +15,6 @@ use Laminas\Router\Http\{
 };
 use Laminas\Router\PriorityList;
 use RuntimeException;
-use Traversable;
 
 class AutomaticControllerTest extends BaseControllerTest
 {
@@ -58,6 +58,8 @@ class AutomaticControllerTest extends BaseControllerTest
                 $this->parseSegment($element);
             } elseif ($element instanceof Regex) {
                 $this->parseRegex($element);
+            } elseif ($element instanceof Method) {
+                $this->parseMethod($element);
             } else {
                 throw new RuntimeException(
                     sprintf(
@@ -122,6 +124,11 @@ class AutomaticControllerTest extends BaseControllerTest
         $this->parseUrl($url);
     }
 
+    protected function parseMethod(Method $method): void
+    {
+        // We can assemble all we want, but we will never get a testable route (so we do nothing).
+    }
+
     protected function parseUrl(mixed $url): void
     {
         if (is_string($url)) {
@@ -129,7 +136,7 @@ class AutomaticControllerTest extends BaseControllerTest
         } else {
             throw new RuntimeException(
                 sprintf(
-                    'Unexpected type in parseLiteral: %s',
+                    'Unexpected type in parseUrl: %s',
                     get_class($url),
                 )
             );
@@ -184,6 +191,8 @@ class AutomaticControllerTest extends BaseControllerTest
 
         $params['regulation'] = 'key-policy';
         $params['filename'] = 'file.pdf';
+
+        $params['code'] = 'rbIfZwWKyN7gavp00f4Ygs1ANuGDsL8v';
 
         return $params;
     }

--- a/module/Application/test/BaseControllerTest.php
+++ b/module/Application/test/BaseControllerTest.php
@@ -140,7 +140,7 @@ abstract class BaseControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authService->method('getIdentity')->willReturn($this->setUpMockIdentity($role));
 
-        if ($role != 'guest') {
+        if ($role !== 'guest') {
             $this->authService->method('hasIdentity')->willReturn(true);
         } else {
             $this->authService->method('hasIdentity')->willReturn(false);
@@ -197,6 +197,7 @@ abstract class BaseControllerTest extends AbstractHttpControllerTestCase
         $this->member->setLastName('Committee');
         $this->member->setGeneration(2020);
         $this->member->setType(MembershipTypes::Ordinary);
+        $this->member->setMembershipEndsOn(null);
         $this->member->setExpiration(DateTime::createFromFormat('Y/m/d', '2030/01/01'));
         $this->member->setChangedOn(DateTime::createFromFormat('Y/m/d', '2020/01/01'));
     }

--- a/module/Application/view/partial/admin.phtml
+++ b/module/Application/view/partial/admin.phtml
@@ -79,7 +79,7 @@ $flash = $this->plugin('FlashMessenger');
                     <?php endif; ?>
                     <?php if ($this->acl('decision_service_acl')->isAllowed('meeting', 'upload_minutes')): ?>
                         <li class="dropdown">
-                            <a href="<?= $this->url('admin_decision') ?>" class="dropdown-toggle" data-toggle="dropdown"
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown"
                                role="button" aria-haspopup="true" aria-expanded="false">
                                 <?= $this->translate('Meetings') ?> <span class="caret"></span>
                             </a>

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -10,7 +10,10 @@ use Company\Service\{
 use Company\Model\CompanyJobPackage;
 use DateInterval;
 use DateTime;
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
@@ -96,7 +99,9 @@ class AdminController extends AbstractActionController
         $form = $this->companyService->getCompanyForm();
 
         // Handle incoming form results
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             // Check if data is valid, and insert when it is
             $post = array_merge_recursive(
@@ -149,7 +154,9 @@ class AdminController extends AbstractActionController
         }
 
         // Handle incoming form data
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $post = array_merge_recursive(
                 $request->getPost()->toArray(),
@@ -199,7 +206,9 @@ class AdminController extends AbstractActionController
         }
 
         // Handle incoming form data
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if (!$request->isPost()) {
             return $this->notFoundAction();
         }
@@ -234,7 +243,9 @@ class AdminController extends AbstractActionController
         $packageForm = $this->companyService->getPackageForm($type);
 
         // Handle incoming form results
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $post = array_merge_recursive(
                 $request->getPost()->toArray(),
@@ -308,7 +319,9 @@ class AdminController extends AbstractActionController
         $packageForm = $this->companyService->getPackageForm($type);
 
         // Handle incoming form results
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $post = array_merge_recursive(
                 $request->getPost()->toArray(),
@@ -372,7 +385,9 @@ class AdminController extends AbstractActionController
         }
 
         // Handle incoming form data
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if (!$request->isPost()) {
             return $this->notFoundAction();
         }
@@ -431,7 +446,9 @@ class AdminController extends AbstractActionController
         $jobForm = $this->companyService->getJobForm();
 
         // Handle incoming form results
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $post = array_merge_recursive(
                 $request->getPost()->toArray(),
@@ -505,7 +522,9 @@ class AdminController extends AbstractActionController
         $jobForm = $this->companyService->getJobForm();
 
         // Handle incoming form results
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $post = array_merge_recursive(
                 $request->getPost()->toArray(),
@@ -553,7 +572,9 @@ class AdminController extends AbstractActionController
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete jobs'));
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if (!$request->isPost()) {
             return $this->notFoundAction();
         }
@@ -597,7 +618,9 @@ class AdminController extends AbstractActionController
         $categoryForm = $this->companyService->getCategoryForm();
 
         // Handle incoming form results
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             // Check if data is valid, and insert when it is
             $categoryForm->setData($request->getPost()->toArray());
@@ -656,7 +679,9 @@ class AdminController extends AbstractActionController
         $categoryForm = $this->companyService->getCategoryForm();
 
         // Handle incoming form data
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $categoryForm->setData($request->getPost()->toArray());
             $categoryForm->setCurrentSlug($jobCategory->getPluralName());
@@ -683,7 +708,9 @@ class AdminController extends AbstractActionController
         $labelForm = $this->companyService->getLabelForm();
 
         // Handle incoming form results
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             // Check if data is valid, and insert when it is
             $labelForm->setData($request->getPost()->toArray());
@@ -741,7 +768,9 @@ class AdminController extends AbstractActionController
         $labelForm = $this->companyService->getLabelForm();
 
         // Handle incoming form data
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $labelForm->setData($request->getPost()->toArray());
 

--- a/module/Decision/config/module.config.php
+++ b/module/Decision/config/module.config.php
@@ -17,11 +17,13 @@ use Decision\Controller\Factory\{
     OrganControllerFactory,
 };
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Laminas\Http\Request;
 use Laminas\Router\Http\{
     Literal,
     Method,
     Regex,
-    Segment};
+    Segment,
+};
 
 return [
     'router' => [
@@ -165,7 +167,7 @@ return [
                             'post' => [
                                 'type' => Method::class,
                                 'options' => [
-                                    'verb' => 'POST',
+                                    'verb' => Request::METHOD_POST,
                                     'route' => '/document/delete',
                                     'defaults' => [
                                         'action' => 'deleteDocument',
@@ -184,7 +186,7 @@ return [
                             'post' => [
                                 'type' => Method::class,
                                 'options' => [
-                                    'verb' => 'POST',
+                                    'verb' => Request::METHOD_POST,
                                     'defaults' => [
                                         'action' => 'changePositionDocument',
                                     ],

--- a/module/Decision/config/module.config.php
+++ b/module/Decision/config/module.config.php
@@ -19,8 +19,9 @@ use Decision\Controller\Factory\{
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Laminas\Router\Http\{
     Literal,
-    Segment,
-};
+    Method,
+    Regex,
+    Segment};
 
 return [
     'router' => [
@@ -69,7 +70,7 @@ return [
                         'may_terminate' => true,
                         'child_routes' => [
                             'minutes' => [
-                                'type' => Segment::class,
+                                'type' => Literal::class,
                                 'options' => [
                                     'route' => '/minutes',
                                     'defaults' => [
@@ -101,7 +102,7 @@ return [
                         ],
                     ],
                     'files' => [
-                        'type' => 'Regex',
+                        'type' => Regex::class,
                         'options' => [
                             'regex' => '/files(?<path>' . (new Module())->getServiceConfig()['filebrowser_valid_file'] . ')',
                             'defaults' => [
@@ -119,10 +120,9 @@ return [
                     'route' => '/admin/decision',
                     'defaults' => [
                         'controller' => AdminController::class,
-                        'action' => 'index',
                     ],
                 ],
-                'may_terminate' => true,
+                'may_terminate' => false,
                 'child_routes' => [
                     'default' => [
                         'type' => Segment::class,
@@ -156,20 +156,39 @@ return [
                         ],
                     ],
                     'delete_document' => [
-                        'type' => Segment::class,
+                        'type' => Literal::class,
                         'options' => [
                             'route' => '/document/delete',
-                            'defaults' => [
-                                'action' => 'deleteDocument',
+                        ],
+                        'may_terminate' => false,
+                        'child_routes' => [
+                            'post' => [
+                                'type' => Method::class,
+                                'options' => [
+                                    'verb' => 'POST',
+                                    'route' => '/document/delete',
+                                    'defaults' => [
+                                        'action' => 'deleteDocument',
+                                    ],
+                                ],
                             ],
                         ],
                     ],
                     'position_document' => [
-                        'type' => Segment::class,
+                        'type' => Literal::class,
                         'options' => [
                             'route' => '/document/position',
-                            'defaults' => [
-                                'action' => 'changePositionDocument',
+                        ],
+                        'may_terminate' => false,
+                        'child_routes' => [
+                            'post' => [
+                                'type' => Method::class,
+                                'options' => [
+                                    'verb' => 'POST',
+                                    'defaults' => [
+                                        'action' => 'changePositionDocument',
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -265,7 +284,7 @@ return [
                         ],
                     ],
                     'self' => [
-                        'type' => Segment::class,
+                        'type' => Literal::class,
                         'options' => [
                             'route' => '/self',
                             'defaults' => [

--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -7,6 +7,7 @@ use Decision\Service\{
     AclService,
     Decision as DecisionService,
 };
+use Laminas\Http\Request;
 use Laminas\Http\Response\Stream;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
@@ -132,7 +133,9 @@ class DecisionController extends AbstractActionController
             throw new NotAllowedException($this->translator->translate('You are not allowed to search decisions.'));
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         $form = $this->decisionService->getSearchDecisionForm();
 
         if ($request->isPost()) {
@@ -170,7 +173,9 @@ class DecisionController extends AbstractActionController
 
         $form = $this->decisionService->getAuthorizationForm();
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $form->setData($request->getPost()->toArray());
 

--- a/module/Decision/src/Controller/MemberController.php
+++ b/module/Decision/src/Controller/MemberController.php
@@ -190,12 +190,14 @@ class MemberController extends AbstractActionController
     /**
      * Action to download regulations.
      */
-    public function downloadRegulationAction(): Response
+    public function downloadRegulationAction(): Response|ViewModel
     {
         $regulation = $this->params('regulation');
-        if (isset($this->regulationsConfig['regulation'])) {
-            $this->getResponse()->setStatusCode(404);
+
+        if (!isset($this->regulationsConfig[$regulation])) {
+            return $this->notFoundAction();
         }
+
         $path = $this->regulationsConfig[$regulation];
 
         return $this->redirect()->toUrl($this->url()->fromRoute('decision/files', ['path' => '']) . $path);

--- a/module/Decision/src/Controller/OrganAdminController.php
+++ b/module/Decision/src/Controller/OrganAdminController.php
@@ -4,7 +4,10 @@ namespace Decision\Controller;
 
 use Decision\Service\Organ as OrganService;
 use Laminas\Form\FormInterface;
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
@@ -51,7 +54,9 @@ class OrganAdminController extends AbstractActionController
 
         $form = $this->organService->getOrganInformationForm($organInformation);
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $post = array_merge_recursive(
                 $request->getPost()->toArray(),

--- a/module/Decision/src/Model/Enums/MembershipTypes.php
+++ b/module/Decision/src/Model/Enums/MembershipTypes.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace Decision\Model\Enums;
 

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -383,8 +383,10 @@ class Decision
         }
 
         // TODO: The actual file is never deleted.
-        $document = $this->getMeetingDocument($data['document']);
-        $this->meetingMapper->remove($document);
+        if (isset($data['document'])) {
+            $document = $this->getMeetingDocument($data['document']);
+            $this->meetingMapper->remove($document);
+        }
     }
 
     /**

--- a/module/Decision/test/ControllerTest.php
+++ b/module/Decision/test/ControllerTest.php
@@ -3,6 +3,7 @@
 namespace DecisionTest;
 
 use ApplicationTest\BaseControllerTest;
+use Laminas\Http\Request;
 
 class ControllerTest extends BaseControllerTest
 {
@@ -65,6 +66,34 @@ class ControllerTest extends BaseControllerTest
         $this->setUpWithRole('admin');
         $this->dispatch('/admin/decision/document');
         $this->assertResponseStatusCode(200);
+    }
+
+    public function testAdminDecisionDocumentDeleteActionCannotBeAccessedAsAdminViaGet(): void
+    {
+        $this->setUpWithRole('admin');
+        $this->dispatch('/admin/decision/document/delete', Request::METHOD_GET);
+        $this->assertResponseStatusCode(404);
+    }
+
+    public function testAdminDecisionDocumentDeleteActionCanBeAccessedAsAdminViaPost(): void
+    {
+        $this->setUpWithRole('admin');
+        $this->dispatch('/admin/decision/document/delete', Request::METHOD_POST);
+        $this->assertResponseStatusCode(302);
+    }
+
+    public function testAdminDecisionDocumentPositionActionCannotBeAccessedAsAdminViaGet(): void
+    {
+        $this->setUpWithRole('admin');
+        $this->dispatch('/admin/decision/document/position', Request::METHOD_GET);
+        $this->assertResponseStatusCode(404);
+    }
+
+    public function testAdminDecisionDocumentPositionActionCanBeAccessedAsAdminViaPost(): void
+    {
+        $this->setUpWithRole('admin');
+        $this->dispatch('/admin/decision/document/position', Request::METHOD_POST);
+        $this->assertResponseStatusCode(400);
     }
 
     public function testAdminDecisionAuthorizationsActionCanBeAccessedAsAdmin(): void

--- a/module/Decision/view/decision/admin/document.phtml
+++ b/module/Decision/view/decision/admin/document.phtml
@@ -84,7 +84,7 @@ $element = $form->get('meeting');
 
                             $form->setAttributes([
                                 'class' => 'form-reorder-document',
-                                'action' => $this->url('admin_decision/position_document')
+                                'action' => $this->url('admin_decision/position_document/post')
                             ]);
                             $form->populateValues([
                                 'document' => $document->getId()
@@ -103,7 +103,7 @@ $element = $form->get('meeting');
                             </a>
                         </td>
                         <td>
-                            <form method="POST" action="<?= $this->url('admin_decision/delete_document') ?>">
+                            <form method="POST" action="<?= $this->url('admin_decision/delete_document/post') ?>">
                                 <input type="hidden" name="document" value="<?= $document->getId() ?>">
                                 <input type="submit" name="submit" value="<?= $this->translate('Delete') ?>"
                                        class="btn btn-danger btn-xs pull-right"/>

--- a/module/Education/src/Controller/AdminController.php
+++ b/module/Education/src/Controller/AdminController.php
@@ -3,6 +3,7 @@
 namespace Education\Controller;
 
 use Education\Service\Exam as ExamService;
+use Laminas\Http\Request;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -42,6 +43,7 @@ class AdminController extends AbstractActionController
 
     public function addCourseAction(): ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -75,6 +77,7 @@ class AdminController extends AbstractActionController
 
     public function bulkExamAction(): ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -105,6 +108,7 @@ class AdminController extends AbstractActionController
 
     public function bulkSummaryAction(): ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -138,6 +142,7 @@ class AdminController extends AbstractActionController
      */
     public function editExamAction(): ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost() && $this->examService->bulkExamEdit($request->getPost()->toArray())) {
@@ -161,6 +166,7 @@ class AdminController extends AbstractActionController
      */
     public function editSummaryAction(): ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost() && $this->examService->bulkSummaryEdit($request->getPost()->toArray())) {
@@ -183,7 +189,9 @@ class AdminController extends AbstractActionController
 
     public function deleteTempAction(): JsonModel|ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $this->examService->deleteTempExam(
                 $this->params()->fromRoute('filename'),

--- a/module/Education/src/Controller/EducationController.php
+++ b/module/Education/src/Controller/EducationController.php
@@ -37,11 +37,12 @@ class EducationController extends AbstractActionController
 
     public function indexAction(): ViewModel
     {
-        $query = $this->getRequest()->getQuery();
+        /** @var array $query */
+        $query = $this->params()->fromQuery();
         $form = $this->searchCourseForm;
 
         if (isset($query['query'])) {
-            $form->setData($query->toArray());
+            $form->setData($query);
 
             if ($form->isValid()) {
                 $courses = $this->examService->searchCourse($form->getData());

--- a/module/Frontpage/src/Controller/NewsAdminController.php
+++ b/module/Frontpage/src/Controller/NewsAdminController.php
@@ -6,7 +6,10 @@ use Frontpage\Service\{
     AclService,
     News as NewsService,
 };
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Paginator\Paginator;
@@ -77,7 +80,9 @@ class NewsAdminController extends AbstractActionController
 
         $form = $this->newsService->getNewsItemForm();
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $form->setData($request->getPost()->toArray());
 
@@ -119,7 +124,9 @@ class NewsAdminController extends AbstractActionController
 
         $form = $this->newsService->getNewsItemForm();
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $form->setData($request->getPost()->toArray());
 

--- a/module/Frontpage/src/Controller/PageAdminController.php
+++ b/module/Frontpage/src/Controller/PageAdminController.php
@@ -4,6 +4,10 @@ namespace Frontpage\Controller;
 
 use Exception;
 use Frontpage\Service\Page as PageService;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -38,13 +42,14 @@ class PageAdminController extends AbstractActionController
         );
     }
 
-    public function createAction(): ViewModel
+    public function createAction(): Response|ViewModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
             if ($this->pageService->createPage($request->getPost())) {
-                $this->redirect()->toUrl($this->url()->fromRoute('admin_page'));
+                return $this->redirect()->toUrl($this->url()->fromRoute('admin_page'));
             }
         }
 
@@ -63,14 +68,15 @@ class PageAdminController extends AbstractActionController
         return $view;
     }
 
-    public function editAction(): ViewModel
+    public function editAction(): Response|ViewModel
     {
         $pageId = $this->params()->fromRoute('page_id');
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
             if ($this->pageService->updatePage($pageId, $request->getPost())) {
-                $this->redirect()->toUrl($this->url()->fromRoute('admin_page'));
+                return $this->redirect()->toUrl($this->url()->fromRoute('admin_page'));
             }
         }
 
@@ -85,15 +91,17 @@ class PageAdminController extends AbstractActionController
         );
     }
 
-    public function deleteAction(): void
+    public function deleteAction(): Response
     {
         $pageId = $this->params()->fromRoute('page_id');
         $this->pageService->deletePage($pageId);
-        $this->redirect()->toUrl($this->url()->fromRoute('admin_page'));
+
+        return $this->redirect()->toUrl($this->url()->fromRoute('admin_page'));
     }
 
     public function uploadAction(): JsonModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
         $result = [];
         $result['uploaded'] = 0;
@@ -101,7 +109,7 @@ class PageAdminController extends AbstractActionController
         if ($request->isPost()) {
             try {
                 $path = $this->pageService->uploadImage($request->getFiles());
-                $result['url'] = $request->getBasePath() . '/' . $path;
+                $result['url'] = '/' . $path;
                 $result['fileName'] = $path;
                 $result['uploaded'] = 1;
             } catch (Exception $e) {

--- a/module/Frontpage/src/Controller/PollAdminController.php
+++ b/module/Frontpage/src/Controller/PollAdminController.php
@@ -2,9 +2,14 @@
 
 namespace Frontpage\Controller;
 
-use Frontpage\Service\AclService;
-use Frontpage\Service\Poll as PollService;
-use Laminas\Http\Response;
+use Frontpage\Service\{
+    AclService,
+    Poll as PollService,
+};
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Paginator\Paginator;
@@ -86,14 +91,17 @@ class PollAdminController extends AbstractActionController
             throw new NotAllowedException($this->translator->translate('You are not allowed to approve polls'));
         }
 
-        if ($this->getRequest()->isPost()) {
+        /** @var Request $request */
+        $request = $this->getRequest();
+
+        if ($request->isPost()) {
             $pollId = $this->params()->fromRoute('poll_id');
             $poll = $this->pollService->getPoll($pollId);
 
             if (null !== $poll) {
                 $approvalForm = $this->pollService->getPollApprovalForm();
                 $approvalForm->bind($poll);
-                $approvalForm->setData($this->getRequest()->getPost()->toArray());
+                $approvalForm->setData($request->getPost()->toArray());
 
                 if ($approvalForm->isValid()) {
                     if ($this->pollService->approvePoll($poll)) {
@@ -115,7 +123,10 @@ class PollAdminController extends AbstractActionController
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete polls'));
         }
 
-        if ($this->getRequest()->isPost()) {
+        /** @var Request $request */
+        $request = $this->getRequest();
+
+        if ($request->isPost()) {
             $pollId = $this->params()->fromRoute('poll_id');
             $poll = $this->pollService->getPoll($pollId);
 

--- a/module/Frontpage/src/Controller/PollController.php
+++ b/module/Frontpage/src/Controller/PollController.php
@@ -8,11 +8,13 @@ use Frontpage\Service\{
     AclService,
     Poll as PollService,
 };
-use Laminas\Http\PhpEnvironment\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Paginator\Paginator;
-use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\ViewModel;
 use User\Permissions\NotAllowedException;
 
@@ -101,9 +103,10 @@ class PollController extends AbstractActionController
     /**
      * Submits a poll vote.
      */
-    public function voteAction(): Response|ResponseInterface
+    public function voteAction(): Response
     {
         $pollId = (int)$this->params('poll_id');
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -113,9 +116,7 @@ class PollController extends AbstractActionController
             }
         }
 
-        $this->redirect()->toRoute('poll/view', ['poll_id' => $pollId]);
-
-        return $this->getResponse();
+        return $this->redirect()->toRoute('poll/view', ['poll_id' => $pollId]);
     }
 
     /**
@@ -136,7 +137,9 @@ class PollController extends AbstractActionController
             return $this->notFoundAction();
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $this->pollCommentForm->setData($request->getPost()->toArray());
 
@@ -182,7 +185,9 @@ class PollController extends AbstractActionController
     {
         $form = $this->pollService->getPollForm();
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             if ($this->pollService->requestPoll($request->getPost())) {
                 return new ViewModel(

--- a/module/Photo/src/Controller/AlbumAdminController.php
+++ b/module/Photo/src/Controller/AlbumAdminController.php
@@ -3,7 +3,10 @@
 namespace Photo\Controller;
 
 use Exception;
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -68,7 +71,9 @@ class AlbumAdminController extends AbstractActionController
     {
         $form = $this->albumService->getCreateAlbumForm();
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $albumId = $this->params()->fromRoute('album_id');
             $form->setData($request->getPost()->toArray());
@@ -114,7 +119,9 @@ class AlbumAdminController extends AbstractActionController
         $albumId = $this->params()->fromRoute('album_id');
         $form = $this->albumService->getEditAlbumForm($albumId);
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $form->setData($request->getPost()->toArray());
 
@@ -151,7 +158,9 @@ class AlbumAdminController extends AbstractActionController
      */
     public function uploadAction(): JsonModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
+
         $result = [];
         $result['success'] = false;
         if ($request->isPost()) {
@@ -175,7 +184,9 @@ class AlbumAdminController extends AbstractActionController
      */
     public function moveAction(): JsonModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
+
         $result = [];
         if ($request->isPost()) {
             $albumId = $this->params()->fromRoute('album_id');
@@ -196,7 +207,9 @@ class AlbumAdminController extends AbstractActionController
      */
     public function deleteAction(): JsonModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
+
         $albumId = $this->params()->fromRoute('album_id');
         if ($request->isPost()) {
             $this->albumService->deleteAlbum($albumId);
@@ -210,7 +223,10 @@ class AlbumAdminController extends AbstractActionController
      */
     public function coverAction(): JsonModel
     {
-        if ($this->getRequest()->isPost()) {
+        /** @var Request $request */
+        $request = $this->getRequest();
+
+        if ($request->isPost()) {
             $albumId = $this->params()->fromRoute('album_id');
             $this->albumService->generateAlbumCover($albumId);
         }

--- a/module/Photo/src/Controller/PhotoAdminController.php
+++ b/module/Photo/src/Controller/PhotoAdminController.php
@@ -2,6 +2,7 @@
 
 namespace Photo\Controller;
 
+use Laminas\Http\Request;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -67,8 +68,10 @@ class PhotoAdminController extends AbstractActionController
      */
     public function moveAction(): JsonModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
         $result = [];
+
         if ($request->isPost()) {
             $photoId = $this->params()->fromRoute('photo_id');
             $albumId = $request->getPost()['album_id'];
@@ -83,7 +86,9 @@ class PhotoAdminController extends AbstractActionController
      */
     public function deleteAction(): JsonModel
     {
+        /** @var Request $request */
         $request = $this->getRequest();
+
         $result = [];
         if ($request->isPost()) {
             $photoId = $this->params()->fromRoute('photo_id');

--- a/module/Photo/src/Controller/PhotoController.php
+++ b/module/Photo/src/Controller/PhotoController.php
@@ -2,8 +2,11 @@
 
 namespace Photo\Controller;
 
-use Laminas\Http\Response;
-use Laminas\Http\Response\Stream;
+use Laminas\Http\{
+    Request,
+    Response,
+    Response\Stream,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
     JsonModel,
@@ -129,7 +132,10 @@ class PhotoController extends AbstractActionController
      */
     public function setProfilePhotoAction(): JsonModel|ViewModel
     {
-        if ($this->getRequest()->isPost()) {
+        /** @var Request $request */
+        $request = $this->getRequest();
+
+        if ($request->isPost()) {
             $photoId = $this->params()->fromRoute('photo_id');
             $this->photoService->setProfilePhoto($photoId);
 
@@ -170,7 +176,10 @@ class PhotoController extends AbstractActionController
             );
         }
 
-        if ($this->getRequest()->isPost()) {
+        /** @var Request $request */
+        $request = $this->getRequest();
+
+        if ($request->isPost()) {
             $photoId = $this->params()->fromRoute('photo_id');
             $this->photoService->countVote($photoId);
 

--- a/module/Photo/src/Controller/TagController.php
+++ b/module/Photo/src/Controller/TagController.php
@@ -2,6 +2,7 @@
 
 namespace Photo\Controller;
 
+use Laminas\Http\Request;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\JsonModel;
@@ -25,6 +26,8 @@ class TagController extends AbstractActionController
     /**
      * TagController constructor.
      *
+     * @param AclService $aclService
+     * @param Translator $translator
      * @param PhotoService $photoService
      */
     public function __construct(
@@ -43,13 +46,16 @@ class TagController extends AbstractActionController
             throw new NotAllowedException($this->translator->translate('Not allowed to add tags.'));
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
         $result = [];
+
         if ($request->isPost()) {
             $photoId = $this->params()->fromRoute('photo_id');
             $lidnr = $this->params()->fromRoute('lidnr');
             $tag = $this->photoService->addTag($photoId, $lidnr);
-            if (is_null($tag)) {
+
+            if (null === $tag) {
                 $result['success'] = false;
             } else {
                 $result['success'] = true;
@@ -66,8 +72,10 @@ class TagController extends AbstractActionController
             throw new NotAllowedException($this->translator->translate('Not allowed to remove tags.'));
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
         $result = [];
+
         if ($request->isPost()) {
             $photoId = $this->params()->fromRoute('photo_id');
             $lidnr = $this->params()->fromRoute('lidnr');

--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -58,28 +58,14 @@ return [
                             ],
                         ],
                     ],
-                    'activate_reset' => [
-                        'type' => Segment::class,
-                        'options' => [
-                            'route' => '/reset/:code',
-                            'constraints' => [
-                                'code' => '[a-zA-Z0-9]*',
-                            ],
-                            'defaults' => [
-                                'code' => '',
-                                'action' => 'activateReset',
-                            ],
-                        ],
-                    ],
                     'activate' => [
                         'type' => Segment::class,
                         'options' => [
                             'route' => '/activate/:code',
                             'constraints' => [
-                                'code' => '[a-zA-Z0-9]*',
+                                'code' => '[a-zA-Z0-9]{32,}',
                             ],
                             'defaults' => [
-                                'code' => '',
                                 'action' => 'activate',
                             ],
                         ],

--- a/module/User/src/Controller/ApiAdminController.php
+++ b/module/User/src/Controller/ApiAdminController.php
@@ -2,7 +2,10 @@
 
 namespace User\Controller;
 
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use User\Service\ApiUser as ApiUserService;
@@ -45,7 +48,9 @@ class ApiAdminController extends AbstractActionController
     {
         $form = $this->apiUserService->getApiTokenForm();
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $form->setData($request->getPost()->toArray());
 
@@ -76,6 +81,8 @@ class ApiAdminController extends AbstractActionController
     {
         $id = $this->params()->fromRoute('id');
         $service = $this->apiUserService;
+
+        /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {

--- a/module/User/src/Controller/ApiAuthenticationController.php
+++ b/module/User/src/Controller/ApiAuthenticationController.php
@@ -3,7 +3,10 @@
 namespace User\Controller;
 
 use DateTime;
-use Laminas\Http\Response;
+use Laminas\Http\{
+    Request,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use User\Form\{
@@ -107,7 +110,9 @@ class ApiAuthenticationController extends AbstractActionController
             $form = $this->apiAppAuthorisationInitialForm;
         }
 
+        /** @var Request $request */
         $request = $this->getRequest();
+
         if ($request->isPost()) {
             $form->setData($request->getPost()->toArray());
 

--- a/module/User/src/Controller/ApiController.php
+++ b/module/User/src/Controller/ApiController.php
@@ -3,7 +3,10 @@
 namespace User\Controller;
 
 use Decision\Service\MemberInfo as MemberInfoService;
-use Laminas\Http\PhpEnvironment\Response;
+use Laminas\Http\{
+    PhpEnvironment\Response as EnvironmentResponse,
+    Response,
+};
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Stdlib\ResponseInterface;
 use User\Service\AclService;
@@ -38,10 +41,13 @@ class ApiController extends AbstractActionController
     {
         if ($this->aclService->hasIdentity()) {
             $identity = $this->aclService->getIdentity();
+            /** @var EnvironmentResponse $response */
             $response = $this->getResponse();
+
             $response->setStatusCode(200);
             $headers = $response->getHeaders();
             $headers->addHeaderLine('GEWIS-MemberID', (string) $identity->getLidnr());
+
             if (null != $identity->getMember()) {
                 $member = $identity->getMember();
                 $name = $member->getFullName();
@@ -56,6 +62,7 @@ class ApiController extends AbstractActionController
 
             return $response;
         }
+
         $response = $this->getResponse();
         $response->setStatusCode(401);
 

--- a/module/User/src/Controller/UserController.php
+++ b/module/User/src/Controller/UserController.php
@@ -40,15 +40,16 @@ class UserController extends AbstractActionController
 
         if ($request->isPost()) {
             $data = $request->getPost()->toArray();
+            // Update the referrer if a redirect is already set.
+            if (!empty($data['redirect'])) {
+                $referer = $data['redirect'];
+            }
+
             // try to login
             $login = $this->userService->login($data);
 
-            if (!is_null($login)) {
-                if (is_null($data['redirect']) || empty($data['redirect'])) {
-                    return $this->redirect()->toUrl($referer);
-                }
-
-                return $this->redirect()->toUrl($data['redirect']);
+            if (null !== $login) {
+                return $this->redirect()->toUrl($referer);
             }
         }
 

--- a/module/User/src/Controller/UserController.php
+++ b/module/User/src/Controller/UserController.php
@@ -182,12 +182,7 @@ class UserController extends AbstractActionController
      */
     public function activateAction(): Response|ViewModel
     {
-        $code = $this->params()->fromRoute('code');
-
-        if (empty($code)) {
-            // no code given
-            return $this->redirect()->toRoute('home');
-        }
+        $code = (string) $this->params()->fromRoute('code');
 
         // get the new user
         $newUser = $this->userService->getNewUser($code);

--- a/module/User/src/Model/Enums/JWTClaims.php
+++ b/module/User/src/Model/Enums/JWTClaims.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace User\Model\Enums;
 

--- a/module/User/src/Service/User.php
+++ b/module/User/src/Service/User.php
@@ -183,11 +183,11 @@ class User
      *
      * Will also send an email to the user.
      *
-     * @param Parameters $data Registration data
+     * @param array $data Registration data
      *
      * @return NewUserModel|null New registered user. Null when the user could not be registered.
      */
-    public function register(Parameters $data): ?NewUserModel
+    public function register(array $data): ?NewUserModel
     {
         $form = $this->registerForm;
         $form->setData($data);
@@ -337,11 +337,11 @@ class User
     /**
      * Log the user in.
      *
-     * @param Parameters $data Login data
+     * @param array $data Login data
      *
      * @return UserModel|null Authenticated user. Null if not authenticated.
      */
-    public function login(Parameters $data): ?UserModel
+    public function login(array $data): ?UserModel
     {
         $form = $this->getLoginForm();
         $form->setData($data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -759,12 +759,12 @@
             }
         },
         "node_modules/globule": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.3.tgz",
-            "integrity": "sha512-mb1aYtDbIjTu4ShMB85m3UzjX9BVKe9WCzsnfMSZk+K5GpIbBOexgg4PPCt5eHDEG5/ZQAUX2Kct02zfiPLsKg==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
+            "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
             "dependencies": {
                 "glob": "~7.1.1",
-                "lodash": "~4.17.10",
+                "lodash": "^4.17.21",
                 "minimatch": "~3.0.2"
             },
             "engines": {
@@ -1234,9 +1234,9 @@
             }
         },
         "node_modules/minipass": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-            "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
+            "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -1788,11 +1788,11 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
             "dependencies": {
-                "is-core-module": "^2.8.1",
+                "is-core-module": "^2.9.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -2245,7 +2245,7 @@
         "node_modules/verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
             "engines": [
                 "node >=0.6.0"
             ],
@@ -2296,7 +2296,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/y18n": {
             "version": "5.0.8",
@@ -2929,12 +2929,12 @@
             }
         },
         "globule": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.3.tgz",
-            "integrity": "sha512-mb1aYtDbIjTu4ShMB85m3UzjX9BVKe9WCzsnfMSZk+K5GpIbBOexgg4PPCt5eHDEG5/ZQAUX2Kct02zfiPLsKg==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
+            "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
             "requires": {
                 "glob": "~7.1.1",
-                "lodash": "~4.17.10",
+                "lodash": "^4.17.21",
                 "minimatch": "~3.0.2"
             },
             "dependencies": {
@@ -3305,9 +3305,9 @@
             }
         },
         "minipass": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-            "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
+            "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -3720,11 +3720,11 @@
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
         },
         "resolve": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
             "requires": {
-                "is-core-module": "^2.8.1",
+                "is-core-module": "^2.9.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             }
@@ -4067,7 +4067,7 @@
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
             "requires": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -4103,7 +4103,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "y18n": {
             "version": "5.0.8",

--- a/psalm/psalm-baseline.xml
+++ b/psalm/psalm-baseline.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.23.0@f1fe6ff483bf325c803df9f510d09a03fd796f88">
-  <file src="module/Activity/src/Controller/AdminController.php">
-    <MoreSpecificReturnType occurrences="1">
-      <code>Response|ViewModel</code>
-    </MoreSpecificReturnType>
-  </file>
   <file src="module/Activity/src/Model/ActivityCalendarOption.php">
     <InvalidNullableReturnType occurrences="1">
       <code>int|string</code>
@@ -103,12 +98,6 @@
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="1">
       <code>int</code>
-    </InvalidReturnType>
-  </file>
-  <file src="module/User/src/Model/Enums/JWTClaims.php">
-    <InvalidReturnStatement occurrences="1"/>
-    <InvalidReturnType occurrences="1">
-      <code>bool|int|string</code>
     </InvalidReturnType>
   </file>
 </files>


### PR DESCRIPTION
Based on #1479.

Fixes most if not all of the Psalm issues regarding `$this->getRequest()` in the view actions. I am aware that ideally Laminas should use the proper types, but knowing they never responded to Koen's issue it is just easier to do it like this (*).

Fixes #1050.

(*): It is actually a bit weird: the return type of `getRequest()` is the `Laminas\Stdlib\RequestInterface` and type inference automatically adds `Laminas\Http\Request` (aliased `HttpRequest`) if the value is `null`. However, the value should theoretically never be null, because it is created during the application initialisation. Which, funnily enough, does not use `Laminas\Http\Request` but `Laminas\Http\PhpEnvironment\Request` (extension of the former).