### PR TITLE
Multi option creation period selection at proposal stage

### DIFF
--- a/module/Activity/src/Controller/ActivityCalendarController.php
+++ b/module/Activity/src/Controller/ActivityCalendarController.php
@@ -8,15 +8,14 @@ use Activity\Service\{
     ActivityCalendar as ActivityCalendarService,
     ActivityCalendarForm as ActivityCalendarFormService,
 };
-use Activity\Mapper\Proposal;
 use Laminas\Http\{
     Request,
     Response,
 };
 use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\ViewModel;
 use User\Permissions\NotAllowedException;
-use Laminas\Mvc\I18n\Translator;
 
 class ActivityCalendarController extends AbstractActionController
 {

--- a/module/Activity/src/Controller/ActivityCalendarController.php
+++ b/module/Activity/src/Controller/ActivityCalendarController.php
@@ -8,6 +8,7 @@ use Activity\Service\{
     ActivityCalendar as ActivityCalendarService,
     ActivityCalendarForm as ActivityCalendarFormService,
 };
+use Activity\Mapper\Proposal;
 use Laminas\Http\{
     Request,
     Response,
@@ -80,14 +81,16 @@ class ActivityCalendarController extends AbstractActionController
             );
         }
 
+        $form = $this->calendarProposalForm;
+
         /** @var Request $request */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
-            $this->calendarProposalForm->setData($request->getPost()->toArray());
+            $form->setData($request->getPost()->toArray());
 
-            if ($this->calendarProposalForm->isValid()) {
-                if ($this->calendarService->createProposal($this->calendarProposalForm->getData())) {
+            if ($form->isValid()) {
+                if ($this->calendarService->createProposal($form->getData())) {
                     return $this->redirect()->toRoute(
                         'activity_calendar',
                         [],
@@ -101,12 +104,14 @@ class ActivityCalendarController extends AbstractActionController
             }
         }
 
-        $period = $this->calendarFormService->getCurrentPeriod();
+        $periods = $this->calendarFormService->getCurrentPeriods();
+        $createAlways = $this->aclService->isAllowed('create_always', 'activity_calendar_proposal');
 
         return new ViewModel(
             [
-                'period' => $period,
-                'form' => $this->calendarProposalForm,
+                'periods' => $periods,
+                'createAlways' => $createAlways,
+                'form' => $form,
             ]
         );
     }

--- a/module/Activity/src/Controller/AdminOptionController.php
+++ b/module/Activity/src/Controller/AdminOptionController.php
@@ -38,8 +38,8 @@ class AdminOptionController extends AbstractActionController
         }
 
         return new ViewModel([
-            'current' => $this->activityOptionCreationPeriodMapper->getCurrentActivityOptionCreationPeriod(),
-            'upcoming' => $this->activityOptionCreationPeriodMapper->getUpcomingActivityOptionCreationPeriod(),
+            'current' => $this->activityOptionCreationPeriodMapper->getCurrentActivityOptionCreationPeriods(),
+            'upcoming' => $this->activityOptionCreationPeriodMapper->getUpcomingActivityOptionCreationPeriods(),
         ]);
     }
 

--- a/module/Activity/src/Controller/AdminOptionController.php
+++ b/module/Activity/src/Controller/AdminOptionController.php
@@ -110,6 +110,13 @@ class AdminOptionController extends AbstractActionController
             $optionCreationPeriod = $this->activityCalendarService->getOptionCreationPeriod($optionCreationPeriodId);
 
             if (null !== $optionCreationPeriod) {
+                if ($optionCreationPeriod->getEndPlanningTime() < new DateTime('now')) {
+                    return $this->redirectWithMessage(
+                        false,
+                        $this->translator->translate('Past option planning periods cannot be removed.'),
+                    );
+                }
+
                 $this->activityCalendarService->deleteOptionCreationPeriod($optionCreationPeriod);
 
                 return $this->redirectWithMessage(

--- a/module/Activity/src/Controller/AdminOptionController.php
+++ b/module/Activity/src/Controller/AdminOptionController.php
@@ -2,11 +2,11 @@
 
 namespace Activity\Controller;
 
+use Activity\Mapper\ActivityOptionCreationPeriod as ActivityOptionCreationPeriodMapper;
 use Activity\Service\{
     AclService,
     ActivityCalendar as ActivityCalendarService,
 };
-use Activity\Mapper\ActivityOptionCreationPeriod as ActivityOptionCreationPeriodMapper;
 use DateTime;
 use Decision\Service\Organ as OrganService;
 use Laminas\Http\{
@@ -113,7 +113,7 @@ class AdminOptionController extends AbstractActionController
                 if ($optionCreationPeriod->getEndPlanningTime() < new DateTime('now')) {
                     return $this->redirectWithMessage(
                         false,
-                        $this->translator->translate('Past option planning periods cannot be removed.'),
+                        $this->translator->translate('Past option planning periods cannot be deleted.'),
                     );
                 }
 
@@ -121,7 +121,7 @@ class AdminOptionController extends AbstractActionController
 
                 return $this->redirectWithMessage(
                     true,
-                    $this->translator->translate('Option planning period removed.'),
+                    $this->translator->translate('Option planning period deleted.'),
                 );
             }
         }

--- a/module/Activity/src/Form/ActivityCalendarOption.php
+++ b/module/Activity/src/Form/ActivityCalendarOption.php
@@ -98,17 +98,6 @@ class ActivityCalendarOption extends Fieldset implements InputFilterProviderInte
                             },
                         ],
                     ],
