### PR TITLE
Remove `photo_guest` role

### DIFF
--- a/module/Photo/src/Service/AclService.php
+++ b/module/Photo/src/Service/AclService.php
@@ -27,10 +27,6 @@ class AclService extends \User\Service\AclService
         $this->acl->allow('user', 'tag', ['view', 'add', 'remove']);
         $this->acl->allow('user', 'vote', ['view', 'add']);
 
-        $this->acl->allow('photo_guest', 'photo', 'view');
-        $this->acl->allow('photo_guest', 'album', 'view');
-        $this->acl->allow('photo_guest', 'photo', ['download', 'view_metadata']);
-
         // Graduates may not view photos/albums that were made after their membership ended.
         $this->acl->deny('graduate', 'album', 'view', new IsAfterMembershipEndedAndNotTagged());
         $this->acl->deny('graduate', 'photo', ['view', 'download', 'view_metadata'], new IsAfterMembershipEndedAndNotTagged());

--- a/module/User/src/Model/User.php
+++ b/module/User/src/Model/User.php
@@ -194,10 +194,6 @@ class User implements IdentityInterface
             return 'user';
         }
 
-        if (in_array('photo_guest', $roleNames)) {
-            return 'photo_guest';
-        }
-
         throw new RuntimeException(
             sprintf('Could not determine user role unambiguously for user %s', $this->getLidnr())
         );

--- a/module/User/src/Service/AclService.php
+++ b/module/User/src/Service/AclService.php
@@ -69,7 +69,6 @@ class AclService extends GenericAclService
          * - company: a company which uses the career section of the website
          * - apiuser: Automated tool given access by an admin
          * - admin: Defined administrators
-         * - photo_guest: Special role for non-members but friends of GEWIS nonetheless
          */
         $this->acl->addRole(new Role('guest'));
         $this->acl->addRole(new Role('tueguest'), 'guest');
@@ -80,7 +79,6 @@ class AclService extends GenericAclService
         $this->acl->addRole(new Role('graduate'), 'user');
         $this->acl->addrole(new Role('company_admin'), 'active_member');
         $this->acl->addRole(new Role('admin'));
-        $this->acl->addRole(new Role('photo_guest'), 'guest');
 
         // admins (this includes board members) are allowed to do everything
         $this->acl->allow('admin');
@@ -91,6 +89,5 @@ class AclService extends GenericAclService
 
         $this->acl->allow('user', 'user', ['password_change']);
         $this->acl->allow('company', 'user', ['password_change']);
-        $this->acl->allow('photo_guest', 'user', ['password_change']);
     }
 }


### PR DESCRIPTION
This role was never really used and there is currently no implementation that allows this to function.

Closes GH-1595.