### PR TITLE
Enable marking course documents as scanned

### DIFF
--- a/module/Application/src/Service/FileStorage.php
+++ b/module/Application/src/Service/FileStorage.php
@@ -140,6 +140,7 @@ class FileStorage
         string $path,
         string $fileName,
         bool $watermarkPdf = false,
+        bool $scanned = false,
     ): ?Stream {
         $config = $this->storageConfig;
 
@@ -161,6 +162,7 @@ class FileStorage
             $file = $this->watermarkService->watermarkPdf(
                 $file,
                 $fileName,
+                $scanned,
             );
         }
 

--- a/module/Application/src/Service/WatermarkService.php
+++ b/module/Application/src/Service/WatermarkService.php
@@ -36,6 +36,7 @@ class WatermarkService
     public function watermarkPdf(
         string $path,
         string $fileName,
+        bool $scanned = false,
     ): string {
         $pdf = new Fpdi();
         $pdf->setTitle($fileName);
@@ -101,7 +102,9 @@ class WatermarkService
         $tempFile = $tempName . '.pdf';
         $tempFlatFile = $tempName . '-flat.pdf';
         $pdf->Output($tempFile, 'F');
-        exec("convert -density 120 " . escapeshellarg($tempFile) . " " . escapeshellarg($tempFlatFile));
+
+        $quality = $scanned ? '170' : '120';
+        exec("convert -density " . escapeshellarg($quality) . " " . escapeshellarg($tempFile) . " " . escapeshellarg($tempFlatFile));
 
         return $tempFlatFile;
     }

--- a/module/Education/src/Form/Fieldset/Exam.php
+++ b/module/Education/src/Form/Fieldset/Exam.php
@@ -6,6 +6,7 @@ use Application\Model\Enums\Languages;
 use Education\Model\Enums\ExamTypes;
 use Laminas\Filter\StringToUpper;
 use Laminas\Form\Element\{
+    Checkbox,
     Date,
     Hidden,
     Select,
@@ -86,6 +87,16 @@ class Exam extends Fieldset implements InputFilterProviderInterface
                         Languages::EN->value => Languages::EN->getName($this->translator),
                         Languages::NL->value => Languages::NL->getName($this->translator),
                     ],
+                ],
+            ]
+        );
+
+        $this->add(
+            [
+                'name' => 'scanned',
+                'type' => Checkbox::class,
+                'options' => [
+                    'label' => $this->translator->translate('Scanned?'),
                 ],
             ]
         );

--- a/module/Education/src/Form/Fieldset/Summary.php
+++ b/module/Education/src/Form/Fieldset/Summary.php
@@ -8,6 +8,7 @@ use Laminas\Filter\{
     ToNull,
 };
 use Laminas\Form\Element\{
+    Checkbox,
     Date,
     Hidden,
     Select,
@@ -82,6 +83,16 @@ class Summary extends Fieldset implements InputFilterProviderInterface
                         Languages::EN->value => Languages::EN->getName($this->translator),
                         Languages::NL->value => Languages::NL->getName($this->translator),
                     ],
+                ],
+            ]
+        );
+
+        $this->add(
+            [
+                'name' => 'scanned',
+                'type' => Checkbox::class,
+                'options' => [
+                    'label' => $this->translator->translate('Scanned?'),
                 ],
             ]
         );

--- a/module/Education/src/Model/CourseDocument.php
+++ b/module/Education/src/Model/CourseDocument.php
@@ -68,6 +68,12 @@ abstract class CourseDocument implements ResourceInterface
     protected Course $course;
 
     /**
+     * Whether the uploaded document is scanned or not. This influences the quality of the watermarking service.
+     */
+    #[Column(type: "boolean")]
+    protected bool $scanned;
+
+    /**
      * Get the date.
      */
     public function getDate(): DateTime