-                    [
-                        'name' => Callback::class,
-                        'options' => [
-                            'messages' => [
-                                Callback::INVALID_VALUE => $this->translator->translate('The activity must be within the given period'),
-                            ],
-                            'callback' => function ($value, $context = []) {
-                                return $this->cannotPlanInPeriod($value, $context);
-                            },
-                        ],
-                    ],
                 ],
             ],
             'endTime' => [
@@ -159,28 +148,6 @@ class ActivityCalendarOption extends Fieldset implements InputFilterProviderInte
 
             return $this->calendarFormService->toDateTime($value) > $today;
         } catch (Exception) {
-            return false;
-        }
-    }
-
-    /**
-     * Check if a certain date is within the current planning period.
-     *
-     * @param string $value
-     * @param array $context
-     *
-     * @return bool
-     */
-    public function cannotPlanInPeriod(
-        string $value,
-        array $context = [],
-    ): bool {
-        try {
-            $beginTime = $this->calendarFormService->toDateTime($value);
-            $result = $this->calendarFormService->canCreateOption($beginTime);
-
-            return !$result;
-        } catch (Exception $e) {
             return false;
         }
     }

--- a/module/Activity/src/Form/ActivityCalendarProposal.php
+++ b/module/Activity/src/Form/ActivityCalendarProposal.php
@@ -2,8 +2,7 @@
 
 namespace Activity\Form;
 
-use Activity\Service\ActivityCalendarForm;
-use Exception;
+use Activity\Service\ActivityCalendarForm as ActivityCalendarFormService;
 use Laminas\Form\Element\{
     Collection,
     Select,
@@ -15,7 +14,8 @@ use Laminas\Mvc\I18n\Translator;
 use Laminas\Validator\{
     Callback,
     NotEmpty,
-    StringLength};
+    StringLength,
+};
 use User\Permissions\NotAllowedException;
 
 class ActivityCalendarProposal extends Form implements InputFilterProviderInterface
@@ -24,7 +24,7 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
 
     public function __construct(
         private readonly Translator $translator,
-        private readonly ActivityCalendarForm $calendarFormService,
+        private readonly ActivityCalendarFormService $calendarFormService,
         private readonly bool $createAlways,
     ) {
         parent::__construct();
@@ -165,7 +165,9 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
 
                     if (!$this->calendarFormService->canCreateOptionInPeriod($period, $beginTime, $endTime)) {
                         $option->get('beginTime')->setMessages([
-                            $this->translator->translate('Option does not fall within option period (also check the end date).'),
+                            $this->translator->translate(
+                                'Option does not fall within option period (also check the end date).'
+                            ),
                         ]);
                         $valid = false;
                     }

--- a/module/Activity/src/Form/ActivityCalendarProposal.php
+++ b/module/Activity/src/Form/ActivityCalendarProposal.php
@@ -14,8 +14,8 @@ use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Validator\{
     Callback,
-    StringLength,
-};
+    NotEmpty,
+    StringLength};
 use User\Permissions\NotAllowedException;
 
 class ActivityCalendarProposal extends Form implements InputFilterProviderInterface
