### PR TITLE
Do not use `User` for important relations

### DIFF
--- a/module/Activity/src/Model/Activity.php
+++ b/module/Activity/src/Model/Activity.php
@@ -4,7 +4,10 @@ namespace Activity\Model;
 
 use Company\Model\Company as CompanyModel;
 use DateTime;
-use Decision\Model\Organ as OrganModel;
+use Decision\Model\{
+    Member as MemberModel,
+    Organ as OrganModel,
+};
 use Doctrine\Common\Collections\{
     ArrayCollection,
     Collection,
@@ -21,7 +24,6 @@ use Doctrine\ORM\Mapping\{
     OneToMany,
     OneToOne,
 };
-use User\Model\User as UserModel;
 use User\Permissions\Resource\{
     CreatorResourceInterface,
     OrganResourceInterface,
@@ -109,19 +111,19 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     /**
      * Who (dis)approved this activity?
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(referencedColumnName: "lidnr")]
-    protected ?UserModel $approver = null;
+    protected ?MemberModel $approver = null;
 
     /**
      * Who created this activity.
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(
         referencedColumnName: "lidnr",
         nullable: false,
     )]
-    protected UserModel $creator;
+    protected MemberModel $creator;
 
     /**
      * What is the approval status      .
@@ -215,17 +217,17 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     }
 
     /**
-     * @return UserModel|null
+     * @return MemberModel|null
      */
-    public function getApprover(): ?UserModel
+    public function getApprover(): ?MemberModel
     {
         return $this->approver;
     }
 
     /**
-     * @param UserModel|null $approver
+     * @param MemberModel|null $approver
      */
-    public function setApprover(?UserModel $approver): void
+    public function setApprover(?MemberModel $approver): void
     {
         $this->approver = $approver;
     }
@@ -536,14 +538,14 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     }
 
     /**
-     * @return UserModel
+     * @return MemberModel
      */
-    public function getCreator(): UserModel
+    public function getCreator(): MemberModel
     {
         return $this->creator;
     }
 
-    public function setCreator(UserModel $creator): void
+    public function setCreator(MemberModel $creator): void
     {
         $this->creator = $creator;
     }
@@ -609,9 +611,9 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
     /**
      * Get the creator of this resource.
      *
-     * @return UserModel
+     * @return MemberModel
      */
-    public function getResourceCreator(): UserModel
+    public function getResourceCreator(): MemberModel
     {
         return $this->getCreator();
     }

--- a/module/Activity/src/Model/ActivityCalendarOption.php
+++ b/module/Activity/src/Model/ActivityCalendarOption.php
@@ -3,6 +3,7 @@
 namespace Activity\Model;
 
 use DateTime;
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
@@ -11,7 +12,6 @@ use Doctrine\ORM\Mapping\{
     JoinColumn,
     ManyToOne,
 };
-use User\Model\User as UserModel;
 
 /**
  * Activity calendar option model.
@@ -70,9 +70,9 @@ class ActivityCalendarOption
     /**
      * Who modified this activity option, if null then the option is not modified.
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(referencedColumnName: "lidnr")]
-    protected ?UserModel $modifiedBy;
+    protected ?MemberModel $modifiedBy;
 
     /**
      * @return DateTime
@@ -107,17 +107,17 @@ class ActivityCalendarOption
     }
 
     /**
-     * @return UserModel|null
+     * @return MemberModel|null
      */
-    public function getModifiedBy(): ?UserModel
+    public function getModifiedBy(): ?MemberModel
     {
         return $this->modifiedBy;
     }
 
     /**
-     * @param UserModel|null $modifiedBy
+     * @param MemberModel|null $modifiedBy
      */
-    public function setModifiedBy(?UserModel $modifiedBy): void
+    public function setModifiedBy(?MemberModel $modifiedBy): void
     {
         $this->modifiedBy = $modifiedBy;
     }

--- a/module/Activity/src/Model/ActivityOptionProposal.php
+++ b/module/Activity/src/Model/ActivityOptionProposal.php
@@ -3,7 +3,10 @@
 namespace Activity\Model;
 
 use DateTime;
-use Decision\Model\Organ as OrganModel;
+use Decision\Model\{
+    Member as MemberModel,
+    Organ as OrganModel,
+};
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
@@ -12,7 +15,6 @@ use Doctrine\ORM\Mapping\{
     JoinColumn,
     ManyToOne,
 };
-use User\Model\User as UserModel;
 use User\Permissions\Resource\OrganResourceInterface;
 
 /**
@@ -44,12 +46,12 @@ class ActivityOptionProposal implements OrganResourceInterface
     /**
      * Who created this activity option.
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(
         referencedColumnName: "lidnr",
         nullable: false,
     )]
-    protected UserModel $creator;
+    protected MemberModel $creator;
 
     /**
      * The date and time the activity option was created.
@@ -198,7 +200,7 @@ class ActivityOptionProposal implements OrganResourceInterface
             return $this->getOrganAlt();
         }
 
-        return $this->getCreator()->getMember()->getFullName();
+        return $this->getCreator()->getFullName();
     }
 
     /**
@@ -218,17 +220,17 @@ class ActivityOptionProposal implements OrganResourceInterface
     }
 
     /**
-     * @return UserModel
+     * @return MemberModel
      */
-    public function getCreator(): UserModel
+    public function getCreator(): MemberModel
     {
         return $this->creator;
     }
 
     /**
-     * @param UserModel $creator
+     * @param MemberModel $creator
      */
-    public function setCreator(UserModel $creator): void
+    public function setCreator(MemberModel $creator): void
     {
         $this->creator = $creator;
     }

--- a/module/Activity/src/Model/SignupList.php
+++ b/module/Activity/src/Model/SignupList.php
@@ -3,6 +3,7 @@
 namespace Activity\Model;
 
 use DateTime;
+use Decision\Model\Member as MemberModel;
 use Decision\Model\Organ as OrganModel;
 use Doctrine\Common\Collections\{
     ArrayCollection,
@@ -19,7 +20,6 @@ use Doctrine\ORM\Mapping\{
     OneToOne,
     OrderBy,
 };
-use User\Model\User as UserModel;
 use User\Permissions\Resource\{
     CreatorResourceInterface,
     OrganResourceInterface,
@@ -325,9 +325,9 @@ class SignupList implements OrganResourceInterface, CreatorResourceInterface
     /**
      * Get the creator of this resource.
      *
-     * @return UserModel
+     * @return MemberModel
      */
-    public function getResourceCreator(): UserModel
+    public function getResourceCreator(): MemberModel
     {
         return $this->getActivity()->getCreator();
     }

--- a/module/Activity/src/Model/UserSignup.php
+++ b/module/Activity/src/Model/UserSignup.php
@@ -2,12 +2,12 @@
 
 namespace Activity\Model;
 
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\{
     Entity,
     JoinColumn,
     ManyToOne,
 };
-use User\Model\User as UserModel;
 
 /**
  * Signup model.
@@ -18,12 +18,12 @@ class UserSignup extends Signup
     /**
      * Who is subscribed. This association cannot be nonnullable, as this breaks {@link ExternalSignup}.
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(
         name: "user_lidnr",
         referencedColumnName: "lidnr",
     )]
-    protected UserModel $user;
+    protected MemberModel $user;
 
     /**
      * Get the full name of the user whom signed up for the activity.
@@ -32,15 +32,15 @@ class UserSignup extends Signup
      */
     public function getFullName(): string
     {
-        return $this->getUser()->getMember()->getFullName();
+        return $this->getUser()->getFullName();
     }
 
     /**
      * Get the user that is signed up.
      *
-     * @return UserModel
+     * @return MemberModel
      */
-    public function getUser(): UserModel
+    public function getUser(): MemberModel
     {
         return $this->user;
     }
@@ -48,7 +48,7 @@ class UserSignup extends Signup
     /**
      * Set the user for the activity signup.
      */
-    public function setUser(UserModel $user): void
+    public function setUser(MemberModel $user): void
     {
         $this->user = $user;
     }
@@ -60,6 +60,6 @@ class UserSignup extends Signup
      */
     public function getEmail(): ?string
     {
-        return $this->getUser()->getMember()->getEmail();
+        return $this->getUser()->getEmail();
     }
 }

--- a/module/Activity/src/Service/ActivityCalendar.php
+++ b/module/Activity/src/Service/ActivityCalendar.php
@@ -107,7 +107,7 @@ class ActivityCalendar
 
         $proposal->setCreationTime(new DateTime());
         $em = $this->entityManager;
-        $proposal->setCreator($this->aclService->getIdentityOrThrowException());
+        $proposal->setCreator($this->aclService->getIdentityOrThrowException()->getMember());
         $name = $data['name'];
         $proposal->setName($name);
         $description = $data['description'];
@@ -174,7 +174,7 @@ class ActivityCalendar
             return;
         }
 
-        $option->setModifiedBy($this->aclService->getIdentityOrThrowException());
+        $option->setModifiedBy($this->aclService->getIdentityOrThrowException()->getMember());
         $option->setStatus('approved');
         $this->calendarOptionMapper->flush();
 
@@ -216,7 +216,7 @@ class ActivityCalendar
             throw new NotAllowedException($this->translator->translate('You are not allowed to delete this option'));
         }
 
