### PR TITLE
Change `&VeryThinSpace;` to `&nbsp;` in all e-mail templates

### DIFF
--- a/module/Decision/view/email/authorization-grantee.phtml
+++ b/module/Decision/view/email/authorization-grantee.phtml
@@ -214,7 +214,7 @@ GMM&nbsp;authorization&nbsp;from&nbsp;<?= $this->escapeHtml($grantor->getFullNam
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -261,7 +261,7 @@ GMM&nbsp;authorization&nbsp;from&nbsp;<?= $this->escapeHtml($grantor->getFullNam
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>

--- a/module/Decision/view/email/authorization-grantor.phtml
+++ b/module/Decision/view/email/authorization-grantor.phtml
@@ -214,7 +214,7 @@ GMM&nbsp;authorization&nbsp;for&nbsp;<?= $this->escapeHtml($grantee->getFullName
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -261,7 +261,7 @@ GMM&nbsp;authorization&nbsp;for&nbsp;<?= $this->escapeHtml($grantee->getFullName
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>

--- a/module/Decision/view/email/authorization-revoked.phtml
+++ b/module/Decision/view/email/authorization-revoked.phtml
@@ -214,7 +214,7 @@ GMM&nbsp;authorization&nbsp;from&nbsp;<?= $this->escapeHtml($grantor->getFullNam
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -261,7 +261,7 @@ GMM&nbsp;authorization&nbsp;from&nbsp;<?= $this->escapeHtml($grantor->getFullNam
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>

--- a/module/Decision/view/email/organ-update.phtml
+++ b/module/Decision/view/email/organ-update.phtml
@@ -215,7 +215,7 @@
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -262,7 +262,7 @@
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>

--- a/module/Frontpage/view/email/poll.phtml
+++ b/module/Frontpage/view/email/poll.phtml
@@ -215,7 +215,7 @@ New&nbsp;poll&nbsp;requested
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -262,7 +262,7 @@ New&nbsp;poll&nbsp;requested
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>

--- a/module/User/view/user/email/company-register.phtml
+++ b/module/User/view/user/email/company-register.phtml
@@ -215,7 +215,7 @@ Your&nbsp;company&nbsp;account&nbsp;for&nbsp;the&nbsp;GEWIS&nbsp;Career&nbsp;Pla
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -280,7 +280,7 @@ Your&nbsp;company&nbsp;account&nbsp;for&nbsp;the&nbsp;GEWIS&nbsp;Career&nbsp;Pla
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>

--- a/module/User/view/user/email/company-reset.phtml
+++ b/module/User/view/user/email/company-reset.phtml
@@ -216,7 +216,7 @@ Request&nbsp;to&nbsp;reset&nbsp;password
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -263,7 +263,7 @@ Request&nbsp;to&nbsp;reset&nbsp;password
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>

--- a/module/User/view/user/email/register.phtml
+++ b/module/User/view/user/email/register.phtml
@@ -216,7 +216,7 @@ Your&nbsp;account&nbsp;for&nbsp;the&nbsp;GEWIS&nbsp;website
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -281,7 +281,7 @@ Your&nbsp;account&nbsp;for&nbsp;the&nbsp;GEWIS&nbsp;website
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>

--- a/module/User/view/user/email/reset.phtml
+++ b/module/User/view/user/email/reset.phtml
@@ -216,7 +216,7 @@ Request&nbsp;to&nbsp;reset&nbsp;password
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-                                    <div class="spacer_block" style="height:60px;line-height:60px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>
@@ -263,7 +263,7 @@ Request&nbsp;to&nbsp;reset&nbsp;password
                             <tbody>
                             <tr>
                                 <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
-                                    <div class="spacer_block" style="height:40px;line-height:40px;">&VeryThinSpace;</div>
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
                                 </th>
                             </tr>
                             </tbody>


### PR DESCRIPTION
The `&VeryThinSpace;` was added to replace the actual unicode character that caused issues in some e-mail clients, unfortunately this did not fix it.

With `&nbsp;` it should work in any e-mail client that is capable of displaying HTML.

**Before:**
![image](https://user-images.githubusercontent.com/4983571/234680473-ce96bb3f-98cd-433c-a4de-9ce8a46bb70c.png)


**After:**
![image](https://user-images.githubusercontent.com/4983571/234680518-eafeb4d0-7f59-42e8-bc48-978c4ab93363.png)

This fixes ABC-2304-168.