### PR TITLE
Do not use member's name in title on personal page

### DIFF
--- a/module/Decision/view/decision/member/self.phtml
+++ b/module/Decision/view/decision/member/self.phtml
@@ -3,7 +3,7 @@
 use Decision\Model\Member;
 use Decision\Model\Address;
 
-$this->headTitle($member->getFullName());
+$this->headTitle($this->translate('My Information'));
 ?>
 <section class="section">
     <div class="container">


### PR DESCRIPTION
This should reduce the traceability of member's when they first visit their "My Information" page.

Closes ABC-2301-088.