### PR TITLE
Fix being unable to update a `JobCategory`

### DIFF
--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -680,7 +680,7 @@ class AdminController extends AbstractActionController
 
         if ($request->isPost()) {
             $categoryForm->setData($request->getPost()->toArray());
-            $categoryForm->setCurrentSlug($jobCategory->getPluralName());
+            $categoryForm->setCurrentSlug($jobCategory->getSlug());
 
             if ($categoryForm->isValid()) {
                 $this->companyService->updateJobCategory($jobCategory, $categoryForm->getData());

--- a/module/Company/src/Form/Company.php
+++ b/module/Company/src/Form/Company.php
@@ -7,6 +7,7 @@ namespace Company\Form;
 use Application\Form\Localisable as LocalisableForm;
 use Company\Mapper\Company as CompanyMapper;
 use Laminas\Filter\{
+    StringToLower,
     StringTrim,
     StripTags,
     ToNull,
@@ -272,6 +273,11 @@ class Company extends LocalisableForm implements InputFilterProviderInterface
                                 Regex::ERROROUS => $this->getTranslator()->translate('This slug contains invalid characters'),
                             ],
                         ],
+                    ],
+                ],
+                'filters' => [
+                    [
+                        'name' => StringToLower::class,
                     ],
                 ],
             ],

--- a/module/Company/src/Form/JobCategory.php
+++ b/module/Company/src/Form/JobCategory.php
@@ -9,6 +9,7 @@ use Company\Model\CompanyLocalisedText as CompanyLocalisedTextModel;
 use Doctrine\ORM\NonUniqueResultException;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Filter\{
+    StringToLower,
     StringTrim,
     StripTags,
 };
@@ -214,6 +215,9 @@ class JobCategory extends Form implements InputFilterProviderInterface
                     [
                         'name' => StringTrim::class,
                     ],
+                    [
+                        'name' => StringToLower::class,
+                    ],
                 ],
             ];
         }
@@ -245,7 +249,10 @@ class JobCategory extends Form implements InputFilterProviderInterface
         array $context,
         string $languageSuffix,
     ): bool {
-        if ($this->{'currentSlug' . $languageSuffix} === $value) {
+        if (
+            null !== $this->{'currentSlug' . $languageSuffix}
+            && mb_strtolower($this->{'currentSlug' . $languageSuffix}) === mb_strtolower($value)
+        ) {
             return true;
         }
 


### PR DESCRIPTION
This was caused by passing the plural name to the slug uniqueness test instead of the slug. Slugs are now also always lowercase (also applies to companies) to ensure they fit in the URL.

Apparently this has been an issue since September 2021, so we can be certain that no one has ever tried to update a `JobCategory`.

Fixes GH-1626.