### PR TITLE
`gewisdb` parity update

### DIFF
--- a/module/Activity/test/Mapper/ActivityMapperTest.php
+++ b/module/Activity/test/Mapper/ActivityMapperTest.php
@@ -59,7 +59,6 @@ class ActivityMapperTest extends BaseMapperTest
         $this->member->setFirstName('Web');
         $this->member->setMiddleName('');
         $this->member->setLastName('Committee');
-        $this->member->setGender(Member::GENDER_OTHER);
         $this->member->setGeneration(2020);
         $this->member->setType(MembershipTypes::Ordinary);
         $this->member->setChangedOn(new DateTime());

--- a/module/Application/test/BaseControllerTest.php
+++ b/module/Application/test/BaseControllerTest.php
@@ -190,7 +190,6 @@ abstract class BaseControllerTest extends AbstractHttpControllerTestCase
         $this->member->setLidnr($this::LIDNR);
         $this->member->setEmail('web@gewis.nl');
         $this->member->setBirth(DateTime::createFromFormat('Y/m/d', '2000/01/01'));
-        $this->member->setGender(Member::GENDER_MALE);
         $this->member->setInitials('W.C.');
         $this->member->setFirstName('Web');
         $this->member->setMiddleName('');

--- a/module/Decision/config/module.config.php
+++ b/module/Decision/config/module.config.php
@@ -147,7 +147,7 @@ return [
                     'document' => [
                         'type' => Segment::class,
                         'options' => [
-                            'route' => '/document[/:type][/:number]',
+                            'route' => '/document[/:type/:number]',
                             'constraints' => [
                                 'type' => 'BV|AV|VV|Virt',
                                 'number' => '[0-9]+',

--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -2,11 +2,13 @@
 
 namespace Decision\Controller;
 
+use Decision\Model\Enums\MeetingTypes;
 use Decision\Service\Decision as DecisionService;
 use Laminas\Http\{
     PhpEnvironment\Response as EnvironmentResponse,
     Request,
-    Response};
+    Response,
+};
 use Laminas\Json\Json;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
@@ -73,12 +75,16 @@ class AdminController extends AbstractActionController
      */
     public function documentAction(): ViewModel
     {
-        $type = $this->params()->fromRoute('type');
+        $type = MeetingTypes::from($this->params()->fromRoute('type'));
         $number = $this->params()->fromRoute('number');
-        $meetings = $this->decisionService->getMeetingsByType('AV');
-        $meetings = array_merge($meetings, $this->decisionService->getMeetingsByType('VV'));
 
-        if (null === $number && !empty($meetings)) {
+        $meetings = $this->decisionService->getMeetingsByType(MeetingTypes::AV);
+        $meetings = array_merge($meetings, $this->decisionService->getMeetingsByType(MeetingTypes::VV));
+
+        if (
+            null === $number
+            && !empty($meetings)
+        ) {
             $number = $meetings[0]->getNumber();
             $type = $meetings[0]->getType();
         }
@@ -153,7 +159,7 @@ class AdminController extends AbstractActionController
 
     public function authorizationsAction(): ViewModel
     {
-        $meetings = $this->decisionService->getMeetingsByType('AV');
+        $meetings = $this->decisionService->getMeetingsByType(MeetingTypes::AV);
         $number = $this->params()->fromRoute('number');
         $authorizations = [];
 

--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -75,7 +75,12 @@ class AdminController extends AbstractActionController
      */
     public function documentAction(): ViewModel
     {
-        $type = MeetingTypes::from($this->params()->fromRoute('type'));
+        $type = $this->params()->fromRoute('type');
+
+        if (null !== $type) {
+            $type = MeetingTypes::from($type);
+        }
+
         $number = $this->params()->fromRoute('number');
 
         $meetings = $this->decisionService->getMeetingsByType(MeetingTypes::AV);
@@ -83,6 +88,7 @@ class AdminController extends AbstractActionController
 
         if (
             null === $number
+            && null === $type
             && !empty($meetings)
         ) {
             $number = $meetings[0]->getNumber();

--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -89,10 +89,13 @@ class AdminController extends AbstractActionController
         if (
             null === $number
             && null === $type
-            && !empty($meetings)
         ) {
-            $number = $meetings[0]->getNumber();
-            $type = $meetings[0]->getType();
+            if (!empty($meetings)) {
+                $number = $meetings[0]->getNumber();
+                $type = $meetings[0]->getType();
+            } else {
+                return new ViewModel(['noMeetings' => true]);
+            }
         }
 
         $form = $this->decisionService->getDocumentForm();

--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -3,6 +3,7 @@
 namespace Decision\Controller;
 
 use Decision\Controller\FileBrowser\FileReader;
+use Decision\Model\Enums\MeetingTypes;
 use Decision\Service\{
     AclService,
     Decision as DecisionService,
@@ -73,7 +74,7 @@ class DecisionController extends AbstractActionController
      */
     public function minutesAction(): ViewModel|Stream
     {
-        $type = $this->params()->fromRoute('type');
+        $type = MeetingTypes::from($this->params()->fromRoute('type'));
         $number = $this->params()->fromRoute('number');
 
         $meeting = $this->decisionService->getMeeting($type, $number);
@@ -109,7 +110,7 @@ class DecisionController extends AbstractActionController
      */
     public function viewAction(): ViewModel
     {
-        $type = $this->params()->fromRoute('type');
+        $type = MeetingTypes::from($this->params()->fromRoute('type'));
         $number = $this->params()->fromRoute('number');
 
         $meeting = $this->decisionService->getMeeting($type, $number);

--- a/module/Decision/src/Controller/MemberController.php
+++ b/module/Decision/src/Controller/MemberController.php
@@ -8,6 +8,7 @@ use Decision\Service\{
     Member as MemberService,
     MemberInfo as MemberInfoService,
 };
+use Decision\Model\Enums\MeetingTypes;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\{
@@ -78,9 +79,9 @@ class MemberController extends AbstractActionController
     {
         // Get the latest 3 meetings of each type and flatten result
         $meetingsCollection = [
-            'AV' => array_column($this->decisionService->getPastMeetings(3, 'AV'), 0),
-            'BV' => array_column($this->decisionService->getPastMeetings(3, 'BV'), 0),
-            'VV' => array_column($this->decisionService->getPastMeetings(3, 'VV'), 0),
+            MeetingTypes::AV->value => array_column($this->decisionService->getPastMeetings(3, MeetingTypes::AV), 0),
+            MeetingTypes::BV->value => array_column($this->decisionService->getPastMeetings(3, MeetingTypes::BV), 0),
+            MeetingTypes::VV->value => array_column($this->decisionService->getPastMeetings(3, MeetingTypes::VV), 0),
         ];
 
         $member = $this->aclService->getIdentityOrThrowException()->getMember();

--- a/module/Decision/src/Form/Minutes.php
+++ b/module/Decision/src/Form/Minutes.php
@@ -75,8 +75,8 @@ class Minutes extends Form implements InputFilterProviderInterface
         $options = [];
         foreach ($meetings as $meeting) {
             $meeting = $meeting[0];
-            $name = $meeting->getType() . '/' . $meeting->getNumber();
-            $options[$name] = $meeting->getType() . ' ' . $meeting->getNumber()
+            $name = $meeting->getType()->value . '/' . $meeting->getNumber();
+            $options[$name] = $meeting->getType()->value . ' ' . $meeting->getNumber()
                 . ' (' . $meeting->getDate()->format('Y-m-d') . ')';
         }
 

--- a/module/Decision/src/Mapper/Organ.php
+++ b/module/Decision/src/Mapper/Organ.php
@@ -3,6 +3,7 @@
 namespace Decision\Mapper;
 
 use Application\Mapper\BaseMapper;
+use Decision\Model\Enums\OrganTypes;
 use Decision\Model\Organ as OrganModel;
 use Doctrine\ORM\{
     NoResultException,
@@ -20,17 +21,17 @@ class Organ extends BaseMapper
     /**
      * Find all active organs.
      *
-     * @param string|null $type
+     * @param OrganTypes|null $type
      *
      * @return array
      */
-    public function findActive(?string $type = null): array
+    public function findActive(?OrganTypes $type = null): array
     {
         $criteria = [
             'abrogationDate' => null,
         ];
 
-        if (!is_null($type)) {
+        if (null !== $type) {
             $criteria['type'] = $type;
         }
 
@@ -57,16 +58,16 @@ class Organ extends BaseMapper
     /**
      * Find all abrogated organs.
      *
-     * @param string|null $type
+     * @param OrganTypes|null $type
      *
      * @return array
      */
-    public function findAbrogated(?string $type = null): array
+    public function findAbrogated(?OrganTypes $type = null): array
     {
         $qb = $this->getRepository()->createQueryBuilder('o');
         $qb->where('o.abrogationDate IS NOT NULL');
 
-        if (!is_null($type)) {
+        if (null !== $type) {
             $qb->andWhere('o.type = :type')
                 ->setParameter('type', $type);
         }
@@ -105,7 +106,7 @@ class Organ extends BaseMapper
      *
      * @param string $abbr
      * @param bool $latest Whether to retrieve the latest occurrence of an organ or not
-     * @param string|null $type
+     * @param OrganTypes|null $type
      *
      * @return OrganModel|null
      * @throws NoResultException
@@ -114,7 +115,7 @@ class Organ extends BaseMapper
     public function findByAbbr(
         string $abbr,
         bool $latest,
-        ?string $type = null,
+        ?OrganTypes $type = null,
     ): ?OrganModel {
         $qb = $this->getRepository()->createQueryBuilder('o');
         $qb->select('o, om, m')
@@ -123,7 +124,7 @@ class Organ extends BaseMapper
             ->where('o.abbr = :abbr')
             ->setParameter('abbr', $abbr);
 
-        if (!is_null($type)) {
+        if (null !== $type) {
             $qb->andWhere('o.type = :type')
                 ->setParameter('type', $type);
         }

--- a/module/Decision/src/Model/Address.php
+++ b/module/Decision/src/Model/Address.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping\{
     JoinColumn,
     ManyToOne,
 };
-use InvalidArgumentException;
+use Decision\Model\Enums\AddressTypes;
 
 /**
  * Address model.
@@ -17,10 +17,6 @@ use InvalidArgumentException;
 #[Entity]
 class Address
 {
-    public const TYPE_HOME = 'home';
-    public const TYPE_STUDENT = 'student'; // student room
-    public const TYPE_MAIL = 'mail'; // mailing address
-
     /**
      * Member.
      */
@@ -46,8 +42,11 @@ class Address
      * - mail (Where GEWIS mail should go to)
      */
     #[Id]
-    #[Column(type: "string")]
-    protected string $type;
+    #[Column(
+        type: "string",
+        enumType: AddressTypes::class,
+    )]
+    protected AddressTypes $type;
 
     /**
      * Country.
@@ -88,20 +87,6 @@ class Address
     protected string $phone;
 
     /**
-     * Get available address types.
-     *
-     * @return array
-     */
-    public static function getTypes(): array
-    {
-        return [
-            self::TYPE_HOME,
-            self::TYPE_STUDENT,
-            self::TYPE_MAIL,
-        ];
-    }
-
-    /**
      * Get the member.
      *
      * @return Member
@@ -124,9 +109,9 @@ class Address
     /**
      * Get the type.
      *
-     * @return string
+     * @return AddressTypes
      */
-    public function getType(): string
+    public function getType(): AddressTypes
     {
         return $this->type;
     }
@@ -134,15 +119,10 @@ class Address
     /**
      * Set the type.
      *
-     * @param string $type
-     *
-     * @throws InvalidArgumentException When the type is incorrect
+     * @param AddressTypes $type
      */
-    public function setType(string $type): void
+    public function setType(AddressTypes $type): void
     {
-        if (!in_array($type, self::getTypes())) {
-            throw new InvalidArgumentException('Non-existing type.');
-        }
         $this->type = $type;
     }
 

--- a/module/Decision/src/Model/Decision.php
+++ b/module/Decision/src/Model/Decision.php
@@ -2,6 +2,7 @@
 
 namespace Decision\Model;
 
+use Decision\Model\Enums\MeetingTypes;
 use Decision\Model\SubDecision\Destroy;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\{
@@ -46,9 +47,11 @@ class Decision
      * NOTE: This is a hack to make the meeting a primary key here.
      */
     #[Id]
-    #[Column(type: "string")]
-    protected string $meeting_type;
-
+    #[Column(
+        type: "string",
+        enumType: MeetingTypes::class,
+    )]
+    protected MeetingTypes $meeting_type;
     /**
      * Meeting number.
      *
@@ -116,9 +119,9 @@ class Decision
     /**
      * Get the meeting type.
      *
-     * @return string
+     * @return MeetingTypes
      */
-    public function getMeetingType(): string
+    public function getMeetingType(): MeetingTypes
     {
         return $this->meeting_type;
     }

--- a/module/Decision/src/Model/Enums/AddressTypes.php
+++ b/module/Decision/src/Model/Enums/AddressTypes.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Decision\Model\Enums;
+
+use Laminas\Mvc\I18n\Translator;
+
+/**
+ * Enum for the different address types.
+ */
+enum AddressTypes: string
+{
+    case Home = 'home';
+    case Student = 'student';
+    case Mail = 'mail';
+
+    public function getName(Translator $translator): string
+    {
+        return match ($this) {
+            self::Home => $translator->translate('Home address (parents)'),
+            self::Student => $translator->translate('Student address'),
+            self::Mail => $translator->translate('Mail address'),
+        };
+    }
+}

--- a/module/Decision/src/Model/Enums/MeetingTypes.php
+++ b/module/Decision/src/Model/Enums/MeetingTypes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Decision\Model\Enums;
+
+/**
+ * Enum for the different address types.
+ */
+enum MeetingTypes: string
+{
+    case BV = 'BV'; // bestuursvergadering
+    case AV = 'AV'; // algemene leden vergadering
+    case VV = 'VV'; // voorzitters vergadering
+    case VIRT = 'Virt'; // virtual meeting
+}

--- a/module/Decision/src/Model/Enums/OrganTypes.php
+++ b/module/Decision/src/Model/Enums/OrganTypes.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Decision\Model\Enums;
+
+use Laminas\Mvc\I18n\Translator;
+
+/**
+ * Enum for the different organ types.
+ */
+enum OrganTypes: string
+{
+    case Committee = 'committee';
+    case AVC = 'avc';
+    case Fraternity = 'fraternity';
+    case KKK = 'kkk';
+    case AVW = 'avw';
+    case RvA = 'rva';
+
+    public function getName(Translator $translator): string
+    {
+        return match ($this) {
+            self::Committee => $translator->translate('Committee'),
+            self::AVC => $translator->translate('AV-committee'),
+            self::Fraternity => $translator->translate('Fraternity'),
+            self::KKK => $translator->translate('Audit Committee'),
+            self::AVW => $translator->translate('GM Task Force'),
+            self::RvA => $translator->translate('Advisory Board'),
+        };
+    }
+}

--- a/module/Decision/src/Model/Enums/OrganTypes.php
+++ b/module/Decision/src/Model/Enums/OrganTypes.php
@@ -12,7 +12,7 @@ enum OrganTypes: string
     case Committee = 'committee';
     case AVC = 'avc';
     case Fraternity = 'fraternity';
-    case KKK = 'kkk';
+    case KCC = 'kcc';
     case AVW = 'avw';
     case RvA = 'rva';
 
@@ -22,7 +22,7 @@ enum OrganTypes: string
             self::Committee => $translator->translate('Committee'),
             self::AVC => $translator->translate('AV-committee'),
             self::Fraternity => $translator->translate('Fraternity'),
-            self::KKK => $translator->translate('Audit Committee'),
+            self::KCC => $translator->translate('Audit Committee'),
             self::AVW => $translator->translate('GM Task Force'),
             self::RvA => $translator->translate('Advisory Board'),
         };

--- a/module/Decision/src/Model/Meeting.php
+++ b/module/Decision/src/Model/Meeting.php
@@ -3,6 +3,7 @@
 namespace Decision\Model;
 
 use DateTime;
+use Decision\Model\Enums\MeetingTypes;
 use Doctrine\Common\Collections\{
     ArrayCollection,
     Collection,
@@ -15,7 +16,6 @@ use Doctrine\ORM\Mapping\{
     OneToOne,
     OrderBy,
 };
-use InvalidArgumentException;
 
 /**
  * Meeting model.
@@ -23,17 +23,15 @@ use InvalidArgumentException;
 #[Entity]
 class Meeting
 {
-    public const TYPE_BV = 'BV'; // bestuursvergadering
-    public const TYPE_AV = 'AV'; // algemene leden vergadering
-    public const TYPE_VV = 'VV'; // voorzitters vergadering
-    public const TYPE_VIRT = 'Virt'; // virtual meeting
-
     /**
      * Meeting type.
      */
     #[Id]
-    #[Column(type: "string")]
-    protected string $type;
+    #[Column(
+        type: "string",
+        enumType: MeetingTypes::class,
+    )]
+    protected MeetingTypes $type;
 
     /**
      * Meeting number.
@@ -77,21 +75,6 @@ class Meeting
     protected ?MeetingMinutes $meetingMinutes = null;
 
     /**
-     * Get all allowed meeting types.
-     *
-     * @return array
-     */
-    public static function getTypes(): array
-    {
-        return [
-            self::TYPE_BV,
-            self::TYPE_AV,
-            self::TYPE_VV,
-            self::TYPE_VIRT,
-        ];
-    }
-
-    /**
      * Constructor.
      */
     public function __construct()
@@ -103,9 +86,9 @@ class Meeting
     /**
      * Get the meeting type.
      *
-     * @return string
+     * @return MeetingTypes
      */
-    public function getType(): string
+    public function getType(): MeetingTypes
     {
         return $this->type;
     }
@@ -131,13 +114,10 @@ class Meeting
     /**
      * Set the meeting type.
      *
-     * @param string $type
+     * @param MeetingTypes $type
      */
-    public function setType(string $type): void
+    public function setType(MeetingTypes $type): void
     {
-        if (!in_array($type, self::getTypes())) {
-            throw new InvalidArgumentException('Invalid meeting type given.');
-        }
         $this->type = $type;
     }
 

--- a/module/Decision/src/Model/MeetingMinutes.php
+++ b/module/Decision/src/Model/MeetingMinutes.php
@@ -2,6 +2,7 @@
 
 namespace Decision\Model;
 
+use Decision\Model\Enums\MeetingTypes;
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
@@ -21,8 +22,11 @@ class MeetingMinutes implements ResourceInterface
      * Meeting type.
      */
     #[Id]
-    #[Column(type: "string")]
-    protected string $type;
+    #[Column(
+        type: "string",
+        enumType: MeetingTypes::class,
+    )]
+    protected MeetingTypes $meeting_type;
 
     /**
      * Meeting number.
@@ -70,7 +74,7 @@ class MeetingMinutes implements ResourceInterface
     public function setMeeting(Meeting $meeting): void
     {
         $this->meeting = $meeting;
-        $this->type = $meeting->getType();
+        $this->meeting_type = $meeting->getType();
         $this->number = $meeting->getNumber();
     }
 

--- a/module/Decision/src/Model/Member.php
+++ b/module/Decision/src/Model/Member.php
@@ -31,10 +31,6 @@ use User\Model\User as UserModel;
 #[Entity]
 class Member
 {
-    public const GENDER_MALE = 'm';
-    public const GENDER_FEMALE = 'f';
-    public const GENDER_OTHER = 'o';
-
     /**
      * The user.
      */
@@ -79,19 +75,6 @@ class Member
      */
     #[Column(type: "string")]
     protected string $firstName;
-
-    /**
-     * Gender of the member.
-     *
-     * Either one of:
-     * - m
-     * - f
-     */
-    #[Column(
-        type: "string",
-        length: 1,
-    )]
-    protected string $gender;
 
     /**
      * Generation.
@@ -230,20 +213,6 @@ class Member
         mappedBy: "member",
     )]
     protected Collection $boardInstallations;
-
-    /**
-     * Static method to get available genders.
-     *
-     * @return array
-     */
-    protected static function getGenders(): array
-    {
-        return [
-            self::GENDER_MALE,
-            self::GENDER_FEMALE,
-            self::GENDER_OTHER,
-        ];
-    }
 
     /**
      * Constructor.
@@ -392,31 +361,6 @@ class Member
         }
 
         return $name . $this->getLastName();
-    }
-
-    /**
-     * Get the member's gender.
-     *
-     * @return string
-     */
-    public function getGender(): string
-    {
-        return $this->gender;
-    }
-
-    /**
-     * Set the member's gender.
-     *
-     * @param string $gender
-     *
-     * @throws InvalidArgumentException when the gender does not have correct value
-     */
-    public function setGender(string $gender): void
-    {
-        if (!in_array($gender, self::getGenders())) {
-            throw new InvalidArgumentException('Invalid gender value');
-        }
-        $this->gender = $gender;
     }
 
     /**

--- a/module/Decision/src/Model/Organ.php
+++ b/module/Decision/src/Model/Organ.php
@@ -3,6 +3,7 @@
 namespace Decision\Model;
 
 use DateTime;
+use Decision\Model\Enums\OrganTypes;
 use Decision\Model\SubDecision\Foundation;
 use Doctrine\Common\Collections\{
     ArrayCollection,
@@ -29,13 +30,6 @@ use Doctrine\ORM\Mapping\{
 #[Entity]
 class Organ
 {
-    public const ORGAN_TYPE_COMMITTEE = 'committee';
-    public const ORGAN_TYPE_AVC = 'avc';
-    public const ORGAN_TYPE_FRATERNITY = 'fraternity';
-    public const ORGAN_TYPE_AVW = 'avw';
-    public const ORGAN_TYPE_KKK = 'kkk';
-    public const ORGAN_TYPE_RVA = 'rva';
-
     /**
      * Id.
      */
@@ -59,8 +53,11 @@ class Organ
     /**
      * Type of the organ.
      */
-    #[Column(type: "string")]
-    protected string $type;
+    #[Column(
+        type: "string",
+        enumType: OrganTypes::class,
+    )]
+    protected OrganTypes $type;
 
     /**
      * Reference to foundation of organ.
@@ -235,9 +232,9 @@ class Organ
     /**
      * Get the type.
      *
-     * @return string
+     * @return OrganTypes
      */
-    public function getType(): string
+    public function getType(): OrganTypes
     {
         return $this->type;
     }
@@ -245,9 +242,9 @@ class Organ
     /**
      * Set the type.
      *
-     * @param string $type
+     * @param OrganTypes $type
      */
-    public function setType(string $type): void
+    public function setType(OrganTypes $type): void
     {
         $this->type = $type;
     }

--- a/module/Decision/src/Model/SubDecision.php
+++ b/module/Decision/src/Model/SubDecision.php
@@ -2,16 +2,7 @@
 
 namespace Decision\Model;
 
-use Doctrine\ORM\Mapping\{
-    Column,
-    DiscriminatorColumn,
-    DiscriminatorMap,
-    Entity,
-    Id,
-    InheritanceType,
-    JoinColumn,
-    ManyToOne,
-};
+use Decision\Model\Enums\MeetingTypes;
 use Decision\Model\SubDecision\{
     Abrogation,
     Board\Discharge as BoardDischarge,
@@ -25,6 +16,16 @@ use Decision\Model\SubDecision\{
     Installation,
     Other,
     Reckoning,
+};
+use Doctrine\ORM\Mapping\{
+    Column,
+    DiscriminatorColumn,
+    DiscriminatorMap,
+    Entity,
+    Id,
+    InheritanceType,
+    JoinColumn,
+    ManyToOne,
 };
 
 /**
@@ -85,8 +86,11 @@ abstract class SubDecision
      * NOTE: This is a hack to make the decision a primary key here.
      */
     #[Id]
-    #[Column(type: "string")]
-    protected string $meeting_type;
+    #[Column(
+        type: "string",
+        enumType: MeetingTypes::class,
+    )]
+    protected MeetingTypes $meeting_type;
 
     /**
      * Meeting number.
@@ -156,9 +160,9 @@ abstract class SubDecision
     /**
      * Get the meeting type.
      *
-     * @return string
+     * @return MeetingTypes
      */
-    public function getMeetingType(): string
+    public function getMeetingType(): MeetingTypes
     {
         return $this->meeting_type;
     }

--- a/module/Decision/src/Model/SubDecision/Board/Release.php
+++ b/module/Decision/src/Model/SubDecision/Board/Release.php
@@ -96,44 +96,4 @@ class Release extends SubDecision
     {
         $this->date = $date;
     }
-
-    /**
-     * Get the content.
-     *
-     * @return string
-     */
-    public function getContent(): string
-    {
-        $member = $this->getInstallation()->getMember()->getFullName();
-        $function = $this->getInstallation()->getFunction();
-
-        $zh = 'm' == $this->getInstallation()->getMember()->getGender() ? 'zijn' : 'haar';
-
-        return $member . ' wordt per ' . $this->formatDate($this->getDate())
-            . ' ontheven uit ' . $zh . ' functie als ' . $function
-            . ' der s.v. GEWIS.';
-    }
-
-    /**
-     * Format the date.
-     *
-     * returns the localized version of $date->format('d F Y')
-     *
-     * @param DateTime $date
-     *
-     * @return string Formatted date
-     */
-    protected function formatDate(DateTime $date): string
-    {
-        $formatter = new IntlDateFormatter(
-            'nl_NL', // yes, hardcoded :D
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            date_default_timezone_get(),
-            null,
-            'd MMMM Y'
-        );
-
-        return $formatter->format($date);
-    }
 }

--- a/module/Decision/src/Model/SubDecision/Foundation.php
+++ b/module/Decision/src/Model/SubDecision/Foundation.php
@@ -6,6 +6,7 @@ use Decision\Model\{
     Organ,
     SubDecision,
 };
+use Decision\Model\Enums\OrganTypes;
 use Doctrine\Common\Collections\{
     ArrayCollection,
     Collection,
@@ -16,7 +17,6 @@ use Doctrine\ORM\Mapping\{
     OneToMany,
     OneToOne,
 };
-use InvalidArgumentException;
 
 /**
  * Foundation of an organ.
@@ -24,13 +24,6 @@ use InvalidArgumentException;
 #[Entity]
 class Foundation extends SubDecision
 {
-    public const ORGAN_TYPE_COMMITTEE = 'committee';
-    public const ORGAN_TYPE_AVC = 'avc';
-    public const ORGAN_TYPE_FRATERNITY = 'fraternity';
-    public const ORGAN_TYPE_AVW = 'avw';
-    public const ORGAN_TYPE_KKK = 'kkk';
-    public const ORGAN_TYPE_RVA = 'rva';
-
     /**
      * Abbreviation (only for when organs are created).
      */
@@ -46,8 +39,11 @@ class Foundation extends SubDecision
     /**
      * Type of the organ.
      */
-    #[Column(type: "string")]
-    protected string $organType;
+    #[Column(
+        type: "string",
+        enumType: OrganTypes::class,
+    )]
+    protected OrganTypes $organType;
 
     /**
      * References from other subdecisions to this organ.
@@ -73,23 +69,6 @@ class Foundation extends SubDecision
     public function __construct()
     {
         $this->references = new ArrayCollection();
-    }
-
-    /**
-     * Get available organ types.
-     *
-     * @return array
-     */
-    public static function getOrganTypes(): array
-    {
-        return [
-            self::ORGAN_TYPE_COMMITTEE,
-            self::ORGAN_TYPE_AVC,
-            self::ORGAN_TYPE_FRATERNITY,
-            self::ORGAN_TYPE_AVW,
-            self::ORGAN_TYPE_KKK,
-            self::ORGAN_TYPE_RVA,
-        ];
     }
 
     /**
@@ -135,9 +114,9 @@ class Foundation extends SubDecision
     /**
      * Get the type.
      *
-     * @return string
+     * @return OrganTypes
      */
-    public function getOrganType(): string
+    public function getOrganType(): OrganTypes
     {
         return $this->organType;
     }
@@ -145,15 +124,10 @@ class Foundation extends SubDecision
     /**
      * Set the type.
      *
-     * @param string $organType
-     *
-     * @throws InvalidArgumentException if the type is wrong
+     * @param OrganTypes $organType
      */
-    public function setOrganType(string $organType): void
+    public function setOrganType(OrganTypes $organType): void
     {
-        if (!in_array($organType, self::getOrganTypes())) {
-            throw new InvalidArgumentException('Given type does not exist.');
-        }
         $this->organType = $organType;
     }
 

--- a/module/Decision/src/Service/MemberInfo.php
+++ b/module/Decision/src/Service/MemberInfo.php
@@ -126,19 +126,20 @@ class MemberInfo
     public function getOrganMemberships(MemberModel $member): array
     {
         $memberships = [];
-        foreach ($member->getOrganInstallations() as $install) {
-            if (null !== $install->getDischargeDate()) {
-                continue;
-            }
-
+        foreach ($member->getCurrentOrganInstallations() as $install) {
             if (!isset($memberships[$install->getOrgan()->getAbbr()])) {
-                $memberships[$install->getOrgan()->getAbbr()] = [];
-                $memberships[$install->getOrgan()->getAbbr()]['organ'] = $install->getOrgan();
+                $memberships[$install->getOrgan()->getAbbr()] = [
+                    'organ' => $install->getOrgan(),
+                    'functions' => [],
+                ];
             }
 
-            if ('Lid' != $install->getFunction()) {
+            if (
+                'Lid' !== $install->getFunction()
+                && 'Inactief Lid' !== $install->getFunction()
+            ) {
                 $function = $this->translator->translate($install->getFunction());
-                $memberships[$install->getOrgan()->getAbbr()]['functions'] = $function;
+                $memberships[$install->getOrgan()->getAbbr()]['functions'][] = $function;
             }
         }
 

--- a/module/Decision/src/Service/Organ.php
+++ b/module/Decision/src/Service/Organ.php
@@ -159,7 +159,7 @@ class Organ
                 $this->findActiveOrgansByType(OrganTypes::Fraternity),
                 $this->findActiveOrgansByType(OrganTypes::AVC),
                 $this->findActiveOrgansByType(OrganTypes::AVW),
-                $this->findActiveOrgansByType(OrganTypes::KKK),
+                $this->findActiveOrgansByType(OrganTypes::KCC),
                 $this->findActiveOrgansByType(OrganTypes::RvA),
             );
         }

--- a/module/Decision/src/Service/Organ.php
+++ b/module/Decision/src/Service/Organ.php
@@ -481,7 +481,7 @@ class Organ
             }
         }
 
-        $oldMembers = array_filter($oldMembers, function ($member) use ($activeMembers) {
+        $oldMembers = array_filter($oldMembers, function ($member) use ($activeMembers, $inactiveMembers) {
             return !isset($activeMembers[$member->getLidnr()])
                 && !isset($inactiveMembers[$member->getLidnr()]);
         });

--- a/module/Decision/src/Service/Organ.php
+++ b/module/Decision/src/Service/Organ.php
@@ -22,6 +22,7 @@ use Decision\Model\{
     Organ as OrganModel,
     OrganInformation as OrganInformationModel,
 };
+use Decision\Model\Enums\OrganTypes;
 use Imagick;
 use Laminas\Mvc\I18n\Translator;
 use User\Permissions\NotAllowedException;
@@ -154,12 +155,12 @@ class Organ
 
         if ($this->aclService->isAllowed('editall', 'organ')) {
             return array_merge(
-                $this->findActiveOrgansByType(OrganModel::ORGAN_TYPE_COMMITTEE),
-                $this->findActiveOrgansByType(OrganModel::ORGAN_TYPE_FRATERNITY),
-                $this->findActiveOrgansByType(OrganModel::ORGAN_TYPE_AVC),
-                $this->findActiveOrgansByType(OrganModel::ORGAN_TYPE_AVW),
-                $this->findActiveOrgansByType(OrganModel::ORGAN_TYPE_KKK),
-                $this->findActiveOrgansByType(OrganModel::ORGAN_TYPE_RVA)
+                $this->findActiveOrgansByType(OrganTypes::Committee),
+                $this->findActiveOrgansByType(OrganTypes::Fraternity),
+                $this->findActiveOrgansByType(OrganTypes::AVC),
+                $this->findActiveOrgansByType(OrganTypes::AVW),
+                $this->findActiveOrgansByType(OrganTypes::KKK),
+                $this->findActiveOrgansByType(OrganTypes::RvA),
             );
         }
 
@@ -197,11 +198,11 @@ class Organ
     }
 
     /**
-     * @param string $type either committee, avc or fraternity
+     * @param OrganTypes $type either committee, avc or fraternity
      *
      * @return array
      */
-    public function findActiveOrgansByType(string $type): array
+    public function findActiveOrgansByType(OrganTypes $type): array
     {
         return $this->organMapper->findActive($type);
     }
@@ -217,11 +218,11 @@ class Organ
     }
 
     /**
-     * @param string $type either committee, avc or fraternity
+     * @param OrganTypes $type either committee, avc or fraternity
      *
      * @return array
      */
-    public function findAbrogatedOrgansByType(string $type): array
+    public function findAbrogatedOrgansByType(OrganTypes $type): array
     {
         return $this->organMapper->findAbrogated($type);
     }
@@ -230,7 +231,7 @@ class Organ
      * Finds an organ by its abbreviation.
      *
      * @param string $abbr
-     * @param string|null $type
+     * @param OrganTypes|null $type
      * @param bool $latest  Whether to retrieve the latest occurrence of an organ or not
      *
      * @return OrganModel|null
@@ -241,7 +242,7 @@ class Organ
      */
     public function findOrganByAbbr(
         string $abbr,
-        ?string $type = null,
+        ?OrganTypes $type = null,
         bool $latest = false,
     ): ?OrganModel {
         return $this->organMapper->findByAbbr(

--- a/module/Decision/view/decision/admin/document.phtml
+++ b/module/Decision/view/decision/admin/document.phtml
@@ -25,9 +25,9 @@ $element = $form->get('meeting');
         <select class="form-control" name="meeting"
                 onchange="window.location='<?= $this->url('admin_decision/document') ?>/'+this.value">
             <?php foreach ($meetings as $m): ?>
-                <option value="<?= $m->getType() ?>/<?= $m->getNumber() ?>"
+                <option value="<?= $m->getType()->value ?>/<?= $m->getNumber() ?>"
                     <?= $m->getNumber() === intval($number) ? 'selected' : '' ?>>
-                    <?= $m->getType() ?> <?= $m->getNumber() ?> (<?= $m->getDate()->format('Y-m-d') ?>)
+                    <?= $m->getType()->value ?> <?= $m->getNumber() ?> (<?= $m->getDate()->format('Y-m-d') ?>)
                 </option>
             <?php endforeach; ?>
         </select>

--- a/module/Decision/view/decision/admin/document.phtml
+++ b/module/Decision/view/decision/admin/document.phtml
@@ -4,225 +4,230 @@ $this->breadcrumbs()
     ->addBreadcrumb($this->translate('Meetings'))
     ->addBreadcrumb($this->translate('Documents'));
 
-if (isset($success) && $success): ?>
-    <?= $this->translate('Meeting document uploaded'); ?>
-<?php endif; ?>
+if (isset($noMeetings) && $noMeetings): ?>
+    <?= $this->translate('There are no meetings for which you can upload documents.') ?>
 <?php
-$form = $this->form;
-$form->prepare();
-
-$form->setAttribute('method', 'post');
-
-$form->setAttribute('class', 'form-horizontal');
-?>
-<?= $this->form()->openTag($form); ?>
-<?php
-$element = $form->get('meeting');
-?>
-<div class="form-group">
-    <label for="<?= $element->getName() ?>" class="control-label col-sm-2"><?= $element->getLabel() ?></label>
-    <div class="col-sm-10">
-        <select class="form-control" name="meeting"
-                onchange="window.location='<?= $this->url('admin_decision/document') ?>/'+this.value">
-            <?php foreach ($meetings as $m): ?>
-                <option value="<?= $m->getType()->value ?>/<?= $m->getNumber() ?>"
-                    <?= $m->getNumber() === intval($number) ? 'selected' : '' ?>>
-                    <?= $m->getType()->value ?> <?= $m->getNumber() ?> (<?= $m->getDate()->format('Y-m-d') ?>)
-                </option>
-            <?php endforeach; ?>
-        </select>
-    </div>
-</div>
-<div class="form-group">
+else:
+    if (isset($success) && $success): ?>
+        <?= $this->translate('Meeting document uploaded'); ?>
+    <?php endif; ?>
     <?php
-    $element = $form->get('name');
-    $element->setAttribute('class', 'form-control');
-    $element->setAttribute('placeholder', $this->translate('Name'));
-    $element->setAttribute('required', 'required');
+    $form = $this->form;
+    $form->prepare();
+
+    $form->setAttribute('method', 'post');
+
+    $form->setAttribute('class', 'form-horizontal');
     ?>
-    <label for="<?= $element->getName() ?>" class="control-label col-sm-2"><?= $element->getLabel() ?></label>
-    <div class="col-sm-10">
-        <?= $this->formText($element); ?>
-        <?= $this->formElementErrors($element); ?>
+    <?= $this->form()->openTag($form); ?>
+    <?php
+    $element = $form->get('meeting');
+    ?>
+    <div class="form-group">
+        <label for="<?= $element->getName() ?>" class="control-label col-sm-2"><?= $element->getLabel() ?></label>
+        <div class="col-sm-10">
+            <select class="form-control" name="meeting"
+                    onchange="window.location='<?= $this->url('admin_decision/document') ?>/'+this.value">
+                <?php foreach ($meetings as $m): ?>
+                    <option value="<?= $m->getType()->value ?>/<?= $m->getNumber() ?>"
+                        <?= $m->getNumber() === intval($number) ? 'selected' : '' ?>>
+                        <?= $m->getType()->value ?> <?= $m->getNumber() ?> (<?= $m->getDate()->format('Y-m-d') ?>)
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
     </div>
-</div>
-
-<div class="form-group">
-    <?php $fileElement = $form->get('upload'); ?>
-    <label for="<?= $fileElement->getName() ?>" class="control-label col-sm-2"><?= $fileElement->getLabel() ?></label>
-    <div class="col-sm-10">
-        <?= $this->formFile($fileElement); ?>
-        <?= $this->formElementErrors($fileElement); ?>
-    </div>
-</div>
-
-<div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
+    <div class="form-group">
         <?php
-        $submit = $form->get('submit');
-        $submit->setLabel($submit->getValue());
-        $submit->setAttribute('class', 'btn btn-default');
+        $element = $form->get('name');
+        $element->setAttribute('class', 'form-control');
+        $element->setAttribute('placeholder', $this->translate('Name'));
+        $element->setAttribute('required', 'required');
         ?>
-        <?= $this->formButton($submit) ?>
+        <label for="<?= $element->getName() ?>" class="control-label col-sm-2"><?= $element->getLabel() ?></label>
+        <div class="col-sm-10">
+            <?= $this->formText($element); ?>
+            <?= $this->formElementErrors($element); ?>
+        </div>
     </div>
-</div>
 
-<?= $this->form()->closeTag(); ?>
-<?php if (null !== $meeting): ?>
-    <h3><?= $this->translate('Documents for this meeting') ?></h3>
-    <div class="col-sm-12">
-        <?php if (0 === $meeting->getDocuments()->count()): ?>
-            <p><?= $this->translate('This meeting does not have any associated documents.') ?></p>
-        <?php else: ?>
-            <table class="table table-striped table-hover table-documents">
-                <?php foreach ($meeting->getDocuments() as $document): ?>
-                    <tr data-id="<?= $document->getId() ?>">
-                        <td class="btn-group-move">
-                            <?php
-                            /** @var Form $form */
-                            $form = $this->reorderDocumentForm;
-
-                            $form->setAttributes([
-                                'class' => 'form-reorder-document',
-                                'action' => $this->url('admin_decision/position_document/post')
-                            ]);
-                            $form->populateValues([
-                                'document' => $document->getId()
-                            ]);
-                            $form->prepare();
-                            ?>
-                            <?= $this->form()->openTag($form) ?>
-                            <?php foreach ($form as $element): ?>
-                                <?= $this->formElement($element); ?>
-                            <?php endforeach; ?>
-                            <?= $this->form()->closeTag($form) ?>
-                        </td>
-                        <td>
-                            <a href="<?= $this->url('decision/document', ['id' => $document->getId()]) ?>">
-                                <?= $document->getName() ?>
-                            </a>
-                        </td>
-                        <td>
-                            <form method="POST" action="<?= $this->url('admin_decision/delete_document/post') ?>">
-                                <input type="hidden" name="document" value="<?= $document->getId() ?>">
-                                <input type="submit" name="submit" value="<?= $this->translate('Delete') ?>"
-                                       class="btn btn-danger btn-xs pull-right"/>
-                            </form>
-                        </td>
-                    </tr>
-                <?php endforeach ?>
-            </table>
-        <?php endif; ?>
+    <div class="form-group">
+        <?php $fileElement = $form->get('upload'); ?>
+        <label for="<?= $fileElement->getName() ?>" class="control-label col-sm-2"><?= $fileElement->getLabel() ?></label>
+        <div class="col-sm-10">
+            <?= $this->formFile($fileElement); ?>
+            <?= $this->formElementErrors($fileElement); ?>
+        </div>
     </div>
-<?php endif; ?>
-<script>
-    var OrderableList = function ($list, itemContainerSelector) {
-        var history = [];
 
-        var findListItem = function (id) {
-            return $('[data-id="' + id + '"]', $list).closest(itemContainerSelector);
-        };
+    <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+            <?php
+            $submit = $form->get('submit');
+            $submit->setLabel($submit->getValue());
+            $submit->setAttribute('class', 'btn btn-default');
+            ?>
+            <?= $this->formButton($submit) ?>
+        </div>
+    </div>
 
-        /**
-         * Adds an action to the history
-         *
-         * @param reverseFn Function name to reverse the action
-         * @param parameter Parameter to reverse the action
-         * @param predicate Predicate to determine if the history should be populated
-         */
-        var pushToHistory = function (reverseFn, parameter, predicate) {
-            if (predicate) {
-                history.push({fn: reverseFn, parameter: parameter});
-            }
-        };
+    <?= $this->form()->closeTag(); ?>
+    <?php if (null !== $meeting): ?>
+        <h3><?= $this->translate('Documents for this meeting') ?></h3>
+        <div class="col-sm-12">
+            <?php if (0 === $meeting->getDocuments()->count()): ?>
+                <p><?= $this->translate('This meeting does not have any associated documents.') ?></p>
+            <?php else: ?>
+                <table class="table table-striped table-hover table-documents">
+                    <?php foreach ($meeting->getDocuments() as $document): ?>
+                        <tr data-id="<?= $document->getId() ?>">
+                            <td class="btn-group-move">
+                                <?php
+                                /** @var Form $form */
+                                $form = $this->reorderDocumentForm;
 
-        return {
+                                $form->setAttributes([
+                                    'class' => 'form-reorder-document',
+                                    'action' => $this->url('admin_decision/position_document/post')
+                                ]);
+                                $form->populateValues([
+                                    'document' => $document->getId()
+                                ]);
+                                $form->prepare();
+                                ?>
+                                <?= $this->form()->openTag($form) ?>
+                                <?php foreach ($form as $element): ?>
+                                    <?= $this->formElement($element); ?>
+                                <?php endforeach; ?>
+                                <?= $this->form()->closeTag($form) ?>
+                            </td>
+                            <td>
+                                <a href="<?= $this->url('decision/document', ['id' => $document->getId()]) ?>">
+                                    <?= $document->getName() ?>
+                                </a>
+                            </td>
+                            <td>
+                                <form method="POST" action="<?= $this->url('admin_decision/delete_document/post') ?>">
+                                    <input type="hidden" name="document" value="<?= $document->getId() ?>">
+                                    <input type="submit" name="submit" value="<?= $this->translate('Delete') ?>"
+                                           class="btn btn-danger btn-xs pull-right"/>
+                                </form>
+                            </td>
+                        </tr>
+                    <?php endforeach ?>
+                </table>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
+    <script>
+        var OrderableList = function ($list, itemContainerSelector) {
+            var history = [];
+
+            var findListItem = function (id) {
+                return $('[data-id="' + id + '"]', $list).closest(itemContainerSelector);
+            };
+
             /**
-             * Moves a list item upwards
+             * Adds an action to the history
              *
-             * @param id List item ID
-             * @param history If the action should be recorded in the history, defaults to TRUE
+             * @param reverseFn Function name to reverse the action
+             * @param parameter Parameter to reverse the action
+             * @param predicate Predicate to determine if the history should be populated
              */
-            moveUp: function (id, history = true) {
-                var $listItem = findListItem(id),
-                    inserted = $listItem.insertBefore($listItem.prev());
-
-                // jQuery returns the inserted element. Empty array if the item
-                // is already at the top.
-                var hasMoved = (inserted.length === 1);
-
-                pushToHistory('moveDown', id, (history && hasMoved));
-            },
-            /**
-             * Moves a list item downwards
-             *
-             * @param id List item ID
-             * @param history If the action should be recorded in the history, defaults to TRUE
-             */
-            moveDown: function (id, history = true) {
-                var $listItem = findListItem(id),
-                    inserted = $listItem.insertAfter($listItem.next());
-
-                // jQuery returns the inserted element. Empty array if the item
-                // is already at the bottom.
-                var hasMoved = (inserted.length === 1);
-
-                pushToHistory('moveUp', id, (history && hasMoved));
-            },
-            /**
-             * Reverses the last action
-             */
-            reverseLastStep: function () {
-                var reverseAction = history[history.length - 1];
-
-                if (this.hasOwnProperty(reverseAction.fn)) {
-                    history.pop(); // Remove last action from history
-
-                    // Call function to reverse the last action
-                    this[reverseAction.fn].apply(null, [reverseAction.parameter, false]);
+            var pushToHistory = function (reverseFn, parameter, predicate) {
+                if (predicate) {
+                    history.push({fn: reverseFn, parameter: parameter});
                 }
-            }
+            };
+
+            return {
+                /**
+                 * Moves a list item upwards
+                 *
+                 * @param id List item ID
+                 * @param history If the action should be recorded in the history, defaults to TRUE
+                 */
+                moveUp: function (id, history = true) {
+                    var $listItem = findListItem(id),
+                        inserted = $listItem.insertBefore($listItem.prev());
+
+                    // jQuery returns the inserted element. Empty array if the item
+                    // is already at the top.
+                    var hasMoved = (inserted.length === 1);
+
+                    pushToHistory('moveDown', id, (history && hasMoved));
+                },
+                /**
+                 * Moves a list item downwards
+                 *
+                 * @param id List item ID
+                 * @param history If the action should be recorded in the history, defaults to TRUE
+                 */
+                moveDown: function (id, history = true) {
+                    var $listItem = findListItem(id),
+                        inserted = $listItem.insertAfter($listItem.next());
+
+                    // jQuery returns the inserted element. Empty array if the item
+                    // is already at the bottom.
+                    var hasMoved = (inserted.length === 1);
+
+                    pushToHistory('moveUp', id, (history && hasMoved));
+                },
+                /**
+                 * Reverses the last action
+                 */
+                reverseLastStep: function () {
+                    var reverseAction = history[history.length - 1];
+
+                    if (this.hasOwnProperty(reverseAction.fn)) {
+                        history.pop(); // Remove last action from history
+
+                        // Call function to reverse the last action
+                        this[reverseAction.fn].apply(null, [reverseAction.parameter, false]);
+                    }
+                }
+            };
         };
-    };
 
-    var documentsList = new OrderableList($('.table-documents'), 'tr');
+        var documentsList = new OrderableList($('.table-documents'), 'tr');
 
-    $('.form-reorder-document label input[type=radio]').on('change', function () {
-        var $radio = $(this),
-            $form = $radio.closest('.form-reorder-document');
+        $('.form-reorder-document label input[type=radio]').on('change', function () {
+            var $radio = $(this),
+                $form = $radio.closest('.form-reorder-document');
 
-        // Disable all labels while processing
-        $('.form-reorder-document label')
-            .addClass('disabled')
-            .find('input').not($radio).attr('disabled', 'disabled'); // Exclude $(this) so it's included in POST
+            // Disable all labels while processing
+            $('.form-reorder-document label')
+                .addClass('disabled')
+                .find('input').not($radio).attr('disabled', 'disabled'); // Exclude $(this) so it's included in POST
 
-        var documentID = $('input[name="document"]', $form).val();
-        if ($radio.val() === 'up') {
-            documentsList.moveUp(documentID);
-        }
-        if ($radio.val() === 'down') {
-            documentsList.moveDown(documentID);
-        }
-
-        $.ajax({
-            method: $form.attr('method'),
-            url: $form.attr('action'),
-            data: $form.serialize(),
-            success: function () {
-                // Reset input to allow movement in the same direction
-                // Note that onChange event is not fire when unchecking
-                $radio.attr('checked', false);
-
-                // Done processing so allow reordering again
-                $('.form-reorder-document label')
-                    .removeClass('disabled')
-                    .find('input').removeAttr('disabled');
-            },
-            error: function (e) {
-                console.error("Something unexpected happened. Reordering the list failed.", JSON.parse(e.responseText));
-
-                documentsList.reverseLastStep();
+            var documentID = $('input[name="document"]', $form).val();
+            if ($radio.val() === 'up') {
+                documentsList.moveUp(documentID);
             }
+            if ($radio.val() === 'down') {
+                documentsList.moveDown(documentID);
+            }
+
+            $.ajax({
+                method: $form.attr('method'),
+                url: $form.attr('action'),
+                data: $form.serialize(),
+                success: function () {
+                    // Reset input to allow movement in the same direction
+                    // Note that onChange event is not fire when unchecking
+                    $radio.attr('checked', false);
+
+                    // Done processing so allow reordering again
+                    $('.form-reorder-document label')
+                        .removeClass('disabled')
+                        .find('input').removeAttr('disabled');
+                },
+                error: function (e) {
+                    console.error("Something unexpected happened. Reordering the list failed.", JSON.parse(e.responseText));
+
+                    documentsList.reverseLastStep();
+                }
+            });
         });
-    });
-</script>
+    </script>
+<?php endif; ?>

--- a/module/Decision/view/decision/decision/index.phtml
+++ b/module/Decision/view/decision/decision/index.phtml
@@ -14,21 +14,40 @@ $this->headTitle($this->translate('Meetings')); ?>
             </thead>
             <tbody>
             <?php foreach ($meetings as $info): ?>
-                <?php $meeting = $info[0] ?>
-                <?php $url = $this->url('decision/meeting', ['type' => $meeting->getType(), 'number' => $meeting->getNumber()]) ?>
+                <?php
+                $meeting = $info[0];
+                $url = $this->url(
+                    'decision/meeting',
+                    [
+                        'type' => $meeting->getType()->value,
+                        'number' => $meeting->getNumber(),
+                    ],
+                ) ?>
                 <tr>
-                    <td><a style="display: block; height: 100%; width: 100%"
-                           href="<?= $url ?>"><?= $meeting->getType() ?></a></td>
-                    <td><a style="display: block; height: 100%; width: 100%"
-                           href="<?= $url ?>"><?= $meeting->getNumber() ?></a></td>
-                    <td><a style="display: block; height: 100%; width: 100%"
-                           href="<?= $url ?>"><?= $this->dateFormat(
-                            $meeting->getDate(),
-                            IntlDateFormatter::FULL,
-                            IntlDateFormatter::NONE
-                        ) ?></td>
-                    <td><a style="display: block; height: 100%; width: 100%"
-                           href="<?= $url ?>"><?= $info[1] ?></a></td>
+                    <td>
+                        <a style="display: block; height: 100%; width: 100%" href="<?= $url ?>">
+                            <?= $meeting->getType()->value ?>
+                        </a>
+                    </td>
+                    <td>
+                        <a style="display: block; height: 100%; width: 100%" href="<?= $url ?>">
+                            <?= $meeting->getNumber() ?>
+                        </a>
+                    </td>
+                    <td>
+                        <a style="display: block; height: 100%; width: 100%" href="<?= $url ?>">
+                            <?= $this->dateFormat(
+                                $meeting->getDate(),
+                                IntlDateFormatter::FULL,
+                                IntlDateFormatter::NONE
+                            ) ?>
+                        </a>
+                    </td>
+                    <td>
+                        <a style="display: block; height: 100%; width: 100%" href="<?= $url ?>">
+                            <?= $info[1] ?>
+                        </a>
+                    </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/module/Decision/view/decision/decision/view.phtml
+++ b/module/Decision/view/decision/decision/view.phtml
@@ -1,5 +1,5 @@
 <?php
-$meetingName = sprintf('%s %d', $meeting->getType(), $meeting->getNumber());
+$meetingName = sprintf('%s %d', $meeting->getType()->value, $meeting->getNumber());
 
 $this->headTitle($meetingName);
 ?>
@@ -34,8 +34,8 @@ $this->headTitle($meetingName);
                     <h3><?= $this->translate('Minutes') ?></h3>
                     <?php
                     $minutesUrl = $this->url('decision/meeting/minutes', [
-                        'type' => $meeting->getType(),
-                        'number' => $meeting->getNumber()
+                        'type' => $meeting->getType()->value,
+                        'number' => $meeting->getNumber(),
                     ])
                     ?>
                     <p>
@@ -54,7 +54,7 @@ $this->headTitle($meetingName);
                         <?php foreach ($meeting->getDecisions() as $decision): ?>
                             <?php
                             $id = vsprintf('%s %s.%s.%s', [
-                                $meeting->getType(),
+                                $meeting->getType()->value,
                                 $meeting->getNumber(),
                                 $decision->getPoint(),
                                 $decision->getNumber(),

--- a/module/Decision/view/decision/member/index.phtml
+++ b/module/Decision/view/decision/member/index.phtml
@@ -98,11 +98,21 @@ $meetings = $this->meetings;
                             <?=
                             sprintf(
                                 $this->translate('The next meeting is %s%s %s%s on %s.'),
-                                '<a href="' . $this->url('decision/meeting', ['type' => $this->upcoming->getType(), 'number' => $this->upcoming->getNumber()]) . '">',
-                                $this->upcoming->getType(),
+                                '<a href="' . $this->url(
+                                    'decision/meeting',
+                                    [
+                                        'type' => $this->upcoming->getType()->value,
+                                        'number' => $this->upcoming->getNumber(),
+                                    ],
+                                ) . '">',
+                                $this->upcoming->getType()->value,
                                 $this->upcoming->getNumber(),
                                 '</a>',
-                                $this->dateFormat($this->upcoming->getDate()->getTimestamp(), IntlDateFormatter::FULL, IntlDateFormatter::NONE)
+                                $this->dateFormat(
+                                    $this->upcoming->getDate()->getTimestamp(),
+                                    IntlDateFormatter::FULL,
+                                    IntlDateFormatter::NONE,
+                                ),
                             )
                             ?>
                         </div>
@@ -132,15 +142,23 @@ $meetings = $this->meetings;
                     <ul>
                         <?php foreach ($meetings as $meeting): ?>
                             <li>
-                                <a href="<?= $this->url('decision/meeting', ['type' => $meeting->getType(), 'number' => $meeting->getNumber()]) ?>">
-                                    <?=
-                                    sprintf(
+                                <a href="<?= $this->url(
+                                    'decision/meeting',
+                                    [
+                                        'type' => $meeting->getType()->value,
+                                        'number' => $meeting->getNumber(),
+                                    ],
+                                ) ?>">
+                                    <?= sprintf(
                                         $this->translate('%s %s on %s'),
-                                        $meeting->getType(),
+                                        $meeting->getType()->value,
                                         $meeting->getNumber(),
-                                        $this->dateFormat($meeting->getDate()->getTimestamp(), IntlDateFormatter::FULL, IntlDateFormatter::NONE)
-                                    )
-                                    ?>
+                                        $this->dateFormat(
+                                            $meeting->getDate()->getTimestamp(),
+                                            IntlDateFormatter::FULL,
+                                            IntlDateFormatter::NONE,
+                                        ),
+                                    ) ?>
                                 </a>
                             </li>
                         <?php endforeach; ?>

--- a/module/Decision/view/decision/member/self.phtml
+++ b/module/Decision/view/decision/member/self.phtml
@@ -32,22 +32,6 @@ $this->headTitle($member->getFullName());
                         <td><?= $member->getLastName() ?></td>
                     </tr>
                     <tr>
-                        <th><?= $this->translate('Gender') ?></th>
-                        <td><?php
-                            switch ($member->getGender()) {
-                                case Member::GENDER_MALE:
-                                    echo $this->translate('Male');
-                                    break;
-                                case Member::GENDER_FEMALE:
-                                    echo $this->translate('Female');
-                                    break;
-                                case Member::GENDER_OTHER:
-                                    echo $this->translate('Other');
-                                    break;
-                            }
-                            ?></td>
-                    </tr>
-                    <tr>
                         <th><?= $this->translate('Email') ?></th>
                         <td>
                             <?php if (null !== ($email = $member->getEmail())): ?>

--- a/module/Decision/view/decision/member/self.phtml
+++ b/module/Decision/view/decision/member/self.phtml
@@ -91,11 +91,20 @@ $this->headTitle($member->getFullName());
                 <h3><?= $this->translate('Membership of committees and fraternities') ?></h3>
                 <ul>
                     <?php foreach ($memberships as $abbr => $install): ?>
-                        <li><a href="<?= $this->url('home/organ', ['type' => $install['organ']->getType(), 'abbr' =>
-                                $abbr]) ?>"><?= $abbr ?></a>
-                            <?php $functions = $install['functions']; ?>
-                            <?php if (!empty($functions)): ?> (<?= $functions ?>)
-                            <?php endif ?></li>
+                        <li>
+                            <a href="<?= $this->url(
+                                'home/organ',
+                                [
+                                    'type' => $install['organ']->getType(),
+                                    'abbr' => $abbr,
+                                ],
+                            ) ?>">
+                                <?= $abbr ?>
+                            </a>
+                            <?php if (!empty($install['functions'])): ?>
+                                (<?= implode(', ', $install['functions']) ?>)
+                            <?php endif ?>
+                        </li>
                     <?php endforeach; ?>
                 </ul>
                 <h3><?= $this->translate('Adresses') ?></h3>

--- a/module/Decision/view/decision/member/self.phtml
+++ b/module/Decision/view/decision/member/self.phtml
@@ -93,19 +93,7 @@ $this->headTitle($member->getFullName());
                 </ul>
                 <h3><?= $this->translate('Adresses') ?></h3>
                 <?php foreach ($member->getAddresses() as $address): ?>
-                    <h4><?php
-                        switch ($address->getType()) {
-                            case Address::TYPE_HOME:
-                                echo $this->translate('Home address (parents)');
-                                break;
-                            case Address::TYPE_STUDENT:
-                                echo $this->translate('Student address');
-                                break;
-                            case Address::TYPE_MAIL:
-                                echo $this->translate('Mail address');
-                                break;
-                        }
-                        ?></h4>
+                    <h4><?= $address->getType()->getName($this->plugin('translate')->getTranslator()) ?></h4>
                     <table class="table table-bordered">
                         <tr>
                             <th><?= $this->translate('Country') ?></th>

--- a/module/Decision/view/decision/member/self.phtml
+++ b/module/Decision/view/decision/member/self.phtml
@@ -85,7 +85,7 @@ $this->headTitle($member->getFullName());
                             ) ?>">
                                 <?= $abbr ?>
                             </a>
-                            <?php if (!empty($install['functions'])): ?>
+                            <?php if (isset($install['functions'])): ?>
                                 (<?= implode(', ', $install['functions']) ?>)
                             <?php endif ?>
                         </li>

--- a/module/Decision/view/decision/member/view.phtml
+++ b/module/Decision/view/decision/member/view.phtml
@@ -13,22 +13,6 @@ $this->headTitle($this->translate('Members'));
         <div class="row">
             <div class="col-md-6">
                 <table class="table table-bordered">
-                    <tr>
-                        <th><?= $this->translate('Gender') ?></th>
-                        <td><?php
-                            switch ($member->getGender()) {
-                                case Member::GENDER_MALE:
-                                    echo $this->translate('Male');
-                                    break;
-                                case Member::GENDER_FEMALE:
-                                    echo $this->translate('Female');
-                                    break;
-                                case Member::GENDER_OTHER:
-                                    echo $this->translate('Other');
-                                    break;
-                            }
-                            ?></td>
-                    </tr>
                     <?php if ($this->acl('decision_service_acl')->isAllowed('member', 'view_full')): ?>
                         <tr>
                             <th><?= $this->translate('Email') ?></th>

--- a/module/Decision/view/decision/member/view.phtml
+++ b/module/Decision/view/decision/member/view.phtml
@@ -60,13 +60,19 @@ $this->headTitle($this->translate('Members'));
                 <h3><?= $this->translate('Membership of committees and fraternities') ?></h3>
                 <ul>
                     <?php foreach ($memberships as $abbr => $install): ?>
-                        <li><a
-                                href="<?= $this->url('home/organ', ['type' => $install['organ']->getType(), 'abbr' =>
-                                    $abbr]) ?>"
-                            ><?= $abbr ?></a>
-                            <?php if (isset($install['functions'])): ?>
-                                (<?= $install['functions'] ?>)
-                            <?php endif; ?>
+                        <li>
+                            <a href="<?= $this->url(
+                                'home/organ',
+                                [
+                                    'type' => $install['organ']->getType(),
+                                    'abbr' => $abbr,
+                                ],
+                            ) ?>">
+                                <?= $abbr ?>
+                            </a>
+                            <?php if (!empty($install['functions'])): ?>
+                                (<?= implode(', ', $install['functions']) ?>)
+                            <?php endif ?>
                         </li>
                     <?php endforeach; ?>
                 </ul>

--- a/module/Decision/view/decision/member/view.phtml
+++ b/module/Decision/view/decision/member/view.phtml
@@ -63,19 +63,7 @@ $this->headTitle($this->translate('Members'));
                 <?php if ($this->acl('decision_service_acl')->isAllowed('member', 'view_full')): ?>
                     <h3><?= $this->translate('Adresses') ?></h3>
                     <?php foreach ($member->getAddresses() as $address): ?>
-                        <h4><?php
-                            switch ($address->getType()) {
-                                case Address::TYPE_HOME:
-                                    echo $this->translate('Home address (parents)');
-                                    break;
-                                case Address::TYPE_STUDENT:
-                                    echo $this->translate('Student address');
-                                    break;
-                                case Address::TYPE_MAIL:
-                                    echo $this->translate('Mail address');
-                                    break;
-                            }
-                            ?></h4>
+                        <h4><<?= $address->getType()->getName($this->plugin('translate')->getTranslator()) ?></h4>
                         <table class="table table-bordered">
                             <tr>
                                 <th><?= $this->translate('Country') ?></th>

--- a/module/Decision/view/decision/organ/index.phtml
+++ b/module/Decision/view/decision/organ/index.phtml
@@ -19,32 +19,21 @@ $this->headTitle($this->translate('Organ list'));
             <?php foreach ($this->organs as $organ): ?>
                 <?php $url = $this->url('organ/show', ['organ' => $organ->getId()]) ?>
                 <tr>
-                    <td><a style="display: block; height: 100%; width:100%"
-                           href="<?= $url ?>"><?= $organ->getAbbr() ?></a></td>
-                    <td><a style="display: block; height: 100%; width:100%"
-                           href="<?= $url ?>"><?= $organ->getName() ?></a></td>
-                    <td><a style="display: block; height: 100%; width:100%" href="<?= $url ?>"><?php
-                            switch ($organ->getType()) {
-                                case Organ::ORGAN_TYPE_COMMITTEE:
-                                    echo $this->translate('Committee');
-                                    break;
-                                case Organ::ORGAN_TYPE_AVC:
-                                    echo $this->translate('AV Committee');
-                                    break;
-                                case Organ::ORGAN_TYPE_FRATERNITY:
-                                    echo $this->translate('Fraternity');
-                                    break;
-                                case Organ::ORGAN_TYPE_AVW:
-                                    echo $this->translate('GM Task Force');
-                                    break;
-                                case Organ::ORGAN_TYPE_KKK:
-                                    echo $this->translate('Audit Committee');
-                                    break;
-                                case Organ::ORGAN_TYPE_RVA:
-                                    echo $this->translate('Advisory Board');
-                                    break;
-                            }
-                            ?></a></td>
+                    <td>
+                        <a style="display: block; height: 100%; width:100%" href="<?= $url ?>">
+                            <?= $organ->getAbbr() ?>
+                        </a>
+                    </td>
+                    <td>
+                        <a style="display: block; height: 100%; width:100%" href="<?= $url ?>">
+                            <?= $organ->getName() ?>
+                        </a>
+                    </td>
+                    <td>
+                        <a style="display: block; height: 100%; width:100%" href="<?= $url ?>">
+                            <?= $organ->getType()->getName($this->plugin('translate')->getTranslator()) ?>
+                        </a>
+                    </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/module/Decision/view/decision/organ/show.phtml
+++ b/module/Decision/view/decision/organ/show.phtml
@@ -6,16 +6,37 @@ $this->headTitle($organ->getName()); ?>
         <div class="row">
             <h1><?= $organ->getName() ?> (<?= $organ->getAbbr() ?>)</h1>
             <div class="col-md-4">
-                <h2><?= $this->translate('Current members') ?></h2>
+                <h2><?= $this->translate('Active members') ?></h2>
                 <ul>
-                    <?php foreach ($currentMembers as $membership): ?>
+                    <?php foreach ($activeMembers as $membership): ?>
+                        <li>
+                            <a href="<?= $this->url(
+                                'member/view',
+                                ['lidnr' => $membership['member']->getLidnr()],
+                            ) ?>">
+                                <?= $membership['member']->getFullName() ?>
+                            </a>
+                            <?php if (!empty($membership['functions'])): ?>
+                                (<?= implode(
+                                    ', ',
+                                    array_map(
+                                        fn (string $value): string => $this->translate($value),
+                                        $membership['functions'],
+                                    ),
+                                ) ?>)
+                            <?php endif ?>
+                        </li>
+                    <?php endforeach ?>
+                </ul>
+
+                <h2><?= $this->translate('Inactive members') ?></h2>
+                <ul>
+                    <?php foreach ($inactiveMembers as $membership): ?>
                         <li>
                             <a href="<?= $this->url('member/view', ['lidnr' => $membership['member']->getLidnr()]) ?>">
                                 <?= $membership['member']->getFullName() ?>
                             </a>
-                            <?php if (!empty($membership['functions'])): ?>
-                                (<?= implode(', ', array_map(fn(string $value): string => $this->translate($value), $membership['functions'])) ?>)
-                            <?php endif ?></li>
+                        </li>
                     <?php endforeach ?>
                 </ul>
 

--- a/module/Frontpage/config/module.config.php
+++ b/module/Frontpage/config/module.config.php
@@ -65,7 +65,7 @@ return [
                         'options' => [
                             'route' => 'association/:type/:abbr',
                             'constraints' => [
-                                'type' => 'committee|fraternity|avc|avw|rva|kkk',
+                                'type' => 'committee|fraternity|avc|avw|rva|kcc',
                                 'abbr' => '[^/]+',
                             ],
                             'defaults' => [

--- a/module/Frontpage/src/Controller/OrganController.php
+++ b/module/Frontpage/src/Controller/OrganController.php
@@ -3,6 +3,7 @@
 namespace Frontpage\Controller;
 
 use Activity\Service\ActivityQuery as ActivityQueryService;
+use Decision\Model\Enums\OrganTypes;
 use Decision\Model\Organ;
 use Decision\Service\Organ as OrganService;
 use Laminas\Mvc\Controller\AbstractActionController;
@@ -36,7 +37,7 @@ class OrganController extends AbstractActionController
 
     public function committeeListAction(): ViewModel
     {
-        $committees = $this->organService->findActiveOrgansByType(Organ::ORGAN_TYPE_COMMITTEE);
+        $committees = $this->organService->findActiveOrgansByType(OrganTypes::Committee);
 
         return new ViewModel(
             [
@@ -47,8 +48,8 @@ class OrganController extends AbstractActionController
 
     public function fraternityListAction(): ViewModel
     {
-        $activeFraternities = $this->organService->findActiveOrgansByType(Organ::ORGAN_TYPE_FRATERNITY);
-        $abrogatedFraternities = $this->organService->findAbrogatedOrgansByType(Organ::ORGAN_TYPE_FRATERNITY);
+        $activeFraternities = $this->organService->findActiveOrgansByType(OrganTypes::Fraternity);
+        $abrogatedFraternities = $this->organService->findAbrogatedOrgansByType(OrganTypes::Fraternity);
 
         return new ViewModel(
             [
@@ -60,7 +61,7 @@ class OrganController extends AbstractActionController
 
     public function organAction(): ViewModel
     {
-        $type = $this->params()->fromRoute('type');
+        $type = OrganTypes::from($this->params()->fromRoute('type'));
         $abbr = $this->params()->fromRoute('abbr');
         $organ = $this->organService->findOrganByAbbr($abbr, $type, true);
 

--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -115,14 +115,23 @@ function getOrganDescription($organInformation, $lang)
         <div class="row">
             <div class="col-md-12">
                 <?php if ($this->acl('decision_service_acl')->isAllowed('organ', 'view')): ?>
-                    <h1><?= $this->translate('Current members') ?></h1>
+                    <h1><?= $this->translate('Active members') ?></h1>
                     <ul>
-                        <?php foreach ($currentMembers as $membership): ?>
+                        <?php foreach ($activeMembers as $membership): ?>
                             <li>
-                                <a href="<?= $this->url('member/view', ['lidnr' => $membership['member']->getLidnr()]) ?>">
+                                <a href="<?= $this->url(
+                                    'member/view',
+                                    ['lidnr' => $membership['member']->getLidnr()],
+                                ) ?>">
                                     <?= $membership['member']->getFullName() ?>
                                     <?php if (!empty($membership['functions'])): ?>
-                                        (<?= implode(', ', array_map(fn(string $value): string => $this->translate($value), $membership['functions'])) ?>)
+                                        (<?= implode(
+                                            ', ',
+                                            array_map(
+                                                fn (string $value): string => $this->translate($value),
+                                                $membership['functions'],
+                                            ),
+                                        ) ?>)
                                     <?php endif ?>
                                 </a>
                             </li>


### PR DESCRIPTION
This is a parity update for the website based on the changes that will be made to [`GEWIS/gewisdb`](https://github.com/GEWIS/gewisdb) in August 2022.

Changes include:
- [X] Removal of gender from `Member`s
- [X] Switching to `AddressTypes` enum for `Address` types.
- [X] Switching to `MeetingTypes` enum for `Meeting` types (also used in `(Sub)Decision`).
- [X] Switching to `OrganTypes` enum for `Organ` types (also used in `Foundation` subdecision).
- [X] Adding distinction between active and inactive organ members (closes #1484 and fixes #1495).
- [x] Switching the audit committee from `KKK` to `KCC`.