### PR TITLE
Compare meeting type values for meeting selection document upload

### DIFF
--- a/module/Decision/view/decision/admin/document.phtml
+++ b/module/Decision/view/decision/admin/document.phtml
@@ -40,7 +40,7 @@ else:
                 <?php if (!empty($meetings)): ?>
                     <?php foreach ($meetings as $m): ?>
                         <option value="<?= $m->getType()->value ?>/<?= $m->getNumber() ?>"
-                            <?= ($m->getNumber() === intval($number) && $m->getType()->value === $type) ? 'selected' : '' ?>>
+                            <?= ($m->getNumber() === intval($number) && $m->getType()->value === $type->value) ? 'selected' : '' ?>>
                             <?= $m->getType()->value ?> <?= $m->getNumber() ?> (<?= $m->getDate()->format('Y-m-d') ?>)
                         </option>
                     <?php endforeach; ?>


### PR DESCRIPTION
Otherwise, all documents that are uploaded are always uploaded to the latest available meeting instead of the selected meeting.

Fixes ABC-2303-157.