### PR TITLE
Allow `MeetingDocument`s to be renamed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "laminas/laminas-validator": "^2.28.0",
         "laminas/laminas-view": "^2.25.0",
         "doctrine/dbal": "^3.5.0",
-        "doctrine/orm": "^2.14.0",
+        "doctrine/orm": "2.14.0",
         "doctrine/doctrine-module": "^5.3.0",
         "doctrine/doctrine-orm-module": "^5.3.0",
         "doctrine/doctrine-laminas-hydrator": "^3.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "394a6aa9f2bd7082ed22d26203974af3",
+    "content-hash": "c2e75c061fac98853b3f0b22cdbff35d",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1326,16 +1326,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.14.1",
+            "version": "2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "de7eee5ed7b1b35c99b118f26f210a8281e6db8e"
+                "reference": "f82485e651763fbd1b34879726f4d3b91c358bd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/de7eee5ed7b1b35c99b118f26f210a8281e6db8e",
-                "reference": "de7eee5ed7b1b35c99b118f26f210a8281e6db8e",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/f82485e651763fbd1b34879726f4d3b91c358bd9",
+                "reference": "f82485e651763fbd1b34879726f4d3b91c358bd9",
                 "shasum": ""
             },
             "require": {
@@ -1364,14 +1364,14 @@
                 "doctrine/annotations": "^1.13 || ^2",
                 "doctrine/coding-standard": "^9.0.2 || ^11.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "~1.4.10 || 1.9.8",
+                "phpstan/phpstan": "~1.4.10 || 1.9.4",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
                 "psr/log": "^1 || ^2 || ^3",
                 "squizlabs/php_codesniffer": "3.7.1",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
                 "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-                "vimeo/psalm": "4.30.0 || 5.4.0"
+                "vimeo/psalm": "4.30.0 || 5.3.0"
             },
             "suggest": {
                 "ext-dom": "Provides support for XSD validation for XML mapping files",
@@ -1421,9 +1421,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.14.1"
+                "source": "https://github.com/doctrine/orm/tree/2.14.0"
             },
-            "time": "2023-01-16T18:36:59+00:00"
+            "time": "2022-12-19T21:51:58+00:00"
         },
         {
             "name": "doctrine/persistence",

--- a/module/Application/test/AutomaticControllerTest.php
+++ b/module/Application/test/AutomaticControllerTest.php
@@ -200,6 +200,8 @@ class AutomaticControllerTest extends BaseControllerTest
         $params['course'] = '2IABS0';
         $params['document'] = 1;
 
+        $params['document_id'] = 42;
+
         return $params;
     }
 }

--- a/module/Decision/config/module.config.php
+++ b/module/Decision/config/module.config.php
@@ -170,21 +170,14 @@ return [
                         ],
                     ],
                     'delete_document' => [
-                        'type' => Literal::class,
+                        'type' => Segment::class,
                         'options' => [
-                            'route' => '/document/delete',
-                        ],
-                        'may_terminate' => false,
-                        'child_routes' => [
-                            'post' => [
-                                'type' => Method::class,
-                                'options' => [
-                                    'verb' => Request::METHOD_POST,
-                                    'route' => '/document/delete',
-                                    'defaults' => [
-                                        'action' => 'deleteDocument',
-                                    ],
-                                ],
+                            'route' => '/document/delete/:document_id',
+                            'constraints' => [
+                                'document_id' => '[0-9]+',
+                            ],
+                            'defaults' => [
+                                'action' => 'deleteDocument',
                             ],
                         ],
                     ],
@@ -203,6 +196,18 @@ return [
                                         'action' => 'changePositionDocument',
                                     ],
                                 ],
+                            ],
+                        ],
+                    ],
+                    'rename_document' => [
+                        'type' => Segment::class,
+                        'options' => [
+                            'route' => '/document/rename/:document_id',
+                            'constraints' => [
+                                'document_id' => '[0-9]+',
+                            ],
+                            'defaults' => [
+                                'action' => 'renameDocument',
                             ],
                         ],
                     ],