-        $option->setModifiedBy($this->aclService->getIdentityOrThrowException());
+        $option->setModifiedBy($this->aclService->getIdentityOrThrowException()->getMember());
         $option->setStatus('deleted');
         $this->calendarOptionMapper->flush();
     }

--- a/module/Activity/src/Service/Signup.php
+++ b/module/Activity/src/Service/Signup.php
@@ -169,7 +169,7 @@ class Signup
             );
         }
 
-        $user = $this->aclService->getIdentityOrThrowException();
+        $user = $this->aclService->getIdentityOrThrowException()->getMember();
         $signup = new UserSignupModel();
         $signup->setUser($user);
 

--- a/module/Activity/test/Mapper/ActivityMapperTest.php
+++ b/module/Activity/test/Mapper/ActivityMapperTest.php
@@ -38,7 +38,7 @@ class ActivityMapperTest extends BaseMapperTest
         $this->object->setDescription($this->localisedText);
         $this->object->setLocation($this->localisedText);
         $this->object->setCosts($this->localisedText);
-        $this->object->setCreator($this->user);
+        $this->object->setCreator($this->member);
         $this->object->setBeginTime(new DateTime());
         $this->object->setEndTime(new DateTime());
         $this->object->setStatus(Activity::STATUS_APPROVED);

