### PR TITLE
Fix issue with sorting `Organ`s by hash

### DIFF
--- a/module/Decision/src/Model/SubDecision.php
+++ b/module/Decision/src/Model/SubDecision.php
@@ -200,7 +200,7 @@ abstract class SubDecision
      */
     public function getDecisionNumber(): int
     {
-        return $this->number;
+        return $this->decision_number;
     }
 
     /**


### PR DESCRIPTION
The original code from GEWISDB (as copied in 2015) contained a tiny mistake in `getDecisionNumber()`, the subdecision number was returned instead of the decision number.

This was fixed in 2017 in GEWISDB, however, the fix was never copied to the website.