### PR TITLE
Fix slow or no download for exams and summaries

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -218,6 +218,8 @@
       <path value="$PROJECT_DIR$/vendor/bnf/phpstan-psr-container" />
       <path value="$PROJECT_DIR$/vendor/phpstan/phpstan-phpunit" />
       <path value="$PROJECT_DIR$/vendor/lctrs/psalm-psr-container-plugin" />
+      <path value="$PROJECT_DIR$/vendor/setasign/fpdi" />
+      <path value="$PROJECT_DIR$/vendor/tecnickcom/tcpdf" />
     </include_path>
   </component>
   <component name="PhpInterpreters">

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,9 @@
         "league/glide": "^2.0.0",
         "fortawesome/font-awesome": "^6.0.0",
         "slowprog/composer-copy-file": "^0.3.0",
-        "cweagans/composer-patches": "^1.7.1"
+        "cweagans/composer-patches": "^1.7.1",
+        "setasign/fpdi": "2.3.6",
+        "tecnickcom/tcpdf": "6.5.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5c1d48d03d2b127dcef1fe799bb2e9e",
+    "content-hash": "660d9598ef5c83b021a89dbf865476fe",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -6087,6 +6087,78 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
+            "name": "setasign/fpdi",
+            "version": "v2.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDI.git",
+                "reference": "6231e315f73e4f62d72b73f3d6d78ff0eed93c31"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/6231e315f73e4f62d72b73f3d6d78ff0eed93c31",
+                "reference": "6231e315f73e4f62d72b73f3d6d78ff0eed93c31",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zlib": "*",
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "setasign/tfpdf": "<1.31"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7",
+                "setasign/fpdf": "~1.8",
+                "setasign/tfpdf": "1.31",
+                "squizlabs/php_codesniffer": "^3.5",
+                "tecnickcom/tcpdf": "~6.2"
+            },
+            "suggest": {
+                "setasign/fpdf": "FPDI will extend this class but as it is also possible to use TCPDF or tFPDF as an alternative. There's no fixed dependency configured."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "setasign\\Fpdi\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Slabon",
+                    "email": "jan.slabon@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                },
+                {
+                    "name": "Maximilian Kresse",
+                    "email": "maximilian.kresse@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                }
+            ],
+            "description": "FPDI is a collection of PHP classes facilitating developers to read pages from existing PDF documents and use them as templates in FPDF. Because it is also possible to use FPDI with TCPDF, there are no fixed dependencies defined. Please see suggestions for packages which evaluates the dependencies automatically.",
+            "homepage": "https://www.setasign.com/fpdi",
+            "keywords": [
+                "fpdf",
+                "fpdi",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/Setasign/FPDI/issues",
+                "source": "https://github.com/Setasign/FPDI/tree/v2.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/setasign/fpdi",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-11T11:37:01+00:00"
+        },
+        {
             "name": "slowprog/composer-copy-file",
             "version": "0.3.3",
             "source": {
@@ -7206,6 +7278,78 @@
                 }
             ],
             "time": "2022-07-27T15:50:51+00:00"
+        },
+        {
+            "name": "tecnickcom/tcpdf",
+            "version": "6.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tecnickcom/TCPDF.git",
+                "reference": "cc54c1503685e618b23922f53635f46e87653662"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/cc54c1503685e618b23922f53635f46e87653662",
+                "reference": "cc54c1503685e618b23922f53635f46e87653662",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "config",
+                    "include",
+                    "tcpdf.php",
+                    "tcpdf_parser.php",
+                    "tcpdf_import.php",
+                    "tcpdf_barcodes_1d.php",
+                    "tcpdf_barcodes_2d.php",
+                    "include/tcpdf_colors.php",
+                    "include/tcpdf_filters.php",
+                    "include/tcpdf_font_data.php",
+                    "include/tcpdf_fonts.php",
+                    "include/tcpdf_images.php",
+                    "include/tcpdf_static.php",
+                    "include/barcodes/datamatrix.php",
+                    "include/barcodes/pdf417.php",
+                    "include/barcodes/qrcode.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Nicola Asuni",
+                    "email": "info@tecnick.com",
+                    "role": "lead"
+                }
+            ],
+            "description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
+            "homepage": "http://www.tcpdf.org/",
+            "keywords": [
+                "PDFD32000-2008",
+                "TCPDF",
+                "barcodes",
+                "datamatrix",
+                "pdf",
+                "pdf417",
+                "qrcode"
+            ],
+            "support": {
+                "issues": "https://github.com/tecnickcom/TCPDF/issues",
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_donations&currency_code=GBP&business=paypal@tecnick.com&item_name=donation%20for%20tcpdf%20project",
+                    "type": "custom"
+                }
+            ],
+            "time": "2022-08-12T07:50:54+00:00"
         },
         {
             "name": "twbs/bootstrap-sass",

--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -49,7 +49,6 @@ return [
     ],
     'storage' => [
         'storage_dir' => 'public/data',
-        'watermark_dir' => 'public/data/watermark',
         'public_dir' => 'data',
         'cache_dir' => 'data/cache',
         'dir_mode' => 0777, // rwx by default

--- a/docker/web/development/Dockerfile
+++ b/docker/web/development/Dockerfile
@@ -71,6 +71,9 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
 COPY --chown=www-data:www-data ./composer.json ./
 RUN php composer.phar install
 
+# If you are not a member of the ApplicatieBeheerCommissie comment the line below.
+COPY --from=web.docker-registry.gewis.nl/gewisweb_patches:latest . /code
+
 COPY --chown=www-data:www-data ./package.json ./package-lock.json ./
 RUN npm install --production=false
 

--- a/docker/web/production/Dockerfile
+++ b/docker/web/production/Dockerfile
@@ -74,6 +74,8 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
 COPY ./composer.json ./composer.lock ./
 RUN php composer.phar install -o --no-dev
 
+COPY --from=web.docker-registry.gewis.nl/gewisweb_patches:latest . /code
+
 COPY --chown=www-data:www-data ./docker/web/production/php.ini /usr/local/etc/php/conf.d/default.ini
 COPY --chown=www-data:www-data ./docker/web/production/php-fpm.conf /usr/local/etc/php-fpm.d/zz-gewisweb.conf
 COPY --chown=www-data:www-data ./config/autoload/local.production.php.dist ./config/autoload/local.php

--- a/module/Application/src/Module.php
+++ b/module/Application/src/Module.php
@@ -187,11 +187,10 @@ class Module
                     return new FileStorageService($translator, $storageConfig, $watermarkService);
                 },
                 'application_service_watermark' => function (ContainerInterface $container) {
-                    $storageConfig = $container->get('config')['storage'];
                     $authService = $container->get('user_auth_service');
                     $remoteAddress = $container->get('user_remoteaddress');
 
-                    return new WatermarkService($storageConfig, $authService, $remoteAddress);
+                    return new WatermarkService($authService, $remoteAddress);
                 },
                 'application_get_languages' => function () {
                     return ['nl', 'en'];

--- a/psalm/psalm-baseline.xml
+++ b/psalm/psalm-baseline.xml
@@ -27,6 +27,11 @@
       <code>string</code>
     </InvalidNullableReturnType>
   </file>
+  <file src="module/Application/src/Service/WatermarkService.php">
+    <TypeDoesNotContainNull occurrences="1">
+      <code>$this-&gt;remoteAddress</code>
+    </TypeDoesNotContainNull>
+  </file>
   <file src="module/Application/test/BaseControllerTest.php">
     <InvalidArgument occurrences="2">
       <code>[[$this::LIDNR], $this-&gt;member]</code>


### PR DESCRIPTION
This changes the backend for generating and applying the watermarks to PDFs. ImageMagick has been replaced with FPDI and TCPDF.

Furthermore, the PDFs are no longer flattened (the real cause of the problem) but to ensure that the watermark cannot be removed a random password (which is subsequently encrypted with AES-256) is applied to the PDF ensuring that it can only be printed. By not flattening the PDF, the experience of using the PDFs is also improved as it allows for the selection of / searching for text.

This fixes #1344 and #ABC-2209-244.