### PR TITLE
Add `createdAt` property to `SignUp`s

### DIFF
--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -255,6 +255,8 @@ class AdminController extends AbstractActionController
             unset($activityAdminSession->message);
         }
 
+        $result['canSeeTimeOfSignup'] = $this->aclService->isAllowed('viewParticipantDetails', 'activity');
+
         return new ViewModel($result);
     }
 

--- a/module/Activity/src/Model/Signup.php
+++ b/module/Activity/src/Model/Signup.php
@@ -2,7 +2,10 @@
 
 namespace Activity\Model;
 
-use Application\Model\Traits\IdentifiableTrait;
+use Application\Model\Traits\{
+    IdentifiableTrait,
+    TimestampableTrait,
+};
 use Doctrine\Common\Collections\{
     ArrayCollection,
     Collection,
@@ -11,6 +14,7 @@ use Doctrine\ORM\Mapping\{
     DiscriminatorColumn,
     DiscriminatorMap,
     Entity,
+    HasLifecycleCallbacks,
     InheritanceType,
     JoinColumn,
     ManyToOne,
@@ -32,9 +36,11 @@ use Doctrine\ORM\Mapping\{
         "external" => ExternalSignup::class,
     ],
 )]
+#[HasLifecycleCallbacks]
 abstract class Signup
 {
     use IdentifiableTrait;
+    use TimestampableTrait;
 
     /**
      * The SignupList the signup is for.

--- a/module/Activity/src/Service/AclService.php
+++ b/module/Activity/src/Service/AclService.php
@@ -47,6 +47,8 @@ class AclService extends \User\Service\AclService
             new IsCreatorOrOrganMember()
         );
 
+        $this->acl->allow('admin', 'activity', 'viewParticipantDetails');
+
         $this->acl->allow('user', 'activityApi', 'list');
         $this->acl->allow('apiuser', 'activityApi', 'list');
     }

--- a/module/Activity/view/activity/admin/participants.phtml
+++ b/module/Activity/view/activity/admin/participants.phtml
@@ -51,6 +51,7 @@ $this->breadcrumbs()
                 'activity' => $activity,
                 'signupList' => $signupList,
                 'detailed' => true,
+                'canSeeTimeOfSignup' => $canSeeTimeOfSignup,
                 'externalSignoffForm' => $externalSignoffForm,
             ]); ?>
         <?php else: ?>

--- a/module/Activity/view/activity/admin/participantsTable.phtml
+++ b/module/Activity/view/activity/admin/participantsTable.phtml
@@ -12,6 +12,9 @@ use Decision\Model\Member;
         <th><?= $this->translate('Email') ?></th>
         <th><?= $this->translate('Type') ?></th>
         <th><?= $this->translate('Generation') ?></th>
+        <?php if (isset($canSeeTimeOfSignup) && $canSeeTimeOfSignup): ?>
+            <th><?= $this->translate('Date and time') ?></th>
+        <?php endif; ?>
         <?php if (!isset($signupList)): ?>
             <th><?= $this->translate('Sign-up List') ?></th>
         <?php endif; ?>
@@ -82,6 +85,9 @@ use Decision\Model\Member;
                     <?php endif; ?>
                 </td>
                 <td><?= $this->translate('N/A') ?></td>
+            <?php endif; ?>
+            <?php if (isset($canSeeTimeOfSignup) && $canSeeTimeOfSignup): ?>
+                <td><?= $signup->getCreatedAt()->format('Y-m-d H:i:s') ?></td>
             <?php endif; ?>
             <?php if (!isset($signupList)): ?>
                 <td><?= $this->escapeHtml($this->localiseText($signup->getSignupList()->getName())) ?></td>


### PR DESCRIPTION
Only visible to administrators and are used to aid in resolving problems with `first-come-first-serve` policies. Uses the existing `TimestampableTrait` to facilite this. The actual date and time is only visible for administrators, not for creators or organs.

Closes GH-994.