### PR TITLE
Fix profile photo association being incorrectly mapped

### DIFF
--- a/module/Photo/src/Model/Photo.php
+++ b/module/Photo/src/Model/Photo.php
@@ -3,7 +3,10 @@
 namespace Photo\Model;
 
 use DateTime;
-use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\{
+    ArrayCollection,
+    Collection,
+};
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
@@ -184,6 +187,17 @@ class Photo implements ResourceInterface
     protected Collection $tags;
 
     /**
+     * All the profile photos that use this photo.
+     */
+    #[OneToMany(
+        targetEntity: ProfilePhoto::class,
+        mappedBy: "photo",
+        cascade: ["persist", "remove"],
+        fetch: "EXTRA_LAZY",
+    )]
+    protected Collection $profilePhotos;
+
+    /**
      * The corresponding WeeklyPhoto entity if this photo has been a weekly photo.
      */
     #[OneToOne(
@@ -201,6 +215,12 @@ class Photo implements ResourceInterface
         nullable: true,
     )]
     protected ?float $aspectRatio = null;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+        $this->profilePhotos = new ArrayCollection();
+    }
 
     /**
      * Get the ID.
@@ -590,6 +610,36 @@ class Photo implements ResourceInterface
     {
         $tag->setPhoto($this);
         $this->tags[] = $tag;
+    }
+
+    public function addProfilePhotos(array $profilePhotos): void
+    {
+        foreach ($profilePhotos as $profilePhoto) {
+            $this->addProfilePhoto($profilePhoto);
+        }
+    }
+
+    public function addProfilePhoto(ProfilePhoto $profilePhoto): void
+    {
+        $profilePhoto->setPhoto($this);
+        $this->profilePhotos->add($profilePhoto);
+    }
+
+    public function removeProfilePhotos(array $profilePhotos): void
+    {
+        foreach ($profilePhotos as $profilePhoto) {
+            $this->removeProfilePhoto($profilePhoto);
+        }
+    }
+
+    public function removeProfilePhoto(ProfilePhoto $profilePhoto): void
+    {
+        $this->profilePhotos->removeElement($profilePhoto);
+    }
+
+    public function getProfilePhotos(): Collection
+    {
+        return $this->profilePhotos;
     }
 
     /**


### PR DESCRIPTION
This fixes an issue where the only the owning side of the profile photo association to a photo was mapped and that definition used the incorrect property. This meant that when a photo as deleted, it would fail if a profile photo was set with that photo.

This has been resolved by properly defining the inverse side and fixing the owning side of the association.

Fixes #1493.