--- a/module/Activity/view/activity/admin-approval/view-proposal.phtml
+++ b/module/Activity/view/activity/admin-approval/view-proposal.phtml
@@ -59,7 +59,7 @@ function diff($oldValue, $newValue)
             } else if (!is_null($old->getCompany())) {
                 $oldOrganisingParty = $this->escapeHtml($old->getCompany()->getName());
             } else {
-                $oldOrganisingParty = $this->escapeHtml($old->getCreator()->getMember()->getFullName());
+                $oldOrganisingParty = $this->escapeHtml($old->getCreator()->getFullName());
             }
 
             $newOrganisingParty = "";
@@ -72,7 +72,7 @@ function diff($oldValue, $newValue)
             } else if (!is_null($old->getCompany())) {
                 $newOrganisingParty = $this->escapeHtml($new->getCompany()->getName());
             } else {
-                $newOrganisingParty = $this->escapeHtml($new->getCreator()->getMember()->getFullName());
+                $newOrganisingParty = $this->escapeHtml($new->getCreator()->getFullName());
             }
 
             echo sprintf(

--- a/module/Activity/view/activity/admin-approval/view.phtml
+++ b/module/Activity/view/activity/admin-approval/view.phtml
@@ -30,7 +30,7 @@ $this->breadcrumbs()
             } else if (!is_null($activity->getCompany())) {
                 $organisingParty = $this->escapeHtml($activity->getCompany()->getName());
             } else {
-                $organisingParty = $this->escapeHtml($activity->getCreator()->getMember()->getFullName());
+                $organisingParty = $this->escapeHtml($activity->getCreator()->getFullName());
             }
 
             echo sprintf(

--- a/module/Activity/view/activity/admin/list.phtml
+++ b/module/Activity/view/activity/admin/list.phtml
@@ -36,7 +36,7 @@
             <td><?= $activity->getBeginTime()->format('Y-m-d') ?></td>
             <td><?= is_null($activity->getOrgan()) ? $this->translate('None') : $this->escapeHtml($activity->getOrgan()->getAbbr()) ?></td>
             <td><?= is_null($activity->getCompany()) ? $this->translate('None') : $this->escapeHtml($activity->getCompany()->getName()) ?></td>
-            <td><?= $this->escapeHtml($activity->getCreator()->getMember()->getFullName()) ?></td>
+            <td><?= $this->escapeHtml($activity->getCreator()->getFullName()) ?></td>
             <?php if ($admin): ?>
                 <td><?= $activity->getUpdateProposal()->count() === 0 ? '(-)' :
                         '<a href="' . $this->url('activity_admin_approval/proposal', ['id' => $activity->getUpdateProposal()->first()->getId()]) . '">' . $this->translate('Update pending') . '</a>' ?></td>

--- a/module/Activity/view/activity/admin/view.phtml
+++ b/module/Activity/view/activity/admin/view.phtml
@@ -75,7 +75,7 @@ $this->breadcrumbs()
                 <td><?= $activity->getBeginTime()->format('Y-m-d') ?></td>
                 <td><?= is_null($activity->getOrgan()) ? $this->translate('None') : $this->escapeHtml($activity->getOrgan()->getAbbr()) ?></td>
                 <td><?= is_null($activity->getCompany()) ? $this->translate('None') : $this->escapeHtml($activity->getCompany()->getName()) ?></td>
-                <td><?= $activity->getCreator()->getMember()->getFullName() ?></td>
+                <td><?= $activity->getCreator()->getFullName() ?></td>
                 <?php if ($admin): ?>
                     <td>
                         <a class="btn btn-primary btn-xs"

--- a/module/Application/src/Service/Email.php
+++ b/module/Application/src/Service/Email.php
@@ -56,14 +56,14 @@ class Email
      * @param String $view Template of the email
      * @param String $subject Subject of the email
      * @param array $data Variables that you want to have available in the template
-     * @param UserModel $user The user as which the email should be sent
+     * @param MemberModel $user The user as which the email should be sent
      */
     public function sendEmailAsUser(
         string $type,
         string $view,
         string $subject,
         array $data,
-        UserModel $user,
+        MemberModel $user,
     ): void {
         $message = $this->createMessageFromView($view, $data);
 

--- a/module/Decision/src/Model/OrganInformation.php
+++ b/module/Decision/src/Model/OrganInformation.php
@@ -2,6 +2,7 @@
 
 namespace Decision\Model;
 
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
@@ -10,7 +11,6 @@ use Doctrine\ORM\Mapping\{
     JoinColumn,
     ManyToOne,
 };
-use User\Model\User as UserModel;
 
 /**
  * Organ information.
@@ -115,9 +115,9 @@ class OrganInformation
     /**
      * Who was the last one to approve this information. If null then nobody approved it.
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(referencedColumnName: "lidnr")]
-    protected ?UserModel $approver = null;
+    protected ?MemberModel $approver = null;
 
     /**
      * @return int|null
@@ -240,17 +240,17 @@ class OrganInformation
     }
 
     /**
-     * @return UserModel|null
+     * @return MemberModel|null
      */
-    public function getApprover(): ?UserModel
+    public function getApprover(): ?MemberModel
     {
         return $this->approver;
     }
 
     /**
-     * @param UserModel|null $approver
+     * @param MemberModel|null $approver
      */
-    public function setApprover(?UserModel $approver): void
+    public function setApprover(?MemberModel $approver): void
     {
         $this->approver = $approver;
     }

--- a/module/Decision/src/Service/Organ.php
+++ b/module/Decision/src/Service/Organ.php
@@ -300,7 +300,7 @@ class Organ
             $em->remove($oldInformation);
         }
 
-        $user = $this->aclService->getIdentityOrThrowException();
+        $user = $this->aclService->getIdentityOrThrowException()->getMember();
         $organInformation->setApprover($user);
         $em->flush();
     }