--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -120,6 +120,7 @@ class AdminController extends AbstractActionController
                 'meetings' => $meetings,
                 'meeting' => $meeting,
                 'number' => $number,
+                'type' => $type,
                 'success' => $success,
                 'reorderDocumentForm' => $this->decisionService->getReorderDocumentForm(),
             ]

--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -3,7 +3,10 @@
 namespace Decision\Controller;
 
 use Decision\Model\Enums\MeetingTypes;
-use Decision\Service\Decision as DecisionService;
+use Decision\Service\{
+    AclService,
+    Decision as DecisionService,
+};
 use Laminas\Http\{
     PhpEnvironment\Response as EnvironmentResponse,
     Request,
@@ -14,6 +17,7 @@ use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger;
 use Laminas\View\Model\ViewModel;
+use User\Permissions\NotAllowedException;
 
 /**
  * @method FlashMessenger flashMessenger()
@@ -21,6 +25,7 @@ use Laminas\View\Model\ViewModel;
 class AdminController extends AbstractActionController
 {
     public function __construct(
+        private readonly AclService $aclService,
         private readonly Translator $translator,
         private readonly DecisionService $decisionService,
     ) {
@@ -121,11 +126,57 @@ class AdminController extends AbstractActionController
         );
     }
 
-    public function deleteDocumentAction(): Response
+    public function renameDocumentAction(): Response|ViewModel
     {
+        if (!$this->aclService->isAllowed('rename_document', 'meeting')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to rename meeting documents')
+            );
+        }
+
         /** @var Request $request */
         $request = $this->getRequest();
-        $this->decisionService->deleteDocument($request->getPost()->toArray());
+        if ($request->isPost()) {
+            $document = $this->decisionService->getMeetingDocument((int) $this->params()->fromRoute('document_id'));
+
+            if (null !== $document) {
+                $form = $this->decisionService->getDocumentForm();
+                $form->setData($request->getPost()->toArray());
+                $form->setValidationGroup(['name']);
+
+                if ($form->isValid()) {
+                    $this->decisionService->renameDocument(
+                        $document,
+                        $form->getData(),
+                    );
+                }
+
+                return $this->redirect()->toRoute('admin_decision/document');
+            }
+
+            return $this->notFoundAction();
+        }
+
+        return $this->notFoundAction();
+    }
+
+    public function deleteDocumentAction(): Response
+    {
+        if (!$this->aclService->isAllowed('delete_document', 'meeting')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to delete meeting documents.')
+            );
+        }
+
+        /** @var Request $request */
+        $request = $this->getRequest();
+        if ($request->isPost()) {
+            $document = $this->decisionService->getMeetingDocument((int) $this->params()->fromRoute('document_id'));
+
+            if (null !== $document) {
+                $this->decisionService->deleteDocument($document);
+            }
+        }
 
         return $this->redirect()->toRoute('admin_decision/document');
     }

--- a/module/Decision/src/Controller/Factory/AdminControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/AdminControllerFactory.php
@@ -22,6 +22,7 @@ class AdminControllerFactory implements FactoryInterface
         ?array $options = null,
     ): AdminController {
         return new AdminController(
+            $container->get('decision_service_acl'),
             $container->get(MvcTranslator::class),
             $container->get('decision_service_decision'),
         );

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -282,11 +282,11 @@ class Decision
     }
 
     /**
-     * @param array $data
+     * @param MeetingDocumentModel $meetingDocument
      *
      * @throws ORMException
      */
