### PR TITLE
Improve performance of `/career` page by reducing #queries

### DIFF
--- a/module/Company/src/Mapper/Company.php
+++ b/module/Company/src/Mapper/Company.php
@@ -4,32 +4,50 @@ namespace Company\Mapper;
 
 use Application\Mapper\BaseMapper;
 use Company\Model\Company as CompanyModel;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
 
 /**
  * Mappers for companies.
  *
- * NOTE: Companies will be modified externally by a script. Modifycations will be
+ * NOTE: Companies will be modified externally by a script. Modifications will be
  * overwritten.
  */
 class Company extends BaseMapper
 {
     /**
-     * Find all public companies with a certain locale.
+     * Find all public companies, these are companies that are published and have at least one non-expired package.
      *
      * @return array
      */
     public function findAllPublic(): array
     {
-        $qb = $this->getRepository()->createQueryBuilder('c');
-        $qb->where('c.published = 1')
-            ->orderBy('c.name', 'ASC');
+        $rsmBuilder = new ResultSetMappingBuilder($this->getEntityManager());
+        $rsmBuilder->addRootEntityFromClassMetadata($this->getRepositoryName(), 'c');
 
-        return array_filter(
-            $qb->getQuery()->getResult(),
-            function ($company) {
-                return $company->getNumberOfPackages() > $company->getNumberOfExpiredPackages();
-            }
-        );
+        $select = $rsmBuilder->generateSelectClause(['c' => 't1']);
+
+        $sql = <<<QUERY
+            SELECT {$select} FROM `Company` AS `t1`
+            LEFT JOIN (
+                SELECT `company_id`,
+                    COUNT(`company_id`) AS `totalPackages`,
+                    SUM(
+                        CASE WHEN `expires` <= CURRENT_TIMESTAMP
+                                OR `published` = 0
+                                OR `starts` > CURRENT_TIMESTAMP
+                            THEN 1
+                            ELSE 0
+                        END
+                    ) AS `expiredHiddenOrNotStartedPackages`
+                FROM `CompanyPackage`
+                GROUP BY `company_id`
+            ) `CompanyPackages` ON `CompanyPackages`.`company_id` = `t1`.`id`
+            WHERE `t1`.`published` = 1
+            AND `CompanyPackages`.`totalPackages` > `CompanyPackages`.`expiredHiddenOrNotStartedPackages`
+            ORDER BY `t1`.`name` ASC
+            QUERY;
+
+        return $this->getEntityManager()->createNativeQuery($sql, $rsmBuilder)->getResult();
     }
 
     /**

--- a/module/Company/view/company/company/list.phtml
+++ b/module/Company/view/company/company/list.phtml
@@ -58,12 +58,14 @@ $this->headTitle($this->translate('Companies'));
                         <?php
                         // Randomize the order of companies
                         shuffle($companyList);
+                        $jobCategories = $this->jobCategories();
 
                         foreach ($companyList as $company) {
                             echo $this->partial(
                                 'partial/company/company/grid/company.phtml',
                                 [
                                     'company' => $company,
+                                    'jobCategories' => $jobCategories,
                                 ],
                             );
                         }

--- a/module/Company/view/partial/company/company/grid/company.phtml
+++ b/module/Company/view/partial/company/company/grid/company.phtml
@@ -27,8 +27,8 @@ $companyURL = $this->url(
                     <em><?= $this->escapeHtml($this->localiseText($company->getSlogan())) ?></em>
                 </p>
                 <ul>
-                    <?php foreach ($this->jobCategories() as $category): ?>
-                        <?php if ($company->getNumberOfActiveJobs($category) > 0): ?>
+                    <?php foreach ($jobCategories as $category): ?>
+                        <?php if (0 < ($activeJobsInCategory = $company->getNumberOfActiveJobs($category))): ?>
                             <li>
                                 <a href="<?= $this->url(
                                     'company/companyItem/joblist',
@@ -37,7 +37,7 @@ $companyURL = $this->url(
                                         'category' => $this->localiseText($category->getSlug()),
                                     ],
                                 ) ?>">
-                                    <?= $company->getNumberOfActiveJobs($category) ?> <?= $this->escapeHtml($this->localiseText($company->getNumberOfActiveJobs($category) === 1 ? $category->getName() : $category->getPluralName())) ?>
+                                    <?= $activeJobsInCategory ?> <?= $this->escapeHtml($this->localiseText(1 === $activeJobsInCategory ? $category->getName() : $category->getPluralName())) ?>
                                 </a>
                             </li>
                         <?php endif ?>
@@ -47,4 +47,3 @@ $companyURL = $this->url(
         </div>
     </div>
 </div>
-


### PR DESCRIPTION
This takes advantage of a customised native query to select all public companies (which are companies that are published AND have at least one active package).

Furthermore, there were unnecessary calls to get all job categories that caused a lot of additional queries. Furthermore, improved logic allows us to calculate the number of active jobs in a category to be calculated only once instead of three times.

In my limited testing this reduces the number of executed queries by 2/3.

Fixes #1517.