--- a/module/Frontpage/src/Model/Poll.php
+++ b/module/Frontpage/src/Model/Poll.php
@@ -3,6 +3,7 @@
 namespace Frontpage\Model;
 
 use DateTime;
+use Decision\Model\Member as MemberModel;
 use Doctrine\Common\Collections\{
     ArrayCollection,
     Collection,
@@ -17,7 +18,6 @@ use Doctrine\ORM\Mapping\{
     OneToMany,
 };
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
-use User\Model\User as UserModel;
 
 /**
  * Poll.
@@ -74,19 +74,19 @@ class Poll implements ResourceInterface
     /**
      * Who approved this poll. If null then nobody approved it.
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(
         referencedColumnName: "lidnr",
         nullable: false,
     )]
-    protected UserModel $creator;
+    protected MemberModel $creator;
 
     /**
      * Who approved this poll. If null then nobody approved it.
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(referencedColumnName: "lidnr")]
-    protected ?UserModel $approver = null;
+    protected ?MemberModel $approver = null;
 
     public function __construct()
     {
@@ -143,17 +143,17 @@ class Poll implements ResourceInterface
     }
 
     /**
-     * @return UserModel|null
+     * @return MemberModel|null
      */
-    public function getApprover(): ?UserModel
+    public function getApprover(): ?MemberModel
     {
         return $this->approver;
     }
 
     /**
-     * @return UserModel
+     * @return MemberModel
      */
-    public function getCreator(): UserModel
+    public function getCreator(): MemberModel
     {
         return $this->creator;
     }
@@ -196,17 +196,17 @@ class Poll implements ResourceInterface
     }
 
     /**
-     * @param UserModel $approver
+     * @param MemberModel $approver
      */
