### PR TITLE
Timestamp `MeetingDocument`s and `MeetingMinutes`'

### DIFF
--- a/module/Decision/src/Model/MeetingDocument.php
+++ b/module/Decision/src/Model/MeetingDocument.php
@@ -2,10 +2,14 @@
 
 namespace Decision\Model;
 
-use Application\Model\Traits\IdentifiableTrait;
+use Application\Model\Traits\{
+    IdentifiableTrait,
+    TimestampableTrait,
+};
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
+    HasLifecycleCallbacks,
     JoinColumn,
     ManyToOne,
 };
@@ -14,9 +18,11 @@ use Doctrine\ORM\Mapping\{
  * Meeting document model.
  */
 #[Entity]
+#[HasLifecycleCallbacks]
 class MeetingDocument
 {
     use IdentifiableTrait;
+    use TimestampableTrait;
 
     /**
      * Meeting.

--- a/module/Decision/src/Model/MeetingMinutes.php
+++ b/module/Decision/src/Model/MeetingMinutes.php
@@ -2,22 +2,26 @@
 
 namespace Decision\Model;
 
+use Application\Model\Traits\TimestampableTrait;
 use Decision\Model\Enums\MeetingTypes;
 use Doctrine\ORM\Mapping\{
     Column,
     Entity,
+    HasLifecycleCallbacks,
     Id,
     JoinColumn,
-    OneToOne,
-};
+    OneToOne};
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 /**
  * Meeting minutes.
  */
 #[Entity]
+#[HasLifecycleCallbacks]
 class MeetingMinutes implements ResourceInterface
 {
+    use TimestampableTrait;
+
     /**
      * Meeting type.
      */


### PR DESCRIPTION
Requested by the board to prevent misuse of documents and/or late uploads.

In the future this timestamp can be shown on the actual page instead of having a user-entered date.