### PR TITLE
Fix generation of album covers without sufficient photos

### DIFF
--- a/module/Photo/src/Controller/AlbumAdminController.php
+++ b/module/Photo/src/Controller/AlbumAdminController.php
@@ -210,9 +210,14 @@ class AlbumAdminController extends AbstractActionController
 
         if ($request->isPost()) {
             $albumId = $this->params()->fromRoute('album_id');
-            $this->albumService->generateAlbumCover($albumId);
+            if (null !== ($cover = $this->albumService->generateAlbumCover($albumId))) {
+                return new JsonModel([
+                    'success' => true,
+                    'coverPath' => $cover,
+                ]);
+            }
         }
 
-        return new JsonModel([]);
+        return new JsonModel(['success' => false]);
     }
 }

--- a/module/Photo/src/Module.php
+++ b/module/Photo/src/Module.php
@@ -128,14 +128,12 @@ class Module
                 },
                 'photo_service_album_cover' => function (ContainerInterface $container) {
                     $photoMapper = $container->get('photo_mapper_photo');
-                    $albumMapper = $container->get('photo_mapper_album');
                     $storage = $container->get('application_service_storage');
                     $photoConfig = $container->get('config')['photo'];
                     $storageConfig = $container->get('config')['storage'];
 
                     return new AlbumCoverService(
                         $photoMapper,
-                        $albumMapper,
                         $storage,
                         $photoConfig,
                         $storageConfig,

--- a/module/Photo/src/Service/Album.php
+++ b/module/Photo/src/Service/Album.php
@@ -453,7 +453,7 @@ class Album
      *
      * @throws Exception
      */
-    public function generateAlbumCover(int $albumId): void
+    public function generateAlbumCover(int $albumId): ?string
     {
         if (!$this->aclService->isAllowed('edit', 'album')) {
             throw new NotAllowedException($this->translator->translate('Not allowed to generate album covers.'));
@@ -463,12 +463,18 @@ class Album
         //if an existing cover photo was generated earlier, delete it.
         $coverPath = $this->albumCoverService->createCover($album);
 
+        if (null === $coverPath) {
+            return null;
+        }
+
         if (null !== $album->getCoverPath()) {
             $this->storageService->removeFile($album->getCoverPath());
         }
 
         $album->setCoverPath($coverPath);
         $this->albumMapper->flush();
+
+        return $coverPath;
     }
 
     /**

--- a/module/Photo/src/Service/AlbumCover.php
+++ b/module/Photo/src/Service/AlbumCover.php
@@ -30,11 +30,16 @@ class AlbumCover
      *
      * @param AlbumModel $album the album to create the cover for
      *
-     * @return string the path to the cover image
+     * @return string|null the path to the cover image
      */
-    public function createCover(AlbumModel $album): string
+    public function createCover(AlbumModel $album): ?string
     {
         $cover = $this->generateCover($album);
+
+        if (null === $cover) {
+            return null;
+        }
+
         $tempFileName = sys_get_temp_dir() . '/CoverImage' . random_int(0, getrandmax()) . '.png';
         $cover->writeImage($tempFileName);
 
@@ -46,9 +51,9 @@ class AlbumCover
      *
      * @param AlbumModel $album the album to create a cover image for
      *
-     * @return Imagick the cover image
+     * @return Imagick|null the cover image or null if one could not be created
      */
-    protected function generateCover(AlbumModel $album): Imagick
+    protected function generateCover(AlbumModel $album): ?Imagick
     {
         $columns = $this->photoConfig['album_cover']['cols'];
         $rows = $this->photoConfig['album_cover']['rows'];
@@ -74,9 +79,11 @@ class AlbumCover
             $this->photoConfig['album_cover']['background']
         );
 
-        if (count($images) > 0) {
-            $this->drawComposition($target, $columns, $rows, $images);
+        if (0 === count($images)) {
+            return null;
         }
+
+        $this->drawComposition($target, $columns, $rows, $images);
         $target->setImageFormat('png');
 
         return $target;

--- a/module/Photo/src/Service/AlbumCover.php
+++ b/module/Photo/src/Service/AlbumCover.php
@@ -102,11 +102,7 @@ class AlbumCover
         int $count,
     ): array {
         $photos = $this->photoMapper->getRandomAlbumPhotos($album, $count);
-        //retrieve more photo's from subalbums
-        foreach ($this->albumMapper->getSubAlbums($album) as $subAlbum) {
-            $needed = $count - count($photos);
-            $photos = array_merge($photos, $this->photoMapper->getRandomAlbumPhotos($subAlbum, $needed));
-        }
+
         //convert the photo objects to Imagick objects
         $images = [];
         foreach ($photos as $photo) {

--- a/module/Photo/src/Service/AlbumCover.php
+++ b/module/Photo/src/Service/AlbumCover.php
@@ -4,10 +4,7 @@ namespace Photo\Service;
 
 use Application\Service\FileStorage as FileStorageService;
 use Imagick;
-use Photo\Mapper\{
-    Album as AlbumMapper,
-    Photo as PhotoMapper,
-};
+use Photo\Mapper\Photo as PhotoMapper;
 use Photo\Model\Album as AlbumModel;
 
 /**
@@ -17,7 +14,6 @@ class AlbumCover
 {
     public function __construct(
         private readonly PhotoMapper $photoMapper,
-        private readonly AlbumMapper $albumMapper,
         private readonly FileStorageService $storage,
         private readonly array $photoConfig,
         private readonly array $storageConfig,
@@ -59,6 +55,11 @@ class AlbumCover
         $rows = $this->photoConfig['album_cover']['rows'];
         $count = $columns * $rows;
         $images = $this->getImages($album, $count);
+
+        if (0 === count($images)) {
+            return null;
+        }
+
         /*
          * If there are not enough images available to fill the matrix we
          * reduce the amount of rows and columns
@@ -79,10 +80,6 @@ class AlbumCover
             $this->photoConfig['album_cover']['background']
         );
 
-        if (0 === count($images)) {
-            return null;
-        }
-
         $this->drawComposition($target, $columns, $rows, $images);
         $target->setImageFormat('png');
 
@@ -100,8 +97,16 @@ class AlbumCover
     protected function getImages(
         AlbumModel $album,
         int $count,
+        int $maxDepth = 3,
     ): array {
-        $photos = $this->photoMapper->getRandomAlbumPhotos($album, $count);
+        $albums = [];
+        if (0 === $album->getPhotos()->count()) {
+            $albums = $this->getLayerWithPhotos($album->getChildren()->toArray(), $maxDepth);
+        } else {
+            $albums[] = $album;
+        }
+
+        $photos = $this->photoMapper->getRandomPhotosFromAlbums($albums, $count);
 
         //convert the photo objects to Imagick objects
         $images = [];
@@ -111,6 +116,37 @@ class AlbumCover
         }
 
         return $images;
+    }
+
+    /**
+     * @param AlbumModel[] $subAlbums
+     *
+     * @return AlbumModel[]
+     */
+    protected function getLayerWithPhotos(
+        array $subAlbums,
+        int $maxDepth,
+    ): array {
+        if ($maxDepth < 0) {
+            return [];
+        }
+
+        $allChildren = [];
+        $output = [];
+
+        foreach ($subAlbums as $subAlbum) {
+            $allChildren = array_merge($allChildren, $subAlbum->getChildren()->toArray());
+
+            if (0 !== $subAlbum->getPhotos()->count()) {
+                $output[] = $subAlbum;
+            }
+        }
+
+        if (empty($output)) {
+            $output = $this->getLayerWithPhotos($allChildren, $maxDepth - 1);
+        }
+
+        return $output;
     }
 
     /**

--- a/module/Photo/view/photo/album-admin/index.phtml
+++ b/module/Photo/view/photo/album-admin/index.phtml
@@ -149,6 +149,9 @@ $this->scriptUrl()->requireUrl('admin_photo/album_page', ['album_id', 'page'])
             <div class="modal-body">
                 <center>
                     <div id="coverSpinner" class="spinner"></div>
+                    <p id="coverError"  style="display: none;">
+                        <?= $this->translate('An error occurred while trying to generate an album photo.') ?>
+                    </p>
                     <img id="coverPreview" class="cover-preview" src="">
                 </center>
             </div>

--- a/public/js/photo-admin.js
+++ b/public/js/photo-admin.js
@@ -85,11 +85,14 @@ Photo.Admin.regenerateCover = function () {
     $("#coverPreview").hide();
     $("#coverSpinner").show();
     $.post(URLHelper.url('admin_photo/album_cover', {'album_id': Photo.Admin.activeData.album.id}), function (data) {
-        $.getJSON(Photo.Admin.activePage, function (data) {
-            $("#coverPreview").attr('src', URLHelper.url('home') + 'data/' + data.album.coverPath);
-            $("#coverPreview").show();
+        if (data.success) {
+            $("#coverPreview").attr('src', URLHelper.url('home') + 'data/' + data.coverPath);
             $("#coverSpinner").hide();
-        });
+            $("#coverPreview").show();
+        } else {
+            $("#coverSpinner").hide();
+            $("#coverError").show();
+        }
     });
 }
 


### PR DESCRIPTION
Changes how the cover photo of an album is generated. This correctly uses all sub-albums that have photos (in a specific layer) to generate a cover.

This fixes #1503, fixes #611, and fixes #577. 

---
**OLD:**

This uses a native SQL to accomplish this, unfortunately, this does not support an early-abort (as recursive CTEs cannot `COUNT()` on results).

```sql
WITH RECURSIVE `subAlbumContents` (`depth`, `id`, `photo_id`) AS (
    -- select the root album and all its contents
    SELECT 0 AS `depth`, `a`.`id`, `p`.`id` AS `photo_id`
    FROM `Album` `a`
    LEFT JOIN `Photo` `p` ON `p`.`album_id` = `a`.`id`
    WHERE `a`.`id` = :album_id

    UNION ALL

    -- subsequently (and recursively) select its children and their contents
    SELECT `s`.`depth` + 1 AS `depth`, `a`.`id`, `p`.`id` AS `photo_id`
    FROM `Album` `a`
    LEFT JOIN `Photo` `p` ON `p`.`album_id` = `a`.`id`
    INNER JOIN `subAlbumContents` `s` ON `s`.`id` = `a`.`parent_id`
    -- to a limit of :depth INCLUSIVELY (even though we use a strict less than), + 1 from the SELECT must be accounted for
    WHERE `depth` < :depth
)
SELECT `photo_id`
FROM `subAlbumContents`
WHERE `photo_id` IS NOT NULL
    -- use first layer of albums that is not empty
    AND `depth` = (
        SELECT MIN(`depth`)
        FROM `subAlbumContents`
        WHERE `photo_id` IS NOT NULL
    )
-- RAND() is incredibly inefficient, but no better way to do this (scales linear with number of results in `subAlbumContents`)
ORDER BY RAND()
LIMIT :limit;
```

Because there is no early-abort, this can get quite slow for large albums and/or large max depths. I have tested it on the production data and it can return results in 0.01 to 0.02 seconds for large albums (including many sub-albums).