-    public function setApprover(UserModel $approver): void
+    public function setApprover(MemberModel $approver): void
     {
         $this->approver = $approver;
     }
 
     /**
-     * @param UserModel $creator
+     * @param MemberModel $creator
      */
-    public function setCreator(UserModel $creator): void
+    public function setCreator(MemberModel $creator): void
     {
         $this->creator = $creator;
     }

--- a/module/Frontpage/src/Model/PollComment.php
+++ b/module/Frontpage/src/Model/PollComment.php
@@ -3,6 +3,7 @@
 namespace Frontpage\Model;
 
 use DateTime;
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
@@ -12,7 +13,6 @@ use Doctrine\ORM\Mapping\{
     ManyToOne,
 };
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
-use User\Model\User as UserModel;
 
 /**
  * Poll comment.
@@ -45,13 +45,13 @@ class PollComment implements ResourceInterface
     /**
      * User that posted the comment.
      */
-    #[ManyToOne(targetEntity: UserModel::class)]
+    #[ManyToOne(targetEntity: MemberModel::class)]
     #[JoinColumn(
         name: "user_lidnr",
         referencedColumnName: "lidnr",
         nullable: false,
     )]
-    protected UserModel $user;
+    protected MemberModel $user;
 
     /**
      * Author of the comment.
@@ -102,9 +102,9 @@ class PollComment implements ResourceInterface
     /**
      * Get the user.
      *
-     * @return UserModel
+     * @return MemberModel
      */
-    public function getUser(): UserModel
+    public function getUser(): MemberModel
     {
         return $this->user;
     }
@@ -112,7 +112,7 @@ class PollComment implements ResourceInterface
     /**
      * Set the user.
      */
-    public function setUser(UserModel $user): void
+    public function setUser(MemberModel $user): void
     {
         $this->user = $user;
     }

--- a/module/Frontpage/src/Model/PollVote.php
+++ b/module/Frontpage/src/Model/PollVote.php
@@ -2,6 +2,7 @@
 
 namespace Frontpage\Model;
 
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\{
     Entity,
     Id,
@@ -10,7 +11,6 @@ use Doctrine\ORM\Mapping\{
     UniqueConstraint,
 };
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
-use User\Model\User as UserModel;
 
 /**
  * Poll response
@@ -54,7 +54,7 @@ class PollVote implements ResourceInterface
      */
     #[Id]
     #[ManyToOne(
-        targetEntity: UserModel::class,
+        targetEntity: MemberModel::class,
         cascade: ["persist"],
     )]
     #[JoinColumn(
@@ -62,7 +62,7 @@ class PollVote implements ResourceInterface
         referencedColumnName: "lidnr",
         nullable: false,
     )]
-    protected UserModel $respondent;
+    protected MemberModel $respondent;
 
     /**
      * @return PollOption
@@ -89,9 +89,9 @@ class PollVote implements ResourceInterface
     }
 
     /**
-     * @param UserModel $respondent
+     * @param MemberModel $respondent
      */
-    public function setRespondent(UserModel $respondent): void
+    public function setRespondent(MemberModel $respondent): void
     {
         $this->respondent = $respondent;
     }

