### PR TITLE
Fix "Inactief Lid" gets too much privileges when `graduate`

### DIFF
--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -133,6 +133,10 @@ class DecisionController extends AbstractActionController
 
     public function authorizationsAction(): ViewModel
     {
+        if (!$this->aclService->isAllowed('create', 'authorization')) {
+            throw new NotAllowedException($this->translator->translate('You are not allowed to authorize someone'));
+        }
+
         $meeting = $this->decisionService->getLatestALV();
         $authorization = null;
 

--- a/module/Decision/src/Model/Member.php
+++ b/module/Decision/src/Model/Member.php
@@ -671,7 +671,7 @@ class Member
                 $dischargeDate = $organ->getDischargeDate();
 
                 // Keep installation if not discharged or discharged in the future
-                return is_null($dischargeDate) || $dischargeDate >= $today;
+                return null === $dischargeDate || $dischargeDate >= $today;
             }
         );
     }

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -433,10 +433,6 @@ class Decision
      */
     public function createAuthorization(array $data): ?AuthorizationModel
     {
-        if (!$this->aclService->isAllowed('create', 'authorization')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to authorize someone.'));
-        }
-
         $authorizer = $this->aclService->getUserIdentityOrThrowException()->getMember();
         $recipient = $this->memberMapper->findByLidnr($data['recipient']);
 

--- a/module/User/src/Model/User.php
+++ b/module/User/src/Model/User.php
@@ -182,13 +182,13 @@ class User implements IdentityInterface
             return 'company_admin';
         }
 
-        if (count($this->getMember()->getCurrentOrganInstallations()) > 0) {
-            return 'active_member';
-        }
-
         if (empty($roleNames)) {
             if (MembershipTypes::Graduate === $this->getMember()->getType()) {
                 return 'graduate';
+            }
+
+            if (count($this->getMember()->getCurrentOrganInstallations()) > 0) {
+                return 'active_member';
             }
 
             return 'user';


### PR DESCRIPTION
You cannot be `graduate` and `active_member` at the same time.

Fixes GH-1593.