### PR TITLE
Switch to Alpine based images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,7 +41,7 @@ data/logs/*
 data/mail/*
 docker/glide/
 docker/nginx/
-docker/matomo
+docker/matomo/
 Dockerfile
 docker-compose.*
 gewisweb-vagrant/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
         volumes:
             - gewisweb_public:/code/public:ro
             - gewisweb_glide_public:/glide/public:ro
+            - gewisweb_matomo:/var/www/html:ro
             - gewisweb_logs:/etc/nginx/logs:rw
         networks:
             - gewisweb_network
@@ -99,6 +100,8 @@ services:
 #            - MATOMO_DATABASE_USERNAME=
 #            - MATOMO_DATABASE_PASSWORD=
 #            - MATOMO_DATABASE_DBNAME=
+        volumes:
+            - gewisweb_matomo:/var/www/html:rw
         networks:
             - gewisweb_network
         restart: unless-stopped
@@ -108,6 +111,7 @@ volumes:
     gewisweb_public:
     gewisweb_glide_public:
     gewisweb_logs:
+    gewisweb_matomo:
 
 networks:
     gewisweb_network:

--- a/docker/glide/Dockerfile
+++ b/docker/glide/Dockerfile
@@ -1,16 +1,16 @@
 FROM php:8.1-fpm-alpine as php-target
 
-RUN apk add --no-cache \
-    $PHPIZE_DEPS \
-    freetype-dev \
-    imagemagick-dev \
-    libjpeg-turbo-dev \
-    libpng-dev \
-    libwebp-dev \
-    libzip-dev \
-    unzip
-
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        freetype-dev \
+        imagemagick-dev \
+        libjpeg-turbo-dev \
+        libpng-dev \
+        libwebp-dev \
+        libzip-dev \
+    && apk add --no-cache --virtual .runtime-deps \
+        unzip \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) \
         exif \
         fileinfo \
@@ -18,7 +18,16 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
         opcache \
         zip \
     && pecl install imagick \
-    && docker-php-ext-enable imagick
+    && docker-php-ext-enable imagick \
+    && rm -r /tmp/pear \
+    && runtimeDeps="$( \
+            scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        )" \
+    && apk add --virtual .gewisweb-runtime-deps $runtimeDeps \
+    && apk del .build-deps
 
 FROM php-target as composer-build
 WORKDIR /glide

--- a/docker/glide/Dockerfile
+++ b/docker/glide/Dockerfile
@@ -1,16 +1,14 @@
-FROM php:8.1-fpm as php-target
+FROM php:8.1-fpm-alpine as php-target
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libmagickwand-dev \
-        libpng-dev \
-        libwebp-dev \
-        libzip-dev \
-        unzip \
-    && apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    $PHPIZE_DEPS \
+    freetype-dev \
+    imagemagick-dev \
+    libjpeg-turbo-dev \
+    libpng-dev \
+    libwebp-dev \
+    libzip-dev \
+    unzip
 
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) \

--- a/docker/matomo/Dockerfile
+++ b/docker/matomo/Dockerfile
@@ -1,10 +1,8 @@
-FROM matomo:latest as gewisweb_matomo
+FROM matomo:4.10-fpm-alpine as gewisweb_matomo
 
-RUN apt update && apt install -y --no-install-recommends \
-    gettext-base \
-    unzip \
-    && apt upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+        gettext \
+        unzip
 
 RUN curl -o LogViewer.zip \
       https://plugins.matomo.org/api/2.0/plugins/LogViewer/download/latest \
@@ -24,6 +22,6 @@ RUN curl -L -o TrackingOptOut.zip \
       && rm TrackingOptOut.zip \
       && mv TrackingOptOut /usr/src/matomo/plugins
 
-COPY --chown=www-data:www-data config.ini.php /var/www/html/config/config.ini.php.template
+COPY --chown=www-data:www-data config.ini.php ./config/config.ini.php.template
 
-CMD ["/bin/sh" , "-c" , "envsubst '${MATOMO_DATABASE_HOST} ${MATOMO_DATABASE_PORT} ${MATOMO_DATABASE_USERNAME} ${MATOMO_DATABASE_PASSWORD} ${MATOMO_DATABASE_DBNAME}' < /var/www/html/config/config.ini.php.template > /var/www/html/config/config.ini.php && chown www-data:www-data /var/www/html/config/config.ini.php && exec apache2-foreground"]
+CMD ["/bin/sh" , "-c" , "envsubst '${MATOMO_DATABASE_HOST} ${MATOMO_DATABASE_PORT} ${MATOMO_DATABASE_USERNAME} ${MATOMO_DATABASE_PASSWORD} ${MATOMO_DATABASE_DBNAME}' < /var/www/html/config/config.ini.php.template > /var/www/html/config/config.ini.php && chown www-data:www-data /var/www/html/config/config.ini.php && php-fpm -F -O"]

--- a/docker/matomo/Dockerfile
+++ b/docker/matomo/Dockerfile
@@ -1,4 +1,4 @@
-FROM matomo:4.10-fpm-alpine as gewisweb_matomo
+FROM matomo:4.11-fpm-alpine as gewisweb_matomo
 
 RUN apk add --no-cache \
         gettext \

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:stable-alpine as gewisweb_nginx
 
-RUN adduser -D -H -u 1000 -s /bin/bash www-data -G www-data
+RUN adduser -D -H -u 1000 -s /bin/sh www-data -G www-data
 
 COPY --chown=www-data:www-data . /etc/nginx
 COPY --chown=www-data:www-data nginx.conf /etc/nginx/nginx.conf.template

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,6 @@
-FROM nginx:latest as gewisweb_nginx
+FROM nginx:stable-alpine as gewisweb_nginx
+
+RUN adduser -D -H -u 1000 -s /bin/bash www-data -G www-data
 
 COPY --chown=www-data:www-data . /etc/nginx
 COPY --chown=www-data:www-data nginx.conf /etc/nginx/nginx.conf.template

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -162,9 +162,61 @@ http {
         auth_basic              ${NGINX_REQUIRE_AUTH};
         auth_basic_user_file    /etc/nginx/.htpasswd;
 
-        location / {
+        root /var/www/html;
+        index index.php;
+
+        location ~ ^/(index|matomo|piwik|js/index)\.php$ {
             # access_log /etc/nginx/logs/matomo.log scripts; # This line is useful for debugging routing errors between nginx and matomo
-            proxy_pass                  http://matomo:80;
+            fastcgi_pass                matomo:9000;
+            fastcgi_hide_header         Cache-Control;
+            fastcgi_hide_header         Expires;
+            fastcgi_keep_conn           on;
+            add_header                  X-XSS-Protection                    $x_css_protection;
+            add_header                  Referrer-Policy                     $referrer_policy;
+        }
+
+        location ~* ^.+\.php$ {
+            deny all;
+            return 403;
+        }
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+
+        location ~ ^/(config|tmp|core|lang) {
+            deny all;
+            return 403;
+        }
+
+        location ~ /\.ht {
+            deny  all;
+            return 403;
+        }
+
+        location ~ js/container_.*_preview\.js$ {
+            expires off;
+            add_header                  Cache-Control                       'private, no-cache, no-store';
+            add_header                  X-XSS-Protection                    $x_css_protection;
+            add_header                  Referrer-Policy                     $referrer_policy;
+        }
+
+        location ~ \.(gif|ico|jpg|png|svg|js|css|htm|html|mp3|mp4|wav|ogg|avi|ttf|eot|woff|woff2|json)$ {
+            allow all;
+            expires 1h;
+            add_header                  Pragma                              public;
+            add_header                  Cache-Control                       "public";
+            add_header                  X-XSS-Protection                    $x_css_protection;
+            add_header                  Referrer-Policy                     $referrer_policy;
+        }
+
+        location ~ ^/(libs|vendor|plugins|misc|node_modules) {
+            deny all;
+            return 403;
+        }
+
+        location ~/(.*\.md|LEGALNOTICE|LICENSE) {
+            default_type text/plain;
         }
     }
 }

--- a/docker/web/development/Dockerfile
+++ b/docker/web/development/Dockerfile
@@ -1,31 +1,31 @@
 FROM php:8.1-fpm-alpine as gewisweb_web_development
 
-RUN apk add --no-cache \
-    $PHPIZE_DEPS \
-    curl-dev \
-    freetype-dev \
-    git \
-    ghostscript \
-    icu-dev \
-    imagemagick-dev \
-    imagemagick \
-    libjpeg-turbo-dev \
-    libmemcached-dev \
-    libpng-dev \
-    libpq-dev \
-    libzip-dev \
-    nano \
-    nodejs \
-    npm \
-    openssh \
-    poppler-utils \
-    rsync \
-    sqlite-dev \
-    sshpass \
-    unzip \
-    zip
-
-RUN docker-php-ext-configure \
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        curl-dev \
+        freetype-dev \
+        icu-dev \
+        imagemagick-dev \
+        libjpeg-turbo-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libzip-dev \
+        sqlite-dev \
+    && apk add --no-cache --virtual .runtime-deps \
+        git \
+        ghostscript \
+        imagemagick \
+        nano \
+        nodejs \
+        npm \
+        openssh \
+        poppler-utils \
+        rsync \
+        sshpass \
+        unzip \
+        zip \
+    && docker-php-ext-configure \
         gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) \
         calendar \
@@ -39,14 +39,22 @@ RUN docker-php-ext-configure \
         pdo_mysql \
         pdo_pgsql \
         pdo_sqlite \
-        zip
-
-RUN pecl install imagick \
+        zip \
+    && pecl install imagick \
     && docker-php-ext-enable imagick \
     && pecl install memcached \
     && docker-php-ext-enable memcached \
     && pecl install xdebug \
-    && docker-php-ext-enable xdebug
+    && docker-php-ext-enable xdebug \
+    && rm -r /tmp/pear \
+    && runtimeDeps="$( \
+            scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        )" \
+    && apk add --virtual .gewisweb-runtime-deps $runtimeDeps \
+    && apk del .build-deps
 
 RUN sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-7/policy.xml
 

--- a/docker/web/development/Dockerfile
+++ b/docker/web/development/Dockerfile
@@ -1,29 +1,29 @@
-FROM php:8.1-fpm as gewisweb_web_development
+FROM php:8.1-fpm-alpine as gewisweb_web_development
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        cron \
-        git \
-        ghostscript \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg62-turbo-dev \
-        libmagickwand-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libsqlite3-dev \
-        libzip-dev \
-        nano \
-        poppler-utils \
-        rsync \
-        ssh \
-        sshpass \
-        unzip \
-        zip \
-    && apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    $PHPIZE_DEPS \
+    curl-dev \
+    freetype-dev \
+    git \
+    ghostscript \
+    icu-dev \
+    imagemagick-dev \
+    imagemagick \
+    libjpeg-turbo-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libpq-dev \
+    libzip-dev \
+    nano \
+    nodejs \
+    npm \
+    openssh \
+    poppler-utils \
+    rsync \
+    sqlite-dev \
+    sshpass \
+    unzip \
+    zip
 
 RUN docker-php-ext-configure \
         gd --with-freetype --with-jpeg \
@@ -48,20 +48,13 @@ RUN pecl install imagick \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug
 
-RUN sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml
+RUN sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-7/policy.xml
 
 WORKDIR /code
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php composer-setup.php \
     && php -r "unlink('composer-setup.php');"
-
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        nodejs \
-    && apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=www-data:www-data ./composer.json ./
 RUN php composer.phar install

--- a/docker/web/production/Dockerfile
+++ b/docker/web/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine as node-build
+FROM node:lts-alpine as node-build
 WORKDIR /code
 
 COPY ./package.json ./package-lock.json ./
@@ -9,29 +9,27 @@ RUN mkdir public && mkdir public/scss && mkdir public/css
 COPY ./public/scss ./public/scss/
 RUN npm run scss
 
-FROM php:8.1-fpm as php-target
+FROM php:8.1-fpm-alpine as php-target
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        cron \
-        git \
-        ghostscript \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg62-turbo-dev \
-        libmagickwand-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libzip-dev \
-        poppler-utils \
-        rsync \
-        ssh \
-        sshpass \
-        unzip \
-    && apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    $PHPIZE_DEPS \
+    curl-dev \
+    freetype-dev \
+    git \
+    ghostscript \
+    icu-dev \
+    imagemagick-dev \
+    imagemagick \
+    libjpeg-turbo-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libpq-dev \
+    libzip-dev \
+    openssh \
+    poppler-utils \
+    rsync \
+    sshpass \
+    unzip
 
 RUN docker-php-ext-configure \
         gd --with-freetype --with-jpeg \
@@ -52,7 +50,7 @@ RUN pecl install -o imagick \
     && pecl install -o memcached \
     && docker-php-ext-enable memcached
 
-RUN sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml
+RUN sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-7/policy.xml
 
 FROM php-target as gewisweb_web_production
 WORKDIR /code

--- a/docker/web/production/Dockerfile
+++ b/docker/web/production/Dockerfile
@@ -11,27 +11,27 @@ RUN npm run scss
 
 FROM php:8.1-fpm-alpine as php-target
 
-RUN apk add --no-cache \
-    $PHPIZE_DEPS \
-    curl-dev \
-    freetype-dev \
-    git \
-    ghostscript \
-    icu-dev \
-    imagemagick-dev \
-    imagemagick \
-    libjpeg-turbo-dev \
-    libmemcached-dev \
-    libpng-dev \
-    libpq-dev \
-    libzip-dev \
-    openssh \
-    poppler-utils \
-    rsync \
-    sshpass \
-    unzip
-
-RUN docker-php-ext-configure \
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        curl-dev \
+        freetype-dev \
+        icu-dev \
+        imagemagick-dev \
+        libjpeg-turbo-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libzip-dev \
+    && apk add --no-cache --virtual .runtime-deps \
+        git \
+        ghostscript \
+        imagemagick \
+        openssh \
+        poppler-utils \
+        rsync \
+        sshpass \
+        unzip \
+    && docker-php-ext-configure \
         gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) \
         calendar \
@@ -43,12 +43,20 @@ RUN docker-php-ext-configure \
         pgsql \
         pdo_mysql \
         pdo_pgsql \
-        zip
-
-RUN pecl install -o imagick \
+        zip \
+    && pecl install -o imagick \
     && docker-php-ext-enable imagick \
     && pecl install -o memcached \
-    && docker-php-ext-enable memcached
+    && docker-php-ext-enable memcached \
+    && rm -r /tmp/pear \
+    && runtimeDeps="$( \
+            scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        )" \
+    && apk add --virtual .gewisweb-runtime-deps $runtimeDeps \
+    && apk del .build-deps
 
 RUN sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-7/policy.xml
 

--- a/translate-helper
+++ b/translate-helper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 dir="$PWD"
 cd `dirname $0`
 


### PR DESCRIPTION
~~I wanted to change a bit more, but I think this is a good start.~~ This replaces all the existing base images for our images with Alpine based images. This should result in images that are generally ~~200-300~~ **500** MB smaller.

~~Further size reductions can be made by combining more steps in the Dockerfiles that allow us to use virtual `apk` packages that can subsequently be deleted. For example, the `pecl` installs require `$PHPIZE_DEPS` (among other things), we could create a new virtual package installing the dependencies, make the extensions, and remove the dependencies again. This should reduce the size of the layer even more.~~

**Important changes:**
- Moves production NodeJS version to LTS (16 instead of 14, parity with dev image),
- Updates ImageMagick to v7,
- Matomo no longer uses the latest version* (to prevent accidental breakages due to unseen updates),
- NGINX no longer uses the latest version (now `stable`), and
- `bash` is no longer available (use `sh`).

*: I know that Matomo v4.11 was released last night, but the creation of the Docker images takes a bit of time, hence this is still on v4.10.1.