-    public function deleteDocument(array $data): void
+    public function deleteDocument(MeetingDocumentModel $meetingDocument): void
     {
         if (!$this->aclService->isAllowed('delete_document', 'meeting')) {
             throw new NotAllowedException(
@@ -295,11 +295,23 @@ class Decision
         }
 
         // TODO: The actual file is never deleted.
-        if (isset($data['document'])) {
-            $document = $this->getMeetingDocument($data['document']);
-            $this->meetingMapper->remove($document);
-        }
+        $this->meetingMapper->remove($meetingDocument);
     }
+
+    /**
+     * @param MeetingDocumentModel $meetingDocument
+     * @param array $data
+     *
+     * @throws ORMException
+     */
+    public function renameDocument(
+        MeetingDocumentModel $meetingDocument,
+        array $data,
+    ): void {
+        $meetingDocument->setName($data['name']);
+        $this->meetingMapper->persist($meetingDocument);
+    }
+
 
     /**
      * Changes a document's position in the ordering.

--- a/module/Decision/test/ControllerTest.php
+++ b/module/Decision/test/ControllerTest.php
@@ -75,13 +75,6 @@ class ControllerTest extends BaseControllerTest
         $this->assertResponseStatusCode(404);
     }
 
-    public function testAdminDecisionDocumentDeleteActionCanBeAccessedAsAdminViaPost(): void
-    {
-        $this->setUpWithRole('admin');
-        $this->dispatch('/admin/decision/document/delete', Request::METHOD_POST);
-        $this->assertResponseStatusCode(302);
-    }
-
     public function testAdminDecisionDocumentPositionActionCannotBeAccessedAsAdminViaGet(): void
     {
         $this->setUpWithRole('admin');

--- a/module/Decision/view/decision/admin/document.phtml
+++ b/module/Decision/view/decision/admin/document.phtml
@@ -40,7 +40,7 @@ else:
                 <?php if (!empty($meetings)): ?>
                     <?php foreach ($meetings as $m): ?>
                         <option value="<?= $m->getType()->value ?>/<?= $m->getNumber() ?>"
-                            <?= $m->getNumber() === intval($number) ? 'selected' : '' ?>>
+                            <?= ($m->getNumber() === intval($number) && $m->getType()->value === $type) ? 'selected' : '' ?>>
                             <?= $m->getType()->value ?> <?= $m->getNumber() ?> (<?= $m->getDate()->format('Y-m-d') ?>)
                         </option>
                     <?php endforeach; ?>

--- a/module/Decision/view/decision/admin/document.phtml
+++ b/module/Decision/view/decision/admin/document.phtml
@@ -1,4 +1,14 @@
-<?php use Laminas\Form\Form;
+<?php
+
+use Laminas\Form\Form;
+
+$this->scriptUrl()->requireUrls(
+    [
+        'admin_decision/delete_document',
+        'admin_decision/rename_document',
+    ],
+    ['document_id'],
+);
 
 $this->breadcrumbs()
     ->addBreadcrumb($this->translate('Meetings'))
@@ -81,6 +91,11 @@ else:
             <?php if (0 === $meeting->getDocuments()->count()): ?>
                 <p><?= $this->translate('This meeting does not have any associated documents.') ?></p>
             <?php else: ?>
+                <?php $pastMeeting = $meeting->getDate() <= new DateTime('now'); ?>
+                <span id="meeting-info"
+                      data-meeting-type="<?= $meeting->getType()->value ?>"
+                      data-meeting-number="<?= $meeting->getNumber() ?>">
+                </span>
                 <table class="table table-striped table-hover table-documents">
                     <?php foreach ($meeting->getDocuments() as $document): ?>
                         <tr data-id="<?= $document->getId() ?>">
@@ -106,19 +121,83 @@ else:
                             </td>
                             <td>
                                 <a href="<?= $this->url('decision/document', ['id' => $document->getId()]) ?>">
-                                    <?= $document->getName() ?>
+                                    <?= $this->escapeHtml($document->getName()) ?>
                                 </a>
                             </td>
                             <td>
-                                <form method="POST" action="<?= $this->url('admin_decision/delete_document/post') ?>">
-                                    <input type="hidden" name="document" value="<?= $document->getId() ?>">
-                                    <input type="submit" name="submit" value="<?= $this->translate('Delete') ?>"
-                                           class="btn btn-danger btn-xs pull-right"/>
-                                </form>
+                                <button data-document-id="<?= $document->getId() ?>"
+                                        data-document-name="<?= $this->escapeHtmlAttr($document->getName()) ?>"
+                                        class="btn btn-primary btn-xs btn-rename">
+                                    <?= $this->translate('Rename')?>
+                                </button>
+                                <button data-document-id="<?= $document->getId() ?>"
+                                        data-document-name="<?= $this->escapeHtmlAttr($document->getName()) ?>"
+                                        class="btn btn-primary btn-xs btn-delete">
+                                    <?= $this->translate('Delete')?>
+                                </button>
                             </td>
                         </tr>
                     <?php endforeach ?>
                 </table>
+                <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                                <h4 class="modal-title"><?= $this->translate('Delete Document') ?></h4>
+                            </div>
+                            <div class="modal-body">
+                                <p>
+                                    <?= sprintf(
+                                        $this->translate(
+                                            'Are you sure you want to delete %s?'
+                                        ),
+                                        '<strong id="delete-document-name"></strong>',
+                                    ) ?>
+                                </p>
+                            </div>
+                            <div class="modal-footer">
+                                <form method="post" class="form form-inline form-delete">
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">
+                                        <?= $this->translate('Cancel') ?>
+                                    </button>
+                                    <button type="submit" class="btn btn-danger">
+                                        <span class="far fa-trash-alt"></span>&nbsp;<?= $this->translate('Delete') ?>
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal fade" id="renameModal" tabindex="-1" role="dialog">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                                <h4 class="modal-title"><?= $this->translate('Rename Meeting Document') ?></h4>
+                            </div>
+                            <div class="modal-body">
+                                <p><?= $this->translate('Enter a new name for this document:') ?></p>
+                                <input type="text" name="name" placeholder="Name" class="form-control"
+                                       id="new-document-name" form="form-rename">
+                            </div>
+                            <div class="modal-footer">
+                                <form method="post" class="form form-inline form-rename" id="form-rename">
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">
+                                        <?= $this->translate('Cancel') ?>
+                                    </button>
+                                    <button type="submit" class="btn btn-success">
+                                        <span class="fas fa-file-pen"></span>&nbsp;<?= $this->translate('Rename') ?>
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             <?php endif; ?>
         </div>
     <?php endif; ?>
@@ -235,6 +314,28 @@ else:
 
         document.getElementById('meeting-selector').addEventListener('change', e => {
             window.location = '<?= $this->url('admin_decision/document') ?>/' + e.target.value;
+        });
+
+        document.querySelectorAll('.btn-delete').forEach((element) => {
+            element.addEventListener('click', () => {
+                document.querySelector('#delete-document-name').textContent = element.dataset.documentName;
+                document.querySelector('.form-delete').action = URLHelper.url(
+                    'admin_decision/delete_document',
+                    {'document_id': element.dataset.documentId},
+                );
+                $('#deleteModal').modal('show');
+            })
+        });
+
+        document.querySelectorAll('.btn-rename').forEach((element) => {
+            element.addEventListener('click', () => {
+                document.querySelector('#new-document-name').value = element.dataset.documentName;
+                document.querySelector('.form-rename').action = URLHelper.url(
+                    'admin_decision/rename_document',
+                    {'document_id': element.dataset.documentId},
+                );
+                $('#renameModal').modal('show');
+            })
         });
     </script>
 <?php endif; ?>


### PR DESCRIPTION
As requested, closes GH-1578.

Additionally, I found out that `doctrine/orm` has a regression in `v2.14.1` that breaks some parts of the website. This PR downgrades the dependency to a known working version and fixes #1585.