--- a/module/Frontpage/src/Service/Poll.php
+++ b/module/Frontpage/src/Service/Poll.php
@@ -4,6 +4,7 @@ namespace Frontpage\Service;
 
 use Application\Service\Email as EmailService;
 use DateTime;
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Exception\ORMException;
 use DoctrineORMModule\Paginator\Adapter\DoctrinePaginator;
 use Laminas\Stdlib\Parameters;
@@ -197,7 +198,7 @@ class Poll
         }
 
         $pollVote = new PollVoteModel();
-        $pollVote->setRespondent($this->aclService->getIdentity());
+        $pollVote->setRespondent($this->aclService->getIdentity()->getMember());
         $pollVote->setPoll($poll);
         $pollOption->addVote($pollVote);
         $this->pollMapper->persist($pollOption);
@@ -220,7 +221,7 @@ class Poll
         PollModel $poll,
         array $data,
     ): bool {
-        $user = $this->aclService->getIdentity();
+        $user = $this->aclService->getIdentity()->getMember();
         $comment = $this->saveCommentData($data, $poll, $user);
 
         $poll->addComment($comment);
@@ -236,7 +237,7 @@ class Poll
      *
      * @param array $data
      * @param PollModel $poll
-     * @param UserModel $user
+     * @param MemberModel $user
      *
      * @return PollCommentModel
      *
@@ -245,7 +246,7 @@ class Poll
     public function saveCommentData(
         array $data,
         PollModel $poll,
-        UserModel $user,
+        MemberModel $user,
     ): PollCommentModel {
         $comment = new PollCommentModel();
 
@@ -279,7 +280,7 @@ class Poll
         }
 
         // TODO: Change to {@link getIdentityOrThrowException()}.
-        $user = $this->aclService->getIdentity();
+        $user = $this->aclService->getIdentity()->getMember();
         $poll = $this->savePollData($form->getData(), $user);
 
         $this->pollMapper->persist($poll);
@@ -297,7 +298,7 @@ class Poll
 
     /**
      * @param array $data
-     * @param UserModel $user
+     * @param MemberModel $user
      *
      * @return PollModel
      *
@@ -305,7 +306,7 @@ class Poll
      */
     public function savePollData(
         array $data,
-        UserModel $user,
+        MemberModel $user,
     ): PollModel {
         $poll = new PollModel();
         $poll->setDutchQuestion($data['dutchQuestion']);
@@ -386,7 +387,7 @@ class Poll
      */
     public function approvePoll(PollModel $poll): bool
     {
-        $poll->setApprover($this->aclService->getIdentity());
+        $poll->setApprover($this->aclService->getIdentity()->getMember());
         $this->pollMapper->flush();
 
         return true;

--- a/module/Frontpage/view/email/poll.phtml
+++ b/module/Frontpage/view/email/poll.phtml
@@ -6,7 +6,7 @@ Lieve bestuurder,<br/><br/>
 Er is een nieuwe poll aangemaakt op de GEWIS website.
 
 <h3>Vraag van de poll: <?= $this->escapeHtml($poll->getDutchQuestion()) ?></h3>
-<p>Deze poll is aangemaakt door lid <?= $this->escapeHtml($poll->getCreator()->getMember()->getLidnr()) ?>
+<p>Deze poll is aangemaakt door lid <?= $this->escapeHtml($poll->getCreator()->getLidnr()) ?>
     (lidnummer)</p>
 
 <br/>
@@ -22,7 +22,7 @@ Dear board member,<br/><br/>
 A new poll was created at the GEWIS website. See below for details.
 
 <h3>Question of the poll: <?= $this->escapeHtml($poll->getEnglishQuestion()) ?></h3>
-<p>Author of the poll: <?= $this->escapeHtml($poll->getCreator()->getMember()->getLidnr()) ?> (membership number)</p>
+<p>Author of the poll: <?= $this->escapeHtml($poll->getCreator()->getLidnr()) ?> (membership number)</p>
 
 <br/>
 Click <a href="<?= $this->serverUrl($this->url('admin_poll')) ?>">here</a> to approve or disapprove this poll.

--- a/module/Frontpage/view/frontpage/poll-admin/list.phtml
+++ b/module/Frontpage/view/frontpage/poll-admin/list.phtml
@@ -61,7 +61,7 @@ $this->breadcrumbs()
             <td><?= $this->escapeHtml($poll->getDutchQuestion()) ?></td>
             <td><?= $this->escapeHtml($poll->getEnglishQuestion()) ?></td>
             <td><?= $poll->getExpiryDate()->format('Y-m-d') ?></td>
-            <td><?= $poll->getCreator()->getMember()->getFullName() ?></td>
+            <td><?= $poll->getCreator()->getFullName() ?></td>
             <td></td>
             <td>
                 <button type="button" class="btn btn-success btn-xs approve-poll" data-poll-id="<?= $poll->getId() ?>"
@@ -134,7 +134,7 @@ $this->breadcrumbs()
                 <td><?= $this->escapeHtml($poll->getDutchQuestion()) ?></td>
                 <td><?= $this->escapeHtml($poll->getEnglishQuestion()) ?></td>
                 <td><?= $poll->getExpiryDate()->format('Y-m-d') ?></td>
-                <td><?= $poll->getCreator()->getMember()->getFullName() ?></td>
+                <td><?= $poll->getCreator()->getFullName() ?></td>
                 <td><?= $poll->getApprover()->getMember()->getFullName() ?></td>
                 <td>
                     <?php if ($poll->isActive()): ?>

--- a/module/Photo/src/Model/Vote.php
+++ b/module/Photo/src/Model/Vote.php
@@ -3,6 +3,7 @@
 namespace Photo\Model;
 
 use DateTime;
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
@@ -11,7 +12,6 @@ use Doctrine\ORM\Mapping\{
     JoinColumn,
     ManyToOne,
 };
-use User\Model\User as UserModel;
 
 /**
  * Vote, represents a vote for a photo of the week.
@@ -37,7 +37,7 @@ class Vote
      * Vote constructor.
      *
      * @param Photo $photo
-     * @param UserModel $voter The member who voted
+     * @param MemberModel $voter The member who voted
      */
     public function __construct(
         #[ManyToOne(
@@ -50,13 +50,13 @@ class Vote
             nullable: false,
         )]
         protected Photo $photo,
-        #[ManyToOne(targetEntity: UserModel::class)]
+        #[ManyToOne(targetEntity: MemberModel::class)]
         #[JoinColumn(
             name: "voter_id",
             referencedColumnName: "lidnr",
             nullable: false,
         )]
