### PR TITLE
Generate a `Message-Id` for e-mails

### DIFF
--- a/module/Application/src/Service/Email.php
+++ b/module/Application/src/Service/Email.php
@@ -6,13 +6,15 @@ use Decision\Model\{
     Member as MemberModel,
     OrganInformation as OrganInformationModel,
 };
+use Laminas\Mail\Header\MessageId;
 use Laminas\Mail\Message;
 use Laminas\Mail\Transport\TransportInterface;
-use Laminas\Mime\Message as MimeMessage;
-use Laminas\Mime\Part as MimePart;
+use Laminas\Mime\{
+    Message as MimeMessage,
+    Part as MimePart,
+};
 use Laminas\View\Model\ViewModel;
 use Laminas\View\Renderer\PhpRenderer;
-use User\Model\User as UserModel;
 
 /**
  * This service is used for sending emails.
@@ -148,6 +150,7 @@ class Email
         $mimeMessage->setParts([$html]);
 
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
 
         return $message;

--- a/module/User/src/Service/Email.php
+++ b/module/User/src/Service/Email.php
@@ -3,6 +3,7 @@
 namespace User\Service;
 
 use Decision\Model\Member as MemberModel;
+use Laminas\Mail\Header\MessageId;
 use Laminas\Mail\Message;
 use Laminas\Mail\Transport\TransportInterface;
 use Laminas\Mvc\I18n\Translator;
@@ -39,6 +40,7 @@ class Email
         );
 
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
 
         $message->addFrom($this->emailConfig['from']);
         $message->addTo($member->getEmail());
@@ -67,6 +69,7 @@ class Email
         );
 
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
 
         $message->addFrom($this->emailConfig['from']);
         $message->addTo($member->getEmail());


### PR DESCRIPTION
`laminas/laminas-mail` does not do this automatically and not having a `Message-Id` can be bad for the spam score of our e-mails.

Fixes #1534.