### PR TITLE
Give `tueguest` to IP addresses in one of multiple ranges

### DIFF
--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -37,10 +37,15 @@ return [
     'bcrypt_cost' => 13,
 
     /*
-     * IP address start for the TU/e. All IP addresses starting with this will
-     * be allowed more base rights, like viewing exams
+     * Subnets in use by the TU/e. All IP addresses in a listed subnet will be allowed more base rights, like being able
+     * to download exams.
+     *
+     * Note: the subnets must be provided in CIDR format.
      */
-    'tue_range' => '131.155.',
+    'tue_ranges' => [
+        '131.155.0.0/16',
+        '10.64.0.0/10',
+    ],
 
     'login_rate_limits' => [
          'user' => 5,

--- a/module/User/src/Authorization/AclServiceFactory.php
+++ b/module/User/src/Authorization/AclServiceFactory.php
@@ -12,6 +12,10 @@ use Laminas\Mvc\I18n\Translator as MvcTranslator;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\Exception\InvalidArgumentException;
 use Photo\Service\AclService as PhotoAclService;
+use User\Authentication\{
+    ApiAuthenticationService,
+    AuthenticationService as UserAuthenticationService,
+};
 use User\Service\AclService as UserAclService;
 
 class AclServiceFactory implements FactoryInterface
@@ -28,61 +32,66 @@ class AclServiceFactory implements FactoryInterface
         $requestedName,
         ?array $options = null,
     ): GenericAclService {
+        /** @var MvcTranslator $translator */
         $translator = $container->get(MvcTranslator::class);
+        /** @var UserAuthenticationService $authService */
         $authService = $container->get('user_auth_service');
+        /** @var ApiAuthenticationService $apiAuthService */
         $apiAuthService = $container->get('user_apiauth_service');
+        /** @var array<array-key, string> $tueRanges */
+        $tueRanges = $container->get('config')['tue_ranges'];
+        /** @var string $remoteAddress */
         $remoteAddress = $container->get('user_remoteaddress');
-        $tueRange = $container->get('config')['tue_range'];
 
         return match ($requestedName) {
             'activity_service_acl' => new ActivityAclService(
                 $translator,
                 $authService,
                 $apiAuthService,
+                $tueRanges,
                 $remoteAddress,
-                $tueRange,
             ),
             'company_service_acl' => new CompanyAclService(
                 $translator,
                 $authService,
                 $apiAuthService,
+                $tueRanges,
                 $remoteAddress,
-                $tueRange,
             ),
             'decision_service_acl' => new DecisionAclService(
                 $translator,
                 $authService,
                 $apiAuthService,
+                $tueRanges,
                 $remoteAddress,
-                $tueRange,
             ),
             'education_service_acl' => new EducationAclService(
                 $translator,
                 $authService,
                 $apiAuthService,
+                $tueRanges,
                 $remoteAddress,
-                $tueRange,
             ),
             'frontpage_service_acl' => new FrontpageAclService(
                 $translator,
                 $authService,
                 $apiAuthService,
+                $tueRanges,
                 $remoteAddress,
-                $tueRange,
             ),
             'photo_service_acl' => new PhotoAclService(
                 $translator,
                 $authService,
                 $apiAuthService,
+                $tueRanges,
                 $remoteAddress,
-                $tueRange,
             ),
             'user_service_acl' => new UserAclService(
                 $translator,
                 $authService,
                 $apiAuthService,
+                $tueRanges,
                 $remoteAddress,
-                $tueRange,
             ),
             default => throw new InvalidArgumentException(
                 sprintf(

--- a/module/User/src/Authorization/GenericAclService.php
+++ b/module/User/src/Authorization/GenericAclService.php
@@ -14,12 +14,14 @@ use User\Permissions\NotAllowedException;
 
 abstract class GenericAclService extends AbstractAclService
 {
+    private array $checkedIps = [];
+
     public function __construct(
         private readonly Translator $translator,
         private readonly AuthenticationService $authService,
         private readonly ApiAuthenticationService $apiAuthService,
+        private readonly array $tueRanges,
         private readonly string $remoteAddress,
-        private readonly string $tueRange,
     ) {
     }
 
@@ -39,8 +41,7 @@ abstract class GenericAclService extends AbstractAclService
             return $this->apiAuthService->getIdentity();
         }
 
-        // TODO: We could create an assertion for this.
-        if (str_starts_with($this->remoteAddress, $this->tueRange)) {
+        if ($this->fromTueNetwork()) {
             return 'tueguest';
         }
 
@@ -80,5 +81,50 @@ abstract class GenericAclService extends AbstractAclService
     public function hasIdentity(): bool
     {
         return !is_null($this->getIdentity());
+    }
+
+    /**
+     * Check whether the remote address (as returned by the proxy) comes from a TU/e network. Networks are provided in
+     * CIDR notation.
+     */
+    private function fromTueNetwork(): bool
+    {
+        // If we already checked the in the past, we do not need to do it again.
+        if (isset($this->checkedIps[$this->remoteAddress])) {
+            return $this->checkedIps[$this->remoteAddress];
+        }
+
+        // We only accept and expect IPv4 addresses.
+        if (!filter_var($this->remoteAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            return $this->checkedIps[$this->remoteAddress] = false;
+        }
+
+        if (!empty($this->tueRanges)) {
+            foreach ($this->tueRanges as $range) {
+                // Ensure that we actually check against a range.
+                if (!str_contains($range, '/')) {
+                    continue;
+                }
+
+                [$subnet, $bits] = explode('/', $range, 2);
+
+                // Ensure that the subnet is valid.
+                if (
+                    0 > $bits
+                    || 32 < $bits
+                    || false === ip2long($subnet)
+                ) {
+                    continue;
+                }
+
+                // Precompute the netmask to be able to re-align the range (if necessary) and check the remote address.
+                $netmask = -1 << (32 - $bits);
+                if ((ip2long($subnet) & $netmask) === (ip2long($this->remoteAddress) & $netmask)) {
+                    return $this->checkedIps[$this->remoteAddress] = true;
+                }
+            }
+        }
+
+        return $this->checkedIps[$this->remoteAddress] = false;
     }
 }

--- a/module/User/src/Authorization/GenericAclService.php
+++ b/module/User/src/Authorization/GenericAclService.php
@@ -107,6 +107,7 @@ abstract class GenericAclService extends AbstractAclService
                 }
 
                 [$subnet, $bits] = explode('/', $range, 2);
+                $bits = (int) $bits;
 
                 // Ensure that the subnet is valid.
                 if (

--- a/module/User/src/Service/AclService.php
+++ b/module/User/src/Service/AclService.php
@@ -20,10 +20,10 @@ class AclService extends GenericAclService
         Translator $translator,
         AuthenticationService $authService,
         ApiAuthenticationService $apiAuthService,
+        array $tueRanges,
         string $remoteAddress,
-        string $tueRange,
     ) {
-        parent::__construct($translator, $authService, $apiAuthService, $remoteAddress, $tueRange);
+        parent::__construct($translator, $authService, $apiAuthService, $tueRanges, $remoteAddress);
         $this->createAcl();
     }
 


### PR DESCRIPTION
The university has started to roll out a new NAT to free up some of the IP addresses in `131.155.0.0/16`. This breaks the `tueguest` privilege that should be assigned to everyone in the TU/e network.

This change addresses that, by making the check work for multiple subnets. Including the new `10.64.0.0/10` NAT subnet.

Fixes #1543.