@@ -25,13 +25,13 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
     public function __construct(
         private readonly Translator $translator,
         private readonly ActivityCalendarForm $calendarFormService,
-        bool $createAlways,
+        private readonly bool $createAlways,
     ) {
         parent::__construct();
 
         try {
-            $organs = $calendarFormService->getEditableOrgans();
-        } catch (NotAllowedException $e) {
+            $organs = $this->calendarFormService->getEditableOrgans();
+        } catch (NotAllowedException) {
             $organs = [];
         }
 
@@ -39,12 +39,35 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
         foreach ($organs as $organ) {
             $organOptions[$organ->getId()] = $organ->getAbbr();
         }
-        if ($createAlways) {
+
+        $periodOptions = [];
+        foreach ($this->calendarFormService->getCurrentPeriods() as $period) {
+            $periodOptions[$period->getId()] = $period->getBeginOptionTime()->format('Y-m-d')
+                . ' - ' . $period->getEndOptionTime()->format('Y-m-d');
+        }
+
+        if ($this->createAlways) {
             $organOptions[-1] = 'Board';
             $organOptions[-2] = 'Other';
+            $periodOptions[-1] = 'Board';
         }
 
         $this->maxOptions = 3;
+
+        $this->add(
+            [
+                'name' => 'period',
+                'type' => Select::class,
+                'options' => [
+                    'empty_option' => [
+                        'label' => $this->translator->translate('Select a period'),
+                        'selected' => 'selected',
+                        'disabled' => 'disabled',
+                    ],
+                    'value_options' => $periodOptions,
+                ],
+            ]
+        );
 
         $this->add(
             [
@@ -93,11 +116,75 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
     }
 
     /**
+     * Validate the form.
+     *
+     * @return bool
+     */
+    public function isValid(): bool
+    {
+        $valid = parent::isValid();
+
+        foreach ($this->get('options')->getFieldSets() as $option) {
+            if (!(new NotEmpty())->isValid($option->get('type')->getValue())) {
+                $option->get('type')->setMessages([
+                    $this->translator->translate('Value is required and can\'t be empty'),
+                ]);
+                $valid = false;
+            }
+
+            if (null !== ($period = $this->data['period'] ?? null)) {
+                $period = (int) $period;
+
+                $missingDate = false;
+                if (!(new NotEmpty())->isValid($option->get('beginTime')->getValue())) {
+                    $option->get('beginTime')->setMessages([
+                        $this->translator->translate('Value is required and can\'t be empty'),
+                    ]);
+                    $valid = false;
+                    $missingDate = true;
+                }
+
+                if (!(new NotEmpty())->isValid($option->get('endTime')->getValue())) {
+                    $option->get('endTime')->setMessages([
+                        $this->translator->translate('Value is required and can\'t be empty'),
+                    ]);
+                    $valid = false;
+                    $missingDate = true;
+                }
+
+                if (!$missingDate) {
+                    $beginTime = $this->calendarFormService->toDateTime($option->get('beginTime')->getValue());
+                    $endTime = $this->calendarFormService->toDateTime($option->get('endTime')->getValue());
+
+                    if ($endTime < $beginTime) {
+                        $option->get('endTime')->setMessages([
+                            $this->translator->translate('Option should end after it starts.'),
+                        ]);
+                        $valid = false;
+                    }
+
+                    if (!$this->calendarFormService->canCreateOptionInPeriod($period, $beginTime, $endTime)) {
+                        $option->get('beginTime')->setMessages([
+                            $this->translator->translate('Option does not fall within option period (also check the end date).'),
+                        ]);
+                        $valid = false;
+                    }
+                }
+            }
+        }
+
+        return $valid;
+    }
+
+    /**
      * Input filter specification.
      */
     public function getInputFilterSpecification(): array
     {
         return [
+            'period' => [
+                'required' => true,
+            ],
             'organ' => [
                 'required' => true,
             ],
@@ -132,19 +219,6 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
                             },
                         ],
                     ],
-                    [
-                        'name' => Callback::class,
-                        'options' => [
-                            'messages' => [
-                                Callback::INVALID_VALUE => $this->translator->translate(
-                                    'The options for this proposal do not fit in the valid range.',
-                                ),
-                            ],
-                            'callback' => function ($value, $context = []) {
-                                return $this->areGoodOptionDates($value, $context);
-                            },
-                        ],
-                    ],
                 ],
             ],
         ];
@@ -162,36 +236,13 @@ class ActivityCalendarProposal extends Form implements InputFilterProviderInterf
         array $value,
         array $context = [],
     ): bool {
-        if (count($value) < 1 || count($value) > $this->maxOptions) {
+        if (
+            count($value) < 1
+            || count($value) > $this->maxOptions
+        ) {
             return false;
         }
 
         return true;
-    }
-
-    /**
-     * Check if the begin times of the options are acceptable.
-     *
-     * @param array $value
-     * @param array $context
-     *
-     * @return bool
-     */
-    public function areGoodOptionDates(
-        array $value,
-        array $context = [],
-    ): bool {
-        $final = true;
-        foreach ($value as $option) {
-            try {
-                $beginTime = $this->calendarFormService->toDateTime($option['beginTime']);
-                $result = $this->calendarFormService->canCreateOption($beginTime);
-                $final = $final && $result;
-            } catch (Exception $e) {
-                return false;
-            }
-        }
-
-        return $final;
     }
 }