@@ -129,6 +135,22 @@ abstract class CourseDocument implements ResourceInterface
     public function setCourse(Course $course): void
     {
         $this->course = $course;
+    }
+
+    /**
+     * Get whether the document is scanned or not.
+     */
+    public function getScanned(): bool
+    {
+        return $this->scanned;
+    }
+
+    /**
+     * Set whether the document is scanned or not.
+     */
+    public function setScanned(bool $scanned): void
+    {
+        $this->scanned = $scanned;
     }
 
     /**

--- a/module/Education/src/Service/Exam.php
+++ b/module/Education/src/Service/Exam.php
@@ -92,13 +92,19 @@ class Exam
             );
         }
 
+        /** @var CourseDocumentModel|null $document */
         $document = $this->courseDocumentMapper->find($id);
 
         if (null === $document) {
             return null;
         }
 
-        return $this->storageService->downloadFile($document->getFilename(), $this->courseDocumentToFilename($document), true);
+        return $this->storageService->downloadFile(
+            $document->getFilename(),
+            $this->courseDocumentToFilename($document),
+            true,
+            $document->getScanned(),
+        );
     }
 
     /**
@@ -150,6 +156,7 @@ class Exam
                     }
 
                     $document->setLanguage(Languages::from($documentData['language']));
+                    $document->setScanned($documentData['scanned']);
                     $localFile = $temporaryEducationConfig['upload_' . $type . '_dir'] . '/' . $documentData['file'];
                     $document->setFilename($storage->storeFile($localFile));
 

--- a/module/Education/view/education/admin/edit-exam.phtml
+++ b/module/Education/view/education/admin/edit-exam.phtml
@@ -5,6 +5,12 @@ $this->inlineScript()
         'text/javascript',
         ['nonce' => NONCE_REPLACEMENT_STRING],
     );
+$this->headScript()
+    ->appendFile(
+        $this->basePath() . '/js/bootstrap/tooltip.js',
+        'text/javascript',
+        ['nonce' => NONCE_REPLACEMENT_STRING],
+    );
 
 $this->scriptUrl()->requireUrl('admin_education/delete_temp', ['type', 'filename']);
 
@@ -51,7 +57,7 @@ $this->breadcrumbs()
             $element->setAttribute('class', 'form-control');
             $element->setAttribute('placeholder', $element->getLabel());
             ?>
-            <div class="form-group<?= count($element->getMessages()) > 0 ? ' has-error' : '' ?>">
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
                 <label for="<?= $element->getName() ?>"
                        class="control-label col-sm-2"><?= $element->getLabel() ?></label>
                 <div class="col-sm-10">
@@ -65,7 +71,7 @@ $this->breadcrumbs()
             $element->setAttribute('class', 'form-control');
             $element->setAttribute('placeholder', $element->getLabel());
             ?>
-            <div class="form-group<?= count($element->getMessages()) > 0 ? ' has-error' : '' ?>">
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
                 <label for="<?= $element->getName() ?>"
                        class="control-label col-sm-2"><?= $element->getLabel() ?></label>
                 <div class="col-sm-10">
@@ -78,7 +84,7 @@ $this->breadcrumbs()
             $element = $fs->get('examType');
             $element->setAttribute('class', 'form-control');
             ?>
-            <div class="form-group<?= count($element->getMessages()) > 0 ? ' has-error' : '' ?>">
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
                 <label for="<?= $element->getName() ?>"
                        class="control-label col-sm-2"><?= $element->getLabel() ?></label>
                 <div class="col-sm-10">
@@ -90,11 +96,27 @@ $this->breadcrumbs()
             $element = $fs->get('language');
             $element->setAttribute('class', 'form-control');
             ?>
-            <div class="form-group<?= count($element->getMessages()) > 0 ? ' has-error' : '' ?>">
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
                 <label for="<?= $element->getName() ?>"
                        class="control-label col-sm-2"><?= $element->getLabel() ?></label>
                 <div class="col-sm-10">
                     <?= $this->formSelect($element) ?>
+                    <?= $this->formElementErrors($element) ?>
+                </div>
+            </div>
+            <?php
+            $element = $fs->get('scanned');
+            $element->setAttribute('class', 'form-control');
+            ?>
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
+                <label for="<?= $element->getName() ?>" class="control-label col-sm-2">
+                    <?= $element->getLabel() ?>
+                    <span data-toggle="tooltip" data-placement="right"
+                          title="<?= $this->translate('Check this if the document is scanned, as this will enable higher quality downloads. Please note that enabling setting this for non-scanned documents will significantly impact the ability to download the document.') ?>"
+                          class="fas fa-info-circle" aria-hidden="true"></span>
+                </label>
+                <div class="col-sm-10">
+                    <?= $this->formCheckbox($element) ?>
                     <?= $this->formElementErrors($element) ?>
                 </div>
             </div>

--- a/module/Education/view/education/admin/edit-summary.phtml
+++ b/module/Education/view/education/admin/edit-summary.phtml
@@ -5,6 +5,12 @@ $this->inlineScript()
         'text/javascript',
         ['nonce' => NONCE_REPLACEMENT_STRING],
     );
+$this->headScript()
+    ->appendFile(
+        $this->basePath() . '/js/bootstrap/tooltip.js',
+        'text/javascript',
+        ['nonce' => NONCE_REPLACEMENT_STRING],
+    );
 
 $this->scriptUrl()->requireUrl('admin_education/delete_temp', ['type', 'filename']);
 
@@ -51,7 +57,7 @@ $this->breadcrumbs()
             $element->setAttribute('class', 'form-control');
             $element->setAttribute('placeholder', $element->getLabel());
             ?>
-            <div class="form-group<?= count($element->getMessages()) > 0 ? ' has-error' : '' ?>">
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
                 <label for="<?= $element->getName() ?>"
                        class="control-label col-sm-2"><?= $element->getLabel() ?></label>
                 <div class="col-sm-10">
@@ -65,7 +71,7 @@ $this->breadcrumbs()
             $element->setAttribute('class', 'form-control');
             $element->setAttribute('placeholder', $element->getLabel());
             ?>
-            <div class="form-group<?= count($element->getMessages()) > 0 ? ' has-error' : '' ?>">
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
                 <label for="<?= $element->getName() ?>"
                        class="control-label col-sm-2"><?= $element->getLabel() ?></label>
                 <div class="col-sm-10">
@@ -79,7 +85,7 @@ $this->breadcrumbs()
             $element->setAttribute('class', 'form-control');
             $element->setAttribute('placeholder', $element->getLabel());
             ?>
-            <div class="form-group<?= count($element->getMessages()) > 0 ? ' has-error' : '' ?>">
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
                 <label for="<?= $element->getName() ?>"
                        class="control-label col-sm-2"><?= $element->getLabel() ?></label>
                 <div class="col-sm-10">
@@ -92,11 +98,27 @@ $this->breadcrumbs()
             $element = $fs->get('language');
             $element->setAttribute('class', 'form-control');
             ?>
-            <div class="form-group<?= count($element->getMessages()) > 0 ? ' has-error' : '' ?>">
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
                 <label for="<?= $element->getName() ?>"
                        class="control-label col-sm-2"><?= $element->getLabel() ?></label>
                 <div class="col-sm-10">
                     <?= $this->formSelect($element) ?>
+                    <?= $this->formElementErrors($element) ?>
+                </div>
+            </div>
+            <?php
+            $element = $fs->get('scanned');
+            $element->setAttribute('class', 'form-control');
+            ?>
+            <div class="form-group <?= $this->bootstrapElementError($element) ?>">
+                <label for="<?= $element->getName() ?>" class="control-label col-sm-2">
+                    <?= $element->getLabel() ?>
+                    <span data-toggle="tooltip" data-placement="right"
+                          title="<?= $this->translate('Check this if the document is scanned, as this will enable higher quality downloads. Please note that enabling setting this for non-scanned documents will significantly impact the ability to download the document.') ?>"
+                          class="fas fa-info-circle" aria-hidden="true"></span>
+                </label>
+                <div class="col-sm-10">
+                    <?= $this->formCheckbox($element) ?>
                     <?= $this->formElementErrors($element) ?>
                 </div>
             </div>


### PR DESCRIPTION
Scanned course documents are often of lower quality than actual PDFs, this results in pixelated downloads where somethings certain parts of the original scan are removed due to the flattening process.

By marking a course document as being scanned, it can be downloaded at a higher quality. It should be noted that setting this option for normal PDFs will significantly affect the download size and speed, likely resulting in no file being downloaded.

This closes GH-1620.