### PR TITLE
Change how Composer dependencies are installed in GH Actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -25,7 +25,10 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: '8.2'
-                    tools: cs2pr, phpcs
+                    tools: cs2pr
+
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Run PHPCS
-                run: phpcs --report=checkstyle -q | cs2pr --graceful-warnings
+                run: vendor/bin/phpcs --report=checkstyle -q | cs2pr --graceful-warnings

--- a/.github/workflows/static-analysis-phpstan.yml
+++ b/.github/workflows/static-analysis-phpstan.yml
@@ -37,17 +37,6 @@ jobs:
                     extensions: calendar, curl, exif, gd, intl, opcache, pgsql, pdo_mysql, pdo_pgsql, zip, imagick, memcached, xdebug
                     tools: cs2pr
 
-            -   name: Get Composer cache directory
-                id: composer-cache-head
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            -   name: Cache dependencies
-                uses: actions/cache@v2
-                with:
-                    path: ${{ steps.composer-cache-head.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: ${{ runner.os }}-composer-
-
             -   name: Extract configuration files
                 run: |
                     cp config/autoload/doctrine.local.development.php.dist config/autoload/doctrine.local.php
@@ -60,8 +49,8 @@ jobs:
                     git update-ref refs/heads/temp-phpstanpr refs/remotes/origin/master
                     git checkout --detach temp-phpstanpr
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Load environment variables
                 uses: c-py/action-dotenv-to-setenv@v3
@@ -87,8 +76,8 @@ jobs:
                     git checkout --theirs -- config/modules.config.php
                     git checkout -
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Load environment variables
                 uses: c-py/action-dotenv-to-setenv@v3

--- a/.github/workflows/static-analysis-psalm.yml
+++ b/.github/workflows/static-analysis-psalm.yml
@@ -23,17 +23,6 @@ jobs:
                     php-version: '8.2'
                     extensions: calendar, curl, exif, gd, intl, opcache, pgsql, pdo_mysql, pdo_pgsql, zip, imagick, memcached, xdebug
 
-            -   name: Get Composer cache directory
-                id: composer-cache-head
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            -   name: Cache dependencies
-                uses: actions/cache@v2
-                with:
-                    path: ${{ steps.composer-cache-head.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: ${{ runner.os }}-composer-
-
             -   name: Extract configuration files
                 run: |
                     cp config/autoload/doctrine.local.development.php.dist config/autoload/doctrine.local.php
@@ -46,8 +35,8 @@ jobs:
                     git update-ref refs/heads/temp-psalmpr refs/remotes/origin/master
                     git checkout --detach temp-psalmpr
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Load environment variables
                 uses: c-py/action-dotenv-to-setenv@v3
@@ -66,8 +55,8 @@ jobs:
                     git checkout --theirs -- config/modules.config.php
                     git checkout -
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Load environment variables
                 uses: c-py/action-dotenv-to-setenv@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,19 +30,8 @@ jobs:
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            -   name: Cache dependencies
-                uses: actions/cache@v2
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: ${{ runner.os }}-composer-
-
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Extract configuration files
                 run: |


### PR DESCRIPTION
This fixes PHP_CS not working (not the issue with `readonly` classes) and probably also fixes slower runs because our caching of the dependencies was suboptimal.