### PR TITLE
Font and SVG preloading (fixes #1560)

### DIFF
--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -47,6 +47,10 @@
     ]); ?>
     <?php $this->headLink([
         'as' => 'font', 'rel' => 'preload', 'type' => 'font/woff2', 'crossorigin' => 'anonymous',
+        'href' => '/fonts/lato/lato-v22-latin-italic.woff2'
+    ]); ?>
+    <?php $this->headLink([
+        'as' => 'font', 'rel' => 'preload', 'type' => 'font/woff2', 'crossorigin' => 'anonymous',
         'href' => '/fonts/fontawesome/fa-solid-900.woff2'
     ]); ?>
     <?php $this->headLink([
@@ -55,7 +59,7 @@
     ]); ?>
     <?php $this->headLink([
         'as' => 'font', 'rel' => 'preload', 'type' => 'font/ttf', 'crossorigin' => 'anonymous',
-        'href' => '/fonts/gewisicons/gewisicons.ttf?37l19n='
+        'href' => '/fonts/gewisicons/gewisicons.ttf?37l19n'
     ]); ?>
     <?php $this->headLink([
         'as' => 'image', 'rel' => 'preload', 'type' => 'image/svg+xml', 'crossorigin' => 'anonymous',

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -62,11 +62,11 @@
         'href' => '/fonts/gewisicons/gewisicons.ttf?37l19n'
     ]); ?>
     <?php $this->headLink([
-        'as' => 'image', 'rel' => 'preload', 'type' => 'image/svg+xml', 'crossorigin' => 'anonymous',
+        'as' => 'image', 'rel' => 'preload', 'type' => 'image/svg+xml',
         'href' => '/img/nl.svg'
     ]); ?>
     <?php $this->headLink([
-        'as' => 'image', 'rel' => 'preload', 'type' => 'image/svg+xml', 'crossorigin' => 'anonymous',
+        'as' => 'image', 'rel' => 'preload', 'type' => 'image/svg+xml',
         'href' => '/img/en.svg'
     ]); ?>
 


### PR DESCRIPTION
Actually, I saw the SVG resources also did not get used; the second commit fixes that as well