### PR TITLE
Fix e-mails not being sent when headers contain unicode

### DIFF
--- a/module/Application/src/Service/Email.php
+++ b/module/Application/src/Service/Email.php
@@ -17,6 +17,8 @@ use Laminas\Mime\{
 use Laminas\View\Model\ViewModel;
 use Laminas\View\Renderer\PhpRenderer;
 
+use function mb_encode_mimeheader;
+
 /**
  * This service is used for sending emails.
  */
@@ -97,7 +99,15 @@ class Email
         $message = $this->createMessageFromView($view, $data);
 
         $message->setFrom($this->emailConfig['from']['address'], $this->emailConfig['from']['name']);
-        $message->setTo($recipient->getEmail(), $recipient->getFullName());
+        $message->setTo(
+            $recipient->getEmail(),
+            mb_encode_mimeheader(
+                $recipient->getFullName(),
+                'UTF-8',
+                'Q',
+                '',
+            ),
+        );
         $message->setSubject($subject);
         $message->setReplyTo($user->getEmail());
 

--- a/module/User/src/Service/Email.php
+++ b/module/User/src/Service/Email.php
@@ -19,6 +19,8 @@ use User\Model\{
     NewUser as NewUserModel,
 };
 
+use function mb_encode_mimeheader;
+
 class Email
 {
     public function __construct(
@@ -55,7 +57,15 @@ class Email
         $message = new Message();
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setFrom($this->emailConfig['from']['address'], $this->emailConfig['from']['name']);
-        $message->setTo($member->getEmail(), $member->getFullName());
+        $message->setTo(
+            $member->getEmail(),
+            mb_encode_mimeheader(
+                $member->getFullName(),
+                'UTF-8',
+                'Q',
+                '',
+            ),
+        );
         $message->setSubject('Your account for the GEWIS website');
         $message->setBody($mimeMessage);
 
@@ -83,7 +93,15 @@ class Email
         $message = new Message();
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setFrom($this->emailConfig['from']['address'], $this->emailConfig['from']['name']);
-        $message->setTo($newCompanyUser->getEmail(), $newCompanyUser->getCompany()->getRepresentativeName());
+        $message->setTo(
+            $newCompanyUser->getEmail(),
+            mb_encode_mimeheader(
+                $newCompanyUser->getCompany()->getRepresentativeName(),
+                'UTF-8',
+                'Q',
+                '',
+            ),
+        );
         $message->setSubject('Your company account for the GEWIS Career Platform');
         $message->setBody($mimeMessage);
 
@@ -117,7 +135,15 @@ class Email
         $message = new Message();
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setFrom($this->emailConfig['from']['address'], $this->emailConfig['from']['name']);
-        $message->setTo($member->getEmail(), $member->getFullName());
+        $message->setTo(
+            $member->getEmail(),
+            mb_encode_mimeheader(
+                $member->getFullName(),
+                'UTF-8',
+                'Q',
+                '',
+            ),
+        );
         $message->setSubject('Password reset request for the GEWIS website');
         $message->setBody($mimeMessage);
 
@@ -145,7 +171,15 @@ class Email
         $message = new Message();
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setFrom($this->emailConfig['from']['address'], $this->emailConfig['from']['name']);
-        $message->setTo($newCompanyUser->getEmail(), $newCompanyUser->getCompany()->getRepresentativeName());
+        $message->setTo(
+            $newCompanyUser->getEmail(),
+            mb_encode_mimeheader(
+                $newCompanyUser->getCompany()->getRepresentativeName(),
+                'UTF-8',
+                'Q',
+                '',
+            ),
+        );
         $message->setSubject('Password reset request for the GEWIS Career Platform');
         $message->setBody($mimeMessage);
 


### PR DESCRIPTION
Unfortunately, the e-mail protocols are still archaic. Even with RFCs like 6532, there is no support for actual unicode characters in e-mail headers.

We can circumvent this to a certain degree by re-encoding strings that may contain unicode characters. This is done through `mb_encode_mimeheader`. However, it should be pointed out that this function has a hard line length of 74 characters. This is rather annoying (and incredibly stupid), as it also breaks the e-mail headers (CRLF injection), so we also have to fix this by replacing the EOL with nothing.

This fixes GH-1607.