-        protected UserModel $voter,
+        protected MemberModel $voter,
     ) {
         $this->dateTime = new DateTime();
     }

--- a/module/Photo/src/Service/Photo.php
+++ b/module/Photo/src/Service/Photo.php
@@ -617,7 +617,7 @@ class Photo
         }
 
         $photo = $this->getPhoto($photoId);
-        $vote = new VoteModel($photo, $identity);
+        $vote = new VoteModel($photo, $identity->getMember());
 
         $this->voteMapper->persist($vote);
         $this->voteMapper->flush();

--- a/module/User/src/Permissions/Assertion/IsCreator.php
+++ b/module/User/src/Permissions/Assertion/IsCreator.php
@@ -2,6 +2,7 @@
 
 namespace User\Permissions\Assertion;
 
+use Decision\Model\Member;
 use Laminas\Permissions\Acl\Acl;
 use Laminas\Permissions\Acl\Assertion\AssertionInterface;
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
@@ -43,7 +44,7 @@ class IsCreator implements AssertionInterface
 
         $creator = $resource->getResourceCreator();
 
-        if (!$creator instanceof User) {
+        if (!$creator instanceof Member) {
             return false;
         }
 

--- a/module/User/src/Permissions/Resource/CreatorResourceInterface.php
+++ b/module/User/src/Permissions/Resource/CreatorResourceInterface.php
@@ -2,15 +2,15 @@
 
 namespace User\Permissions\Resource;
 
+use Decision\Model\Member as MemberModel;
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
-use User\Model\User;
 
 interface CreatorResourceInterface extends ResourceInterface
 {
     /**
-     * Get the creator (a user) of this resource.
+     * Get the creator (a member) of this resource.
      *
-     * @return User
+     * @return MemberModel
      */
-    public function getResourceCreator(): User;
+    public function getResourceCreator(): MemberModel;
 }


### PR DESCRIPTION
By using both `User`s and `Member`s for relations we unnecessarily complicate the process of removing data of association members.

Therefore, we should only use `Member`s.

This only changes the types of the relations, not the names or anything else (so the ORM update should be very easy).