--- a/module/Activity/src/Mapper/ActivityOptionCreationPeriod.php
+++ b/module/Activity/src/Mapper/ActivityOptionCreationPeriod.php
@@ -11,41 +11,29 @@ class ActivityOptionCreationPeriod extends BaseMapper
 {
     /**
      * Finds the ActivityOptionCreationPeriod model that is currently active.
-     *
-     * @return ActivityOptionCreationPeriodModel|null
-     *
-     * @throws Exception
      */
-    public function getCurrentActivityOptionCreationPeriod(): ?ActivityOptionCreationPeriodModel
+    public function getCurrentActivityOptionCreationPeriods(): array
     {
         $qb = $this->getRepository()->createQueryBuilder('o');
         $qb->where('o.beginPlanningTime < :today')
             ->andWhere('o.endPlanningTime > :today')
             ->orderBy('o.beginPlanningTime', 'ASC')
-            ->setParameter('today', new DateTime())
-            ->setMaxResults(1);
+            ->setParameter('today', new DateTime());
 
-        $res = $qb->getQuery()->getResult();
-
-        return empty($res) ? null : $res[0];
+        return $qb->getQuery()->getResult();
     }
 
     /**
      * Finds the ActivityOptionCreationPeriod model that will be active next.
-     *
-     * @return ActivityOptionCreationPeriodModel|null
-     *
-     * @throws Exception
      */
-    public function getUpcomingActivityOptionCreationPeriod(): ?ActivityOptionCreationPeriodModel
+    public function getUpcomingActivityOptionCreationPeriods(): array
     {
         $qb = $this->getRepository()->createQueryBuilder('o');
         $qb->where('o.beginPlanningTime > :today')
             ->orderBy('o.beginPlanningTime', 'ASC')
-            ->setParameter('today', new DateTime())
-            ->setMaxResults(1);
+            ->setParameter('today', new DateTime());
 
-        return $qb->getQuery()->getOneOrNullResult();
+        return $qb->getQuery()->getResult();
     }
 
     /**

--- a/module/Activity/src/Service/Activity.php
+++ b/module/Activity/src/Service/Activity.php
@@ -526,14 +526,14 @@ class Activity
                         if (array_key_exists('options', $field)) {
                             $proposal['signupLists'][$keyOuter]['fields'][$keyInner]['options'] = explode(
                                 ',',
-                                $field['options']
+                                $field['options'],
                             );
                         }
 
                         if (array_key_exists('optionsEn', $field)) {
                             $proposal['signupLists'][$keyOuter]['fields'][$keyInner]['optionsEn'] = explode(
                                 ',',
-                                $field['optionsEn']
+                                $field['optionsEn'],
                             );
                         }
                     }

--- a/module/Activity/src/Service/ActivityCalendar.php
+++ b/module/Activity/src/Service/ActivityCalendar.php
@@ -14,7 +14,8 @@ use Activity\Model\{
     ActivityCalendarOption as ActivityCalendarOptionModel,
     ActivityOptionCreationPeriod as ActivityOptionCreationPeriodModel,
     ActivityOptionProposal as ProposalModel,
-    MaxActivities as MaxActivitiesModel};
+    MaxActivities as MaxActivitiesModel,
+};
 use Application\Service\Email as EmailService;
 use DateInterval;
 use DateTime;

--- a/module/Activity/src/Service/ActivityCalendarForm.php
+++ b/module/Activity/src/Service/ActivityCalendarForm.php
@@ -65,7 +65,7 @@ class ActivityCalendarForm
     {
         $mapper = $this->periodMapper;
 
-        return $mapper->getCurrentActivityOptionCreationPeriod();
+        return $mapper->getCurrentActivityOptionCreationPeriods();
     }
 
     /**

--- a/module/Activity/src/Service/ActivityCalendarForm.php
+++ b/module/Activity/src/Service/ActivityCalendarForm.php
@@ -2,7 +2,6 @@
 
 namespace Activity\Service;
 
-use Activity\Model\ActivityOptionCreationPeriod;
 use Activity\Mapper\{
     ActivityOptionCreationPeriod as ActivityOptionCreationPeriodMapper,
     ActivityOptionProposal as ActivityOptionProposalMapper,
@@ -47,7 +46,7 @@ class ActivityCalendarForm
             return false;
         }
 
-        /** @var ActivityOptionCreationPeriod|null $period */
+        /** @var ActivityOptionCreationPeriodModel|null $period */
         $period = $this->periodMapper->find($period);
 
         if (null === $period) {
@@ -69,7 +68,7 @@ class ActivityCalendarForm
     /**
      * Get the current ActivityOptionCreationPeriod.
      *
-     * @return array<array-key, ActivityOptionCreationPeriod>
+     * @return array<array-key, ActivityOptionCreationPeriodModel>
      */
     public function getCurrentPeriods(): array
     {

--- a/module/Activity/view/activity/activity-calendar/create.phtml
+++ b/module/Activity/view/activity/activity-calendar/create.phtml
@@ -1,4 +1,7 @@
 <?php
+
+use Laminas\Form\Exception\InvalidElementException;
+
 $this->headTitle($this->translate('Create activity proposal'));
 $this->headScript()
     ->appendFile(
@@ -8,163 +11,142 @@ $this->headScript()
     );
 
 $form->prepare();
+$form->setAttribute('class', 'form-activity');
 ?>
-<style>
-    label {
-        cursor: pointer;
-    }
-
-    label input[type=checkbox] {
-        margin-right: 1.5rem;
-    }
-
-    .label-required:after {
-        content: "*";
-        color: #d40026;
-    }
-
-    .spacing-top--lg {
-        margin-top: 4rem;
-    }
-
-    .spacing-top--md {
-        margin-top: 2.5rem;
-    }
-
-    .spacing-top--sm {
-        margin-top: 1rem;
-    }
-
-    @media (max-width: 992px) {
-        .spacing-top-sm--sm {
-            margin-top: 1rem;
-        }
-    }
-
-    @media (min-width: 992px) {
-        .spacing-top-sm--sm {
-            margin-top: 0;
-        }
-    }
-</style>
 <section class="section">
     <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <h1><?= $this->translate('Option calendar') ?></h1>
-                <h2><?= $this->translate('Plan an activity') ?></h2>
-            </div>
-        </div>
-        <?php if ($period): ?>
-            <div class="row spacing-top--md">
-                <div class="col-md-12">
-                    <div class="alert alert-info" role="alert">
-                        <p>
-                            <?= sprintf($this->translate('You can currently plan options between %s and %s.'),
-                                $period->getBeginOptionTime()->format('Y-m-d'),
-                                $period->getEndOptionTime()->format('Y-m-d')) ?>
-                        </p>
-                    </div>
-                </div>
-            </div>
-        <?php endif ?>
         <?= $this->form()->openTag($form) ?>
-        <div class="row spacing-top--md">
-            <div class="col-md-12">
-                <h3><?= $this->translate('Details') ?></h3>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-4">
-                <?php $organ = $form->get('organ')
-                    ->setAttribute('class', 'form-control')
-                ?>
-                <div class="form-group <?= $this->bootstrapElementError($organ) ?>">
-                    <label
-                        for="<?= $organ->getAttribute('id') ?>"
-                        class="control-label<?= $form->getInputFilter()->get('organ')->isRequired() ? ' label-required' : '' ?>">
-                        <?= $this->translate('Committee / fraternity') ?>
-                    </label>
-                    <?= $this->formSelect($organ) ?>
-                    <?= $this->formElementErrors($organ) ?>
+            <div class="row">
+                <div class="col-md-12">
+                    <h1><?= $this->translate('Option calendar') ?></h1>
+                    <h2><?= $this->translate('Propose options for an activity') ?></h2>
                 </div>
             </div>
-        </div>
-        <div class="row spacing-top--sm">
-            <div class="col-md-4">
-                <?php $inputName = $form->get('name')
-                    ->setAttribute('class', 'form-control')
-                    ->setAttribute('id', 'input-name')
-                ?>
-                <div class="form-group <?= $this->bootstrapElementError($inputName) ?>">
-                    <label
-                        for="<?= $inputName->getAttribute('id') ?>"
-                        class="control-label<?= $form->getInputFilter()->get('name')->isRequired() ? ' label-required' : '' ?>">
-                        <?= $this->translate('Name') ?>
-                    </label>
-                    <?= $this->formText($inputName) ?>
-                    <?= $this->formElementErrors($inputName) ?>
-                </div>
-            </div>
-        </div>
-        <div class="row spacing-top--sm">
-            <div class="col-md-6">
-                <?php $inputDescription = $form->get('description')
-                    ->setAttribute('class', 'form-control')
-                    ->setAttribute('id', 'input-description')
-                ?>
-                <div class="form-group <?= $this->bootstrapElementError($inputDescription) ?>">
-                    <label
-                        for="<?= $inputDescription->getAttribute('id') ?>"
-                        class="control-label<?= $form->getInputFilter()->get('description')->isRequired() ? ' label-required' : '' ?>">
-                        <?= $this->translate('Description') ?>
-                    </label>
-                    <?= $this->formTextarea($inputDescription) ?>
-                    <?= $this->formElementErrors($inputDescription) ?>
-                </div>
-            </div>
-        </div>
-        <div class="row spacing-top--lg">
-            <div class="col-md-12">
-                <h3><?= $this->translate('Options') ?></h3>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <?php
-                /* render template for options */
-                $fs = $form->get('options')->getTemplateElement();
-                ob_start();
-                echo $this->partial('partial/option.phtml', ['fs' => $fs, 'index' => '__index__']);
-                $tpl = trim(ob_get_clean())
-                ?>
-                <fieldset id="additionalOptions">
-                    <span class="template" data-template="<?= $this->escapeHtmlAttr($tpl) ?>"></span>
-                    <?php
-                    $index = 0;
-                    foreach ($form->get('options')->getIterator() as $fs) {
-                        echo $this->partial('partial/option.phtml', ['fs' => $fs, 'index' => $index]);
-                        $index++;
-                    }
-                    ?>
-                    <div class="form-group spacing-top--md option-menu">
-                        <button class="btn btn-success add-option" type="button">
-                            <span class="fas fa-plus"></span>
-                            <?= $this->translate('Add an option') ?>
-                        </button>
-                        <button class="btn btn-danger remove-option" type="button">
-                            <span class="fas fa-minus"></span>
-                            <?= $this->translate('Remove the last option') ?>
-                        </button>
+            <hr>
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <h2><?= $this->translate('Organisation') ?></h2>
+                            <p><?= $this->translate('Select the organ for which the options are and in which option period the options should be planned.')?></p>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <?php
+                                    $period = $form->get('period')
+                                        ->setAttribute('class', 'form-control')
+                                    ?>
+                                    <div class="form-group <?= $this->bootstrapElementError($period) ?>">
+                                        <label for="<?= $period->getAttribute('id') ?>" class="control-label label-required">
+                                            <?= $this->translate('Period') ?>
+                                        </label>
+                                        <?= $this->formSelect($period) ?>
+                                        <?= $this->formElementErrors($period) ?>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <?php
+                                    $organ = $form->get('organ')
+                                        ->setAttribute('class', 'form-control')
+                                    ?>
+                                    <div class="form-group <?= $this->bootstrapElementError($organ) ?>">
+                                        <label
+                                            for="<?= $organ->getAttribute('id') ?>"
+                                            class="control-label label-required">
+                                            <?= $this->translate('Committee / fraternity') ?>
+                                        </label>
+                                        <?= $this->formSelect($organ) ?>
+                                        <?= $this->formElementErrors($organ) ?>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <h2><?= $this->translate('Details') ?></h2>
+                            <p><?= $this->translate('Select the organ for which the options are and in which option period the options should be planned.')?></p>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <?php
+                                    $inputName = $form->get('name')
+                                        ->setAttribute('class', 'form-control')
+                                        ->setAttribute('id', 'input-name')
+                                    ?>
+                                    <div class="form-group <?= $this->bootstrapElementError($inputName) ?>">
+                                        <label
+                                            for="<?= $inputName->getAttribute('id') ?>"
+                                            class="control-label<?= $form->getInputFilter()->get('name')->isRequired() ? ' label-required' : '' ?>">
+                                            <?= $this->translate('Name') ?>
+                                        </label>
+                                        <?= $this->formText($inputName) ?>
+                                        <?= $this->formElementErrors($inputName) ?>
+                                    </div>
+                                </div>
+                                <div class="col-md-12">
+                                    <?php
+                                    $inputDescription = $form->get('description')
+                                        ->setAttribute('class', 'form-control')
+                                        ->setAttribute('id', 'input-description')
+                                    ?>
+                                    <div class="form-group <?= $this->bootstrapElementError($inputDescription) ?>">
+                                        <label
+                                            for="<?= $inputDescription->getAttribute('id') ?>"
+                                            class="control-label<?= $form->getInputFilter()->get('description')->isRequired() ? ' label-required' : '' ?>">
+                                            <?= $this->translate('Description') ?>
+                                        </label>
+                                        <?= $this->formTextarea($inputDescription) ?>
+                                        <?= $this->formElementErrors($inputDescription) ?>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-        </div>
-        <div class="row spacing-top--lg">
-            <div class="col-md-12">
-                <input type="submit" class="btn btn-primary" value="<?= $this->translate('Submit') ?>"/>
+            <div class="row">
+                <div class="col-md-12">
+                    <h2><?= $this->translate('Options') ?></h2>
+                    <p><?= $this->translate('Add options for your activity proposal.') ?></p>
+                </div>
+                <div class="col-md-12">
+                    <?php
+                    /* render template for options */
+                    $fs = $form->get('options')->getTemplateElement();
+                    ob_start();
+                    echo $this->partial('partial/option.phtml', ['fs' => $fs, 'index' => '__index__']);
+                    $tpl = trim(ob_get_clean())
+                    ?>
+                    <fieldset id="additionalOptions">
+                        <span class="template" data-template="<?= $this->escapeHtmlAttr($tpl) ?>"></span>
+                        <?php
+                        $index = 0;
+                        foreach ($form->get('options')->getIterator() as $fs) {
+                            echo $this->partial('partial/option.phtml', ['fs' => $fs, 'index' => $index]);
+                            $index++;
+                        }
+                        ?>
+                        <div class="form-group spacing-top--md option-menu">
+                            <button class="btn btn-success add-option" type="button">
+                                <span class="fas fa-plus"></span>
+                                <?= $this->translate('Add an option') ?>
+                            </button>
+                            <button class="btn btn-danger remove-option" type="button">
+                                <span class="fas fa-minus"></span>
+                                <?= $this->translate('Remove the last option') ?>
+                            </button>
+                        </div>
+                    </fieldset>
+                </div>
             </div>
-        </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <input type="submit" class="btn btn-primary" value="<?= $this->translate('Submit') ?>"/>
+                </div>
+            </div>
         <?= $this->form()->closeTag(); ?>
+    </div>
 </section>
 
 <script nonce="<?= NONCE_REPLACEMENT_STRING ?>">

--- a/module/Activity/view/activity/activity-calendar/index.phtml
+++ b/module/Activity/view/activity/activity-calendar/index.phtml
@@ -208,6 +208,8 @@ $this->headLink()
 
         let calendarEl = document.getElementById('calendar');
         let calendar = new FullCalendar.Calendar(calendarEl, {
+            //
+            firstDay: '1',
             // Auto-magically update the height of the view.
             contentHeight: 'auto',
             // Add a custom button to propose an option.

--- a/module/Activity/view/activity/admin-option/index.phtml
+++ b/module/Activity/view/activity/admin-option/index.phtml
@@ -118,7 +118,7 @@ $this->breadcrumbs()
             </div>
             <div class="modal-body">
                 <p>
-                    <?= $this->translate('Are you sure you want to delete this option planning period? <strong>This will also delete all the associated options!</strong>') ?>
+                    <?= $this->translate('Are you sure you want to delete this option planning period? This will <strong>not</strong> delete proposed options.') ?>
                 </p>
             </div>
             <div class="modal-footer">

--- a/module/Activity/view/activity/admin-option/index.phtml
+++ b/module/Activity/view/activity/admin-option/index.phtml
@@ -1,41 +1,148 @@
 <?php
+$this->scriptUrl()->requireUrls(['activity_admin_options/delete'], ['id']);
+
 $this->breadcrumbs()
     ->addBreadcrumb($this->translate('Option Calendar'))
     ->addBreadcrumb($this->translate('Overview'));
-
 ?>
 <div class="row">
-    <div class="col-md-12">
-        <p>
-            <?php if (null !== $current): ?>
-                <?= sprintf(
-                    $this->translate('Options can be proposed from <strong>%s</strong> till <strong>%s</strong> for the period <strong>%s</strong> to <strong>%s</strong>.'),
-                    $this->dateFormat($current->getBeginPlanningTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT),
-                    $this->dateFormat($current->getEndPlanningTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT),
-                    $this->dateFormat($current->getBeginOptionTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT),
-                    $this->dateFormat($current->getEndOptionTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT),
-                ) ?>
-            <?php elseif (null !== $upcoming): ?>
-                <?= sprintf(
-                    $this->translate('The next option creation period will from <strong>%s</strong> till <strong>%s</strong>.'),
-                    $this->dateFormat($upcoming->getBeginPlanningTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT),
-                    $this->dateFormat($upcoming->getEndPlanningTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT),
-                ) ?>
-            <?php else: ?>
-                <?= $this->translate('There is currently no option creation period planned.') ?>
-            <?php endif; ?>
-        </p>
+    <div class="col-md-6">
+        <h3><?= $this->translate('Active Option Planning Periods') ?></h3>
+        <?php if (!empty($current)): ?>
+            <table class="table table-striped">
+                <thead>
+                    <th>#</th>
+                    <th><?= $this->translate('Planning Period') ?></th>
+                    <th><?= $this->translate('Option Period') ?></th>
+                    <th><?= $this->translate('Actions') ?></th>
+                </thead>
+                <tbody>
+                    <?php foreach ($current as $period): ?>
+                        <tr>
+                            <td><?= $period->getId() ?></td>
+                            <td>
+                                <?= sprintf(
+                                    '%s - %s',
+                                    $period->getBeginPlanningTime()->format('Y-m-d'),
+                                    $period->getEndPlanningTime()->format('Y-m-d'),
+                                ) ?>
+                            </td>
+                            <td>
+                                <?= sprintf(
+                                    '%s - %s',
+                                    $period->getBeginOptionTime()->format('Y-m-d'),
+                                    $period->getEndOptionTime()->format('Y-m-d'),
+                                ) ?>
+                            </td>
+                            <td>
+                                <button data-period-id="<?= $period->getId() ?>"
+                                        class="btn btn-primary btn-xs btn-delete">
+                                    <?= $this->translate('Delete')?>
+                                </button>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p><?= $this->translate('There is currently no option creation period planned.') ?></p>
+        <?php endif; ?>
     </div>
-</div>
-<div class="row">
-    <div class="col-md-12">
-        <a href="<?= $this->url('activity_admin_options/add') ?>" class="btn btn-primary">
-            <?= $this->translate('Add Option Period')?>
-        </a>
-        <?php if (null !== $upcoming): ?>
-            <a href="<?= $this->url('activity_admin_options/edit', ['id' => $upcoming->getId()]) ?>" class="btn btn-primary">
-                <?= $this->translate('Edit Upcoming Period')?>
-            </a>
+    <div class="col-md-6">
+        <h3><?= $this->translate('Planned Option Planning Periods') ?></h3>
+        <?php if (!empty($upcoming)): ?>
+            <table class="table table-striped">
+                <thead>
+                    <th>#</th>
+                    <th><?= $this->translate('Planning Period') ?></th>
+                    <th><?= $this->translate('Option Period') ?></th>
+                    <th><?= $this->translate('Actions') ?></th>
+                </thead>
+                <tbody>
+                    <?php foreach ($upcoming as $period): ?>
+                        <tr>
+                            <td><?= $period->getId() ?></td>
+                            <td>
+                                <?= sprintf(
+                                    '%s - %s',
+                                    $period->getBeginPlanningTime()->format('Y-m-d'),
+                                    $period->getEndPlanningTime()->format('Y-m-d'),
+                                ) ?>
+                            </td>
+                            <td>
+                                <?= sprintf(
+                                    '%s - %s',
+                                    $period->getBeginOptionTime()->format('Y-m-d'),
+                                    $period->getEndOptionTime()->format('Y-m-d'),
+                                ) ?>
+                            </td>
+                            <td>
+                                <a href="<?= $this->url(
+                                    'activity_admin_options/edit',
+                                    [
+                                        'id' => $period->getId(),
+                                    ],
+                                ) ?>" class="btn btn-primary btn-xs">
+                                    <?= $this->translate('Edit')?>
+                                </a>
+                                <button data-period-id="<?= $period->getId() ?>"
+                                        class="btn btn-primary btn-xs btn-delete">
+                                    <?= $this->translate('Delete')?>
+                                </button>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p><?= $this->translate('There are no planned option creation periods in the future.') ?></p>
         <?php endif; ?>
     </div>
 </div>
+<div class="row">
+    <div class="col-md-12 text-right">
+        <a href="<?= $this->url('activity_admin_options/add') ?>" class="btn btn-primary">
+            <?= $this->translate('Add Option Period')?>
+        </a>
+    </div>
+</div>
+
+<div class="modal fade" id="deleteModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title"><?= $this->translate('Delete period') ?></h4>
+            </div>
+            <div class="modal-body">
+                <p>
+                    <?= $this->translate('Are you sure you want to delete this option planning period? <strong>This will also delete all the associated options!</strong>') ?>
+                </p>
+            </div>
+            <div class="modal-footer">
+                <form method="post" class="form form-inline form-delete">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">
+                        <?= $this->translate('Cancel') ?>
+                    </button>
+                    <button type="submit" class="btn btn-danger">
+                        <span class="far fa-trash-alt"></span>&nbsp;<?= $this->translate('Delete') ?>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script nonce="<?= NONCE_REPLACEMENT_STRING ?>">
+    document.querySelectorAll('.btn-delete').forEach(function(element) {
+        element.addEventListener('click', function() {
+            document.querySelector('.form-delete').action = URLHelper.url(
+                'activity_admin_options/delete',
+                {'id': element.dataset.periodId},
+            );
+            $('#deleteModal').modal('show');
+        })
+    });
+</script>

--- a/module/Activity/view/partial/option.phtml
+++ b/module/Activity/view/partial/option.phtml
@@ -1,44 +1,45 @@
-<div class="option spacing-top--sm" id="additionalOption<?= $this->index ?>">
-    <div class="row">
-        <div class="col-md-3">
-            <?php $inputType = $this->fs->get('type')
-                ->setAttribute('class', 'form-control')
-                ->setAttribute('id', 'type-field-' . $this->index);
-            ?>
-            <div class="form-group <?= $this->bootstrapElementError($inputType) ?>">
-                <label for="<?= $inputType->getAttribute('id') ?>" class="control-label label-required">
-                    <?= $this->translate('Type') ?>
-                </label>
-                <?= $this->formSelect($inputType) ?>
-                <?= $this->formElementErrors($inputType) ?>
-            </div>
-        </div>
-        <div class="col-md-3 spacing-top-sm--sm">
-            <?php $inputBeginTime = $this->fs->get('beginTime')
-                ->setAttribute('class', 'form-control begin-time')
-                ->setAttribute('data-begin-option-id', $this->index);
-            ?>
-            <div class="form-group <?= $this->bootstrapElementError($inputBeginTime) ?>">
-                <label for="<?= $inputBeginTime->getAttribute('id') ?>" class="control-label label-required">
-                    <?= $this->translate('From') ?>
-                </label>
-                <?= $this->formDate($inputBeginTime) ?>
-                <?= $this->formElementErrors($inputBeginTime) ?>
-            </div>
-        </div>
-        <div class="col-md-3 spacing-top-sm--sm">
-            <?php $inputEndTime = $this->fs->get('endTime')
-                ->setAttribute('class', 'form-control')
-                ->setAttribute('data-end-option-id', $this->index);
-            ?>
-            <div class="form-group <?= $this->bootstrapElementError($inputEndTime) ?>">
-                <label for="<?= $inputEndTime->getAttribute('id') ?>" class="control-label label-required">
-                    <?= $this->translate('Until') ?>
-                </label>
-                <?= $this->formDate($inputEndTime) ?>
-                <?= $this->formElementErrors($inputEndTime) ?>
-            </div>
+<div class="row" id="additionalOption<?= $this->index ?>">
+    <div class="col-md-3">
+        <?php
+        $inputType = $this->fs->get('type')
+            ->setAttribute('class', 'form-control')
+            ->setAttribute('id', 'type-field-' . $this->index);
+        ?>
+        <div class="form-group <?= $this->bootstrapElementError($inputType) ?>">
+            <label for="<?= $inputType->getAttribute('id') ?>" class="control-label label-required">
+                <?= $this->translate('Type') ?>
+            </label>
+            <?= $this->formSelect($inputType) ?>
+            <?= $this->formElementErrors($inputType) ?>
         </div>
     </div>
-    <hr/>
+    <div class="col-md-3 spacing-top-sm--sm">
+        <?php
+        $inputBeginTime = $this->fs->get('beginTime')
+            ->setAttribute('class', 'form-control begin-time')
+            ->setAttribute('data-begin-option-id', $this->index);
+        ?>
+        <div class="form-group <?= $this->bootstrapElementError($inputBeginTime) ?>">
+            <label for="<?= $inputBeginTime->getAttribute('id') ?>" class="control-label label-required">
+                <?= $this->translate('From') ?>
+            </label>
+            <?= $this->formDate($inputBeginTime) ?>
+            <?= $this->formElementErrors($inputBeginTime) ?>
+        </div>
+    </div>
+    <div class="col-md-3 spacing-top-sm--sm">
+        <?php
+        $inputEndTime = $this->fs->get('endTime')
+            ->setAttribute('class', 'form-control')
+            ->setAttribute('data-end-option-id', $this->index);
+        ?>
+        <div class="form-group <?= $this->bootstrapElementError($inputEndTime) ?>">
+            <label for="<?= $inputEndTime->getAttribute('id') ?>" class="control-label label-required">
+                <?= $this->translate('Until') ?>
+            </label>
+            <?= $this->formDate($inputEndTime) ?>
+            <?= $this->formElementErrors($inputEndTime) ?>
+        </div>
+    </div>
 </div>
+<hr/>

--- a/public/js/proposal-create.js
+++ b/public/js/proposal-create.js
@@ -10,7 +10,7 @@ Proposal = {
      * Adds an optional option to the proposal form, at the end of the list.
      */
     addOption: function () {
-        var currentCount = $('#additionalOptions > div.option').length;
+        var currentCount = $('#additionalOptions > div.row').length;
         if (currentCount < maxCount) {
             var template = $('#additionalOptions span.template').data('template');
             template = template.replace(/__index__/g, currentCount);
@@ -24,7 +24,7 @@ Proposal = {
      * Removes the last option from the list.
      */
     removeOption: function () {
-        var currentCount = $('#additionalOptions > div.option').length - 1;
+        var currentCount = $('#additionalOptions > div.row').length - 1;
         if (currentCount >= 0){
             $('#additionalOption' + currentCount).remove();
         }


### PR DESCRIPTION
This fixes the absolute horrible form validation on the option proposal creation form. And it allows organ members to select a certain option period if there are overlapping planning periods.

**Before (option proposal creation form):**
![image](https://user-images.githubusercontent.com/4983571/201387818-973490e7-3aaf-4bf6-816d-5699304fb654.png)

**After (option proposal creation form):**
![image](https://user-images.githubusercontent.com/4983571/201387762-511ddf53-6fda-4684-b580-191fdf7f4acb.png)

**Before (admin):**
![image](https://user-images.githubusercontent.com/4983571/201396380-25b2e19d-cdda-4689-beec-40e36f6fbc4e.png)

**After (admin):**
![image](https://user-images.githubusercontent.com/4983571/201396421-dc9260f7-da21-453c-8520-0e305d93db60.png)

Closes #1532.