### PR TITLE
Update translations and fix `translate-helper`

### DIFF
--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-25 00:26+0200\n"
+"POT-Creation-Date: 2023-06-25 00:47+0200\n"
 "PO-Revision-Date: 2023-06-25 00:27+0200\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -19,4068 +19,1129 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: module/Activity/src/Controller/ActivityCalendarController.php:82
-msgid "You are not allowed to create activity proposals"
-msgstr "You are not allowed to create activity proposals"
-
-#: module/Activity/src/Controller/ActivityController.php:228
-#: module/Activity/view/activity/activity/index.phtml:45
-msgid "Create Activity"
-msgstr "Create Activity"
-
-#: module/Activity/src/Controller/ActivityController.php:258
-#: module/Activity/src/Controller/ActivityController.php:351
-#: module/Activity/src/Controller/AdminController.php:294
-#: module/Activity/src/Controller/AdminController.php:381
-msgid "Invalid form"
-msgstr "Invalid form"
-
-#: module/Activity/src/Controller/ActivityController.php:267
-#: module/Activity/src/Controller/ActivityController.php:360
-msgid "You need to log in to subscribe"
-msgstr "You need to log in to subscribe"
-
-#: module/Activity/src/Controller/ActivityController.php:277
-#: module/Activity/src/Controller/ActivityController.php:370
-msgid "You cannot subscribe to this activity at this moment in time"
-msgstr "You cannot subscribe to this activity at this moment in time"
-
-#: module/Activity/src/Controller/ActivityController.php:286
-msgid "You have already been subscribed for this activity"
-msgstr "You have already been subscribed for this activity"
-
-#: module/Activity/src/Controller/ActivityController.php:292
-msgid "Successfully subscribed"
-msgstr "Successfully subscribed"
-
-#: module/Activity/src/Controller/ActivityController.php:297
-#: module/Activity/src/Controller/ActivityController.php:386
-#: module/Activity/src/Controller/AdminController.php:318
-msgid "Use the form to subscribe"
-msgstr "Use the form to subscribe"
-
-#: module/Activity/src/Controller/ActivityController.php:381
-msgid "Successfully subscribed as external participant"
-msgstr "Successfully subscribed as external participant"
-
-#: module/Activity/src/Controller/ActivityController.php:413
-msgid "Wrong form"
-msgstr "Wrong form"
-
-#: module/Activity/src/Controller/ActivityController.php:420
-msgid "You have to be logged in to subscribe for this activity"
-msgstr "You have to be logged in to subscribe for this activity"
-
-#: module/Activity/src/Controller/ActivityController.php:431
-msgid "You cannot unsubscribe from this activity at this moment in time"
-msgstr "You cannot unsubscribe from this activity at this moment in time"
-
-#: module/Activity/src/Controller/ActivityController.php:441
-msgid "You are not subscribed to this activity!"
-msgstr "You are not subscribed to this activity!"
-
-#: module/Activity/src/Controller/ActivityController.php:447
-msgid "Successfully unsubscribed"
-msgstr "Successfully unsubscribed"
-
-#: module/Activity/src/Controller/ActivityController.php:452
-msgid "Use the form to unsubscribe"
-msgstr "Use the form to unsubscribe"
-
-#: module/Activity/src/Controller/AdminApprovalController.php:41
-msgid "You are not allowed to view the approval of this activity"
-msgstr "You are not allowed to view the approval of this activity"
-
-#: module/Activity/src/Controller/AdminCategoryController.php:50
-#: module/Activity/src/Service/ActivityCategory.php:76
-msgid "You are not allowed to create an activity category"
-msgstr "You are not allowed to create an activity category"
-
-#: module/Activity/src/Controller/AdminCategoryController.php:63
-msgid "The activity category was created successfully!"
-msgstr "The activity category was created successfully!"
-
-#: module/Activity/src/Controller/AdminCategoryController.php:73
-#: module/Activity/src/Form/ActivityCategory.php:44
-msgid "Create Activity Category"
-msgstr "Create Activity Category"
-
-#: module/Activity/src/Controller/AdminCategoryController.php:122
-msgid "You are not allowed to edit an activity category"
-msgstr "You are not allowed to edit an activity category"
-
-#: module/Activity/src/Controller/AdminCategoryController.php:142
-msgid "The activity category was successfully updated!"
-msgstr "The activity category was successfully updated!"
-
-#: module/Activity/src/Controller/AdminCategoryController.php:159
-msgid "Update Activity Category"
-msgstr "Update Activity Category"
-
-#: module/Activity/src/Controller/AdminController.php:62
-msgid "You are not allowed to update this activity"
-msgstr "You are not allowed to update this activity"
-
-#: module/Activity/src/Controller/AdminController.php:76
-msgid ""
-"Activities that have sign-up lists which are open or approved cannot be "
-"updated."
-msgstr ""
-"Activities that have sign-up lists which are open or approved cannot be "
-"updated."
-
-#: module/Activity/src/Controller/AdminController.php:87
-msgid "This activity has already started/ended and can no longer be updated."
-msgstr "This activity has already started/ended and can no longer be updated."
-
-#: module/Activity/src/Controller/AdminController.php:106
-msgid ""
-"You have successfully created an update proposal for the activity! If the "
-"activity was already approved, the proposal will be applied after it has "
-"been approved by the board. Otherwise, the update has already been applied "
-"to the activity."
-msgstr ""
-"You have successfully created an update proposal for the activity! If the "
-"activity was already approved, the proposal will be applied after it has "
-"been approved by the board. Otherwise, the update has already been applied "
-"to the activity."
-
-#: module/Activity/src/Controller/AdminController.php:143
-msgid "Update Activity"
-msgstr "Update Activity"
-
-#: module/Activity/src/Controller/AdminController.php:188
-#: module/Activity/src/Controller/AdminController.php:200
-#: module/Activity/src/Controller/AdminController.php:212
-msgid "You are not allowed to view the participants of this activity"
-msgstr "You are not allowed to view the participants of this activity"
-
-#: module/Activity/src/Controller/AdminController.php:234
-#: module/Activity/src/Controller/AdminController.php:372
-#: module/User/view/user/api-admin/index.phtml:35
-msgid "Remove"
-msgstr "Remove"
-
-#: module/Activity/src/Controller/AdminController.php:273
-#: module/Activity/src/Controller/AdminController.php:364
-msgid "You are not allowed to use this form"
-msgstr "You are not allowed to use this form"
-
-#: module/Activity/src/Controller/AdminController.php:310
-msgid "Successfully subscribed external participant"
-msgstr "Successfully subscribed external participant"
-
-#: module/Activity/src/Controller/AdminController.php:391
-msgid "Successfully removed external participant"
-msgstr "Successfully removed external participant"
-
-#: module/Activity/src/Controller/AdminController.php:399
-msgid "Use the form to unsubscribe an external participant"
-msgstr "Use the form to unsubscribe an external participant"
-
-#: module/Activity/src/Controller/AdminController.php:409
-msgid "You are not allowed to administer activities"
-msgstr "You are not allowed to administer activities"
-
-#: module/Activity/src/Controller/AdminOptionController.php:41
-msgid "You are not allowed to administer option calendar periods"
-msgstr "You are not allowed to administer option calendar periods"
-
-#: module/Activity/src/Controller/AdminOptionController.php:57
-msgid "You are not allowed to create option calendar periods"
-msgstr "You are not allowed to create option calendar periods"
-
-#: module/Activity/src/Controller/AdminOptionController.php:77
-msgid "Option planning period created successfully."
-msgstr "Option planning period created successfully."
-
-#: module/Activity/src/Controller/AdminOptionController.php:101
-#: module/Activity/view/activity/admin-option/index.phtml:113
-msgid "Add Option Period"
-msgstr "Add Option Period"
-
-#: module/Activity/src/Controller/AdminOptionController.php:109
-msgid "You are not allowed to delete option calendar periods"
-msgstr "You are not allowed to delete option calendar periods"
-
-#: module/Activity/src/Controller/AdminOptionController.php:124
-msgid "Past option planning periods cannot be deleted."
-msgstr "Past option planning periods cannot be deleted."
-
-#: module/Activity/src/Controller/AdminOptionController.php:132
-msgid "Option planning period deleted."
-msgstr "Option planning period deleted."
-
-#: module/Activity/src/Controller/AdminOptionController.php:145
-msgid "You are not allowed to edit option calendar periods"
-msgstr "You are not allowed to edit option calendar periods"
-
-#: module/Activity/src/Controller/AdminOptionController.php:161
-msgid "This option planning period cannot be edited."
-msgstr "This option planning period cannot be edited."
-
-#: module/Activity/src/Controller/AdminOptionController.php:185
-msgid "Option planning period has been updated."
-msgstr "Option planning period has been updated."
-
-#: module/Activity/src/Controller/AdminOptionController.php:207
-msgid "Edit Option Period"
-msgstr "Edit Option Period"
-
-#: module/Activity/src/Controller/ApiController.php:30
-msgid "You are not allowed to access the activities through the API"
-msgstr "You are not allowed to access the activities through the API"
-
-#: module/Activity/src/Form/Activity.php:35
-msgid "No organ"
-msgstr "No organ"
-
-#: module/Activity/src/Form/Activity.php:36
-msgid "No Company"
-msgstr "No Company"
-
-#: module/Activity/src/Form/Activity.php:282
-#: module/Activity/src/Form/Activity.php:294
-#: module/Activity/src/Form/Activity.php:308
-#: module/Activity/src/Form/Activity.php:320
-#: module/Activity/src/Form/Activity.php:335
-#: module/Activity/src/Form/Activity.php:350
-#: module/Activity/src/Form/ActivityCalendarProposal.php:128
-#: module/Activity/src/Form/ActivityCalendarProposal.php:142
-#: module/Activity/src/Form/ActivityCalendarProposal.php:150
-#: module/Education/src/Form/Bulk.php:57
-msgid "Value is required and can't be empty"
-msgstr "Value is required and can't be empty"
-
-#: module/Activity/src/Form/Activity.php:373
-msgid ""
-"The sign-up list closing date and time must be before the activity starts."
-msgstr ""
-"The sign-up list closing date and time must be before the activity starts."
-
-#: module/Activity/src/Form/Activity.php:409
-msgid "The activity must start before it ends."
-msgstr "The activity must start before it ends."
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:26
-msgid "Morning"
-msgstr "Morning"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:27
-msgid "Lunch break"
-msgstr "Lunch break"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:28
-msgid "Afternoon"
-msgstr "Afternoon"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:29
-msgid "Evening"
-msgstr "Evening"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:30
-#: module/Activity/view/activity/activity-calendar/index.phtml:160
-msgid "Day"
-msgstr "Day"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:31
-msgid "Multiple days"
-msgstr "Multiple days"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:60
-msgid "Select a type"
-msgstr "Select a type"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:84
-msgid "The activity must start before it ends"
-msgstr "The activity must start before it ends"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:97
-msgid "The activity must start after today"
-msgstr "The activity must start after today"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:30
-msgid "Start date and time of planning period"
-msgstr "Start date and time of planning period"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:41
-msgid "End date and time of planning period"
-msgstr "End date and time of planning period"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:52
-msgid "Start date and time of option period"
-msgstr "Start date and time of option period"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:63
-msgid "End date and time of option period"
-msgstr "End date and time of option period"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:89
-msgid "Create Option Period"
-msgstr "Create Option Period"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:126
-msgid "The planning period must end after it starts."
-msgstr "The planning period must end after it starts."
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:149
-msgid "The option period must start after the planning period ends."
-msgstr "The option period must start after the planning period ends."
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:172
-msgid "The option period must end after it starts."
-msgstr "The option period must end after it starts."
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:63
-msgid "Select a period"
-msgstr "Select a period"
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:78
-msgid "Select an option"
-msgstr "Select an option"
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:165
-msgid "Option should end after it starts."
-msgstr "Option should end after it starts."
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:176
-msgid "Option does not fall within option period (also check the end date)."
-msgstr "Option does not fall within option period (also check the end date)."
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:220
-msgid "The activity does now have an acceptable amount of options"
-msgstr "The activity does now have an acceptable amount of options"
-
-#: module/Activity/src/Form/ActivityCategory.php:24
-#: module/Activity/src/Form/ActivityCategory.php:34
-#: module/Activity/src/Form/SignupList.php:35
-#: module/Activity/src/Form/SignupList.php:45
-#: module/Activity/src/Form/SignupListField.php:34
-#: module/Activity/src/Form/SignupListField.php:44
-#: module/Activity/view/activity/activity-calendar/create.phtml:90
-#: module/Activity/view/activity/activity-calendar/index.phtml:64
-#: module/Activity/view/activity/activity/view.phtml:268
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:133
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:138
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:150
-#: module/Activity/view/activity/admin-approval/view.phtml:80
-#: module/Activity/view/activity/admin-approval/view.phtml:85
-#: module/Activity/view/activity/admin-approval/view.phtml:92
-#: module/Activity/view/activity/admin-category/add.phtml:69
-#: module/Activity/view/activity/admin-category/add.phtml:106
-#: module/Activity/view/activity/admin/participantsTable.phtml:20
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:18
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:23
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:30
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:102
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:107
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:114
-#: module/Activity/view/partial/create.phtml:44
-#: module/Activity/view/partial/create.phtml:118
-#: module/Activity/view/partial/signuplist.phtml:54
-#: module/Activity/view/partial/signuplist.phtml:70
-#: module/Company/src/Form/Company.php:51
-#: module/Company/src/Form/Company.php:93
-#: module/Company/src/Form/Company.php:113 module/Company/src/Form/Job.php:106
-#: module/Company/src/Form/Job.php:137 module/Company/src/Form/Job.php:147
-#: module/Company/src/Form/JobCategory.php:45
-#: module/Company/src/Form/JobCategory.php:55
-#: module/Company/src/Form/JobLabel.php:31
-#: module/Company/src/Form/JobLabel.php:41
-#: module/Company/view/company/admin-approval/index.phtml:30
-#: module/Company/view/company/admin-approval/job-approval.phtml:66
-#: module/Company/view/company/admin-approval/job-approval.phtml:70
-#: module/Company/view/company/admin-approval/job-approval.phtml:119
-#: module/Company/view/company/admin-approval/job-approval.phtml:124
-#: module/Company/view/company/admin-approval/job-approval.phtml:131
-#: module/Company/view/company/admin-approval/job-proposal.phtml:97
-#: module/Company/view/company/admin-approval/job-proposal.phtml:101
-#: module/Company/view/company/admin-approval/job-proposal.phtml:159
-#: module/Company/view/company/admin-approval/job-proposal.phtml:164
-#: module/Company/view/company/admin-approval/job-proposal.phtml:174
-#: module/Company/view/company/admin/edit-package.phtml:83
-#: module/Company/view/company/admin/index.phtml:126
-#: module/Company/view/company/admin/index.phtml:212
-#: module/Company/view/company/company-account/jobs.phtml:196
-#: module/Decision/view/decision/admin/document.phtml:71
-#: module/Decision/view/decision/member/birthdays.phtml:23
-#: module/Decision/view/decision/organ-admin/index.phtml:24
-#: module/Decision/view/decision/organ/index.phtml:23
-#: module/Education/src/Form/Course.php:43
-#: module/Education/view/education/admin/course.phtml:44
-#: module/Photo/view/photo/album-admin/edit.phtml:35
-#: module/User/src/Form/ApiToken.php:25
-#: module/User/view/user/api-admin/add.phtml:57
-#: module/User/view/user/api-admin/index.phtml:22
-msgid "Name"
-msgstr "Name"
-
-#: module/Activity/src/Form/SignupList.php:180
-msgid ""
-"The sign-up list opening date and time must be before the sign-up list "
-"closes."
-msgstr ""
-"The sign-up list opening date and time must be before the sign-up list "
-"closes."
-
-#: module/Activity/src/Form/SignupListField.php:55
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:128
-msgid "Text"
-msgstr "Text"
-
-#: module/Activity/src/Form/SignupListField.php:56
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:131
-msgid "Yes/No"
-msgstr "Yes/No"
-
-#: module/Activity/src/Form/SignupListField.php:57
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
-msgid "Number"
-msgstr "Number"
-
-#: module/Activity/src/Form/SignupListField.php:58
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:137
-msgid "Choice"
-msgstr "Choice"
-
-#: module/Activity/src/Form/SignupListField.php:60
-#: module/Activity/view/activity/activity-calendar/index.phtml:65
-#: module/Activity/view/activity/admin/participantsTable.phtml:22
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
-#: module/Activity/view/partial/option.phtml:19
-#: module/Decision/view/decision/decision/index.phtml:23
-#: module/Decision/view/decision/organ/index.phtml:24
-#: module/Education/src/Form/Fieldset/Exam.php:68
-#: module/Education/view/education/admin/course-documents.phtml:68
-msgid "Type"
-msgstr "Type"
-
-#: module/Activity/src/Form/SignupListField.php:70
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:147
-msgid "Min. value"
-msgstr "Min. value"
-
-#: module/Activity/src/Form/SignupListField.php:80
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:157
-msgid "Max. value"
-msgstr "Max. value"
-
-#: module/Activity/src/Form/SignupListField.php:90
-#: module/Activity/src/Form/SignupListField.php:103
-msgid "Option 1, Option 2, ..."
-msgstr "Option 1, Option 2, ..."
-
-#: module/Activity/src/Form/SignupListField.php:93
-#: module/Activity/src/Form/SignupListField.php:106
-#: module/Activity/view/activity/activity-calendar/create.phtml:119
-#: module/Activity/view/activity/activity-calendar/index.phtml:193
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:169
-#: module/Activity/view/partial/create.phtml:170
-msgid "Options"
-msgstr "Options"
-
-#: module/Activity/src/Form/SignupListField.php:160
-msgid "Some of the required fields for this type are empty"
-msgstr "Some of the required fields for this type are empty"
-
-#: module/Activity/src/Form/SignupListField.php:191
-msgid "The number of English options must equal the number of Dutch options"
-msgstr "The number of English options must equal the number of Dutch options"
-
-#: module/Activity/src/Service/Activity.php:66
-#: module/Activity/src/Service/Activity.php:105
-msgid "You are not allowed to create an activity"
-msgstr "You are not allowed to create an activity"
-
-#: module/Activity/src/Service/Activity.php:145
-msgid "You are not allowed to create an activity for this organ"
-msgstr "You are not allowed to create an activity for this organ"
-
-#: module/Activity/src/Service/Activity.php:406
-msgid "You are not allowed to create activity option proposals"
-msgstr "You are not allowed to create activity option proposals"
-
-#: module/Activity/src/Service/Activity.php:754
-#: module/Activity/src/Service/Activity.php:772
-#: module/Activity/src/Service/Activity.php:790
-msgid "You are not allowed to change the status of the activity"
-msgstr "You are not allowed to change the status of the activity"
-
-#: module/Activity/src/Service/ActivityCalendar.php:169
-msgid "You are not allowed to approve this option"
-msgstr "You are not allowed to approve this option"
-
-#: module/Activity/src/Service/ActivityCalendar.php:209
-msgid "You are not allowed to delete this option"
-msgstr "You are not allowed to delete this option"
-
-#: module/Activity/src/Service/ActivityCategory.php:31
-#: module/Activity/src/Service/ActivityCategory.php:47
-msgid "You are not allowed to view activity categories"
-msgstr "You are not allowed to view activity categories"
-
-#: module/Activity/src/Service/ActivityCategory.php:105
-msgid "You are not allowed to delete an activity category"
-msgstr "You are not allowed to delete an activity category"
-
-#: module/Activity/src/Service/ActivityQuery.php:86
-msgid "You are not allowed to view this activity"
-msgstr "You are not allowed to view this activity"
-
-#: module/Activity/src/Service/ActivityQuery.php:102
-#: module/Activity/src/Service/ActivityQuery.php:262
-#: module/Activity/src/Service/Signup.php:128
-msgid "You are not allowed to view the activities"
-msgstr "You are not allowed to view the activities"
-
-#: module/Activity/src/Service/ActivityQuery.php:117
-msgid "You are not allowed to view unapproved activities"
-msgstr "You are not allowed to view unapproved activities"
-
-#: module/Activity/src/Service/ActivityQuery.php:132
-msgid "You are not allowed to view activities"
-msgstr "You are not allowed to view activities"
-
-#: module/Activity/src/Service/ActivityQuery.php:159
-msgid "You are not allowed to view the disapproved activities"
-msgstr "You are not allowed to view the disapproved activities"
-
-#: module/Activity/src/Service/ActivityQuery.php:177
-msgid "You are not allowed to view upcoming the activities"
-msgstr "You are not allowed to view upcoming the activities"
-
-#: module/Activity/src/Service/ActivityQuery.php:185
-msgid ""
-"You are not allowed to view upcoming activities coupled to a member account"
-msgstr ""
-"You are not allowed to view upcoming activities coupled to a member account"
-
-#: module/Activity/src/Service/Signup.php:47
-#: module/Activity/src/Service/Signup.php:147
-msgid "You need to be logged in to sign up for this activity"
-msgstr "You need to be logged in to sign up for this activity"
-
-#: module/Activity/src/Service/Signup.php:61
-msgid "You are not allowed to use the external admin signup"
-msgstr "You are not allowed to use the external admin signup"
-
-#: module/Activity/src/Service/Signup.php:75
-msgid "You are not allowed to use the external signup"
-msgstr "You are not allowed to use the external signup"
-
-#: module/Activity/src/Service/Signup.php:96
-msgid "You are not allowed to view the sign up data"
-msgstr "You are not allowed to view the sign up data"
-
-#: module/Activity/src/Service/Signup.php:229
-msgid "You are not allowed to subscribe an external user to this sign-up list"
-msgstr "You are not allowed to subscribe an external user to this sign-up list"
-
-#: module/Activity/src/Service/Signup.php:276
-msgid "You are not allowed to subscribe to this sign-up list"
-msgstr "You are not allowed to subscribe to this sign-up list"
-
-#: module/Activity/src/Service/Signup.php:292
-msgid "You need to be logged in to sign off for this activity"
-msgstr "You need to be logged in to sign off for this activity"
-
-#: module/Activity/src/Service/Signup.php:333
-msgid "You are not allowed to remove external signups for this activity"
-msgstr "You are not allowed to remove external signups for this activity"
-
-#: module/Activity/src/Service/SignupListQuery.php:26
-msgid "You are not allowed to view sign-up lists"
-msgstr "You are not allowed to view sign-up lists"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:14
-msgid "Create activity proposal"
-msgstr "Create activity proposal"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:30
-#: module/Activity/view/activity/activity-calendar/index.phtml:38
-#: module/Application/view/partial/main-nav.phtml:417
-#: module/Decision/view/decision/member/index.phtml:207
-msgid "Option calendar"
-msgstr "Option calendar"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:31
-msgid "Propose options for an activity"
-msgstr "Propose options for an activity"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:39
-msgid "Organisation"
-msgstr "Organisation"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:40
-#: module/Activity/view/activity/activity-calendar/create.phtml:78
-msgid ""
-"Select the organ for which the options are and in which option period the "
-"options should be planned."
-msgstr ""
-"Select the organ for which the options are and in which option period the "
-"options should be planned."
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:49
-msgid "Period"
-msgstr "Period"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:64
-#: module/Activity/view/activity/activity/create.phtml:62
-msgid "Committee / fraternity"
-msgstr "Committee / fraternity"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:77
-#: module/Activity/view/activity/admin/list.phtml:67
-#: module/Company/view/company/admin-approval/job-approval.phtml:100
-#: module/Company/view/company/admin-approval/job-proposal.phtml:140
-#: module/Company/view/company/admin/edit-package.phtml:111
-#: module/Company/view/company/company-account/jobs.phtml:234
-msgid "Details"
-msgstr "Details"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:106
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:220
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:225
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:237
-#: module/Activity/view/activity/admin-approval/view.phtml:137
-#: module/Activity/view/activity/admin-approval/view.phtml:142
-#: module/Activity/view/activity/admin-approval/view.phtml:149
-#: module/Activity/view/partial/create.phtml:87
-#: module/Activity/view/partial/create.phtml:161
-#: module/Company/src/Form/Company.php:198
-#: module/Company/src/Form/Company.php:208 module/Company/src/Form/Job.php:201
-#: module/Company/src/Form/Job.php:211
-#: module/Company/view/company/admin-approval/job-approval.phtml:176
-#: module/Company/view/company/admin-approval/job-approval.phtml:181
-#: module/Company/view/company/admin-approval/job-approval.phtml:188
-#: module/Company/view/company/admin-approval/job-proposal.phtml:234
-#: module/Company/view/company/admin-approval/job-proposal.phtml:239
-#: module/Company/view/company/admin-approval/job-proposal.phtml:249
-#: module/Company/view/company/company/jobs.phtml:140
-#: module/Company/view/partial/company/company/list/company.phtml:99
-msgid "Description"
-msgstr "Description"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:120
-msgid "Add options for your activity proposal."
-msgstr "Add options for your activity proposal."
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:142
-msgid "Add an option"
-msgstr "Add an option"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:146
-msgid "Remove the last option"
-msgstr "Remove the last option"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:154
-#: module/Decision/src/Form/Minutes.php:55
-#: module/Frontpage/src/Form/Poll.php:63
-msgid "Submit"
-msgstr "Submit"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:39
-msgid ""
-"Welcome on the page of the digital Option Calendar. In the calendar below "
-"you can place options for GEWIS activities, just like you were used to do in "
-"the paper version of the option calendar before. The red dots indicate "
-"activities that are already fixed in the GEWIS agenda, the blue dots are "
-"options for activities. If you insert an option, please give it a clear "
-"name, so it is clear what the option is for."
-msgstr ""
-"Welcome on the page of the digital Option Calendar. In the calendar below "
-"you can place options for GEWIS activities, just like you were used to do in "
-"the paper version of the option calendar before. The red dots indicate "
-"activities that are already fixed in the GEWIS agenda, the blue dots are "
-"options for activities. If you insert an option, please give it a clear "
-"name, so it is clear what the option is for."
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:41
-msgid "There are a few rules:"
-msgstr "There are a few rules:"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:43
-msgid ""
-"It is not allowed to put more than 3 options for the same activity in the "
-"calendar."
-msgstr ""
-"It is not allowed to put more than 3 options for the same activity in the "
-"calendar."
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:44
-msgid ""
-"The first to put an option for an activity on a particular date, has the "
-"first dibs to let the activity take place on this date. Five weeks before "
-"the activity takes place, the budget must have been presented to the board. "
-"When this has not been done, the option will only stay in the calendar for "
-"two more weeks. In case the entity involved does not present their budget "
-"within these two weeks nontheless, the option lapses and the next one in "
-"line gets the chance to use this date for an activity."
-msgstr ""
-"The first to put an option for an activity on a particular date, has the "
-"first dibs to let the activity take place on this date. Five weeks before "
-"the activity takes place, the budget must have been presented to the board. "
-"When this has not been done, the option will only stay in the calendar for "
-"two more weeks. In case the entity involved does not present their budget "
-"within these two weeks nontheless, the option lapses and the next one in "
-"line gets the chance to use this date for an activity."
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:45
-msgid ""
-"The board can always decide to make an exception to the rules written above, "
-"for example in case of dependence on a third party, or when it concerns very "
-"big activities or weekends."
-msgstr ""
-"The board can always decide to make an exception to the rules written above, "
-"for example in case of dependence on a third party, or when it concerns very "
-"big activities or weekends."
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:51
-msgid "Your option has been added successfully"
-msgstr "Your option has been added successfully"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:59
-msgid "My options"
-msgstr "My options"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:63
-msgid "Creator"
-msgstr "Creator"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:66
-#: module/Activity/view/activity/activity/list.phtml:50
-#: module/Activity/view/activity/activity/view.phtml:90
-msgid "Start"
-msgstr "Start"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:67
-#: module/Activity/view/activity/activity/list.phtml:52
-#: module/Activity/view/activity/activity/view.phtml:93
-msgid "End"
-msgstr "End"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:88
-#: module/Activity/view/activity/activity-calendar/index.phtml:121
-#: module/Activity/view/activity/admin-option/index.phtml:48
-#: module/Activity/view/activity/admin-option/index.phtml:98
-#: module/Activity/view/activity/admin-option/index.phtml:138
-#: module/Company/view/company/admin/edit-company.phtml:162
-#: module/Company/view/company/admin/edit-package.phtml:126
-#: module/Company/view/company/admin/index.phtml:204
-#: module/Company/view/company/company-account/jobs.phtml:254
-#: module/Decision/view/decision/admin/document.phtml:150
-#: module/Decision/view/decision/admin/document.phtml:181
-#: module/Education/view/education/admin/course-documents.phtml:92
-#: module/Education/view/education/admin/course-documents.phtml:141
-#: module/Education/view/education/admin/course-documents.phtml:176
-#: module/Education/view/education/admin/course.phtml:70
-#: module/Education/view/education/admin/course.phtml:105
-#: module/Education/view/education/admin/edit-exam.phtml:62
-#: module/Education/view/education/admin/edit-summary.phtml:62
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:88
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:158
-msgid "Delete"
-msgstr "Delete"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:92
-#: module/Activity/view/activity/activity-calendar/index.phtml:145
-#: module/Activity/view/activity/admin-approval/view.phtml:208
-#: module/Decision/view/decision/organ-admin/edit.phtml:181
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:84
-msgid "Approve"
-msgstr "Approve"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:96
-msgid "Modified by"
-msgstr "Modified by"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:110
-msgid "Delete option"
-msgstr "Delete option"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:113
-msgid "Are you sure you want to delete this option?"
-msgstr "Are you sure you want to delete this option?"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:119
-#: module/Activity/view/activity/activity-calendar/index.phtml:143
-#: module/Activity/view/activity/admin-category/index.phtml:64
-#: module/Activity/view/activity/admin-option/index.phtml:135
-#: module/Company/view/company/admin/edit-company.phtml:214
-#: module/Company/view/company/admin/edit-package.phtml:160
-#: module/Company/view/company/admin/index.phtml:244
-#: module/Company/view/company/company-account/jobs.phtml:304
-#: module/Decision/view/decision/admin/document.phtml:178
-#: module/Decision/view/decision/admin/document.phtml:205
-#: module/Decision/view/decision/decision/authorizations.phtml:185
-#: module/Education/view/education/admin/course-documents.phtml:173
-#: module/Education/view/education/admin/course.phtml:102
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:231
-#: module/Photo/view/photo/album-admin/index.phtml:232
-#: module/Photo/view/photo/album-admin/index.phtml:264
-#: module/Photo/view/photo/photo-admin/index.phtml:158
-#: module/User/src/Form/ApiAppAuthorisation.php:26
-msgid "Cancel"
-msgstr "Cancel"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:134
-msgid "Approve option"
-msgstr "Approve option"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:137
-msgid "Are you sure you want to approve this option?"
-msgstr "Are you sure you want to approve this option?"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:180
-msgid "Planned Activities"
-msgstr "Planned Activities"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:181
-#: module/Activity/view/activity/activity/list.phtml:68
-msgid "There are no activities."
-msgstr "There are no activities."
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:194
-msgid "There are no options."
-msgstr "There are no options."
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:236
-msgid "Plan activity"
-msgstr "Plan activity"
-
-#: module/Activity/view/activity/activity/archive.phtml:34
-#: module/Photo/view/photo/photo/index.phtml:36
-msgid "Older"
-msgstr "Older"
-
-#: module/Activity/view/activity/activity/archive.phtml:54
-msgid "There are no activities in the archive."
-msgstr "There are no activities in the archive."
-
-#: module/Activity/view/activity/activity/create.phtml:51
-msgid "Organizer"
-msgstr "Organizer"
-
-#: module/Activity/view/activity/activity/create.phtml:52
-msgid ""
-"Select whether an organ (committee, fraternity, etc.) or a company is "
-"responsible for this activity, or both."
-msgstr ""
-"Select whether an organ (committee, fraternity, etc.) or a company is "
-"responsible for this activity, or both."
-
-#: module/Activity/view/activity/activity/create.phtml:76
-#: module/Activity/view/activity/admin/list.phtml:25
-#: module/Activity/view/activity/admin/view.phtml:74
-#: module/Company/view/company/admin-approval/index.phtml:58
-#: module/Company/view/company/company/job-list.phtml:85
-#: module/User/view/user/user/login.phtml:34
-msgid "Company"
-msgstr "Company"
-
-#: module/Activity/view/activity/activity/create.phtml:87
-#: module/Activity/view/activity/admin/participantsTable.phtml:25
-msgid "Date and time"
-msgstr "Date and time"
-
-#: module/Activity/view/activity/activity/create.phtml:88
-msgid "Enter the start and end date and time of this activity."
-msgstr "Enter the start and end date and time of this activity."
-
-#: module/Activity/view/activity/activity/create.phtml:101
-msgid "Start date and time"
-msgstr "Start date and time"
-
-#: module/Activity/view/activity/activity/create.phtml:116
-msgid "End date and time"
-msgstr "End date and time"
-
-#: module/Activity/view/activity/activity/create.phtml:130
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:263
-#: module/Activity/view/activity/admin-approval/view.phtml:165
-#: module/Activity/view/activity/admin-category/add.phtml:17
-#: module/Activity/view/activity/admin-category/index.phtml:10
-#: module/Activity/view/activity/admin-category/index.phtml:14
-#: module/Activity/view/activity/admin-category/index.phtml:19
-msgid "Activity Categories"
-msgstr "Activity Categories"
-
-#: module/Activity/view/activity/activity/create.phtml:131
-msgid ""
-"Add activity categories to your activity to give potential subscribers a "
-"better understanding of the activity."
-msgstr ""
-"Add activity categories to your activity to give potential subscribers a "
-"better understanding of the activity."
-
-#: module/Activity/view/activity/activity/create.phtml:151
-#: module/Activity/view/activity/admin-category/index.phtml:24
-msgid "There are currently no activity categories..."
-msgstr "There are currently no activity categories..."
-
-#: module/Activity/view/activity/activity/create.phtml:177
-#: module/Activity/view/activity/activity/view.phtml:134
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:290
-#: module/Activity/view/activity/admin-approval/view.phtml:179
-msgid "Sign-up Lists"
-msgstr "Sign-up Lists"
-
-#: module/Activity/view/activity/activity/create.phtml:178
-msgid ""
-"Add sign-up lists to allow people to sign up for this activity. Each list "
-"can have optional fields to collect specific information from the "
-"participants."
-msgstr ""
-"Add sign-up lists to allow people to sign up for this activity. Each list "
-"can have optional fields to collect specific information from the "
-"participants."
-
-#: module/Activity/view/activity/activity/create.phtml:184
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:120
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:300
-#: module/Activity/view/activity/admin-approval/view.phtml:67
-#: module/Activity/view/activity/admin-approval/view.phtml:185
-#: module/Activity/view/activity/admin-category/add.phtml:53
-#: module/Activity/view/partial/create.phtml:30
-#: module/Application/src/Model/Enums/Languages.php:24
-#: module/Company/view/company/admin-approval/job-approval.phtml:106
-#: module/Company/view/company/admin-approval/job-proposal.phtml:146
-#: module/Company/view/partial/company/admin/editors/category.phtml:20
-#: module/Company/view/partial/company/admin/editors/company.phtml:218
-#: module/Company/view/partial/company/admin/editors/job.phtml:146
-#: module/Company/view/partial/company/admin/editors/label.phtml:29
-#: module/Company/view/partial/company/admin/editors/package.phtml:96
-msgid "Dutch"
-msgstr "Dutch"
-
-#: module/Activity/view/activity/activity/create.phtml:189
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:125
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:305
-#: module/Activity/view/activity/admin-approval/view.phtml:72
-#: module/Activity/view/activity/admin-approval/view.phtml:190
-#: module/Activity/view/activity/admin-category/add.phtml:90
-#: module/Activity/view/partial/create.phtml:104
-#: module/Application/src/Model/Enums/Languages.php:23
-#: module/Company/view/company/admin-approval/job-approval.phtml:111
-#: module/Company/view/company/admin-approval/job-proposal.phtml:151
-#: module/Company/view/partial/company/admin/editors/category.phtml:65
-#: module/Company/view/partial/company/admin/editors/company.phtml:279
-#: module/Company/view/partial/company/admin/editors/job.phtml:240
-#: module/Company/view/partial/company/admin/editors/label.phtml:74
-#: module/Company/view/partial/company/admin/editors/package.phtml:128
-msgid "English"
-msgstr "English"
-
-#: module/Activity/view/activity/activity/create.phtml:217
-msgid "Remove the last sign-up list"
-msgstr "Remove the last sign-up list"
-
-#: module/Activity/view/activity/activity/create.phtml:221
-msgid "Add a sign-up list"
-msgstr "Add a sign-up list"
-
-#: module/Activity/view/activity/activity/createSuccess.phtml:15
-msgid "The activity has been successfully created."
-msgstr "The activity has been successfully created."
-
-#: module/Activity/view/activity/activity/createSuccess.phtml:16
-msgid "It will become visible after it has been approved by the board."
-msgstr "It will become visible after it has been approved by the board."
-
-#: module/Activity/view/activity/activity/index.phtml:15
-#: module/Activity/view/activity/activity/index.phtml:21
-#: module/Activity/view/activity/activity/view.phtml:30
-#: module/Activity/view/activity/activity/view.phtml:38
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:24
-#: module/Activity/view/activity/admin-approval/view.phtml:22
-#: module/Activity/view/activity/admin/participants.phtml:22
-#: module/Activity/view/activity/admin/view.phtml:19
-#: module/Application/view/partial/admin.phtml:38
-#: module/Application/view/partial/main-nav.phtml:374
-#: module/Application/view/partial/main-nav.phtml:378
-#: module/Application/view/partial/main-nav.phtml:383
-#: module/Decision/view/decision/member/index.phtml:203
-msgid "Activities"
-msgstr "Activities"
-
-#: module/Activity/view/activity/activity/index.phtml:27
-msgid "All Activities"
-msgstr "All Activities"
-
-#: module/Activity/view/activity/activity/index.phtml:30
-msgid "Career Activities"
-msgstr "Career Activities"
-
-#: module/Activity/view/activity/activity/index.phtml:34
-msgid "My Activities"
-msgstr "My Activities"
-
-#: module/Activity/view/activity/activity/list.phtml:22
-msgid "MMM d"
-msgstr "MMM d"
-
-#: module/Activity/view/activity/activity/list.phtml:46
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:79
-msgid "Continue reading"
-msgstr "Continue reading"
-
-#: module/Activity/view/activity/activity/list.phtml:55
-#: module/Activity/view/activity/activity/view.phtml:96
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:162
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:167
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:179
-#: module/Activity/view/activity/admin-approval/view.phtml:99
-#: module/Activity/view/activity/admin-approval/view.phtml:104
-#: module/Activity/view/activity/admin-approval/view.phtml:111
-#: module/Activity/view/partial/create.phtml:58
-#: module/Activity/view/partial/create.phtml:132
-#: module/Company/src/Form/Job.php:181 module/Company/src/Form/Job.php:191
-#: module/Company/view/company/admin-approval/job-approval.phtml:157
-#: module/Company/view/company/admin-approval/job-approval.phtml:162
-#: module/Company/view/company/admin-approval/job-approval.phtml:169
-#: module/Company/view/company/admin-approval/job-proposal.phtml:209
-#: module/Company/view/company/admin-approval/job-proposal.phtml:214
-#: module/Company/view/company/admin-approval/job-proposal.phtml:224
-#: module/Photo/view/partial/metadata.phtml:82
-msgid "Location"
-msgstr "Location"
-
-#: module/Activity/view/activity/activity/list.phtml:58
-#: module/Activity/view/activity/activity/view.phtml:99
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:191
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:196
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:208
-#: module/Activity/view/activity/admin-approval/view.phtml:118
-#: module/Activity/view/activity/admin-approval/view.phtml:123
-#: module/Activity/view/activity/admin-approval/view.phtml:130
-#: module/Activity/view/partial/create.phtml:72
-#: module/Activity/view/partial/create.phtml:146
-msgid "Costs"
-msgstr "Costs"
-
-#: module/Activity/view/activity/activity/view.phtml:150
-msgid "the organizing party"
-msgstr "the organizing party"
-
-#: module/Activity/view/activity/activity/view.phtml:162
-#, php-format
-msgid ""
-"Please contact %s or the board (%s) with any questions, concerns or if you "
-"are unable to attend after the deadline for unsubscribing has passed. Have "
-"fun!"
-msgstr ""
-"Please contact %s or the board (%s) with any questions, concerns or if you "
-"are unable to attend after the deadline for unsubscribing has passed. Have "
-"fun!"
-
-#: module/Activity/view/activity/activity/view.phtml:165
-#, php-format
-msgid ""
-"Please contact %s or the board (%s) with any questions or concerns. Have fun!"
-msgstr ""
-"Please contact %s or the board (%s) with any questions or concerns. Have fun!"
-
-#: module/Activity/view/activity/activity/view.phtml:180
-#, php-format
-msgid ""
-"This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
-msgstr ""
-"This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
-
-#: module/Activity/view/activity/activity/view.phtml:181
 msgid " <strong>has a limited capacity</strong> and "
 msgstr " <strong>has a limited capacity</strong> and "
 
-#: module/Activity/view/activity/activity/view.phtml:193
-msgid "Already subscribed"
-msgstr "Already subscribed"
-
-#: module/Activity/view/activity/activity/view.phtml:200
-msgid "Subscription closed"
-msgstr "Subscription closed"
-
-#: module/Activity/view/activity/activity/view.phtml:206
-msgid "Subscribe now"
-msgstr "Subscribe now"
-
-#: module/Activity/view/activity/activity/view.phtml:213
-msgid "Unsubscribe yourself"
-msgstr "Unsubscribe yourself"
-
-#: module/Activity/view/activity/activity/view.phtml:216
-msgid "You are not allowed to unsubscribe after the deadline!"
-msgstr "You are not allowed to unsubscribe after the deadline!"
-
-#: module/Activity/view/activity/activity/view.phtml:235
-#: module/Activity/view/activity/activity/view.phtml:252
-msgid "Subscribe yourself"
-msgstr "Subscribe yourself"
-
-#: module/Activity/view/activity/activity/view.phtml:238
-msgid "Login to subscribe"
-msgstr "Login to subscribe"
-
-#: module/Activity/view/activity/activity/view.phtml:242
-msgid "Or subscribe without a GEWIS membership: "
-msgstr "Or subscribe without a GEWIS membership: "
-
-#: module/Activity/view/activity/activity/view.phtml:263
-msgid "Current subscriptions"
-msgstr "Current subscriptions"
-
-#: module/Activity/view/activity/activity/view.phtml:281
-#, php-format
-msgid "The number of subscribed members is currently %d."
-msgstr "The number of subscribed members is currently %d."
-
-#: module/Activity/view/activity/activity/view.phtml:285
-msgid "Login to view the subscribed members."
-msgstr "Login to view the subscribed members."
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:21
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:31
-msgid "Update Proposal"
-msgstr "Update Proposal"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:56
-#: module/Activity/view/activity/admin-approval/view.phtml:33
-#: module/Activity/view/partial/create.phtml:16
-#: module/Company/view/company/admin-approval/job-approval.phtml:30
-#: module/Company/view/company/admin-approval/job-proposal.phtml:54
-#: module/Company/view/partial/company/admin/editors/category.phtml:16
-#: module/Company/view/partial/company/admin/editors/company.phtml:204
-#: module/Company/view/partial/company/admin/editors/job.phtml:132
-#: module/Company/view/partial/company/admin/editors/label.phtml:16
-#: module/Company/view/partial/company/admin/editors/package.phtml:18
-#: module/Photo/view/photo/album/index.phtml:519
-msgid "Information"
-msgstr "Information"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:60
-#, php-format
-msgid ""
-"Changes in activity attributes are shown like this: %s. If there are no "
-"changes to a certain attribute, you will see the existing data. Sign-up list "
-"differences are <strong>not</strong> shown with colours, both the old sign-"
-"up list(s) and the new sign-up list(s) are shown. There might not be "
-"difference between the two!"
-msgstr ""
-"Changes in activity attributes are shown like this: %s. If there are no "
-"changes to a certain attribute, you will see the existing data. Sign-up list "
-"differences are <strong>not</strong> shown with colours, both the old sign-"
-"up list(s) and the new sign-up list(s) are shown. There might not be "
-"difference between the two!"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
-#: module/Company/view/company/admin-approval/job-proposal.phtml:62
-msgid "new"
-msgstr "new"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
-#: module/Company/view/company/admin-approval/job-proposal.phtml:62
-msgid "old"
-msgstr "old"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:73
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:89
-#: module/Activity/view/activity/admin-approval/view.phtml:42
-#: module/Activity/view/partial/signupForm.phtml:86
-#: module/Photo/view/partial/tags.phtml:52
-#: module/Photo/view/photo/album/index.phtml:342
-#: module/Photo/view/photo/album/index.phtml:687
-msgid "and"
-msgstr "and"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:100
-#: module/Activity/view/activity/admin-approval/view.phtml:53
-#, php-format
-msgid ""
-"This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
-"it will start on <strong>%s</strong> and end on <strong>%s</strong>."
-msgstr ""
-"This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
-"it will start on <strong>%s</strong> and end on <strong>%s</strong>."
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:113
-#: module/Activity/view/activity/admin-approval/view.phtml:60
-msgid "More information about this activity is available below."
-msgstr "More information about this activity is available below."
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:250
-msgid "View details of the old activity"
-msgstr "View details of the old activity"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:255
-msgid "View details of the new activity"
-msgstr "View details of the new activity"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:314
-#: module/Activity/view/activity/admin-approval/view.phtml:19
-#: module/Activity/view/activity/admin-approval/view.phtml:29
-#: module/Activity/view/activity/admin-approval/view.phtml:198
-#: module/Company/view/company/admin-approval/job-approval.phtml:21
-#: module/Company/view/company/admin-approval/job-approval.phtml:238
-#: module/Company/view/company/admin-approval/job-proposal.phtml:23
-#: module/Company/view/company/admin-approval/job-proposal.phtml:333
-msgid "Approval"
-msgstr "Approval"
-
-#: module/Activity/view/activity/admin-approval/view.phtml:157
-msgid "View details / subscriptions"
-msgstr "View details / subscriptions"
-
-#: module/Activity/view/activity/admin-approval/view.phtml:220
-msgid "Disapprove"
-msgstr "Disapprove"
-
-#: module/Activity/view/activity/admin-approval/view.phtml:230
-#, php-format
-msgid "This activity was approved by <strong>%s</strong>."
-msgstr "This activity was approved by <strong>%s</strong>."
-
-#: module/Activity/view/activity/admin-approval/view.phtml:252
-#, php-format
-msgid "This activity was disapproved by <strong>%s</strong>."
-msgstr "This activity was disapproved by <strong>%s</strong>."
-
-#: module/Activity/view/activity/admin-category/add.phtml:50
-#: module/Activity/view/partial/create.phtml:27
-#: module/Application/src/Form/Localisable.php:32
-msgid "Enable Dutch Translations"
-msgstr "Enable Dutch Translations"
-
-#: module/Activity/view/activity/admin-category/add.phtml:87
-#: module/Activity/view/partial/create.phtml:101
-#: module/Application/src/Form/Localisable.php:44
-msgid "Enable English Translations"
-msgstr "Enable English Translations"
-
-#: module/Activity/view/activity/admin-category/index.phtml:20
-msgid ""
-"Here you can add, edit, or remove activity categories. Click on 'Add "
-"Category' to add a new category or click on a category to edit/remove it."
-msgstr ""
-"Here you can add, edit, or remove activity categories. Click on 'Add "
-"Category' to add a new category or click on a category to edit/remove it."
-
-#: module/Activity/view/activity/admin-category/index.phtml:42
-#: module/Company/view/company/admin/categories.phtml:17
-msgid "Add Category"
-msgstr "Add Category"
-
-#: module/Activity/view/activity/admin-category/index.phtml:53
-#: module/Company/view/company/admin/edit-company.phtml:203
-#: module/Company/view/company/admin/edit-package.phtml:151
-#: module/Company/view/company/admin/index.phtml:231
-#: module/Company/view/company/company-account/jobs.phtml:294
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:175
-#: module/Photo/view/photo/album-admin/index.phtml:213
-#: module/Photo/view/photo/album-admin/index.phtml:245
-#: module/Photo/view/photo/photo-admin/index.phtml:139
-msgid "Delete confirmation"
-msgstr "Delete confirmation"
-
-#: module/Activity/view/activity/admin-category/index.phtml:56
-msgid "Are you sure you want to delete this activity category?"
-msgstr "Are you sure you want to delete this activity category?"
-
-#: module/Activity/view/activity/admin-category/index.phtml:62
-msgid "Delete Activity Category"
-msgstr "Delete Activity Category"
-
-#: module/Activity/view/activity/admin-option/add.phtml:16
-#: module/Activity/view/activity/admin-option/index.phtml:13
-#: module/Application/view/partial/admin.phtml:62
-msgid "Option Calendar"
-msgstr "Option Calendar"
-
-#: module/Activity/view/activity/admin-option/add.phtml:25
-#: module/Activity/view/activity/admin-option/index.phtml:23
-#: module/Activity/view/activity/admin-option/index.phtml:65
-msgid "Planning Period"
-msgstr "Planning Period"
-
-#: module/Activity/view/activity/admin-option/add.phtml:26
-msgid "Enter the start and end date and time of the planning period."
-msgstr "Enter the start and end date and time of the planning period."
-
-#: module/Activity/view/activity/admin-option/add.phtml:65
-#: module/Activity/view/activity/admin-option/index.phtml:24
-#: module/Activity/view/activity/admin-option/index.phtml:66
-msgid "Option Period"
-msgstr "Option Period"
-
-#: module/Activity/view/activity/admin-option/add.phtml:66
-msgid "Enter the start and end date and time of the option period."
-msgstr "Enter the start and end date and time of the option period."
-
-#: module/Activity/view/activity/admin-option/add.phtml:105
-msgid "Max Activities"
-msgstr "Max Activities"
-
-#: module/Activity/view/activity/admin-option/add.phtml:106
-msgid ""
-"Enter the maximum number of activities for which options can be created. You "
-"can either set the number globally or individually for each organ."
-msgstr ""
-"Enter the maximum number of activities for which options can be created. You "
-"can either set the number globally or individually for each organ."
-
-#: module/Activity/view/activity/admin-option/add.phtml:113
-msgid "Global Value"
-msgstr "Global Value"
-
-#: module/Activity/view/activity/admin-option/index.phtml:14
-#: module/Activity/view/activity/admin/view.phtml:20
-#: module/Application/view/partial/admin.phtml:43
-msgid "Overview"
-msgstr "Overview"
-
-#: module/Activity/view/activity/admin-option/index.phtml:18
-msgid "Active Option Planning Periods"
-msgstr "Active Option Planning Periods"
-
-#: module/Activity/view/activity/admin-option/index.phtml:25
-#: module/Activity/view/activity/admin-option/index.phtml:67
-#: module/Company/view/company/admin-approval/index.phtml:31
-#: module/Company/view/company/admin-approval/index.phtml:59
-#: module/Company/view/company/admin/edit-company.phtml:116
-#: module/Company/view/company/admin/edit-package.phtml:86
-#: module/Company/view/company/admin/index.phtml:177
-#: module/Company/view/company/admin/index.phtml:218
-#: module/Company/view/company/company-account/jobs.phtml:66
-#: module/Company/view/company/company-account/jobs.phtml:199
-#: module/Education/view/education/admin/course-documents.phtml:74
-#: module/Education/view/education/admin/course-documents.phtml:125
-#: module/Education/view/education/admin/course.phtml:47
-msgid "Actions"
-msgstr "Actions"
-
-#: module/Activity/view/activity/admin-option/index.phtml:56
-msgid "There is currently no option creation period planned."
-msgstr "There is currently no option creation period planned."
-
-#: module/Activity/view/activity/admin-option/index.phtml:60
-msgid "Planned Option Planning Periods"
-msgstr "Planned Option Planning Periods"
-
-#: module/Activity/view/activity/admin-option/index.phtml:94
-#: module/Activity/view/activity/admin/list.phtml:63
-#: module/Company/view/company/admin/edit-company.phtml:157
-#: module/Company/view/company/admin/edit-package.phtml:122
-#: module/Company/view/company/company-account/jobs.phtml:245
-#: module/Decision/view/decision/organ-admin/edit.phtml:49
-#: module/Education/view/education/admin/course-documents.phtml:34
-#: module/Education/view/education/admin/course.phtml:65
-#: module/Education/view/education/admin/edit-course.phtml:24
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:40
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:38
-msgid "Edit"
-msgstr "Edit"
-
-#: module/Activity/view/activity/admin-option/index.phtml:106
-msgid "There are no planned option creation periods in the future."
-msgstr "There are no planned option creation periods in the future."
-
-#: module/Activity/view/activity/admin-option/index.phtml:125
-msgid "Delete period"
-msgstr "Delete period"
-
-#: module/Activity/view/activity/admin-option/index.phtml:129
-msgid ""
-"Are you sure you want to delete this option planning period? This will "
-"<strong>not</strong> delete proposed options."
-msgstr ""
-"Are you sure you want to delete this option planning period? This will "
-"<strong>not</strong> delete proposed options."
-
-#: module/Activity/view/activity/admin/list.phtml:21
-#: module/Activity/view/activity/admin/view.phtml:70
-msgid "Dutch name"
-msgstr "Dutch name"
-
-#: module/Activity/view/activity/admin/list.phtml:22
-#: module/Activity/view/activity/admin/view.phtml:71
-msgid "English name"
-msgstr "English name"
-
-#: module/Activity/view/activity/admin/list.phtml:23
-#: module/Activity/view/activity/admin/view.phtml:72
-#: module/Company/view/company/admin/edit-company.phtml:107
-#: module/Company/view/company/company-account/jobs.phtml:57
-#: module/Photo/src/Form/EditAlbum.php:37
-msgid "Start date"
-msgstr "Start date"
-
-#: module/Activity/view/activity/admin/list.phtml:24
-#: module/Activity/view/activity/admin/view.phtml:73
-msgid "Organ"
-msgstr "Organ"
-
-#: module/Activity/view/activity/admin/list.phtml:26
-#: module/Activity/view/activity/admin/view.phtml:75
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:42
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:115
-msgid "Submitter"
-msgstr "Submitter"
-
-#: module/Activity/view/activity/admin/list.phtml:27
-msgid "Update status"
-msgstr "Update status"
-
-#: module/Activity/view/activity/admin/list.phtml:29
-#: module/Company/view/company/admin/edit-package.phtml:85
-msgid "Approved"
-msgstr "Approved"
-
-#: module/Activity/view/activity/admin/list.phtml:45
-#: module/Activity/view/activity/admin/list.phtml:46
-#: module/Activity/view/activity/admin/view.phtml:91
-#: module/Activity/view/activity/admin/view.phtml:92
-#: module/Education/view/education/education/index.phtml:112
-msgid "None"
-msgstr "None"
-
-#: module/Activity/view/activity/admin/list.phtml:50
-#: module/Activity/view/activity/admin/list.phtml:52
-msgid "Update pending"
-msgstr "Update pending"
-
-#: module/Activity/view/activity/admin/list.phtml:71
-#: module/Activity/view/activity/admin/participants.phtml:19
-#: module/Activity/view/activity/admin/participants.phtml:29
-#: module/Activity/view/activity/admin/participants.phtml:61
-#: module/Activity/view/activity/admin/view.phtml:97
-msgid "Participants"
-msgstr "Participants"
-
-#: module/Activity/view/activity/admin/participants.phtml:41
-msgid "General"
-msgstr "General"
-
-#: module/Activity/view/activity/admin/participants.phtml:55
-msgid ""
-"Here you can find everyone who signed up for this activity (may contain "
-"duplicates). Using the tabs above you can navigate to the different sign-up "
-"lists of this activity. From there you can remove external participants and "
-"(when supplied) view additional signup information from each participant."
-msgstr ""
-"Here you can find everyone who signed up for this activity (may contain "
-"duplicates). Using the tabs above you can navigate to the different sign-up "
-"lists of this activity. From there you can remove external participants and "
-"(when supplied) view additional signup information from each participant."
-
-#: module/Activity/view/activity/admin/participants.phtml:57
-msgid ""
-"Here you can find everyone who signed up to this sign-up list. Here you can "
-"add or remove external participants and view detailed information regarding "
-"the signup of all participants."
-msgstr ""
-"Here you can find everyone who signed up to this sign-up list. Here you can "
-"add or remove external participants and view detailed information regarding "
-"the signup of all participants."
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:21
-#: module/Decision/src/Form/OrganInformation.php:32
-#: module/Decision/view/decision/member/self.phtml:49
-#: module/Decision/view/decision/member/view.phtml:33
-#: module/Frontpage/view/frontpage/organ/organ.phtml:99
-msgid "Email"
-msgstr "Email"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:23
-#: module/Decision/view/decision/member/self.phtml:64
-#: module/Decision/view/decision/member/view.phtml:49
-msgid "Generation"
-msgstr "Generation"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:28
-msgid "Sign-up List"
-msgstr "Sign-up List"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:70
-#: module/Decision/view/decision/member/self.phtml:55
-#: module/Decision/view/decision/member/view.phtml:39
-#: module/Photo/view/partial/metadata.phtml:21
-#: module/Photo/view/partial/metadata.phtml:28
-#: module/Photo/view/partial/metadata.phtml:49
-#: module/Photo/view/partial/metadata.phtml:56
-#: module/Photo/view/partial/metadata.phtml:63
-#: module/Photo/view/partial/metadata.phtml:70
-#: module/Photo/view/partial/metadata.phtml:77
-#: module/Photo/view/partial/metadata.phtml:86
-msgid "Unknown"
-msgstr "Unknown"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:76
-#, php-format
-msgid "User (%s)"
-msgstr "User (%s)"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:83
-#: module/Decision/src/Model/Enums/MembershipTypes.php:23
-msgid "External"
-msgstr "External"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:96
-#: module/Education/view/education/admin/course-documents.phtml:133
-msgid "N/A"
-msgstr "N/A"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:116
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
-#: module/Application/language/additional-strings:20
-#: module/Company/view/company/admin/edit-company.phtml:126
-#: module/Company/view/company/admin/edit-package.phtml:92
-#: module/Company/view/company/admin/index.phtml:197
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:214
-#: module/Company/view/company/company-account/jobs.phtml:222
-#: module/Decision/view/decision/member/view.phtml:59
-#: module/Photo/view/partial/metadata.phtml:42
-msgid "Yes"
-msgstr "Yes"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:118
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
-#: module/Application/language/additional-strings:21
-#: module/Company/view/company/admin/edit-company.phtml:126
-#: module/Company/view/company/admin/edit-package.phtml:92
-#: module/Company/view/company/admin/index.phtml:197
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:214
-#: module/Decision/view/decision/member/view.phtml:59
-#: module/Photo/view/partial/metadata.phtml:42
-msgid "No"
-msgstr "No"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:141
-msgid "Additional actions"
-msgstr "Additional actions"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:145
-msgid "Mail everybody"
-msgstr "Mail everybody"
-
-#: module/Activity/view/activity/admin/view.phtml:24
-msgid "Unapproved Activities"
-msgstr "Unapproved Activities"
-
-#: module/Activity/view/activity/admin/view.phtml:31
-msgid "Approved Activities"
-msgstr "Approved Activities"
-
-#: module/Activity/view/activity/admin/view.phtml:38
-msgid "Disapproved Activities"
-msgstr "Disapproved Activities"
-
-#: module/Activity/view/activity/admin/view.phtml:46
-msgid "Upcoming Activities"
-msgstr "Upcoming Activities"
-
-#: module/Activity/view/activity/admin/view.phtml:53
-msgid "Old activities"
-msgstr "Old activities"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:37
-#: module/Activity/view/partial/signuplist.phtml:25
-msgid "Open date and time"
-msgstr "Open date and time"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:48
-#: module/Activity/view/partial/signuplist.phtml:39
-msgid "Close date and time"
-msgstr "Close date and time"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:59
-msgid "GEWIS members only"
-msgstr "GEWIS members only"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:70
-msgid "Display GEWIS member count"
-msgstr "Display GEWIS member count"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:81
-#: module/Activity/view/partial/signuplist.phtml:120
-msgid "Has limited capacity"
-msgstr "Has limited capacity"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:93
-msgid ""
-"This sign-up list contains additional fields which require input from "
-"subscribers, they are shown below."
-msgstr ""
-"This sign-up list contains additional fields which require input from "
-"subscribers, they are shown below."
-
-#: module/Activity/view/partial/create.phtml:17
-msgid ""
-"What is this activity about? Fill in the blanks below, please note that at "
-"least one language must be used."
-msgstr ""
-"What is this activity about? Fill in the blanks below, please note that at "
-"least one language must be used."
-
-#: module/Activity/view/partial/create.phtml:171
-msgid "Choose which options are applicable to this activity."
-msgstr "Choose which options are applicable to this activity."
-
-#: module/Activity/view/partial/create.phtml:181
-msgid "This is a career related activity"
-msgstr "This is a career related activity"
-
-#: module/Activity/view/partial/create.phtml:183
-msgid ""
-"If this is checked the My Future logo will be displayed on the activity page "
-"and the activity will be included on the career activities page."
-msgstr ""
-"If this is checked the My Future logo will be displayed on the activity page "
-"and the activity will be included on the career activities page."
-
-#: module/Activity/view/partial/create.phtml:195
-msgid "This activity needs a GEFLITST member to take photos"
-msgstr "This activity needs a GEFLITST member to take photos"
-
-#: module/Activity/view/partial/create.phtml:197
-msgid ""
-"When this is checked, GEFLITST will be notified that this activity needs a "
-"photographer."
-msgstr ""
-"When this is checked, GEFLITST will be notified that this activity needs a "
-"photographer."
-
-#: module/Activity/view/partial/option.phtml:33
-msgid "From"
-msgstr "From"
-
-#: module/Activity/view/partial/option.phtml:47
-msgid "Until"
-msgstr "Until"
-
-#: module/Activity/view/partial/signupForm.phtml:21
-#: module/Activity/view/partial/signupForm.phtml:26
-msgid "By subscribing to this activity, you agree to the terms outlined in the"
-msgstr ""
-"By subscribing to this activity, you agree to the terms outlined in the"
-
-#: module/Activity/view/partial/signupForm.phtml:23
-msgid "Confirm subscription"
-msgstr "Confirm subscription"
-
-#: module/Activity/view/partial/signupForm.phtml:28
-msgid "Subscribe as external participant"
-msgstr "Subscribe as external participant"
-
-#: module/Activity/view/partial/signupForm.phtml:33
-msgid ""
-"By subscribing an external participant to this activity, they must agree to "
-"the terms outlined in the"
-msgstr ""
-"By subscribing an external participant to this activity, they must agree to "
-"the terms outlined in the"
-
-#: module/Activity/view/partial/signupForm.phtml:35
-msgid "Subscribe an external participant"
-msgstr "Subscribe an external participant"
-
-#: module/Activity/view/partial/signupForm.phtml:67
-msgid "Full name:"
-msgstr "Full name:"
-
-#: module/Activity/view/partial/signupForm.phtml:68
-msgid "Email address:"
-msgstr "Email address:"
-
-#: module/Activity/view/partial/signupForm.phtml:72
-msgid "Please fill in this CAPTCHA:"
-msgstr "Please fill in this CAPTCHA:"
-
-#: module/Activity/view/partial/signupForm.phtml:86
-#: module/Decision/view/decision/member/index.phtml:254
-msgid "Activity Policy"
-msgstr "Activity Policy"
-
-#: module/Activity/view/partial/signupForm.phtml:88
-#: module/Decision/view/decision/member/index.phtml:259
-msgid "Alcohol Policy"
-msgstr "Alcohol Policy"
-
-#: module/Activity/view/partial/signuplist-fields.phtml:95
-msgid "Please note that numbers are not dependant on the selected language(s)."
-msgstr ""
-"Please note that numbers are not dependant on the selected language(s)."
-
-#: module/Activity/view/partial/signuplist.phtml:88
-msgid "Only allow GEWIS members"
-msgstr "Only allow GEWIS members"
-
-#: module/Activity/view/partial/signuplist.phtml:90
-msgid "Deselect this to allow people without a GEWIS account to subscribe."
-msgstr "Deselect this to allow people without a GEWIS account to subscribe."
-
-#: module/Activity/view/partial/signuplist.phtml:103
-msgid "Display number of subscribed members"
-msgstr "Display number of subscribed members"
-
-#: module/Activity/view/partial/signuplist.phtml:105
-msgid ""
-"Select this to display the number of subscribed GEWIS members to external "
-"visitors."
-msgstr ""
-"Select this to display the number of subscribed GEWIS members to external "
-"visitors."
-
-#: module/Activity/view/partial/signuplist.phtml:122
-msgid ""
-"Select this if this sign-up list has limited capacity or is expected to have "
-"limited capacity. Please ensure that you also write this in the description "
-"of the activity."
-msgstr ""
-"Select this if this sign-up list has limited capacity or is expected to have "
-"limited capacity. Please ensure that you also write this in the description "
-"of the activity."
-
-#: module/Activity/view/partial/signuplist.phtml:153
-msgid "Remove the last sign-up list field"
-msgstr "Remove the last sign-up list field"
-
-#: module/Activity/view/partial/signuplist.phtml:158
-msgid "Add a sign-up list field"
-msgstr "Add a sign-up list field"
-
-#: module/Application/language/additional-strings:1
-msgid "Lid"
-msgstr "Member"
-
-#: module/Application/language/additional-strings:2
-msgid "Brand Manager"
-msgstr "Brand Manager"
-
-#: module/Application/language/additional-strings:3
-msgid "Commissaris Carrièreontwikkeling en Externe Betrekkingen"
-msgstr "Career Development and External Affairs Officer"
-
-#: module/Application/language/additional-strings:4
-msgid "Commissaris Externe Betrekkingen"
-msgstr "External Affairs Officer"
-
-#: module/Application/language/additional-strings:5
-msgid "Commissaris Innovatie"
-msgstr "Innovation Officer"
-
-#: module/Application/language/additional-strings:6
-msgid "Commissaris Interne Betrekkingen"
-msgstr "Internal Affairs Officer"
-
-#: module/Application/language/additional-strings:7
-msgid "Commissaris Kennisbeheer"
-msgstr "Information Officer"
-
-#: module/Application/language/additional-strings:8
-msgid "Commissaris Onderwijs"
-msgstr "Educational Officer"
-
-#: module/Application/language/additional-strings:9
-msgid "Digital Infrastructure Officer"
-msgstr "Digital Infrastructure Officer"
-
-#: module/Application/language/additional-strings:10
-msgid "Onderwijscommissaris"
-msgstr "Educational Officer"
-
-#: module/Application/language/additional-strings:11
-msgid "Penningmeester"
-msgstr "Treasurer"
-
-#: module/Application/language/additional-strings:12
-msgid "PR-Functionaris"
-msgstr "PR-Functionaris"
-
-#: module/Application/language/additional-strings:13
-msgid "Secretaris"
-msgstr "Secretary"
-
-#: module/Application/language/additional-strings:14
-msgid "Vicevoorzitter"
-msgstr "Vice-Chair"
-
-#: module/Application/language/additional-strings:15
-msgid "Vice-Voorzitter"
-msgstr "Vice-Chair"
-
-#: module/Application/language/additional-strings:16
-msgid "Voorzitter"
-msgstr "Chair"
-
-#: module/Application/language/additional-strings:17
-msgid "Tafelvoetbalcoordinator"
-msgstr "Tafelvoetbalcoordinator"
-
-#: module/Application/language/additional-strings:18
-msgid "Inkoper"
-msgstr "Inkoper"
-
-#: module/Application/language/additional-strings:19
-msgid "Inactief Lid"
-msgstr "Inactive Member"
-
-#: module/Application/src/Service/FileStorage.php:91
-msgid "An unknown error occurred during uploading (%i)"
-msgstr "An unknown error occurred during uploading (%i)"
-
-#: module/Application/src/Service/Infimum.php:66
-#: module/Application/view/partial/footer.phtml:36
-#: module/Application/view/partial/footer.phtml:41
-msgid "Unable to retrieve infimum."
-msgstr "Unable to retrieve infimum."
-
-#: module/Application/view/error/403.phtml:17
-msgid "You do not have the required privileges to view this page"
-msgstr "You do not have the required privileges to view this page"
-
-#: module/Application/view/error/403.phtml:22
-msgid "You might be able to view this page by logging in"
-msgstr "You might be able to view this page by logging in"
-
-#: module/Application/view/error/403.phtml:28
-#: module/Application/view/partial/admin.phtml:28
-#: module/Application/view/partial/main-nav.phtml:87
-#: module/User/view/user/user/login.phtml:39
-msgid "Login"
-msgstr "Login"
-
-#: module/Application/view/error/404.phtml:12
-#: module/Application/view/error/debug/404.phtml:12
-msgid "A 404 error occurred"
-msgstr "A 404 error occurred"
-
-#: module/Application/view/error/500.phtml:12
-#: module/Application/view/error/debug/500.phtml:13
-msgid "An error occurred"
-msgstr "An error occurred"
-
-#: module/Application/view/error/500.phtml:13
-msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
-msgstr "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
-
-#: module/Application/view/error/debug/403.phtml:12
-msgid "403 Forbidden"
-msgstr "403 Forbidden"
-
-#: module/Application/view/error/debug/404.phtml:22
-msgid "The requested controller was unable to dispatch the request."
-msgstr "The requested controller was unable to dispatch the request."
-
-#: module/Application/view/error/debug/404.phtml:26
-msgid ""
-"The requested controller could not be mapped to an existing controller class."
-msgstr ""
-"The requested controller could not be mapped to an existing controller class."
-
-#: module/Application/view/error/debug/404.phtml:30
-msgid "The requested controller was not dispatchable."
-msgstr "The requested controller was not dispatchable."
-
-#: module/Application/view/error/debug/404.phtml:33
-msgid "The requested URL could not be matched by routing."
-msgstr "The requested URL could not be matched by routing."
-
-#: module/Application/view/error/debug/404.phtml:36
-msgid "We cannot determine at this time why a 404 was generated."
-msgstr "We cannot determine at this time why a 404 was generated."
-
-#: module/Application/view/error/debug/404.phtml:50
-msgid "Controller"
-msgstr "Controller"
-
-#: module/Application/view/error/debug/404.phtml:58
-#, php-format
-msgid "resolves to %s"
-msgstr "resolves to %s"
-
-#: module/Application/view/error/debug/404.phtml:75
-#: module/Application/view/error/debug/500.phtml:24
-msgid "Additional information"
-msgstr "Additional information"
-
-#: module/Application/view/error/debug/404.phtml:78
-#: module/Application/view/error/debug/404.phtml:104
-#: module/Application/view/error/debug/500.phtml:29
-#: module/Application/view/error/debug/500.phtml:69
-msgid "File"
-msgstr "File"
-
-#: module/Application/view/error/debug/404.phtml:83
-#: module/Application/view/error/debug/404.phtml:109
-#: module/Application/view/error/debug/500.phtml:38
-#: module/Application/view/error/debug/500.phtml:78
-msgid "Message"
-msgstr "Message"
-
-#: module/Application/view/error/debug/404.phtml:87
-#: module/Application/view/error/debug/404.phtml:113
-#: module/Application/view/error/debug/500.phtml:46
-#: module/Application/view/error/debug/500.phtml:86
-msgid "Stack trace"
-msgstr "Stack trace"
-
-#: module/Application/view/error/debug/404.phtml:97
-#: module/Application/view/error/debug/500.phtml:60
-msgid "Previous exceptions"
-msgstr "Previous exceptions"
-
-#: module/Application/view/error/debug/404.phtml:130
-#: module/Application/view/error/debug/500.phtml:107
-msgid "No Exception available"
-msgstr "No Exception available"
-
-#: module/Application/view/layout/layout.phtml:15
-msgid "Study Association GEWIS"
-msgstr "Study Association GEWIS"
-
-#: module/Application/view/partial/admin.phtml:50
-#: module/Application/view/partial/admin.phtml:105
-#: module/Company/view/company/admin/categories.phtml:23
-#: module/Company/view/company/admin/categories.phtml:43
-msgid "Categories"
-msgstr "Categories"
-
-#: module/Application/view/partial/admin.phtml:76
-#: module/Application/view/partial/main-nav.phtml:326
-#: module/Application/view/partial/main-nav.phtml:330
-#: module/Application/view/partial/main-nav.phtml:335
-#: module/Company/view/company/admin-approval/index.phtml:19
-#: module/Company/view/company/admin-approval/job-approval.phtml:24
-#: module/Company/view/company/admin-approval/job-proposal.phtml:26
-#: module/Company/view/company/admin/edit-company.phtml:19
-#: module/Company/view/company/admin/index.phtml:20
-msgid "Career"
-msgstr "Career"
-
-#: module/Application/view/partial/admin.phtml:83
-#: module/Company/view/company/admin/index.phtml:21
-#: module/Company/view/company/company/job-list.phtml:36
-#: module/Company/view/company/company/jobs.phtml:34
-#: module/Company/view/company/company/list.phtml:21
-#: module/Company/view/company/company/show.phtml:17
-#: module/Company/view/company/company/show.phtml:24
-#: module/Company/view/company/company/spotlight.phtml:33
-msgid "Companies"
-msgstr "Companies"
-
-#: module/Application/view/partial/admin.phtml:96
-#: module/Company/view/company/admin-approval/index.phtml:20
-#: module/Company/view/company/admin-approval/job-approval.phtml:25
-msgid "Approvals"
-msgstr "Approvals"
-
-#: module/Application/view/partial/admin.phtml:114
-#: module/Company/src/Form/Job.php:241
-#: module/Company/view/company/admin-approval/job-approval.phtml:224
-#: module/Company/view/company/admin/labels.phtml:23
-#: module/Company/view/company/admin/labels.phtml:42
-msgid "Labels"
-msgstr "Labels"
-
-#: module/Application/view/partial/admin.phtml:128
-#: module/Application/view/partial/main-nav.phtml:368
-#: module/Education/view/education/admin/add-course.phtml:15
-#: module/Education/view/education/admin/bulk-exam.phtml:19
-#: module/Education/view/education/admin/bulk-summary.phtml:19
-#: module/Education/view/education/admin/course-documents.phtml:27
-#: module/Education/view/education/admin/course.phtml:17
-#: module/Education/view/education/admin/edit-course.phtml:17
-#: module/Education/view/education/admin/edit-exam.phtml:31
-#: module/Education/view/education/admin/edit-summary.phtml:31
-#: module/Education/view/education/admin/index.phtml:11
-#: module/Education/view/education/education/course.phtml:21
-#: module/Education/view/education/education/index.phtml:16
-#: module/Education/view/education/education/index.phtml:31
-msgid "Education"
-msgstr "Education"
-
-#: module/Application/view/partial/admin.phtml:133
-#: module/Education/view/education/admin/add-course.phtml:16
-#: module/Education/view/education/admin/course-documents.phtml:28
-#: module/Education/view/education/admin/course.phtml:18
-#: module/Education/view/education/admin/edit-course.phtml:18
-msgid "Courses"
-msgstr "Courses"
-
-#: module/Application/view/partial/admin.phtml:138
-#: module/Education/view/education/admin/bulk-exam.phtml:24
-msgid "Upload exams"
-msgstr "Upload exams"
-
-#: module/Application/view/partial/admin.phtml:143
-#: module/Education/view/education/admin/bulk-summary.phtml:24
-msgid "Upload summaries"
-msgstr "Upload summaries"
-
-#: module/Application/view/partial/admin.phtml:155
-#: module/Decision/view/decision/admin/authorizations.phtml:14
-#: module/Decision/view/decision/admin/document.phtml:29
-#: module/Decision/view/decision/admin/minutes.phtml:15
-#: module/Decision/view/decision/decision/index.phtml:17
-#: module/Decision/view/decision/member/index.phtml:100
-msgid "Meetings"
-msgstr "Meetings"
-
-#: module/Application/view/partial/admin.phtml:160
-#: module/Decision/view/decision/admin/minutes.phtml:16
-#: module/Decision/view/decision/decision/view.phtml:53
-msgid "Minutes"
-msgstr "Minutes"
-
-#: module/Application/view/partial/admin.phtml:165
-#: module/Decision/view/decision/admin/document.phtml:30
-#: module/Decision/view/decision/decision/view.phtml:31
-#: module/Education/view/education/admin/course.phtml:60
-msgid "Documents"
-msgstr "Documents"
-
-#: module/Application/view/partial/admin.phtml:170
-#: module/Decision/view/decision/admin/authorizations.phtml:15
-#: module/Decision/view/decision/decision/authorizations.phtml:27
-#: module/Decision/view/decision/decision/authorizations.phtml:34
-#: module/Decision/view/decision/member/index.phtml:61
-msgid "Authorizations"
-msgstr "Authorizations"
-
-#: module/Application/view/partial/admin.phtml:181
-#: module/Decision/view/decision/member/index.phtml:73
-#: module/Decision/view/decision/organ-admin/edit.phtml:48
-#: module/Decision/view/decision/organ-admin/index.phtml:15
-msgid "Organs"
-msgstr "Organs"
-
-#: module/Application/view/partial/admin.phtml:189
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:54
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:39
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:14
-msgid "News"
-msgstr "News"
-
-#: module/Application/view/partial/admin.phtml:196
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:23
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:25
-msgid "Pages"
-msgstr "Pages"
-
-#: module/Application/view/partial/admin.phtml:203
-#: module/Application/view/partial/main-nav.phtml:434
-#: module/Application/view/partial/main-nav.phtml:438
-#: module/Application/view/partial/main-nav.phtml:443
-#: module/Application/view/partial/main-nav.phtml:452
-#: module/Photo/view/photo/album-admin/add.phtml:33
-#: module/Photo/view/photo/album-admin/create.phtml:15
-#: module/Photo/view/photo/album-admin/edit.phtml:15
-#: module/Photo/view/photo/album-admin/index.phtml:33
-#: module/Photo/view/photo/album/index.phtml:29
-#: module/Photo/view/photo/album/index.phtml:69
-#: module/Photo/view/photo/photo-admin/index.phtml:38
-#: module/Photo/view/photo/photo/index.phtml:15
-msgid "Photos"
-msgstr "Photos"
-
-#: module/Application/view/partial/admin.phtml:210
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:32
-#: module/Frontpage/view/frontpage/poll/index.phtml:22
-#: module/Frontpage/view/frontpage/poll/index.phtml:30
-msgid "Polls"
-msgstr "Polls"
-
-#: module/Application/view/partial/admin.phtml:219
-msgid "Users"
-msgstr "Users"
-
-#: module/Application/view/partial/admin.phtml:224
-msgid "API Users"
-msgstr "API Users"
-
-#: module/Application/view/partial/admin.phtml:245
-#: module/Application/view/partial/main-nav.phtml:161
-msgid "Admin"
-msgstr "Admin"
-
-#: module/Application/view/partial/company.phtml:26
-#: module/Frontpage/view/frontpage/page/page.phtml:20
-msgid "Home"
-msgstr "Home"
-
-#: module/Application/view/partial/company.phtml:31
-#: module/Company/src/Form/JobsTransfer.php:27
-#: module/Company/view/company/admin/edit-package.phtml:79
-#: module/Company/view/company/admin/index.phtml:135
-#: module/Company/view/company/admin/index.phtml:213
-#: module/Company/view/company/company-account/jobs.phtml:26
-#: module/Company/view/company/company-account/jobs.phtml:30
-#: module/Company/view/company/company-account/jobs.phtml:33
-#: module/Company/view/company/company-account/jobs.phtml:188
-#: module/Company/view/company/company-account/transfer-jobs.phtml:17
-msgid "Jobs"
-msgstr "Jobs"
-
-#: module/Application/view/partial/company.phtml:36
-#: module/Company/view/company/company-account/highlights.phtml:10
-#: module/Company/view/company/company-account/highlights.phtml:13
-msgid "Highlights"
-msgstr "Highlights"
-
-#: module/Application/view/partial/company.phtml:41
-#: module/Company/src/Form/Package.php:112
-#: module/Company/view/company/admin/edit-package.phtml:70
-#: module/Company/view/company/company-account/banner.phtml:10
-#: module/Company/view/company/company-account/banner.phtml:13
-msgid "Banner"
-msgstr "Banner"
-
-#: module/Application/view/partial/company.phtml:46
-msgid "Settings"
-msgstr "Settings"
-
-#: module/Application/view/partial/company.phtml:58
-#: module/Application/view/partial/main-nav.phtml:116
-msgid "My Company"
-msgstr "My Company"
-
-#: module/Application/view/partial/footer.phtml:21
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:273
-msgid "Infimum"
-msgstr "Infimum"
-
-#: module/Application/view/partial/footer.phtml:22
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:276
-msgid "Loading an infimum..."
-msgstr "Loading an infimum..."
-
-#: module/Application/view/partial/footer.phtml:50
-msgid "All rights reserved."
-msgstr "All rights reserved."
-
-#: module/Application/view/partial/footer.phtml:52
-msgid ""
-"Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
-"2022)."
-msgstr ""
-"Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
-"2022)."
-
-#: module/Application/view/partial/footer.phtml:58
-#: module/Application/view/partial/main-nav.phtml:318
-#: module/Company/view/company/company/companyStory.phtml:37
-#: module/Company/view/company/company/jobs.phtml:105
-#: module/Company/view/partial/company/company/list/company.phtml:41
-msgid "Contact"
-msgstr "Contact"
-
-#: module/Application/view/partial/main-nav.phtml:53
-msgid "Language settings"
-msgstr "Language settings"
-
-#: module/Application/view/partial/main-nav.phtml:81
-#: module/Application/view/partial/main-nav.phtml:485
-#: module/Decision/view/decision/member/birthdays.phtml:15
-#: module/Decision/view/decision/member/index.phtml:22
-#: module/Decision/view/decision/member/index.phtml:28
-#: module/Decision/view/decision/member/search.phtml:11
-#: module/Decision/view/decision/member/view.phtml:23
-msgid "Members"
-msgstr "Members"
-
-#: module/Application/view/partial/main-nav.phtml:98
-msgid "Subscribe"
-msgstr "Subscribe"
-
-#: module/Application/view/partial/main-nav.phtml:121
-#: module/Application/view/partial/main-nav.phtml:154
-#: module/Decision/view/decision/member/index.phtml:42
-#: module/User/src/Form/Password.php:59
-#: module/User/view/user/user/change-password.phtml:15
-#: module/User/view/user/user/change-password.phtml:36
-msgid "Change password"
-msgstr "Change password"
-
-#: module/Application/view/partial/main-nav.phtml:126
-#: module/Application/view/partial/main-nav.phtml:168
-msgid "Logout"
-msgstr "Logout"
-
-#: module/Application/view/partial/main-nav.phtml:144
-msgid "My information"
-msgstr "My information"
-
-#: module/Application/view/partial/main-nav.phtml:149
-#: module/Decision/view/decision/member/index.phtml:56
-msgid "SudoSOS"
-msgstr "SudoSOS"
-
-#: module/Application/view/partial/main-nav.phtml:177
-msgid "Toggle navigation"
-msgstr "Toggle navigation"
-
-#: module/Application/view/partial/main-nav.phtml:191
-#: module/Application/view/partial/main-nav.phtml:196
-#: module/Application/view/partial/main-nav.phtml:201
-#: module/Decision/view/decision/member/index.phtml:69
-msgid "Association"
-msgstr "Association"
-
-#: module/Application/view/partial/main-nav.phtml:212
-#: module/Decision/view/decision/member/view.phtml:72
-msgid "Board"
-msgstr "Board"
-
-#: module/Application/view/partial/main-nav.phtml:217
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:14
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:20
-#: module/Frontpage/view/frontpage/organ/organ.phtml:64
-msgid "Committees"
-msgstr "Committees"
-
-#: module/Application/view/partial/main-nav.phtml:222
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:15
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:19
-#: module/Frontpage/view/frontpage/organ/organ.phtml:60
-msgid "Fraternities"
-msgstr "Fraternities"
-
-#: module/Application/view/partial/main-nav.phtml:233
-msgid "Exceptional Members"
-msgstr "Exceptional Members"
-
-#: module/Application/view/partial/main-nav.phtml:244
-msgid "GEWIS song"
-msgstr "GEWIS song"
-
-#: module/Application/view/partial/main-nav.phtml:255
-#: module/Decision/view/decision/member/index.phtml:226
-msgid "Regulations"
-msgstr "Regulations"
-
-#: module/Application/view/partial/main-nav.phtml:262
-#: module/Application/view/partial/main-nav.phtml:267
-msgid "Useful Information"
-msgstr "Useful Information"
-
-#: module/Application/view/partial/main-nav.phtml:273
-#: module/Decision/view/decision/member/index.phtml:93
-msgid "Links"
-msgstr "Links"
-
-#: module/Application/view/partial/main-nav.phtml:278
-msgid "Well-being"
-msgstr "Well-being"
-
-#: module/Application/view/partial/main-nav.phtml:289
-msgid "Confidential Contact Person (CCP)"
-msgstr "Confidential Contact Person (CCP)"
-
-#: module/Application/view/partial/main-nav.phtml:294
-msgid "FAQ"
-msgstr "FAQ"
-
-#: module/Application/view/partial/main-nav.phtml:305
-msgid "Housing"
-msgstr "Housing"
-
-#: module/Application/view/partial/main-nav.phtml:343
-#: module/Company/view/company/admin/index.phtml:161
-msgid "Featured"
-msgstr "Featured"
-
-#: module/Application/view/partial/main-nav.phtml:390
-msgid "My activities"
-msgstr "My activities"
-
-#: module/Application/view/partial/main-nav.phtml:399
-msgid "Activity Archive"
-msgstr "Activity Archive"
-
-#: module/Application/view/partial/main-nav.phtml:408
-msgid "Create an activity"
-msgstr "Create an activity"
-
-#: module/Application/view/partial/main-nav.phtml:424
-msgid "Career related"
-msgstr "Career related"
-
-#: module/Application/view/partial/main-nav.phtml:457
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:218
-msgid "Photo of the week"
-msgstr "Photo of the week"
-
-#: module/Application/view/partial/main-nav.phtml:470
-#: module/Decision/view/decision/member/index.phtml:52
-msgid "My photo's"
-msgstr "My photos"
-
-#: module/Application/view/partial/main-nav.phtml:499
-msgid "You are currently using administrator privileges to use the website!"
-msgstr "You are currently using administrator privileges to use the website!"
-
-#: module/Application/view/partial/paginator.phtml:19
-#: module/Photo/view/photo/album/index.phtml:437
-msgid "Previous"
-msgstr "Previous"
-
-#: module/Application/view/partial/paginator.phtml:37
-#: module/Photo/view/photo/album/index.phtml:438
-msgid "Next"
-msgstr "Next"
-
-#: module/Application/view/partial/privacy-widget.phtml:13
-msgid ""
-"S.v. GEWIS uses cookies on this website, these are required for the website "
-"to function. Additionally, we may collection information about how you use "
-"our website in order to improve your experience. If you do not want your "
-"behaviour to be tracked please opt out below."
-msgstr ""
-"S.v. GEWIS uses cookies on this website, these are required for the website "
-"to function. Additionally, we may collection information about how you use "
-"our website in order to improve your experience. If you do not want your "
-"behaviour to be tracked please opt out below."
-
-#: module/Application/view/partial/privacy-widget.phtml:19
-msgid "Tracking is currently"
-msgstr "Tracking is currently"
-
-#: module/Application/view/partial/privacy-widget.phtml:20
-msgid "enabled"
-msgstr "enabled"
-
-#: module/Application/view/partial/privacy-widget.phtml:21
-msgid "disabled"
-msgstr "disabled"
-
-#: module/Application/view/partial/privacy-widget.phtml:23
-msgid "disabled (Do Not Track)"
-msgstr "disabled (Do Not Track)"
-
-#: module/Application/view/partial/privacy-widget.phtml:25
-msgid "unavailable"
-msgstr "unavailable"
-
-#: module/Application/view/partial/privacy-widget.phtml:31
-#: module/Decision/view/decision/member/index.phtml:294
-msgid "Privacy Policy"
-msgstr "Privacy Policy"
-
-#: module/Application/view/partial/privacy-widget.phtml:33
-#: module/User/src/Form/ApiAppAuthorisation.php:48
-msgid "Continue"
-msgstr "Continue"
-
-#: module/Company/src/Controller/AdminApprovalController.php:45
-#: module/Company/src/Controller/AdminApprovalController.php:71
-msgid "You are not allowed to view the approval status of jobs"
-msgstr "You are not allowed to view the approval status of jobs"
-
-#: module/Company/src/Controller/AdminApprovalController.php:89
-msgid "Approve Job"
-msgstr "Approve Job"
-
-#: module/Company/src/Controller/AdminApprovalController.php:93
-msgid "Disapprove Job"
-msgstr "Disapprove Job"
-
-#: module/Company/src/Controller/AdminApprovalController.php:97
-msgid "Reset Approval Status"
-msgstr "Reset Approval Status"
-
-#: module/Company/src/Controller/AdminApprovalController.php:107
-msgid "You are not allowed to change the approval status of jobs"
-msgstr "You are not allowed to change the approval status of jobs"
-
-#: module/Company/src/Controller/AdminApprovalController.php:141
-msgid "Job approved!"
-msgstr "Job approved!"
-
-#: module/Company/src/Controller/AdminApprovalController.php:149
-msgid "Job disapproved!"
-msgstr "Job disapproved!"
-
-#: module/Company/src/Controller/AdminApprovalController.php:153
-msgid "Job approval status reset!"
-msgstr "Job approval status reset!"
-
-#: module/Company/src/Controller/AdminApprovalController.php:164
-#: module/Company/src/Controller/AdminApprovalController.php:194
-msgid "You are not allowed to approve update proposals of jobs"
-msgstr "You are not allowed to approve update proposals of jobs"
-
-#: module/Company/src/Controller/AdminApprovalController.php:180
-msgid "Apply Update"
-msgstr "Apply Update"
-
-#: module/Company/src/Controller/AdminApprovalController.php:184
-msgid "Reject Update"
-msgstr "Reject Update"
-
-#: module/Company/src/Controller/AdminApprovalController.php:218
-msgid ""
-"An unknown error occurred while try to change the status of a job update "
-"proposal. Please try again."
-msgstr ""
-"An unknown error occurred while try to change the status of a job update "
-"proposal. Please try again."
-
-#: module/Company/src/Controller/AdminApprovalController.php:230
-msgid "Job has been updated!"
-msgstr "Job has been updated!"
-
-#: module/Company/src/Controller/AdminApprovalController.php:238
-msgid "Job update has been rejected!"
-msgstr "Job update has been rejected!"
-
-#: module/Company/src/Controller/AdminController.php:47
-msgid "You are not allowed to administer career settings"
-msgstr "You are not allowed to administer career settings"
-
-#: module/Company/src/Controller/AdminController.php:80
-msgid "You are not allowed to create companies"
-msgstr "You are not allowed to create companies"
-
-#: module/Company/src/Controller/AdminController.php:123
-msgid "You are not allowed to edit companies"
-msgstr "You are not allowed to edit companies"
-
-#: module/Company/src/Controller/AdminController.php:190
-#: module/Company/src/Service/Company.php:856
-msgid "You are not allowed to delete companies"
-msgstr "You are not allowed to delete companies"
-
-#: module/Company/src/Controller/AdminController.php:215
-msgid "You are not allowed to create packages"
-msgstr "You are not allowed to create packages"
-
-#: module/Company/src/Controller/AdminController.php:284
-#: module/Company/src/Service/Company.php:905
-msgid "You are not allowed to edit packages"
-msgstr "You are not allowed to edit packages"
-
-#: module/Company/src/Controller/AdminController.php:372
-#: module/Company/src/Service/Company.php:741
-msgid "You are not allowed to delete packages"
-msgstr "You are not allowed to delete packages"
-
-#: module/Company/src/Controller/AdminController.php:414
-#: module/Company/src/Controller/CompanyAccountController.php:120
-msgid "You are not allowed to create jobs"
-msgstr "You are not allowed to create jobs"
-
-#: module/Company/src/Controller/AdminController.php:453
-msgid "Job successfully created!"
-msgstr "Job successfully created!"
-
-#: module/Company/src/Controller/AdminController.php:493
-#: module/Company/src/Controller/CompanyAccountController.php:203
-#: module/Company/src/Service/Company.php:931
-#: module/Company/src/Service/Company.php:1002
-msgid "You are not allowed to edit jobs"
-msgstr "You are not allowed to edit jobs"
-
-#: module/Company/src/Controller/AdminController.php:532
-msgid "Job successfully edited!"
-msgstr "Job successfully edited!"
-
-#: module/Company/src/Controller/AdminController.php:568
-#: module/Company/src/Controller/CompanyAccountController.php:310
-msgid "You are not allowed to delete jobs"
-msgstr "You are not allowed to delete jobs"
-
-#: module/Company/src/Controller/AdminController.php:610
-msgid "You are not allowed to create job categories"
-msgstr "You are not allowed to create job categories"
-
-#: module/Company/src/Controller/AdminController.php:629
-msgid "Job category successfully created!"
-msgstr "Job category successfully created!"
-
-#: module/Company/src/Controller/AdminController.php:665
-#: module/Company/src/Service/Company.php:881
-msgid "You are not allowed to edit job categories"
-msgstr "You are not allowed to edit job categories"
-
-#: module/Company/src/Controller/AdminController.php:705
-msgid "You are not allowed to create job labels"
-msgstr "You are not allowed to create job labels"
-
-#: module/Company/src/Controller/AdminController.php:724
-msgid "Job label successfully created!"
-msgstr "Job label successfully created!"
-
-#: module/Company/src/Controller/AdminController.php:758
-#: module/Company/src/Service/Company.php:893
-msgid "You are not allowed to edit job labels"
-msgstr "You are not allowed to edit job labels"
-
-#: module/Company/src/Controller/CompanyAccountController.php:47
-#: module/Company/src/Controller/CompanyAccountController.php:58
-#: module/Company/src/Controller/CompanyAccountController.php:69
-msgid "You are not allowed to view the company accounts"
-msgstr "You are not allowed to view the company accounts"
-
-#: module/Company/src/Controller/CompanyAccountController.php:143
-msgid "You cannot create new jobs in expired job packages."
-msgstr "You cannot create new jobs in expired job packages."
-
-#: module/Company/src/Controller/CompanyAccountController.php:166
-msgid ""
-"Job proposal successfully created! It will become active after it has been "
-"approved."
-msgstr ""
-"Job proposal successfully created! It will become active after it has been "
-"approved."
-
-#: module/Company/src/Controller/CompanyAccountController.php:223
-msgid "You cannot update jobs in expired job packages."
-msgstr "You cannot update jobs in expired job packages."
-
-#: module/Company/src/Controller/CompanyAccountController.php:249
-msgid ""
-"Update proposal for job successfully created! It will become active after it "
-"has been approved."
-msgstr ""
-"Update proposal for job successfully created! It will become active after it "
-"has been approved."
-
-#: module/Company/src/Controller/CompanyAccountController.php:335
-msgid "Job successfully deleted."
-msgstr "Job successfully deleted."
-
-#: module/Company/src/Controller/CompanyAccountController.php:344
-msgid "You are not allowed to view the status of a job"
-msgstr "You are not allowed to view the status of a job"
-
-#: module/Company/src/Controller/CompanyAccountController.php:369
-msgid "You are not allowed to transfer jobs"
-msgstr "You are not allowed to transfer jobs"
-
-#: module/Company/src/Controller/CompanyAccountController.php:406
-msgid "Jobs successfully transferred"
-msgstr "Jobs successfully transferred"
-
-#: module/Company/src/Controller/CompanyAccountController.php:417
-msgid ""
-"An unknown error occurred while trying to transfer jobs, please try again."
-msgstr ""
-"An unknown error occurred while trying to transfer jobs, please try again."
-
-#: module/Company/src/Form/Company.php:61 module/Company/src/Form/Job.php:69
-#: module/Company/src/Form/JobCategory.php:85
-#: module/Company/src/Form/JobCategory.php:95
-#: module/Company/view/company/admin-approval/job-approval.phtml:44
-#: module/Company/view/company/admin-approval/job-approval.phtml:48
-#: module/Company/view/company/admin-approval/job-proposal.phtml:69
-#: module/Company/view/company/admin-approval/job-proposal.phtml:73
-#: module/Company/view/partial/company/admin/editors/company.phtml:18
-#: module/Company/view/partial/company/admin/editors/job.phtml:18
-msgid "Slug"
-msgstr "Slug"
-
-#: module/Company/src/Form/Company.php:71
-msgid "Logo"
-msgstr "Logo"
-
-#: module/Company/src/Form/Company.php:81 module/Company/src/Form/Job.php:91
-#: module/Company/src/Form/Package.php:66
-msgid "Published"
-msgstr "Published"
-
-#: module/Company/src/Form/Company.php:103
-#: module/Company/src/Form/Company.php:133 module/Company/src/Form/Job.php:116
-msgid "E-mail Address"
-msgstr "E-mail Address"
-
-#: module/Company/src/Form/Company.php:123
-msgid "Address"
-msgstr "Address"
-
-#: module/Company/src/Form/Company.php:143 module/Company/src/Form/Job.php:126
-msgid "Phone Number"
-msgstr "Phone Number"
-
-#: module/Company/src/Form/Company.php:154
-#: module/Company/src/Form/Company.php:164
-msgid "Slogan"
-msgstr "Slogan"
-
-#: module/Company/src/Form/Company.php:178
-#: module/Company/src/Form/Company.php:188 module/Company/src/Form/Job.php:161
-#: module/Company/src/Form/Job.php:171
-#: module/Company/view/company/admin-approval/job-approval.phtml:138
-#: module/Company/view/company/admin-approval/job-approval.phtml:143
-#: module/Company/view/company/admin-approval/job-approval.phtml:150
-#: module/Company/view/company/admin-approval/job-proposal.phtml:184
-#: module/Company/view/company/admin-approval/job-proposal.phtml:189
-#: module/Company/view/company/admin-approval/job-proposal.phtml:199
-#: module/Decision/src/Form/OrganInformation.php:42
-#: module/Frontpage/view/frontpage/organ/organ.phtml:110
-msgid "Website"
-msgstr "Website"
-
-#: module/Company/src/Form/Company.php:261 module/Company/src/Form/Job.php:282
-#: module/Company/src/Form/JobCategory.php:194
-msgid "This slug is already taken"
-msgstr "This slug is already taken"
-
-#: module/Company/src/Form/Company.php:272 module/Company/src/Form/Job.php:293
-#: module/Company/src/Form/JobCategory.php:204
-msgid "This slug contains invalid characters"
-msgstr "This slug contains invalid characters"
-
-#: module/Company/src/Form/Company.php:346
-msgid "E-mail address format is not valid."
-msgstr "E-mail address format is not valid."
-
-#: module/Company/src/Form/Company.php:356
-msgid "The e-mail address must be unique across companies."
-msgstr "The e-mail address must be unique across companies."
-
-#: module/Company/src/Form/Company.php:400 module/Company/src/Form/Job.php:341
-#: module/User/src/Form/CompanyUserLogin.php:125
-#: module/User/src/Form/CompanyUserReset.php:64
-#: module/User/src/Form/UserReset.php:93
-msgid "E-mail address format is not valid"
-msgstr "E-mail address format is not valid"
-
-#: module/Company/src/Form/Job.php:79
-#: module/Company/view/company/admin-approval/job-approval.phtml:55
-#: module/Company/view/company/admin-approval/job-approval.phtml:59
-#: module/Company/view/company/admin-approval/job-proposal.phtml:83
-#: module/Company/view/company/admin-approval/job-proposal.phtml:87
-msgid "Category"
-msgstr "Category"
-
-#: module/Company/src/Form/Job.php:80
-msgid "Select a job category"
-msgstr "Select a job category"
-
-#: module/Company/src/Form/Job.php:221 module/Company/src/Form/Job.php:231
-#: module/Company/view/company/admin-approval/job-approval.phtml:195
-#: module/Company/view/company/admin-approval/job-approval.phtml:200
-#: module/Company/view/company/admin-approval/job-approval.phtml:211
-#: module/Company/view/company/admin-approval/job-proposal.phtml:259
-#: module/Company/view/company/admin-approval/job-proposal.phtml:264
-#: module/Company/view/company/admin-approval/job-proposal.phtml:280
-msgid "Attachment"
-msgstr "Attachment"
-
-#: module/Company/src/Form/JobCategory.php:65
-#: module/Company/src/Form/JobCategory.php:75
-msgid "Name (Plural)"
-msgstr "Name (Plural)"
-
-#: module/Company/src/Form/JobCategory.php:105
-msgid "Hidden"
-msgstr "Hidden"
-
-#: module/Company/src/Form/JobLabel.php:51
-#: module/Company/src/Form/JobLabel.php:61
-#: module/Decision/view/decision/organ-admin/index.phtml:23
-#: module/Decision/view/decision/organ/index.phtml:22
-msgid "Abbreviation"
-msgstr "Abbreviation"
-
-#: module/Company/src/Form/JobsTransfer.php:38
-msgid "Select a target job package"
-msgstr "Select a target job package"
-
-#: module/Company/src/Form/JobsTransfer.php:39
-#: module/Company/view/company/admin/edit-company.phtml:59
-msgid "Packages"
-msgstr "Packages"
-
-#: module/Company/src/Form/JobsTransfer.php:50
-#: module/Company/view/company/company-account/jobs.phtml:272
-#: module/Company/view/company/company-account/transfer-jobs.phtml:14
-#: module/Company/view/company/company-account/transfer-jobs.phtml:24
-msgid "Transfer Jobs"
-msgstr "Transfer Jobs"
-
-#: module/Company/src/Form/Package.php:38
-msgid "Start Date"
-msgstr "Start Date"
-
-#: module/Company/src/Form/Package.php:52
-msgid "Expiration Date"
-msgstr "Expiration Date"
-
-#: module/Company/src/Form/Package.php:79
-#: module/Company/view/company/admin/edit-company.phtml:101
-#: module/Company/view/company/company-account/jobs.phtml:54
-msgid "Contract Number"
-msgstr "Contract Number"
-
-#: module/Company/src/Form/Package.php:90
-#: module/Company/src/Form/Package.php:100
-msgid "Article"
-msgstr "Article"
-
-#: module/Company/src/Form/Package.php:179
-msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
-msgstr ""
-"Contract numbers can only contain letters, numbers, _, -, ., and spaces"
-
-#: module/Company/src/Service/Company.php:92
-msgid "You are not allowed to view the banner"
-msgstr "You are not allowed to view the banner"
-
-#: module/Company/src/Service/Company.php:102
-msgid "You are not allowed to view the featured company"
-msgstr "You are not allowed to view the featured company"
-
-#: module/Company/src/Service/Company.php:170
-#: module/Company/src/Service/Company.php:190
-#: module/Company/src/Service/Company.php:218
-msgid "You are not allowed to list the companies"
-msgstr "You are not allowed to list the companies"
-
-#: module/Company/src/Service/Company.php:205
-msgid "You are not allowed to access the admin interface"
-msgstr "You are not allowed to access the admin interface"
-
-#: module/Company/src/Service/Company.php:948
-msgid "You are not allowed to edit categories"
-msgstr "You are not allowed to edit categories"
-
-#: module/Company/src/Service/Company.php:965
-msgid "You are not allowed to edit labels"
-msgstr "You are not allowed to edit labels"
-
-#: module/Company/src/Service/Company.php:1015
-msgid "You are not allowed to create a company"
-msgstr "You are not allowed to create a company"
-
-#: module/Company/src/Service/CompanyQuery.php:98
-msgid "You are not allowed to list all job categories"
-msgstr "You are not allowed to list all job categories"
-
-#: module/Company/src/Service/CompanyQuery.php:106
-msgid "You are not allowed to list job categories"
-msgstr "You are not allowed to list job categories"
-
-#: module/Company/src/Service/CompanyQuery.php:146
-msgid "You are not allowed to list all job labels"
-msgstr "You are not allowed to list all job labels"
-
-#: module/Company/src/Service/CompanyQuery.php:154
-msgid "You are not allowed to list job labels"
-msgstr "You are not allowed to list job labels"
-
-#: module/Company/view/company/admin-approval/index.phtml:24
-msgid "Unapproved Companies"
-msgstr "Unapproved Companies"
-
-#: module/Company/view/company/admin-approval/index.phtml:38
-msgid "There is no company or update proposal that requires your approval."
-msgstr "There is no company or update proposal that requires your approval."
-
-#: module/Company/view/company/admin-approval/index.phtml:50
-msgid "Unapproved Jobs"
-msgstr "Unapproved Jobs"
-
-#: module/Company/view/company/admin-approval/index.phtml:56
-msgid "Dutch Name"
-msgstr "Dutch Name"
-
-#: module/Company/view/company/admin-approval/index.phtml:57
-msgid "English Name"
-msgstr "English Name"
-
-#: module/Company/view/company/admin-approval/index.phtml:66
-msgid "There is no job or update proposal that requires your approval."
-msgstr "There is no job or update proposal that requires your approval."
-
-#: module/Company/view/company/admin-approval/index.phtml:82
-msgid "View Update"
-msgstr "View Update"
-
-#: module/Company/view/company/admin-approval/index.phtml:90
-msgid "View Proposal"
-msgstr "View Proposal"
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:35
-#, php-format
-msgid "This job is proposed by <strong>%s</strong> as part of job package %s."
-msgstr "This job is proposed by <strong>%s</strong> as part of job package %s."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:77
-#: module/Company/view/company/admin-approval/job-approval.phtml:81
-#: module/Company/view/company/admin-approval/job-proposal.phtml:111
-#: module/Company/view/company/admin-approval/job-proposal.phtml:115
-#: module/Decision/view/decision/member/self.phtml:174
-msgid "Phone number"
-msgstr "Phone number"
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:88
-#: module/Company/view/company/admin-approval/job-approval.phtml:92
-#: module/Company/view/company/admin-approval/job-proposal.phtml:125
-#: module/Company/view/company/admin-approval/job-proposal.phtml:129
-#: module/User/src/Form/UserReset.php:40
-#: module/User/src/Model/Enums/JWTClaims.php:39
-msgid "E-mail address"
-msgstr "E-mail address"
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:204
-#: module/Company/view/company/admin-approval/job-approval.phtml:215
-#: module/Company/view/company/admin-approval/job-proposal.phtml:284
-#: module/Company/view/company/company/jobs.phtml:133
-msgid "View Attachment"
-msgstr "View Attachment"
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:244
-msgid ""
-"If approved, this job will be <strong>published</strong>, however, its "
-"actual visiblity depends on the company and associated job package."
-msgstr ""
-"If approved, this job will be <strong>published</strong>, however, its "
-"actual visiblity depends on the company and associated job package."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:246
-msgid "If approved, this job will be <strong>hidden</strong>."
-msgstr "If approved, this job will be <strong>hidden</strong>."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:291
-#: module/Company/view/company/admin-approval/job-proposal.phtml:397
-msgid "Optional message..."
-msgstr "Optional message..."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:312
-#, php-format
-msgid "This job was approved by <strong>%s</strong>."
-msgstr "This job was approved by <strong>%s</strong>."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:341
-#, php-format
-msgid ""
-"This job was disapproved by <strong>%s</strong> with the message \"%s\"."
-msgstr ""
-"This job was disapproved by <strong>%s</strong> with the message \"%s\"."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:347
-#, php-format
-msgid "This job was disapproved by <strong>%s</strong>."
-msgstr "This job was disapproved by <strong>%s</strong>."
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:27
-msgid "Proposals"
-msgstr "Proposals"
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:59
-#, php-format
-msgid ""
-"This job update is proposed by <strong>%s</strong> as part of job package "
-"%s. Changes in the job's attributes are shown like this: %s. If there are no "
-"changes to a certain attribute, you will see the existing data."
-msgstr ""
-"This job update is proposed by <strong>%s</strong> as part of job package "
-"%s. Changes in the job's attributes are shown like this: %s. If there are no "
-"changes to a certain attribute, you will see the existing data."
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:268
-msgid "View Original Attachment"
-msgstr "View Original Attachment"
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:273
-#: module/Company/view/company/admin-approval/job-proposal.phtml:289
-msgid "View New Attachment"
-msgstr "View New Attachment"
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:297
-#: module/Company/view/partial/company/admin/editors/job.phtml:328
-msgid "Job Labels"
-msgstr "Job Labels"
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:328
-msgid ""
-"Original job and proposed update do not have any job labels applied to them."
-msgstr ""
-"Original job and proposed update do not have any job labels applied to them."
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:340
-msgid ""
-"Warning! This is an update to an unapproved job. Applying this update will "
-"approve the job."
-msgstr ""
-"Warning! This is an update to an unapproved job. Applying this update will "
-"approve the job."
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:350
-msgid ""
-"Warning! This is an update to rejected job. Applying this update will "
-"approve the job."
-msgstr ""
-"Warning! This is an update to rejected job. Applying this update will "
-"approve the job."
-
-#: module/Company/view/company/admin/add-category.phtml:14
-#: module/Company/view/company/admin/add-category.phtml:22
-#: module/Company/view/company/admin/add-category.phtml:37
-msgid "Create Job Category"
-msgstr "Create Job Category"
-
-#: module/Company/view/company/admin/add-company.phtml:14
-#: module/Company/view/company/admin/add-company.phtml:28
-#: module/Company/view/company/admin/add-company.phtml:43
-msgid "Create Company"
-msgstr "Create Company"
-
-#: module/Company/view/company/admin/add-job.phtml:14
-#: module/Company/view/company/admin/add-job.phtml:33
-#: module/Company/view/company/admin/add-job.phtml:48
-#: module/Company/view/company/admin/edit-package.phtml:140
-#: module/Company/view/company/company-account/jobs.phtml:97
-#: module/Company/view/company/company-account/jobs.phtml:282
-msgid "Add Job"
-msgstr "Add Job"
-
-#: module/Company/view/company/admin/add-label.phtml:14
-#: module/Company/view/company/admin/add-label.phtml:28
-#: module/Company/view/company/admin/add-label.phtml:43
-msgid "Create Job Label"
-msgstr "Create Job Label"
-
-#: module/Company/view/company/admin/add-package.phtml:15
-#: module/Company/view/company/admin/add-package.phtml:29
-#: module/Company/view/company/admin/add-package.phtml:45
-msgid "Add Package"
-msgstr "Add Package"
-
-#: module/Company/view/company/admin/categories.phtml:36
-#: module/Company/view/company/admin/labels.phtml:35
-msgid "edit"
-msgstr "edit"
-
-#: module/Company/view/company/admin/edit-category.phtml:14
-#: module/Company/view/company/admin/edit-category.phtml:21
-msgid "Edit Job Category"
-msgstr "Edit Job Category"
-
-#: module/Company/view/company/admin/edit-category.phtml:36
-msgid "Update Job Category"
-msgstr "Update Job Category"
-
-#: module/Company/view/company/admin/edit-company.phtml:17
-msgid "Edit Company"
-msgstr "Edit Company"
-
-#: module/Company/view/company/admin/edit-company.phtml:53
-#, php-format
-msgid "Edit %s"
-msgstr "Edit %s"
-
-#: module/Company/view/company/admin/edit-company.phtml:70
-msgid "Add Job Package"
-msgstr "Add Job Package"
-
-#: module/Company/view/company/admin/edit-company.phtml:80
-msgid "Add Spotlight Package"
-msgstr "Add Spotlight Package"
-
-#: module/Company/view/company/admin/edit-company.phtml:90
-msgid "Add Banner Package"
-msgstr "Add Banner Package"
-
-#: module/Company/view/company/admin/edit-company.phtml:104
-#: module/Company/view/company/admin/edit-package.phtml:84
-#: module/Company/view/company/company-account/jobs.phtml:197
-msgid "Active"
-msgstr "Active"
-
-#: module/Company/view/company/admin/edit-company.phtml:110
-#: module/Company/view/company/company-account/jobs.phtml:60
-msgid "Expiration date"
-msgstr "Expiration date"
-
-#: module/Company/view/company/admin/edit-company.phtml:113
-msgid "Jobs (Active) / Type"
-msgstr "Jobs (Active) / Type"
-
-#: module/Company/view/company/admin/edit-company.phtml:136
-#: module/Company/view/company/admin/index.phtml:50
-#: module/Company/view/company/admin/index.phtml:82
-msgid "Banner Package"
-msgstr "Banner Package"
-
-#: module/Company/view/company/admin/edit-company.phtml:139
-#: module/Company/view/company/admin/index.phtml:53
-#: module/Company/view/company/admin/index.phtml:85
-msgid "Featured Package"
-msgstr "Featured Package"
-
-#: module/Company/view/company/admin/edit-company.phtml:187
-msgid "Update Company"
-msgstr "Update Company"
-
-#: module/Company/view/company/admin/edit-company.phtml:206
-msgid "Are you sure you want to delete this package?"
-msgstr "Are you sure you want to delete this package?"
-
-#: module/Company/view/company/admin/edit-company.phtml:212
-msgid "Delete package"
-msgstr "Delete package"
-
-#: module/Company/view/company/admin/edit-job.phtml:19
-#: module/Company/view/company/admin/edit-job.phtml:38
-msgid "Edit Job"
-msgstr "Edit Job"
-
-#: module/Company/view/company/admin/edit-job.phtml:47
-#, php-format
-msgid ""
-"You are currently updating an update proposal that was previously rejected "
-"for the following reason: %s"
-msgstr ""
-"You are currently updating an update proposal that was previously rejected "
-"for the following reason: %s"
-
-#: module/Company/view/company/admin/edit-job.phtml:53
-msgid ""
-"You are currently updating an update proposal that was previously rejected, "
-"however, no reason was provided."
-msgstr ""
-"You are currently updating an update proposal that was previously rejected, "
-"however, no reason was provided."
-
-#: module/Company/view/company/admin/edit-job.phtml:58
-#, php-format
-msgid ""
-"You are currently updating a job that was previously rejected for the "
-"following reason: %s"
-msgstr ""
-"You are currently updating a job that was previously rejected for the "
-"following reason: %s"
-
-#: module/Company/view/company/admin/edit-job.phtml:64
-msgid ""
-"You are currently updating a job that was previously rejected, however, no "
-"reason was provided."
-msgstr ""
-"You are currently updating a job that was previously rejected, however, no "
-"reason was provided."
-
-#: module/Company/view/company/admin/edit-job.phtml:85
-msgid "Update Job"
-msgstr "Update Job"
-
-#: module/Company/view/company/admin/edit-label.phtml:14
-#: module/Company/view/company/admin/edit-label.phtml:28
-msgid "Edit Job Label"
-msgstr "Edit Job Label"
-
-#: module/Company/view/company/admin/edit-label.phtml:43
-msgid "Update Job Label"
-msgstr "Update Job Label"
-
-#: module/Company/view/company/admin/edit-package.phtml:19
-#: module/Company/view/company/admin/edit-package.phtml:40
-msgid "Edit Package"
-msgstr "Edit Package"
-
-#: module/Company/view/company/admin/edit-package.phtml:56
-msgid "Update Package"
-msgstr "Update Package"
-
-#: module/Company/view/company/admin/edit-package.phtml:101
-msgid "(Update Pending)"
-msgstr "(Update Pending)"
-
-#: module/Company/view/company/admin/edit-package.phtml:154
-#: module/Company/view/company/company-account/jobs.phtml:297
-msgid "Are you sure you want to delete this job?"
-msgstr "Are you sure you want to delete this job?"
-
-#: module/Company/view/company/admin/edit-package.phtml:159
-#: module/Company/view/company/company-account/jobs.phtml:302
-msgid "Delete job"
-msgstr "Delete job"
-
-#: module/Company/view/company/admin/index.phtml:36
-#: module/Company/view/company/company-account/jobs.phtml:39
-msgid "Notifications"
-msgstr "Notifications"
-
-#: module/Company/view/company/admin/index.phtml:38
-msgid "No notifications"
-msgstr "No notifications"
-
-#: module/Company/view/company/admin/index.phtml:56
-#: module/Company/view/company/admin/index.phtml:88
-#, php-format
-msgid "Job Package (%s active)"
-msgstr "Job Package (%s active)"
-
-#: module/Company/view/company/admin/index.phtml:63
-#, php-format
-msgid "%s for company %s will start on %s"
-msgstr "%s for company %s will start on %s"
-
-#: module/Company/view/company/admin/index.phtml:95
-#, php-format
-msgid "%s for company %s will expire on %s"
-msgstr "%s for company %s will expire on %s"
-
-#: module/Company/view/company/admin/index.phtml:110
-#: module/Education/view/education/admin/course.phtml:27
-msgid "Filter..."
-msgstr "Filter..."
-
-#: module/Company/view/company/admin/index.phtml:115
-msgid "Add Company"
-msgstr "Add Company"
-
-#: module/Company/view/company/admin/index.phtml:144
-#: module/Company/view/company/admin/index.phtml:214
-msgid "Active jobs"
-msgstr "Active jobs"
-
-#: module/Company/view/company/admin/index.phtml:152
-#: module/Company/view/company/admin/index.phtml:215
-msgid "Banner active"
-msgstr "Banner active"
-
-#: module/Company/view/company/admin/index.phtml:169
-#: module/Company/view/company/admin/index.phtml:217
-msgid "Expired packages"
-msgstr "Expired packages"
-
-#: module/Company/view/company/admin/index.phtml:216
-msgid "Featured in language"
-msgstr "Featured in language"
-
-#: module/Company/view/company/admin/index.phtml:234
-#: module/Decision/view/decision/admin/document.phtml:169
-#, php-format
-msgid "Are you sure you want to delete %s?"
-msgstr "Are you sure you want to delete %s?"
-
-#: module/Company/view/company/admin/index.phtml:241
-msgid "Delete company"
-msgstr "Delete company"
-
-#: module/Company/view/company/admin/labels.phtml:17
-msgid "Add Label"
-msgstr "Add Label"
-
-#: module/Company/view/company/company-account/banner.phtml:20
-#: module/Company/view/company/company-account/highlights.phtml:20
-msgid ""
-"This functionality is currently unavailable. Our apologies for the "
-"inconvenience."
-msgstr ""
-"This functionality is currently unavailable. Our apologies for the "
-"inconvenience."
-
-#: module/Company/view/company/company-account/jobs.phtml:45
-msgid "Job Packages"
-msgstr "Job Packages"
-
-#: module/Company/view/company/company-account/jobs.phtml:63
-msgid "Jobs (Active)"
-msgstr "Jobs (Active)"
-
-#: module/Company/view/company/company-account/jobs.phtml:106
-#: module/Company/view/company/company/job-list.phtml:152
-msgid "View"
-msgstr "View"
-
-#: module/Company/view/company/company-account/jobs.phtml:118
-msgid "Recently Approved Jobs"
-msgstr "Recently Approved Jobs"
-
-#: module/Company/view/company/company-account/jobs.phtml:120
-msgid "You do not have recently approved jobs."
-msgstr "You do not have recently approved jobs."
-
-#: module/Company/view/company/company-account/jobs.phtml:140
-msgid "Recently Rejected Jobs"
-msgstr "Recently Rejected Jobs"
-
-#: module/Company/view/company/company-account/jobs.phtml:142
-msgid "You do not have recently rejected jobs."
-msgstr "You do not have recently rejected jobs."
-
-#: module/Company/view/company/company-account/jobs.phtml:162
-msgid "Recently Unapproved Jobs"
-msgstr "Recently Unapproved Jobs"
-
-#: module/Company/view/company/company-account/jobs.phtml:164
-msgid "You do not have any recent jobs pending approval."
-msgstr "You do not have any recent jobs pending approval."
-
-#: module/Company/view/company/company-account/jobs.phtml:198
-msgid "Approved (Has Updates)"
-msgstr "Approved (Has Updates)"
-
-#: module/Company/view/company/company-account/jobs.phtml:206
-msgid "This job package does not contain any jobs."
-msgstr "This job package does not contain any jobs."
-
-#: module/Company/view/company/company-account/self.phtml:10
-msgid "Company Account"
-msgstr "Company Account"
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:30
-msgid "Select the jobs that you want to transfer to another job package."
-msgstr "Select the jobs that you want to transfer to another job package."
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:48
-msgid "There are no jobs that you can transfer..."
-msgstr "There are no jobs that you can transfer..."
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:64
-msgid "Choose to which job package you want to transfer the selected jobs."
-msgstr "Choose to which job package you want to transfer the selected jobs."
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:81
-msgid "Move Jobs"
-msgstr "Move Jobs"
-
-#: module/Company/view/company/company/companyStory.phtml:34
-#: module/Company/view/company/company/jobs.phtml:95
-#: module/Company/view/partial/company/company/grid/company.phtml:32
-#: module/Company/view/partial/company/company/list/company.phtml:36
-msgid "Logo of"
-msgstr "Logo of"
-
-#: module/Company/view/company/company/companyStory.phtml:63
-#: module/Company/view/partial/company/company/list/company.phtml:62
-msgid "Visit Website"
-msgstr "Visit Website"
-
-#: module/Company/view/company/company/companyStory.phtml:68
-msgid "Highlighted"
-msgstr "Highlighted"
-
-#: module/Company/view/company/company/job-list.phtml:74
-msgid "What are you looking for?"
-msgstr "What are you looking for?"
-
-#: module/Company/view/company/company/job-list.phtml:77
-msgid "Sort on"
-msgstr "Sort on"
-
-#: module/Company/view/company/company/job-list.phtml:79
-msgid "Random"
-msgstr "Random"
-
-#: module/Company/view/company/company/job-list.phtml:80
-msgid "Most recent"
-msgstr "Most recent"
-
-#: module/Company/view/company/company/job-list.phtml:108
-#, php-format
-msgid "Unfortunately, there aren't any %s at the moment."
-msgstr "Unfortunately, there aren't any %s at the moment."
-
-#: module/Company/view/company/company/job-list.phtml:183
-#, php-format
-msgid "Still haven't found what you're looking for? Take a look at %s."
-msgstr "Still haven't found what you're looking for? Take a look at %s."
-
-#: module/Company/view/company/company/jobs.phtml:76
-msgid "at"
-msgstr "at"
-
-#: module/Company/view/company/company/jobs.phtml:126
-msgid "View Website"
-msgstr "View Website"
-
-#: module/Company/view/company/company/list.phtml:40
-#: module/Company/view/company/company/spotlight.phtml:49
-msgid "in the spotlight"
-msgstr "in the spotlight"
-
-#: module/Company/view/company/company/spotlight.phtml:37
-msgid "Featured company"
-msgstr "Featured company"
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:21
-msgid ""
-"Specify the permanent link for this company, it should be unique across all "
-"companies."
-msgstr ""
-"Specify the permanent link for this company, it should be unique across all "
-"companies."
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:70
-msgid "View current logo"
-msgstr "View current logo"
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:94
-msgid "Representative Information"
-msgstr "Representative Information"
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:95
-msgid "Enter information about the representative of this company."
-msgstr "Enter information about the representative of this company."
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:136
-#: module/Company/view/partial/company/admin/editors/job.phtml:78
-msgid "Contact Information"
-msgstr "Contact Information"
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:137
-msgid ""
-"Enter how someone can contact this company and who is responsible for this "
-"company."
-msgstr ""
-"Enter how someone can contact this company and who is responsible for this "
-"company."
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:205
-#: module/Company/view/partial/company/admin/editors/job.phtml:133
-msgid ""
-"What is this company about? Fill in the blanks below, please note that at "
-"least one language must be used."
-msgstr ""
-"What is this company about? Fill in the blanks below, please note that at "
-"least one language must be used."
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:21
-msgid ""
-"Specify the permanent link for this job, it should be unique for this "
-"company."
-msgstr ""
-"Specify the permanent link for this job, it should be unique for this "
-"company."
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:79
-msgid "Enter how someone can contact the person responsible for this job."
-msgstr "Enter how someone can contact the person responsible for this job."
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:224
-#: module/Company/view/partial/company/admin/editors/job.phtml:320
-msgid "View current attachment"
-msgstr "View current attachment"
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:329
-msgid ""
-"Add job labels to your job to give viewers a better understanding of the job."
-msgstr ""
-"Add job labels to your job to give viewers a better understanding of the job."
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:349
-msgid "There are currently no job labels..."
-msgstr "There are currently no job labels..."
-
-#: module/Decision/src/Controller/AdminController.php:55
-msgid "Meeting minutes uploaded"
-msgstr "Meeting minutes uploaded"
-
-#: module/Decision/src/Controller/AdminController.php:137
-msgid "You are not allowed to rename meeting documents"
-msgstr "You are not allowed to rename meeting documents"
-
-#: module/Decision/src/Controller/AdminController.php:177
-#: module/Decision/src/Service/Decision.php:279
-msgid "You are not allowed to delete meeting documents."
-msgstr "You are not allowed to delete meeting documents."
-
-#: module/Decision/src/Controller/DecisionController.php:109
-msgid "You are not allowed to search decisions."
-msgstr "You are not allowed to search decisions."
-
-#: module/Decision/src/Controller/DecisionController.php:142
-msgid "You are not allowed to authorize someone"
-msgstr "You are not allowed to authorize someone"
-
-#: module/Decision/src/Controller/DecisionController.php:190
-#: module/Decision/src/Service/Decision.php:571
-msgid "You are not allowed to revoke authorizations."
-msgstr "You are not allowed to revoke authorizations."
-
-#: module/Decision/src/Controller/DecisionController.php:219
-msgid "You are not allowed to browse files."
-msgstr "You are not allowed to browse files."
-
-#: module/Decision/src/Controller/MemberController.php:40
-#: module/Decision/src/Service/Decision.php:137
-msgid "You are not allowed to view meetings."
-msgstr "You are not allowed to view meetings."
-
-#: module/Decision/src/Controller/MemberController.php:98
-msgid "Not allowed to search for members."
-msgstr "Not allowed to search for members."
-
-#: module/Decision/src/Controller/MemberController.php:151
-msgid "You are not allowed to view the list of birthdays."
-msgstr "You are not allowed to view the list of birthdays."
-
-#: module/Decision/src/Form/Authorization.php:50
-#: module/Decision/view/decision/decision/authorizations.phtml:133
-#: module/Decision/view/decision/decision/authorizations.phtml:139
-msgid "Authorize"
-msgstr "Authorize"
-
-#: module/Decision/src/Form/AuthorizationRevocation.php:42
-msgid "Revoke authorization"
-msgstr "Revoke authorization"
-
-#: module/Decision/src/Form/Document.php:29
-#: module/Decision/src/Form/Minutes.php:33
-#: module/Decision/view/decision/admin/minutes.phtml:31
-msgid "Meeting"
-msgstr "Meeting"
-
-#: module/Decision/src/Form/Document.php:39
-msgid "Document name"
-msgstr "Document name"
-
-#: module/Decision/src/Form/Document.php:49
-msgid "Document to upload"
-msgstr "Document to upload"
-
-#: module/Decision/src/Form/Document.php:59
-msgid "Upload document"
-msgstr "Upload document"
-
-#: module/Decision/src/Form/Minutes.php:34
-msgid "Choose a meeting"
-msgstr "Choose a meeting"
-
-#: module/Decision/src/Form/Minutes.php:45
-msgid "Minutes to upload"
-msgstr "Minutes to upload"
-
-#: module/Decision/src/Form/Minutes.php:94
-msgid "There already are minutes for this meeting"
-msgstr "There already are minutes for this meeting"
-
-#: module/Decision/src/Form/OrganInformation.php:52
-msgid "Short dutch description"
-msgstr "Short dutch description"
-
-#: module/Decision/src/Form/OrganInformation.php:62
-msgid "Short english description"
-msgstr "Short english description"
-
-#: module/Decision/src/Form/OrganInformation.php:72
-msgid "Long dutch description"
-msgstr "Long dutch description"
-
-#: module/Decision/src/Form/OrganInformation.php:82
-msgid "Long english description"
-msgstr "Long english description"
-
-#: module/Decision/src/Form/OrganInformation.php:92
-msgid "Thumbnail photo to upload"
-msgstr "Thumbnail photo to upload"
-
-#: module/Decision/src/Form/OrganInformation.php:102
-msgid "Cover photo to upload"
-msgstr "Cover photo to upload"
-
-#: module/Decision/src/Form/OrganInformation.php:123
-#: module/Decision/view/decision/organ-admin/edit.phtml:182
-#: module/Frontpage/src/Form/NewsItem.php:78
-#: module/Frontpage/src/Form/Page.php:100
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:110
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:143
-#: module/Photo/src/Form/EditAlbum.php:59
-msgid "Save"
-msgstr "Save"
-
-#: module/Decision/src/Form/ReorderDocument.php:46
-msgid "Move up"
-msgstr "Move up"
-
-#: module/Decision/src/Form/ReorderDocument.php:50
-msgid "Move down"
-msgstr "Move down"
-
-#: module/Decision/src/Form/SearchDecision.php:25
-#: module/Decision/view/decision/decision/search.phtml:32
-#: module/Education/src/Form/SearchCourse.php:23
-msgid "Search query"
-msgstr "Search query"
-
-#: module/Decision/src/Form/SearchDecision.php:35
-#: module/Decision/src/Form/SearchDecision.php:36
-#: module/Decision/view/decision/decision/search.phtml:41
-#: module/Decision/view/decision/member/index.phtml:157
-#: module/Education/view/education/education/index.phtml:59
-msgid "Search"
-msgstr "Search"
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:21
-msgid "Home address (parents)"
-msgstr "Home address (parents)"
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:22
-msgid "Student address"
-msgstr "Student address"
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:23
-msgid "Mail address"
-msgstr "Mail address"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:22
-msgid "Board Meeting"
-msgstr "Board Meeting"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:23
-msgid "General Members Meeting"
-msgstr "General Members Meeting"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:24
-msgid "Chair's Meeting"
-msgstr "Chair's Meeting"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:25
-msgid "Virtual Meeting"
-msgstr "Virtual Meeting"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:32
-msgid "BM"
-msgstr "BM"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:33
-msgid "GMM"
-msgstr "GMM"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:34
-msgid "CM"
-msgstr "CM"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:35
-msgid "VIRT"
-msgstr "VIRT"
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:22
-msgid "Ordinary"
-msgstr "Ordinary"
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:24
-msgid "Graduate"
-msgstr "Graduate"
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:25
-msgid "Honorary"
-msgstr "Honorary"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:24
-msgid "Committee"
-msgstr "Committee"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:25
-msgid "GMM Committee"
-msgstr "GMM Committee"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:26
-msgid "Fraternity"
-msgstr "Fraternity"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:27
-msgid "Financial Audit Committee"
-msgstr "Financial Audit Committee"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:28
-msgid "GMM Taskforce"
-msgstr "GMM Taskforce"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:29
-msgid "Advisory Board"
-msgstr "Advisory Board"
-
-#: module/Decision/src/Service/Decision.php:90
-#: module/Decision/src/Service/Decision.php:109
-#: module/Decision/src/Service/Decision.php:121
-msgid "You are not allowed to list meetings."
-msgstr "You are not allowed to list meetings."
-
-#: module/Decision/src/Service/Decision.php:178
-msgid "You are not allowed to view meeting documents."
-msgstr "You are not allowed to view meeting documents."
-
-#: module/Decision/src/Service/Decision.php:195
-msgid "You are not allowed to view meeting minutes."
-msgstr "You are not allowed to view meeting minutes."
-
-#: module/Decision/src/Service/Decision.php:388
-msgid "You are not allowed to view all authorizations."
-msgstr "You are not allowed to view all authorizations."
-
-#: module/Decision/src/Service/Decision.php:404
-msgid "You are not allowed to view authorizations."
-msgstr "You are not allowed to view authorizations."
-
-#: module/Decision/src/Service/Decision.php:514
-msgid "You are not allowed to upload meeting minutes."
-msgstr "You are not allowed to upload meeting minutes."
-
-#: module/Decision/src/Service/Decision.php:528
-msgid "You are not allowed to upload meeting documents."
-msgstr "You are not allowed to upload meeting documents."
-
-#: module/Decision/src/Service/Decision.php:558
-msgid "You are not allowed authorize people."
-msgstr "You are not allowed authorize people."
-
-#: module/Decision/src/Service/Member.php:50
-#: module/Decision/src/Service/MemberInfo.php:69
-msgid "You are not allowed to view members."
-msgstr "You are not allowed to view members."
-
-#: module/Decision/src/Service/MemberInfo.php:65
-msgid "You are not allowed to view membership info."
-msgstr "You are not allowed to view membership info."
-
-#: module/Decision/src/Service/Organ.php:66
-msgid "Not allowed to view the list of organs"
-msgstr "Not allowed to view the list of organs"
-
-#: module/Decision/src/Service/Organ.php:78
-msgid "Not allowed to view organ information"
-msgstr "Not allowed to view organ information"
-
-#: module/Decision/src/Service/Organ.php:93
-msgid "You are not allowed to edit organ information"
-msgstr "You are not allowed to edit organ information"
-
-#: module/Decision/src/Service/Organ.php:305
-msgid "You are not allowed to edit this organ's information"
-msgstr "You are not allowed to edit this organ's information"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:31
-#, php-format
-msgid "GMM %d (%s)"
-msgstr "GMM %d (%s)"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:38
-msgid "No GMM available."
-msgstr "No GMM available."
-
-#: module/Decision/view/decision/admin/authorizations.phtml:43
-#, php-format
-msgid "Valid authorizations for GMM %d"
-msgstr "Valid authorizations for GMM %d"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:48
-#: module/Decision/view/decision/admin/authorizations.phtml:72
-msgid "Authorizer"
-msgstr "Authorizer"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:49
-#: module/Decision/view/decision/admin/authorizations.phtml:73
-msgid "Recipient"
-msgstr "Recipient"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:50
-#: module/Decision/view/decision/admin/authorizations.phtml:74
-msgid "Created"
-msgstr "Created"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:64
-msgid "There are no valid authorizations for this GMM."
-msgstr "There are no valid authorizations for this GMM."
-
-#: module/Decision/view/decision/admin/authorizations.phtml:67
-#, php-format
-msgid "Revoked authorizations for GMM %d"
-msgstr "Revoked authorizations for GMM %d"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:75
-msgid "Revoked"
-msgstr "Revoked"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:90
-msgid "There are no revoked authorizations for this GMM."
-msgstr "There are no revoked authorizations for this GMM."
-
-#: module/Decision/view/decision/admin/authorizations.phtml:93
-msgid "Please select a GMM to view authorizations."
-msgstr "Please select a GMM to view authorizations."
-
-#: module/Decision/view/decision/admin/document.phtml:33
-msgid "There are no meetings for which you can upload documents."
-msgstr "There are no meetings for which you can upload documents."
-
-#: module/Decision/view/decision/admin/document.phtml:37
-msgid "Meeting document uploaded"
-msgstr "Meeting document uploaded"
-
-#: module/Decision/view/decision/admin/document.phtml:62
-msgid "No meeting available."
-msgstr "No meeting available."
-
-#: module/Decision/view/decision/admin/document.phtml:103
-msgid "Documents for this meeting"
-msgstr "Documents for this meeting"
-
-#: module/Decision/view/decision/admin/document.phtml:106
-msgid "This meeting does not have any associated documents."
-msgstr "This meeting does not have any associated documents."
-
-#: module/Decision/view/decision/admin/document.phtml:145
-#: module/Decision/view/decision/admin/document.phtml:208
-msgid "Rename"
-msgstr "Rename"
-
-#: module/Decision/view/decision/admin/document.phtml:163
-#: module/Education/view/education/admin/course-documents.phtml:163
-msgid "Delete Document"
-msgstr "Delete Document"
-
-#: module/Decision/view/decision/admin/document.phtml:195
-msgid "Rename Meeting Document"
-msgstr "Rename Meeting Document"
-
-#: module/Decision/view/decision/admin/document.phtml:198
-msgid "Enter a new name for this document:"
-msgstr "Enter a new name for this document:"
-
-#: module/Decision/view/decision/admin/minutes.phtml:55
-msgid "Upload"
-msgstr "Upload"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:36
-msgid ""
-"There are no upcoming meetings for which you can authorize someone.\n"
-"You may still be able to authorize someone or revoke an authorization by "
-"contacting the board."
-msgstr ""
-"There are no upcoming meetings for which you can authorize someone.\n"
-"You may still be able to authorize someone or revoke an authorization by "
-"contacting the board."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:40
-#, php-format
-msgid "You have authorized %s for the %s GMM (%s)."
-msgstr "You have authorized %s for the %s GMM (%s)."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:47
-#, php-format
-msgid ""
-"As per HR article 5 paragraph 4, you have the right to revoke your "
-"authorization for the %s GMM. You can communicate this to the board in "
-"writing (not by email) or by using the form below. Please note that you can "
-"only revoke an authorization that was granted via this website by using the "
-"form below."
-msgstr ""
-"As per HR article 5 paragraph 4, you have the right to revoke your "
-"authorization for the %s GMM. You can communicate this to the board in "
-"writing (not by email) or by using the form below. Please note that you can "
-"only revoke an authorization that was granted via this website by using the "
-"form below."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:63
-#: module/Decision/view/decision/decision/authorizations.phtml:118
-msgid "Terms"
-msgstr "Terms"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:68
-#, php-format
-msgid ""
-"I, %s am fully aware that by revoking my authorization, %s cannot represent "
-"me at the %s General Members Meeting (%s) of s.v. GEWIS."
-msgstr ""
-"I, %s am fully aware that by revoking my authorization, %s cannot represent "
-"me at the %s General Members Meeting (%s) of s.v. GEWIS."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:89
-#, php-format
-msgid "Authorize someone for the %s GMM (%s)"
-msgstr "Authorize someone for the %s GMM (%s)"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:105
-#: module/User/view/user/user/login.phtml:29
-msgid "Member"
-msgstr "Member"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:123
-#, php-format
-msgid ""
-"I, %s I am fully aware that by filling in this form I authorize the person "
-"in this form to represent me at the %s General Members Meeting (%s) of s.v. "
-"GEWIS."
-msgstr ""
-"I, %s I am fully aware that by filling in this form I authorize the person "
-"in this form to represent me at the %s General Members Meeting (%s) of s.v. "
-"GEWIS."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:175
-msgid "Are you sure you would like to authorize"
-msgstr "Are you sure you would like to authorize"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:181
-msgid ""
-"This member has already received 2 or more authorizations through the "
-"website. Since you can only use two authorizations at the same time, this "
-"member may have to choose which 2 authorizations they use. This may "
-"<strong>not</strong> include yours. If you want to authorize someone else "
-"instead, click on \"cancel\". If you want to continue with the authorization "
-"click on \"confirm authorization\"."
-msgstr ""
-"This member has already received 2 or more authorizations through the "
-"website. Since you can only use two authorizations at the same time, this "
-"member may have to choose which 2 authorizations they use. This may "
-"<strong>not</strong> include yours. If you want to authorize someone else "
-"instead, click on \"cancel\". If you want to continue with the authorization "
-"click on \"confirm authorization\"."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:187
-msgid "Confirm authorization"
-msgstr "Confirm authorization"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:211
-#, php-format
-msgid "Are you sure you would like to authorize %s"
-msgstr "Are you sure you would like to authorize %s"
-
-#: module/Decision/view/decision/decision/files.phtml:26
-#: module/Decision/view/decision/decision/files.phtml:28
-#: module/Decision/view/decision/decision/files.phtml:47
-#: module/Decision/view/decision/decision/files.phtml:51
-msgid "Root"
-msgstr "Root"
-
-#: module/Decision/view/decision/decision/files.phtml:47
-msgid "Public Archive"
-msgstr "Public Archive"
-
-#: module/Decision/view/decision/decision/files.phtml:51
-msgid "Browsing directory: "
-msgstr "Browsing directory: "
-
-#: module/Decision/view/decision/decision/files.phtml:78
-msgid "Filename"
-msgstr "Filename"
-
-#: module/Decision/view/decision/decision/files.phtml:92
-msgid ".. Move up a folder"
-msgstr ".. Move up a folder"
-
-#: module/Decision/view/decision/decision/files.phtml:101
-msgid "Empty folder"
-msgstr "Empty folder"
-
-#: module/Decision/view/decision/decision/index.phtml:24
-msgid "Meeting number"
-msgstr "Meeting number"
-
-#: module/Decision/view/decision/decision/index.phtml:25
-#: module/Decision/view/decision/member/birthdays.phtml:22
-#: module/Education/view/education/admin/course-documents.phtml:65
-#: module/Education/view/education/admin/course-documents.phtml:116
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:41
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:114
-msgid "Date"
-msgstr "Date"
-
-#: module/Decision/view/decision/decision/index.phtml:26
 msgid "# Decisions"
 msgstr "# Decisions"
 
-#: module/Decision/view/decision/decision/search.phtml:14
-msgid "Search for decision"
-msgstr "Search for decision"
-
-#: module/Decision/view/decision/decision/search.phtml:50
-msgid "No decisions were found."
-msgstr "No decisions were found."
-
-#: module/Decision/view/decision/decision/search.phtml:52
-msgid "Check the spelling of your search term"
-msgstr "Check the spelling of your search term"
-
-#: module/Decision/view/decision/decision/search.phtml:53
-msgid "Try alternate words or selections"
-msgstr "Try alternate words or selections"
-
-#: module/Decision/view/decision/decision/search.phtml:54
-msgid "Try using a more generic search term"
-msgstr "Try using a more generic search term"
-
-#: module/Decision/view/decision/decision/search.phtml:55
-msgid "Try entering fewer keywords"
-msgstr "Try entering fewer keywords"
-
-#: module/Decision/view/decision/decision/search.phtml:56
-msgid ""
-"Looking for a specific decision but forgot the numbers? Try dropping the "
-"decision point and/or number"
-msgstr ""
-"Looking for a specific decision but forgot the numbers? Try dropping the "
-"decision point and/or number"
-
-#: module/Decision/view/decision/decision/view.phtml:47
-msgid "No documents have been added."
-msgstr "No documents have been added."
-
-#: module/Decision/view/decision/decision/view.phtml:62
 #, php-format
-msgid "View the minutes of the %s"
-msgstr "View the minutes of the %s"
+msgid "%d votes"
+msgstr "%d votes"
 
-#: module/Decision/view/decision/decision/view.phtml:71
-msgid "Decisions"
-msgstr "Decisions"
-
-#: module/Decision/view/decision/member/birthdays.phtml:14
-msgid "Birthdays"
-msgstr "Birthdays"
-
-#: module/Decision/view/decision/member/birthdays.phtml:24
-msgid "Age"
-msgstr "Age"
-
-#: module/Decision/view/decision/member/birthdays.phtml:44
-msgid "years"
-msgstr "years"
-
-#: module/Decision/view/decision/member/index.phtml:33
-msgid "Personal"
-msgstr "Personal"
-
-#: module/Decision/view/decision/member/index.phtml:37
-msgid "Profile"
-msgstr "Profile"
-
-#: module/Decision/view/decision/member/index.phtml:78
-msgid "Public archive"
-msgstr "Public archive"
-
-#: module/Decision/view/decision/member/index.phtml:83
-msgid "Find a member"
-msgstr "Find a member"
-
-#: module/Decision/view/decision/member/index.phtml:106
-msgid "Upcoming meeting"
-msgid_plural "Upcoming meetings"
-msgstr[0] "Upcoming meeting"
-msgstr[1] "Upcoming meetings"
-
-#: module/Decision/view/decision/member/index.phtml:118
 #, php-format
-msgid "The %s%s %s%s will be held on %s."
-msgstr "The %s%s %s%s will be held on %s."
+msgid "%s %s"
+msgstr "%s %s"
 
-#: module/Decision/view/decision/member/index.phtml:144
-#, php-format
-msgid ""
-"If you aren't able to attend a GMM in person but you want your voice to be "
-"heard, consider %sauthorizing another member%s to act on your behalf."
-msgstr ""
-"If you aren't able to attend a GMM in person but you want your voice to be "
-"heard, consider %sauthorizing another member%s to act on your behalf."
-
-#: module/Decision/view/decision/member/index.phtml:152
-msgid "Search through the list of decisions accumulated from past meetings:"
-msgstr "Search through the list of decisions accumulated from past meetings:"
-
-#: module/Decision/view/decision/member/index.phtml:155
-msgid "Search by keyword or meeting number"
-msgstr "Search by keyword or meeting number"
-
-#: module/Decision/view/decision/member/index.phtml:162
-#, php-format
-msgid "The latest %s that took place:"
-msgstr "The latest %s that took place:"
-
-#: module/Decision/view/decision/member/index.phtml:174
 #, php-format
 msgid "%s %s on %s"
 msgstr "%s %s on %s"
 
-#: module/Decision/view/decision/member/index.phtml:189
-msgid "View all meetings"
-msgstr "View all meetings"
+#, php-format
+msgid "%s for company %s will expire on %s"
+msgstr "%s for company %s will expire on %s"
 
-#: module/Decision/view/decision/member/index.phtml:194
-#: module/Decision/view/decision/organ/show.phtml:25
-#: module/Frontpage/view/frontpage/organ/organ.phtml:145
-msgid "Active members"
-msgstr "Active members"
+#, php-format
+msgid "%s for company %s will start on %s"
+msgstr "%s for company %s will start on %s"
 
-#: module/Decision/view/decision/member/index.phtml:195
+#, php-format
+msgid "%s has never been part of a committee or fraternity."
+msgstr "%s has never been part of a committee or fraternity."
+
+#, php-format
+msgid "%s is currently a member of:"
+msgstr "%s is currently a member of:"
+
+#, php-format
+msgid "%s is currently the <strong>%s</strong>."
+msgstr "%s is currently the <strong>%s</strong>."
+
+#, php-format
+msgid "%s is the upcoming <strong>%s</strong>."
+msgstr "%s is the upcoming <strong>%s</strong>."
+
+#, php-format
+msgid "%s was a member of:"
+msgstr "%s was a member of:"
+
+#, php-format
+msgid "%s was the <strong>%s</strong> during the association year %d/%d."
+msgstr "%s was the <strong>%s</strong> during the association year %d/%d."
+
+#, php-format
+msgid "%s wil be %s years old today!"
+msgstr "%s will be %s years old today!"
+
+#, php-format
+msgid "%s's activities"
+msgstr "%s's activities"
+
+#, php-format
+msgid "%sRequest a poll%s"
+msgstr "%sRequest a poll%s"
+
+msgid "(Update Pending)"
+msgstr "(Update Pending)"
+
+msgid ".. Move up a folder"
+msgstr ".. Move up a folder"
+
+msgid "1 vote"
+msgstr "1 vote"
+
+msgid "403 Forbidden"
+msgstr "403 Forbidden"
+
+msgid "A 404 error occurred"
+msgstr "A 404 error occurred"
+
 msgid "A list of helpful resources for active members."
 msgstr "A list of helpful resources for active members."
 
-#: module/Decision/view/decision/member/index.phtml:199
-msgid "Webmail"
-msgstr "Webmail"
+msgid "API Tokens"
+msgstr "API Tokens"
 
-#: module/Decision/view/decision/member/index.phtml:211
-msgid "GEWIKI"
-msgstr "GEWIKI"
+msgid "API Users"
+msgstr "API Users"
 
-#: module/Decision/view/decision/member/index.phtml:215
-msgid "Corporate Identity"
-msgstr "Corporate Identity"
+msgid "Abbreviation"
+msgstr "Abbreviation"
 
-#: module/Decision/view/decision/member/index.phtml:219
+msgid "Actions"
+msgstr "Actions"
+
+msgid "Activate"
+msgstr "Activate"
+
+msgid "Active"
+msgstr "Active"
+
+msgid "Active Option Planning Periods"
+msgstr "Active Option Planning Periods"
+
+msgid "Active jobs"
+msgstr "Active jobs"
+
+msgid "Active members"
+msgstr "Active members"
+
+msgid "Activities"
+msgstr "Activities"
+
+msgid ""
+"Activities that have sign-up lists which are open or approved cannot be "
+"updated."
+msgstr ""
+"Activities that have sign-up lists which are open or approved cannot be "
+"updated."
+
+msgid "Activity Archive"
+msgstr "Activity Archive"
+
+msgid "Activity Categories"
+msgstr "Activity Categories"
+
+msgid "Activity Policy"
+msgstr "Activity Policy"
+
+msgid "Add"
+msgstr "Add"
+
+msgid "Add Banner Package"
+msgstr "Add Banner Package"
+
+msgid "Add Category"
+msgstr "Add Category"
+
+msgid "Add Company"
+msgstr "Add Company"
+
+msgid "Add Course"
+msgstr "Add Course"
+
+msgid "Add Job"
+msgstr "Add Job"
+
+msgid "Add Job Package"
+msgstr "Add Job Package"
+
+msgid "Add Label"
+msgstr "Add Label"
+
+msgid "Add Option Period"
+msgstr "Add Option Period"
+
+msgid "Add Package"
+msgstr "Add Package"
+
+msgid "Add Spotlight Package"
+msgstr "Add Spotlight Package"
+
+msgid "Add Token"
+msgstr "Add Token"
+
+msgid "Add a sign-up list"
+msgstr "Add a sign-up list"
+
+msgid "Add a sign-up list field"
+msgstr "Add a sign-up list field"
+
+msgid "Add a token"
+msgstr "Add a token"
+
+msgid ""
+"Add activity categories to your activity to give potential subscribers a "
+"better understanding of the activity."
+msgstr ""
+"Add activity categories to your activity to give potential subscribers a "
+"better understanding of the activity."
+
+msgid "Add an option"
+msgstr "Add an option"
+
+msgid "Add course"
+msgstr "Add course"
+
+msgid ""
+"Add job labels to your job to give viewers a better understanding of the job."
+msgstr ""
+"Add job labels to your job to give viewers a better understanding of the job."
+
+msgid "Add new Token"
+msgstr "Add new Token"
+
+msgid "Add option"
+msgstr "Add option"
+
+msgid "Add options for your activity proposal."
+msgstr "Add options for your activity proposal."
+
+msgid "Add photos"
+msgstr "Add photos"
+
+msgid ""
+"Add sign-up lists to allow people to sign up for this activity. Each list "
+"can have optional fields to collect specific information from the "
+"participants."
+msgstr ""
+"Add sign-up lists to allow people to sign up for this activity. Each list "
+"can have optional fields to collect specific information from the "
+"participants."
+
+msgid "Additional actions"
+msgstr "Additional actions"
+
+msgid "Additional information"
+msgstr "Additional information"
+
+msgid "Address"
+msgstr "Address"
+
+msgid "Addresses"
+msgstr "Addresses"
+
+msgid "Admin"
+msgstr "Admin"
+
 msgid "Administrator"
 msgstr "Administrator"
 
-#: module/Decision/view/decision/member/index.phtml:237
-msgid "Bylaws"
-msgstr "Bylaws"
+msgid "Advisory Board"
+msgstr "Advisory Board"
 
-#: module/Decision/view/decision/member/index.phtml:249
-msgid "Internal Regulations"
-msgstr "Internal Regulations"
+msgid "Advisory Boards"
+msgstr "Advisory Boards"
 
-#: module/Decision/view/decision/member/index.phtml:264
+msgid "Afternoon"
+msgstr "Afternoon"
+
+msgid "Age"
+msgstr "Age"
+
+msgid "Agenda"
+msgstr "Agenda"
+
+msgid "Album title"
+msgstr "Album title"
+
+msgid "Alcohol Policy"
+msgstr "Alcohol Policy"
+
+msgid "All Activities"
+msgstr "All Activities"
+
+msgid "All rights reserved."
+msgstr "All rights reserved."
+
+msgid "Already subscribed"
+msgstr "Already subscribed"
+
+msgid "Already voted!"
+msgstr "Already voted!"
+
+msgid "Also for data removal requests, you can contact"
+msgstr "Also for data removal requests, you can contact"
+
+msgid ""
+"An e-mail has been sent with instructions for resetting your password. If "
+"you have not received an e-mail, try again in 20 minutes."
+msgstr ""
+"An e-mail has been sent with instructions for resetting your password. If "
+"you have not received an e-mail, try again in 20 minutes."
+
+msgid "An error occurred"
+msgstr "An error occurred"
+
+msgid "An error occurred while saving the course!"
+msgstr "An error occurred while saving the course!"
+
+msgid "An error occurred while trying to generate an album photo."
+msgstr "An error occurred while trying to generate an album photo."
+
+msgid "An unknown error occurred during uploading ("
+msgstr "An unknown error occurred during uploading ("
+
+msgid "An unknown error occurred during uploading (%i)"
+msgstr "An unknown error occurred during uploading (%i)"
+
+msgid ""
+"An unknown error occurred while try to change the status of a job update "
+"proposal. Please try again."
+msgstr ""
+"An unknown error occurred while try to change the status of a job update "
+"proposal. Please try again."
+
+msgid ""
+"An unknown error occurred while trying to transfer jobs, please try again."
+msgstr ""
+"An unknown error occurred while trying to transfer jobs, please try again."
+
+msgid "Answers"
+msgstr "Answers"
+
+#, php-format
+msgid "Answers from %s (%s)"
+msgstr "Answers from %s (%s)"
+
+msgid "Aperture"
+msgstr "Aperture"
+
+msgid "App"
+msgstr "App"
+
+msgid "Applied Physics"
+msgstr "Applied Physics"
+
+msgid "Apply Update"
+msgstr "Apply Update"
+
+msgid "Approval"
+msgstr "Approval"
+
+msgid "Approval status"
+msgstr "Approval status"
+
+msgid "Approvals"
+msgstr "Approvals"
+
+msgid "Approve"
+msgstr "Approve"
+
+msgid "Approve Job"
+msgstr "Approve Job"
+
+msgid "Approve option"
+msgstr "Approve option"
+
+msgid "Approve poll"
+msgstr "Approve poll"
+
+msgid "Approved"
+msgstr "Approved"
+
+msgid "Approved (Has Updates)"
+msgstr "Approved (Has Updates)"
+
+msgid "Approved Activities"
+msgstr "Approved Activities"
+
+msgid "Approved polls"
+msgstr "Approved polls"
+
+msgid "Approver"
+msgstr "Approver"
+
+msgid "Are you sure that you want to approve this poll?"
+msgstr "Are you sure that you want to approve this poll?"
+
+msgid "Are you sure you want to approve this option?"
+msgstr "Are you sure you want to approve this option?"
+
+#, php-format
+msgid "Are you sure you want to delete %s?"
+msgstr "Are you sure you want to delete %s?"
+
+#, php-format
+msgid ""
+"Are you sure you want to delete %s? This will also delete all associated "
+"exams and summaries will be deleted."
+msgstr ""
+"Are you sure you want to delete %s? This will also delete all associated "
+"exams and summaries will be deleted."
+
+msgid ""
+"Are you sure you want to delete the selected items? <strong>This action can "
+"not be reverted.</strong>"
+msgstr ""
+"Are you sure you want to delete the selected items? <strong>This action can "
+"not be reverted.</strong>"
+
+msgid "Are you sure you want to delete this activity category?"
+msgstr "Are you sure you want to delete this activity category?"
+
+msgid ""
+"Are you sure you want to delete this album including all photos inside of "
+"it? <strong>This action can not be reverted.</strong>"
+msgstr ""
+"Are you sure you want to delete this album including all photos inside of "
+"it? <strong>This action can not be reverted.</strong>"
+
+msgid "Are you sure you want to delete this document?"
+msgstr "Are you sure you want to delete this document?"
+
+msgid "Are you sure you want to delete this job?"
+msgstr "Are you sure you want to delete this job?"
+
+msgid ""
+"Are you sure you want to delete this option planning period? This will "
+"<strong>not</strong> delete proposed options."
+msgstr ""
+"Are you sure you want to delete this option planning period? This will "
+"<strong>not</strong> delete proposed options."
+
+msgid "Are you sure you want to delete this option?"
+msgstr "Are you sure you want to delete this option?"
+
+msgid "Are you sure you want to delete this package?"
+msgstr "Are you sure you want to delete this package?"
+
+msgid ""
+"Are you sure you want to delete this photo? <strong>This action can not be "
+"reverted.</strong>"
+msgstr ""
+"Are you sure you want to delete this photo? <strong>This action can not be "
+"reverted.</strong>"
+
+msgid "Are you sure you want to delete this poll?"
+msgstr "Are you sure you want to delete this poll?"
+
+msgid "Are you sure you would like to authorize"
+msgstr "Are you sure you would like to authorize"
+
+#, php-format
+msgid "Are you sure you would like to authorize %s"
+msgstr "Are you sure you would like to authorize %s"
+
+msgid "Article"
+msgstr "Article"
+
+msgid "Artist"
+msgstr "Artist"
+
+#, php-format
+msgid ""
+"As per HR article 5 paragraph 4, you have the right to revoke your "
+"authorization for the %s GMM. You can communicate this to the board in "
+"writing (not by email) or by using the form below. Please note that you can "
+"only revoke an authorization that was granted via this website by using the "
+"form below."
+msgstr ""
+"As per HR article 5 paragraph 4, you have the right to revoke your "
+"authorization for the %s GMM. You can communicate this to the board in "
+"writing (not by email) or by using the form below. Please note that you can "
+"only revoke an authorization that was granted via this website by using the "
+"form below."
+
+msgid "Association"
+msgstr "Association"
+
+msgid "Attachment"
+msgstr "Attachment"
+
+msgid "Author"
+msgstr "Author"
+
+msgid "Authorise"
+msgstr "Authorise"
+
+msgid "Authorizations"
+msgstr "Authorizations"
+
+msgid "Authorize"
+msgstr "Authorize"
+
+#, php-format
+msgid "Authorize %s to use your account?"
+msgstr "Authorize %s to use your account?"
+
+#, php-format
+msgid "Authorize someone for the %s GMM (%s)"
+msgstr "Authorize someone for the %s GMM (%s)"
+
+msgid "Authorizer"
+msgstr "Authorizer"
+
+msgid "Available documents"
+msgstr "Available documents"
+
+msgid "BM"
+msgstr "BM"
+
+msgid "Banner"
+msgstr "Banner"
+
+msgid "Banner Package"
+msgstr "Banner Package"
+
+msgid "Banner active"
+msgstr "Banner active"
+
+msgid "Biomedical Engineering"
+msgstr "Biomedical Engineering"
+
+msgid "Birth date"
+msgstr "Birth date"
+
+msgid "Birthdays"
+msgstr "Birthdays"
+
+msgid "Board"
+msgstr "Board"
+
+msgid "Board Meeting"
+msgstr "Board Meeting"
+
 msgid "Board Policies"
 msgstr "Board Policies"
 
-#: module/Decision/view/decision/member/index.phtml:269
+msgid "Books"
+msgstr "Books"
+
 msgid "Borrel Policy"
 msgstr "Borrel Policy"
 
-#: module/Decision/view/decision/member/index.phtml:274
-msgid "House Rules"
-msgstr "House Rules"
+msgid "Brand Manager"
+msgstr "Brand Manager"
 
-#: module/Decision/view/decision/member/index.phtml:279
-msgid "ICT Policy"
-msgstr "ICT Policy"
+msgid "Browsing directory: "
+msgstr "Browsing directory: "
 
-#: module/Decision/view/decision/member/index.phtml:284
-msgid "Key Policy"
-msgstr "Key Policy"
+msgid ""
+"By subscribing an external participant to this activity, they must agree to "
+"the terms outlined in the"
+msgstr ""
+"By subscribing an external participant to this activity, they must agree to "
+"the terms outlined in the"
 
-#: module/Decision/view/decision/member/index.phtml:289
-msgid "Poster Policy"
-msgstr "Poster Policy"
+msgid "By subscribing to this activity, you agree to the terms outlined in the"
+msgstr ""
+"By subscribing to this activity, you agree to the terms outlined in the"
 
-#: module/Decision/view/decision/member/index.phtml:300
-msgid "Organ Regulations"
-msgstr "Organ Regulations"
+msgid "Bylaws"
+msgstr "Bylaws"
 
-#: module/Decision/view/decision/member/search.phtml:10
-#: module/Decision/view/decision/member/search.phtml:16
-msgid "Zoeken op lid"
-msgstr "Search for a member"
+msgid "CM"
+msgstr "CM"
 
-#: module/Decision/view/decision/member/search.phtml:20
-msgid "Zoek"
-msgstr "Search"
+msgid "Camera"
+msgstr "Camera"
 
-#: module/Decision/view/decision/member/search.phtml:30
-msgid "Naam"
-msgstr "Name"
+msgid "Cancel"
+msgstr "Cancel"
 
-#: module/Decision/view/decision/member/search.phtml:31
-msgid "Generatie"
-msgstr "Generation"
+msgid "Cannot load metadata"
+msgstr "Cannot load metadata"
 
-#: module/Decision/view/decision/member/search.phtml:38
+msgid "Cannot load tags"
+msgstr "Cannot load tags"
+
+msgid "Cannot load vote"
+msgstr "Cannot load vote"
+
+msgid "Career"
+msgstr "Career"
+
+msgid "Career Activities"
+msgstr "Career Activities"
+
+msgid "Career related"
+msgstr "Career related"
+
+msgid "Categories"
+msgstr "Categories"
+
+msgid "Category"
+msgstr "Category"
+
+msgid "Chair's Meeting"
+msgstr "Chair's Meeting"
+
+msgid "Change password"
+msgstr "Change password"
+
+#, php-format
+msgid ""
+"Changes in activity attributes are shown like this: %s. If there are no "
+"changes to a certain attribute, you will see the existing data. Sign-up list "
+"differences are <strong>not</strong> shown with colours, both the old sign-"
+"up list(s) and the new sign-up list(s) are shown. There might not be "
+"difference between the two!"
+msgstr ""
+"Changes in activity attributes are shown like this: %s. If there are no "
+"changes to a certain attribute, you will see the existing data. Sign-up list "
+"differences are <strong>not</strong> shown with colours, both the old sign-"
+"up list(s) and the new sign-up list(s) are shown. There might not be "
+"difference between the two!"
+
+msgid "Check the spelling of your search term"
+msgstr "Check the spelling of your search term"
+
+msgid ""
+"Check this if the document is scanned, as this will enable higher quality "
+"downloads. Please note that enabling setting this for non-scanned documents "
+"will significantly impact the ability to download the document."
+msgstr ""
+"Check this if the document is scanned, as this will enable higher quality "
+"downloads. Please note that enabling setting this for non-scanned documents "
+"will significantly impact the ability to download the document."
+
+msgid "Chemical Engineering"
+msgstr "Chemical Engineering"
+
+msgid "Choice"
+msgstr "Choice"
+
+msgid "Choose a meeting"
+msgstr "Choose a meeting"
+
+msgid "Choose to which job package you want to transfer the selected jobs."
+msgstr "Choose to which job package you want to transfer the selected jobs."
+
+msgid "Choose which options are applicable to this activity."
+msgstr "Choose which options are applicable to this activity."
+
+msgid "City and postal code"
+msgstr "City and postal code"
+
+msgid "Close"
+msgstr "Close"
+
+msgid "Close date and time"
+msgstr "Close date and time"
+
+msgid "Code"
+msgstr "Code"
+
+msgid "Comment"
+msgstr "Comment"
+
+msgid "Comment on this poll"
+msgstr "Comment on this poll"
+
+msgid "Comments"
+msgstr "Comments"
+
+msgid "Commissaris Carrièreontwikkeling en Externe Betrekkingen"
+msgstr "Career Development and External Affairs Officer"
+
+msgid "Commissaris Externe Betrekkingen"
+msgstr "External Affairs Officer"
+
+msgid "Commissaris Innovatie"
+msgstr "Innovation Officer"
+
+msgid "Commissaris Interne Betrekkingen"
+msgstr "Internal Affairs Officer"
+
+msgid "Commissaris Kennisbeheer"
+msgstr "Information Officer"
+
+msgid "Commissaris Onderwijs"
+msgstr "Educational Officer"
+
+msgid "Committee"
+msgstr "Committee"
+
+msgid "Committee / fraternity"
+msgstr "Committee / fraternity"
+
+msgid "Committees"
+msgstr "Committees"
+
+msgid "Companies"
+msgstr "Companies"
+
+msgid "Company"
+msgstr "Company"
+
+msgid "Company Account"
+msgstr "Company Account"
+
+msgid "Complaint or suggestion about TU/e education?"
+msgstr "Complaint or suggestion about TU/e education?"
+
+msgid "Complete agenda"
+msgstr "Complete agenda"
+
+msgid "Confidential Contact Person (CCP)"
+msgstr "Confidential Contact Person (CCP)"
+
+msgid "Confirm authorization"
+msgstr "Confirm authorization"
+
+msgid "Confirm subscription"
+msgstr "Confirm subscription"
+
+msgid "Contact"
+msgstr "Contact"
+
+msgid "Contact Information"
+msgstr "Contact Information"
+
+msgid "Content"
+msgstr "Content"
+
+msgid "Continue"
+msgstr "Continue"
+
+msgid "Continue reading"
+msgstr "Continue reading"
+
+msgid "Contract Number"
+msgstr "Contract Number"
+
+msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
+msgstr ""
+"Contract numbers can only contain letters, numbers, _, -, ., and spaces"
+
+msgid "Controller"
+msgstr "Controller"
+
+msgid "Copied URL!"
+msgstr "Copied URL!"
+
+msgid "Corporate Identity"
+msgstr "Corporate Identity"
+
+msgid "Costs"
+msgstr "Costs"
+
+msgid "Could not set as profile photo, try again"
+msgstr "Could not set as profile photo, try again"
+
+msgid "Could not vote, try again"
+msgstr "Could not vote, try again"
+
+msgid "Country"
+msgstr "Country"
+
+msgid "Course Admin"
+msgstr "Course Admin"
+
+#, php-format
+msgid "Course Documents of %s"
+msgstr "Course Documents of %s"
+
+msgid "Course code"
+msgstr "Course code"
+
+msgid "Course code or course description"
+msgstr "Course code or course description"
+
+msgid "Course does not exist"
+msgstr "Course does not exist"
+
+msgid "Course name"
+msgstr "Course name"
+
+msgid "Courses"
+msgstr "Courses"
+
+msgid "Cover photo to upload"
+msgstr "Cover photo to upload"
+
+msgid "Create"
+msgstr "Create"
+
+msgid "Create API token"
+msgstr "Create API token"
+
+msgid "Create Activity"
+msgstr "Create Activity"
+
+msgid "Create Activity Category"
+msgstr "Create Activity Category"
+
+msgid "Create Album"
+msgstr "Create Album"
+
+msgid "Create Company"
+msgstr "Create Company"
+
+msgid "Create Job Category"
+msgstr "Create Job Category"
+
+msgid "Create Job Label"
+msgstr "Create Job Label"
+
+msgid "Create Option Period"
+msgstr "Create Option Period"
+
+msgid "Create a new page"
+msgstr "Create a new page"
+
+msgid "Create activity proposal"
+msgstr "Create activity proposal"
+
+msgid "Create album"
+msgstr "Create album"
+
+msgid "Create an activity"
+msgstr "Create an activity"
+
+msgid "Create new album"
+msgstr "Create new album"
+
+msgid "Create news item"
+msgstr "Create news item"
+
+msgid "Created"
+msgstr "Created"
+
+msgid "Creator"
+msgstr "Creator"
+
+msgid "Current photo of the week"
+msgstr "Current photo of the week"
+
+msgid "Current subscriptions"
+msgstr "Current subscriptions"
+
+msgid "Currently, no pictures of the week are available."
+msgstr "Currently, no pictures of the week are available."
+
+msgid "Date"
+msgstr "Date"
+
+msgid "Date and time"
+msgstr "Date and time"
+
+msgid "Date/time"
+msgstr "Date/time"
+
+msgid "Day"
+msgstr "Day"
+
+msgid "Decisions"
+msgstr "Decisions"
+
+msgid "Delete"
+msgstr "Delete"
+
+msgid "Delete %i photos"
+msgstr "Delete %i photos"
+
+msgid "Delete Activity Category"
+msgstr "Delete Activity Category"
+
+msgid "Delete Course"
+msgstr "Delete Course"
+
+msgid "Delete Document"
+msgstr "Delete Document"
+
+msgid "Delete album"
+msgstr "Delete album"
+
+msgid "Delete company"
+msgstr "Delete company"
+
+msgid "Delete confirmation"
+msgstr "Delete confirmation"
+
+msgid "Delete job"
+msgstr "Delete job"
+
+msgid "Delete option"
+msgstr "Delete option"
+
+msgid "Delete package"
+msgstr "Delete package"
+
+msgid "Delete period"
+msgstr "Delete period"
+
+msgid "Delete photo"
+msgstr "Delete photo"
+
+msgid "Delete photos"
+msgstr "Delete photos"
+
+msgid "Delete poll"
+msgstr "Delete poll"
+
+msgid "Delete this news item"
+msgstr "Delete this news item"
+
+msgid "Delete this page"
+msgstr "Delete this page"
+
+msgid "Description"
+msgstr "Description"
+
+msgid "Deselect this to allow people without a GEWIS account to subscribe."
+msgstr "Deselect this to allow people without a GEWIS account to subscribe."
+
+msgid "Details"
+msgstr "Details"
+
+msgid "Digital Infrastructure Officer"
+msgstr "Digital Infrastructure Officer"
+
+msgid "Disapprove"
+msgstr "Disapprove"
+
+msgid "Disapprove Job"
+msgstr "Disapprove Job"
+
+msgid "Disapproved Activities"
+msgstr "Disapproved Activities"
+
+msgid "Disclaimer on educational content"
+msgstr "Disclaimer on educational content"
+
+msgid "Display GEWIS member count"
+msgstr "Display GEWIS member count"
+
+msgid "Display number of subscribed members"
+msgstr "Display number of subscribed members"
+
+#, php-format
+msgid ""
+"Do you have a complaint or suggestion concerning the education at the TU/e? "
+"Contact the %seducation officer%s to share your ideas."
+msgstr ""
+"Do you have a complaint or suggestion concerning the education at the TU/e? "
+"Contact the %seducation officer%s to share your ideas."
+
+#, php-format
+msgid ""
+"Do you want to contribute to the collection of old exams and summaries? Send "
+"them to the %seducation officer%s so that your (future) peers can benefit."
+msgstr ""
+"Do you want to contribute to the collection of old exams and summaries? Send "
+"them to the %seducation officer%s so that your (future) peers can benefit."
+
+msgid "Document name"
+msgstr "Document name"
+
+msgid "Document to upload"
+msgstr "Document to upload"
+
+msgid "Documents"
+msgstr "Documents"
+
+msgid "Documents for this meeting"
+msgstr "Documents for this meeting"
+
+#, php-format
+msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
+msgstr "Thursdays there is a %ssocial drink%s from 16.30 till 19.00."
+
+msgid "Download"
+msgstr "Download"
+
+msgid "Dutch"
+msgstr "Dutch"
+
+msgid "Dutch Name"
+msgstr "Dutch Name"
+
+msgid "Dutch content"
+msgstr "Dutch content"
+
+msgid "Dutch name"
+msgstr "Dutch name"
+
+msgid "Dutch option"
+msgstr "Dutch option"
+
+msgid "Dutch question"
+msgstr "Dutch question"
+
+msgid "Dutch title"
+msgstr "Dutch title"
+
+msgid "E-mail Address"
+msgstr "E-mail Address"
+
+msgid "E-mail address"
+msgstr "E-mail address"
+
+msgid "E-mail address format is not valid"
+msgstr "E-mail address format is not valid"
+
+msgid "E-mail address format is not valid."
+msgstr "E-mail address format is not valid."
+
+msgid "Edit"
+msgstr "Edit"
+
+#, php-format
+msgid "Edit %s"
+msgstr "Edit %s"
+
+msgid "Edit Album"
+msgstr "Edit Album"
+
+msgid "Edit Company"
+msgstr "Edit Company"
+
+msgid "Edit Course"
+msgstr "Edit Course"
+
+msgid "Edit Exam"
+msgstr "Edit Exam"
+
+msgid "Edit Job"
+msgstr "Edit Job"
+
+msgid "Edit Job Category"
+msgstr "Edit Job Category"
+
+msgid "Edit Job Label"
+msgstr "Edit Job Label"
+
+msgid "Edit Option Period"
+msgstr "Edit Option Period"
+
+msgid "Edit Package"
+msgstr "Edit Package"
+
+msgid "Edit Summary"
+msgstr "Edit Summary"
+
+msgid "Edit album"
+msgstr "Edit album"
+
+msgid "Edit organ information"
+msgstr "Edit organ information"
+
+msgid "Education"
+msgstr "Education"
+
+msgid "Education admin"
+msgstr "Education admin"
+
+msgid "Electrical Engineering"
+msgstr "Electrical Engineering"
+
+msgid "Email"
+msgstr "Email"
+
+msgid "Email address"
+msgstr "Email address"
+
+msgid "Email address:"
+msgstr "Email address:"
+
+msgid "Email the board of GEWIS"
+msgstr "Email the board of GEWIS"
+
+msgid "Email the secretary of GEWIS"
+msgstr "Email the secretary of GEWIS"
+
+msgid "Empty folder"
+msgstr "Empty folder"
+
+msgid "Enable Dutch Translations"
+msgstr "Enable Dutch Translations"
+
+msgid "Enable English Translations"
+msgstr "Enable English Translations"
+
+msgid "End"
+msgstr "End"
+
+msgid "End date"
+msgstr "End date"
+
+msgid "End date and time"
+msgstr "End date and time"
+
+msgid "End date and time of option period"
+msgstr "End date and time of option period"
+
+msgid "End date and time of planning period"
+msgstr "End date and time of planning period"
+
+msgid "End date of membership"
+msgstr "End date of membership"
+
+msgid "English"
+msgstr "English"
+
+msgid "English Name"
+msgstr "English Name"
+
+msgid "English content"
+msgstr "English content"
+
+msgid "English name"
+msgstr "English name"
+
+msgid "English option"
+msgstr "English option"
+
+msgid "English question"
+msgstr "English question"
+
+msgid "English title"
+msgstr "English title"
+
+msgid "Enter a new name for this document:"
+msgstr "Enter a new name for this document:"
+
+msgid "Enter how someone can contact the person responsible for this job."
+msgstr "Enter how someone can contact the person responsible for this job."
+
+msgid ""
+"Enter how someone can contact this company and who is responsible for this "
+"company."
+msgstr ""
+"Enter how someone can contact this company and who is responsible for this "
+"company."
+
+msgid "Enter information about the representative of this company."
+msgstr "Enter information about the representative of this company."
+
+msgid ""
+"Enter the maximum number of activities for which options can be created. You "
+"can either set the number globally or individually for each organ."
+msgstr ""
+"Enter the maximum number of activities for which options can be created. You "
+"can either set the number globally or individually for each organ."
+
+msgid "Enter the start and end date and time of the option period."
+msgstr "Enter the start and end date and time of the option period."
+
+msgid "Enter the start and end date and time of the planning period."
+msgstr "Enter the start and end date and time of the planning period."
+
+msgid "Enter the start and end date and time of this activity."
+msgstr "Enter the start and end date and time of this activity."
+
 msgid ""
 "Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
 "resultaten te zien."
@@ -4088,1856 +1149,2806 @@ msgstr ""
 "There are too many results to display. Try filtering in order to display "
 "other results."
 
-#: module/Decision/view/decision/member/self.phtml:20
-msgid "My Information"
-msgstr "My Information"
+msgid "Evening"
+msgstr "Evening"
 
-#: module/Decision/view/decision/member/self.phtml:29
-#: module/User/src/Form/Register.php:32 module/User/src/Form/UserReset.php:30
-msgid "Membership number"
-msgstr "Membership number"
-
-#: module/Decision/view/decision/member/self.phtml:33
-msgid "Initials"
-msgstr "Initials"
-
-#: module/Decision/view/decision/member/self.phtml:37
-msgid "First name"
-msgstr "First name"
-
-#: module/Decision/view/decision/member/self.phtml:41
-#: module/User/src/Model/Enums/JWTClaims.php:45
-msgid "Middle name"
-msgstr "Middle name"
-
-#: module/Decision/view/decision/member/self.phtml:45
-msgid "Last name"
-msgstr "Last name"
-
-#: module/Decision/view/decision/member/self.phtml:60
-#: module/Decision/view/decision/member/view.phtml:45
-msgid "Birth date"
-msgstr "Birth date"
-
-#: module/Decision/view/decision/member/self.phtml:68
-#: module/Decision/view/decision/member/view.phtml:54
-#: module/User/src/Model/Enums/JWTClaims.php:44
-msgid "Membership type"
-msgstr "Membership type"
-
-#: module/Decision/view/decision/member/self.phtml:72
-msgid "Last membership change"
-msgstr "Last membership change"
-
-#: module/Decision/view/decision/member/self.phtml:76
-msgid "End date of membership"
-msgstr "End date of membership"
-
-#: module/Decision/view/decision/member/self.phtml:83
-msgid ""
-"If your information is no longer up to date and you would like to change it, "
-"you can contact the secretary of GEWIS."
-msgstr ""
-"If your information is no longer up to date and you would like to change it, "
-"you can contact the secretary of GEWIS."
-
-#: module/Decision/view/decision/member/self.phtml:84
-msgid "Also for data removal requests, you can contact"
-msgstr "Also for data removal requests, you can contact"
-
-#: module/Decision/view/decision/member/self.phtml:85
-msgid "Email the secretary of GEWIS"
-msgstr "Email the secretary of GEWIS"
-
-#: module/Decision/view/decision/member/self.phtml:85
-msgid "the secretary of GEWIS"
-msgstr "the secretary of GEWIS"
-
-#: module/Decision/view/decision/member/self.phtml:89
-#: module/Decision/view/decision/member/view.phtml:117
-msgid "Memberships of committees and fraternities"
-msgstr "Memberships of committees and fraternities"
-
-#: module/Decision/view/decision/member/self.phtml:94
-msgid "You have not been a member of a committee or fraternity."
-msgstr "You have not been a member of a committee or fraternity."
-
-#: module/Decision/view/decision/member/self.phtml:97
-msgid "You are currently a member of:"
-msgstr "You are currently a member of:"
-
-#: module/Decision/view/decision/member/self.phtml:121
-msgid "You were a member of:"
-msgstr "You were a member of:"
-
-#: module/Decision/view/decision/member/self.phtml:145
-#: module/Decision/view/decision/member/view.phtml:188
-msgid "Addresses"
-msgstr "Addresses"
-
-#: module/Decision/view/decision/member/self.phtml:150
-#: module/Decision/view/decision/member/view.phtml:193
-msgid "Country"
-msgstr "Country"
-
-#: module/Decision/view/decision/member/self.phtml:154
-#: module/Decision/view/decision/member/view.phtml:197
-msgid "Street and number"
-msgstr "Street and number"
-
-#: module/Decision/view/decision/member/self.phtml:157
-#: module/Decision/view/decision/member/self.phtml:167
-#: module/Decision/view/decision/member/view.phtml:200
-#: module/Decision/view/decision/member/view.phtml:210
-#, php-format
-msgid "%s %s"
-msgstr "%s %s"
-
-#: module/Decision/view/decision/member/self.phtml:164
-#: module/Decision/view/decision/member/view.phtml:207
-msgid "City and postal code"
-msgstr "City and postal code"
-
-#: module/Decision/view/decision/member/self.phtml:180
-msgid "External applications"
-msgstr "External applications"
-
-#: module/Decision/view/decision/member/self.phtml:183
-msgid "App"
-msgstr "App"
-
-#: module/Decision/view/decision/member/self.phtml:184
-msgid "First authentication"
-msgstr "First authentication"
-
-#: module/Decision/view/decision/member/self.phtml:185
-msgid "Last authentication"
-msgstr "Last authentication"
-
-#: module/Decision/view/decision/member/self.phtml:230
-msgid "Remove this picture as your profile picture"
-msgstr "Remove this picture as your profile picture"
-
-#: module/Decision/view/decision/member/self.phtml:232
-msgid "Your profile picture will be chosen automatically instead."
-msgstr "Your profile picture will be chosen automatically instead."
-
-#: module/Decision/view/decision/member/self.phtml:247
-msgid "More of my photo's"
-msgstr "More of my photo's"
-
-#: module/Decision/view/decision/member/view.phtml:58
-msgid "Has key code?"
-msgstr "Has key code?"
-
-#: module/Decision/view/decision/member/view.phtml:79
-#, php-format
-msgid "%s is the upcoming <strong>%s</strong>."
-msgstr "%s is the upcoming <strong>%s</strong>."
-
-#: module/Decision/view/decision/member/view.phtml:95
-#, php-format
-msgid "%s is currently the <strong>%s</strong>."
-msgstr "%s is currently the <strong>%s</strong>."
-
-#: module/Decision/view/decision/member/view.phtml:105
-#, php-format
-msgid "%s was the <strong>%s</strong> during the association year %d/%d."
-msgstr "%s was the <strong>%s</strong> during the association year %d/%d."
-
-#: module/Decision/view/decision/member/view.phtml:124
-#, php-format
-msgid "%s has never been part of a committee or fraternity."
-msgstr "%s has never been part of a committee or fraternity."
-
-#: module/Decision/view/decision/member/view.phtml:132
-#, php-format
-msgid "%s is currently a member of:"
-msgstr "%s is currently a member of:"
-
-#: module/Decision/view/decision/member/view.phtml:161
-#, php-format
-msgid "%s was a member of:"
-msgstr "%s was a member of:"
-
-#: module/Decision/view/decision/member/view.phtml:262
-#, php-format
-msgid "Photo's of %s"
-msgstr "Photo's of %s"
-
-#: module/Decision/view/decision/organ-admin/edit.phtml:75
-msgid "Edit organ information"
-msgstr "Edit organ information"
-
-#: module/Decision/view/decision/organ-admin/edit.phtml:150
-msgid ""
-"To optimally display your image on the overview page, please crop it below"
-msgstr ""
-"To optimally display your image on the overview page, please crop it below"
-
-#: module/Decision/view/decision/organ-admin/edit.phtml:166
-msgid "To optimally display your image your page, please crop it below"
-msgstr "To optimally display your image your page, please crop it below"
-
-#: module/Decision/view/decision/organ-admin/index.phtml:18
-msgid ""
-"Select an organ to edit its information. Changes will not be displayed until "
-"they have been approved."
-msgstr ""
-"Select an organ to edit its information. Changes will not be displayed until "
-"they have been approved."
-
-#: module/Decision/view/decision/organ-admin/index.phtml:25
-msgid "Approval status"
-msgstr "Approval status"
-
-#: module/Decision/view/decision/organ/index.phtml:15
-msgid "Organ list"
-msgstr "Organ list"
-
-#: module/Decision/view/decision/organ/show.phtml:50
-msgid "Inactive members"
-msgstr "Inactive members"
-
-#: module/Decision/view/decision/organ/show.phtml:61
-msgid "Old members"
-msgstr "Old members"
-
-#: module/Decision/view/decision/organ/show.phtml:70
-msgid "Organ mutations"
-msgstr "Organ mutations"
-
-#: module/Education/src/Controller/AdminController.php:41
-msgid "You are not allowed to administer education settings"
-msgstr "You are not allowed to administer education settings"
-
-#: module/Education/src/Controller/AdminController.php:51
-msgid "You are not allowed to administer courses"
-msgstr "You are not allowed to administer courses"
-
-#: module/Education/src/Controller/AdminController.php:60
-#: module/Education/src/Service/Exam.php:473
-msgid "You are not allowed to add courses"
-msgstr "You are not allowed to add courses"
-
-#: module/Education/src/Controller/AdminController.php:76
-msgid "Successfully added course!"
-msgstr "Successfully added course!"
-
-#: module/Education/src/Controller/AdminController.php:83
-#: module/Education/src/Controller/AdminController.php:125
-msgid "An error occurred while saving the course!"
-msgstr "An error occurred while saving the course!"
-
-#: module/Education/src/Controller/AdminController.php:98
-#: module/Education/src/Controller/AdminController.php:162
-msgid "You are not allowed to edit courses"
-msgstr "You are not allowed to edit courses"
-
-#: module/Education/src/Controller/AdminController.php:121
-msgid "Successfully updated course information!"
-msgstr "Successfully updated course information!"
-
-#: module/Education/src/Controller/AdminController.php:140
-msgid "You are not allowed to delete courses"
-msgstr "You are not allowed to delete courses"
-
-#: module/Education/src/Controller/AdminController.php:183
-msgid "You are not allowed to delete course documents"
-msgstr "You are not allowed to delete course documents"
-
-#: module/Education/src/Form/Bulk.php:43
-msgid "Finalize uploads"
-msgstr "Finalize uploads"
-
-#: module/Education/src/Form/Bulk.php:64
-msgid "Course does not exist"
-msgstr "Course does not exist"
-
-#: module/Education/src/Form/Course.php:33
-#: module/Education/src/Form/Fieldset/Exam.php:47
-#: module/Education/src/Form/Fieldset/Summary.php:47
-#: module/Education/view/education/education/index.phtml:91
-msgid "Course code"
-msgstr "Course code"
-
-#: module/Education/src/Form/Course.php:53
-msgid "Add course"
-msgstr "Add course"
-
-#: module/Education/src/Form/Course.php:84
-msgid "There already exists a course with this code"
-msgstr "There already exists a course with this code"
-
-#: module/Education/src/Form/Fieldset/Exam.php:57
 msgid "Exam date"
 msgstr "Exam date"
 
-#: module/Education/src/Form/Fieldset/Exam.php:84
-#: module/Education/src/Form/Fieldset/Summary.php:78
-#: module/Education/view/education/admin/course-documents.phtml:71
-#: module/Education/view/education/admin/course-documents.phtml:122
-msgid "Language"
-msgstr "Language"
-
-#: module/Education/src/Form/Fieldset/Exam.php:98
-#: module/Education/src/Form/Fieldset/Summary.php:92
-msgid "Scanned?"
-msgstr "Scanned?"
-
-#: module/Education/src/Form/Fieldset/Summary.php:57
-msgid "Summary date"
-msgstr "Summary date"
-
-#: module/Education/src/Form/Fieldset/Summary.php:68
-#: module/Education/view/education/admin/course-documents.phtml:119
-#: module/Frontpage/src/Form/PollComment.php:27
-msgid "Author"
-msgstr "Author"
-
-#: module/Education/src/Form/TempUpload.php:25
 msgid "Exam to upload"
 msgstr "Exam to upload"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:25
-msgid "Final"
-msgstr "Final"
-
-#: module/Education/src/Model/Enums/ExamTypes.php:26
-msgid "Interim"
-msgstr "Interim"
-
-#: module/Education/src/Model/Enums/ExamTypes.php:27
-msgid "Answers"
-msgstr "Answers"
-
-#: module/Education/src/Model/Enums/ExamTypes.php:28
-msgid "Other"
-msgstr "Other"
-
-#: module/Education/src/Service/Exam.php:98
-msgid "You are not allowed to download course documents"
-msgstr "You are not allowed to download course documents"
-
-#: module/Education/src/Service/Exam.php:318
-msgid "You are not allowed to delete exams"
-msgstr "You are not allowed to delete exams"
-
-#: module/Education/src/Service/Exam.php:334
-#: module/Education/src/Service/Exam.php:456
-msgid "You are not allowed to upload exams"
-msgstr "You are not allowed to upload exams"
-
-#: module/Education/view/education/admin/add-course.phtml:17
-msgid "Add"
-msgstr "Add"
-
-#: module/Education/view/education/admin/add-course.phtml:28
-#: module/Education/view/education/admin/course.phtml:31
-msgid "Add Course"
-msgstr "Add Course"
-
-#: module/Education/view/education/admin/bulk-exam.phtml:20
-msgid "Upload Exams"
-msgstr "Upload Exams"
-
-#: module/Education/view/education/admin/bulk-exam.phtml:35
-msgid "Finalize exam uploads"
-msgstr "Finalize exam uploads"
-
-#: module/Education/view/education/admin/bulk-summary.phtml:20
-msgid "Upload Summaries"
-msgstr "Upload Summaries"
-
-#: module/Education/view/education/admin/bulk-summary.phtml:35
-msgid "Finalize summary uploads"
-msgstr "Finalize summary uploads"
-
-#: module/Education/view/education/admin/course-documents.phtml:47
-#, php-format
-msgid "Course Documents of %s"
-msgstr "Course Documents of %s"
-
-#: module/Education/view/education/admin/course-documents.phtml:57
-#: module/Education/view/education/education/index.phtml:36
 msgid "Exams"
 msgstr "Exams"
 
-#: module/Education/view/education/admin/course-documents.phtml:100
-#: module/Education/view/education/admin/course-documents.phtml:149
-msgid "This course does not have any exams."
-msgstr "This course does not have any exams."
-
-#: module/Education/view/education/admin/course-documents.phtml:108
-msgid "Summaries"
-msgstr "Summaries"
-
-#: module/Education/view/education/admin/course-documents.phtml:167
-msgid "Are you sure you want to delete this document?"
-msgstr "Are you sure you want to delete this document?"
-
-#: module/Education/view/education/admin/course.phtml:22
-msgid "Course Admin"
-msgstr "Course Admin"
-
-#: module/Education/view/education/admin/course.phtml:41
-msgid "Code"
-msgstr "Code"
-
-#: module/Education/view/education/admin/course.phtml:87
-msgid "Delete Course"
-msgstr "Delete Course"
-
-#: module/Education/view/education/admin/course.phtml:93
-#, php-format
-msgid ""
-"Are you sure you want to delete %s? This will also delete all associated "
-"exams and summaries will be deleted."
-msgstr ""
-"Are you sure you want to delete %s? This will also delete all associated "
-"exams and summaries will be deleted."
-
-#: module/Education/view/education/admin/edit-course.phtml:37
-msgid "Edit Course"
-msgstr "Edit Course"
-
-#: module/Education/view/education/admin/edit-exam.phtml:32
-msgid "Edit Exam"
-msgstr "Edit Exam"
-
-#: module/Education/view/education/admin/edit-exam.phtml:35
-msgid "Upload of all exams was finished."
-msgstr "Upload of all exams was finished."
-
-#: module/Education/view/education/admin/edit-exam.phtml:37
-msgid "There are no exams to be edited. Upload exams to edit them."
-msgstr "There are no exams to be edited. Upload exams to edit them."
-
-#: module/Education/view/education/admin/edit-exam.phtml:128
-#: module/Education/view/education/admin/edit-summary.phtml:130
-msgid ""
-"Check this if the document is scanned, as this will enable higher quality "
-"downloads. Please note that enabling setting this for non-scanned documents "
-"will significantly impact the ability to download the document."
-msgstr ""
-"Check this if the document is scanned, as this will enable higher quality "
-"downloads. Please note that enabling setting this for non-scanned documents "
-"will significantly impact the ability to download the document."
-
-#: module/Education/view/education/admin/edit-summary.phtml:32
-msgid "Edit Summary"
-msgstr "Edit Summary"
-
-#: module/Education/view/education/admin/edit-summary.phtml:35
-msgid "Upload of all summaries was finished."
-msgstr "Upload of all summaries was finished."
-
-#: module/Education/view/education/admin/edit-summary.phtml:37
-msgid "There are no summaries to be edited. Upload exams to edit them."
-msgstr "There are no summaries to be edited. Upload exams to edit them."
-
-#: module/Education/view/education/admin/index.phtml:13
-msgid "Education admin"
-msgstr "Education admin"
-
-#: module/Education/view/education/education/course.phtml:33
 msgid "Exams and summaries"
 msgstr "Exams and summaries"
 
-#: module/Education/view/education/education/course.phtml:44
-#, php-format
-msgid "Summary by %s on %s (%s)"
-msgstr "Summary by %s on %s (%s)"
+msgid "Exceptional Members"
+msgstr "Exceptional Members"
 
-#: module/Education/view/education/education/course.phtml:53
-#, php-format
-msgid "Summary on %s (%s)"
-msgstr "Summary on %s (%s)"
+msgid "Expiration Date"
+msgstr "Expiration Date"
 
-#: module/Education/view/education/education/course.phtml:64
+msgid "Expiration date"
+msgstr "Expiration date"
+
+msgid "Expiration date for the poll (YYYY-MM-DD)"
+msgstr "Expiration date for the poll (YYYY-MM-DD)"
+
+msgid "Expired packages"
+msgstr "Expired packages"
+
+msgid "Exposure time"
+msgstr "Exposure time"
+
+msgid "External"
+msgstr "External"
+
+msgid "External applications"
+msgstr "External applications"
+
+msgid "FAQ"
+msgstr "FAQ"
+
+msgid "Family name"
+msgstr "Family name"
+
+msgid "Featured"
+msgstr "Featured"
+
+msgid "Featured Package"
+msgstr "Featured Package"
+
+msgid "Featured company"
+msgstr "Featured company"
+
+msgid "Featured in language"
+msgstr "Featured in language"
+
+msgid "File"
+msgstr "File"
+
+msgid "Filename"
+msgstr "Filename"
+
+msgid "Filter..."
+msgstr "Filter..."
+
+msgid "Final"
+msgstr "Final"
+
 #, php-format
 msgid "Final test from %s (%s)"
 msgstr "Final test from %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:67
-#, php-format
-msgid "Interim test from %s (%s)"
-msgstr "Interim test from %s (%s)"
+msgid "Finalize exam uploads"
+msgstr "Finalize exam uploads"
 
-#: module/Education/view/education/education/course.phtml:70
-#, php-format
-msgid "Answers from %s (%s)"
-msgstr "Answers from %s (%s)"
+msgid "Finalize summary uploads"
+msgstr "Finalize summary uploads"
 
-#: module/Education/view/education/education/course.phtml:73
-#, php-format
-msgid "Other exam material from %s (%s)"
-msgstr "Other exam material from %s (%s)"
+msgid "Finalize uploads"
+msgstr "Finalize uploads"
 
-#: module/Education/view/education/education/index.phtml:54
-msgid "Course code or course description"
-msgstr "Course code or course description"
+msgid "Financial Audit Committee"
+msgstr "Financial Audit Committee"
 
-#: module/Education/view/education/education/index.phtml:76
+msgid "Financial Audit Committees"
+msgstr "Financial Audit Committees"
+
+msgid "Find a member"
+msgstr "Find a member"
+
+msgid "First authentication"
+msgstr "First authentication"
+
+msgid "First name"
+msgstr "First name"
+
+msgid "Flash"
+msgstr "Flash"
+
+msgid "Focal length"
+msgstr "Focal length"
+
+msgid "For old exams of minor courses, you can also look at:"
+msgstr "For old exams of minor courses, you can also look at:"
+
 #, php-format
 msgid "Found %d %s matching your description"
 msgstr "Found %d %s matching your description"
 
-#: module/Education/view/education/education/index.phtml:79
+msgid "Fraternities"
+msgstr "Fraternities"
+
+msgid "Fraternity"
+msgstr "Fraternity"
+
+msgid "From"
+msgstr "From"
+
+msgid "Full name:"
+msgstr "Full name:"
+
+msgid "GEWIKI"
+msgstr "GEWIKI"
+
+msgid "GEWIS has many different committees, learn more about them below!"
+msgstr "GEWIS has many different committees, learn more about them below!"
+
+msgid "GEWIS members only"
+msgstr "GEWIS members only"
+
+msgid "GEWIS song"
+msgstr "GEWIS song"
+
+msgid "GMM"
+msgstr "GMM"
+
+#, php-format
+msgid "GMM %d (%s)"
+msgstr "GMM %d (%s)"
+
+msgid "GMM Committee"
+msgstr "GMM Committee"
+
+msgid "GMM Committees"
+msgstr "GMM Committees"
+
+msgid "GMM Taskforce"
+msgstr "GMM Taskforce"
+
+msgid "GMM Taskforces"
+msgstr "GMM Taskforces"
+
+msgid "General"
+msgstr "General"
+
+msgid "General Members Meeting"
+msgstr "General Members Meeting"
+
+msgid "Generate a new cover photo"
+msgstr "Generate a new cover photo"
+
+msgid "Generatie"
+msgstr "Generation"
+
+msgid "Generation"
+msgstr "Generation"
+
+msgid "Given name"
+msgstr "Given name"
+
+msgid "Global Value"
+msgstr "Global Value"
+
+msgid "Go to album"
+msgstr "Go to album"
+
+msgid "Google Calendar"
+msgstr "Google Calendar"
+
+msgid "Graduate"
+msgstr "Graduate"
+
+msgid "Has key code?"
+msgstr "Has key code?"
+
+msgid "Has limited capacity"
+msgstr "Has limited capacity"
+
+msgid ""
+"Have you forgotten your e-mail address and do you want to change it? Ask the "
+"secretary by going to GEWIS (preferred) or by sending an e-mail."
+msgstr ""
+"Have you forgotten your e-mail address and do you want to change it? Ask the "
+"secretary by going to GEWIS (preferred) or by sending an e-mail."
+
+msgid ""
+"Here you can add, edit, or remove activity categories. Click on 'Add "
+"Category' to add a new category or click on a category to edit/remove it."
+msgstr ""
+"Here you can add, edit, or remove activity categories. Click on 'Add "
+"Category' to add a new category or click on a category to edit/remove it."
+
+msgid ""
+"Here you can find everyone who signed up for this activity (may contain "
+"duplicates). Using the tabs above you can navigate to the different sign-up "
+"lists of this activity. From there you can remove external participants and "
+"(when supplied) view additional signup information from each participant."
+msgstr ""
+"Here you can find everyone who signed up for this activity (may contain "
+"duplicates). Using the tabs above you can navigate to the different sign-up "
+"lists of this activity. From there you can remove external participants and "
+"(when supplied) view additional signup information from each participant."
+
+msgid ""
+"Here you can find everyone who signed up to this sign-up list. Here you can "
+"add or remove external participants and view detailed information regarding "
+"the signup of all participants."
+msgstr ""
+"Here you can find everyone who signed up to this sign-up list. Here you can "
+"add or remove external participants and view detailed information regarding "
+"the signup of all participants."
+
+msgid "Hidden"
+msgstr "Hidden"
+
+msgid "Highlighted"
+msgstr "Highlighted"
+
+msgid "Highlights"
+msgstr "Highlights"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "Home address (parents)"
+msgstr "Home address (parents)"
+
+msgid "Honorary"
+msgstr "Honorary"
+
+msgid "House Rules"
+msgstr "House Rules"
+
+msgid "Housing"
+msgstr "Housing"
+
+#, php-format
+msgid ""
+"I, %s I am fully aware that by filling in this form I authorize the person "
+"in this form to represent me at the %s General Members Meeting (%s) of s.v. "
+"GEWIS."
+msgstr ""
+"I, %s I am fully aware that by filling in this form I authorize the person "
+"in this form to represent me at the %s General Members Meeting (%s) of s.v. "
+"GEWIS."
+
+#, php-format
+msgid ""
+"I, %s am fully aware that by revoking my authorization, %s cannot represent "
+"me at the %s General Members Meeting (%s) of s.v. GEWIS."
+msgstr ""
+"I, %s am fully aware that by revoking my authorization, %s cannot represent "
+"me at the %s General Members Meeting (%s) of s.v. GEWIS."
+
+msgid "ICT Policy"
+msgstr "ICT Policy"
+
+msgid "ISO"
+msgstr "ISO"
+
+msgid ""
+"If an exam has been put online without the intention of the author, please "
+"let the board of GEWIS know by sending an"
+msgstr ""
+"If an exam has been put online without the intention of the author, please "
+"let the board of GEWIS know by sending an"
+
+msgid "If approved, this job will be <strong>hidden</strong>."
+msgstr "If approved, this job will be <strong>hidden</strong>."
+
+msgid ""
+"If approved, this job will be <strong>published</strong>, however, its "
+"actual visiblity depends on the company and associated job package."
+msgstr ""
+"If approved, this job will be <strong>published</strong>, however, its "
+"actual visiblity depends on the company and associated job package."
+
+msgid ""
+"If this is checked the My Future logo will be displayed on the activity page "
+"and the activity will be included on the career activities page."
+msgstr ""
+"If this is checked the My Future logo will be displayed on the activity page "
+"and the activity will be included on the career activities page."
+
+msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
+msgstr "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
+
+#, php-format
+msgid ""
+"If you aren't able to attend a GMM in person but you want your voice to be "
+"heard, consider %sauthorizing another member%s to act on your behalf."
+msgstr ""
+"If you aren't able to attend a GMM in person but you want your voice to be "
+"heard, consider %sauthorizing another member%s to act on your behalf."
+
+#, php-format
+msgid "If you don't have an account yet, go to the %sRegistration page%s"
+msgstr "If you don't have an account yet, go to the %sRegistration page%s"
+
+#, php-format
+msgid "If you forgot your password, go to the %sPassword reset page%s"
+msgstr "If you forgot your password, go to the %sPassword reset page%s"
+
+#, php-format
+msgid ""
+"If your browser does not redirect you back, please <a href=\"%s\">click "
+"here</a> to continue."
+msgstr ""
+"If your browser does not redirect you back, please <a href=\"%s\">click "
+"here</a> to continue."
+
+msgid ""
+"If your information is no longer up to date and you would like to change it, "
+"you can contact the secretary of GEWIS."
+msgstr ""
+"If your information is no longer up to date and you would like to change it, "
+"you can contact the secretary of GEWIS."
+
+msgid "In this photo:"
+msgstr "In this photo:"
+
+msgid "Inactief Lid"
+msgstr "Inactive Member"
+
+msgid "Inactive members"
+msgstr "Inactive members"
+
+msgid "Infimum"
+msgstr "Infimum"
+
+msgid "Information"
+msgstr "Information"
+
+msgid "Information for committees"
+msgstr "Information for committees"
+
+msgid "Initials"
+msgstr "Initials"
+
+msgid "Inkoper"
+msgstr "Inkoper"
+
+msgid "Innovation Sciences"
+msgstr "Innovation Sciences"
+
+msgid "Interim"
+msgstr "Interim"
+
+#, php-format
+msgid "Interim test from %s (%s)"
+msgstr "Interim test from %s (%s)"
+
+msgid "Internal Regulations"
+msgstr "Internal Regulations"
+
+msgid "Invalid form"
+msgstr "Invalid form"
+
+msgid "Is 18+?"
+msgstr "Is 18+?"
+
+#, php-format
+msgid ""
+"It has been more than 90 days since you last used <strong>%s</strong>. As a "
+"reminder, the application has access to:"
+msgstr ""
+"It has been more than 90 days since you last used <strong>%s</strong>. As a "
+"reminder, the application has access to:"
+
+msgid ""
+"It is not allowed to put more than 3 options for the same activity in the "
+"calendar."
+msgstr ""
+"It is not allowed to put more than 3 options for the same activity in the "
+"calendar."
+
+msgid "It will become visible after it has been approved by the board."
+msgstr "It will become visible after it has been approved by the board."
+
+msgid "Job Labels"
+msgstr "Job Labels"
+
+#, php-format
+msgid "Job Package (%s active)"
+msgstr "Job Package (%s active)"
+
+msgid "Job Packages"
+msgstr "Job Packages"
+
+msgid "Job approval status reset!"
+msgstr "Job approval status reset!"
+
+msgid "Job approved!"
+msgstr "Job approved!"
+
+msgid "Job category successfully created!"
+msgstr "Job category successfully created!"
+
+msgid "Job disapproved!"
+msgstr "Job disapproved!"
+
+msgid "Job has been updated!"
+msgstr "Job has been updated!"
+
+msgid "Job label successfully created!"
+msgstr "Job label successfully created!"
+
+msgid ""
+"Job proposal successfully created! It will become active after it has been "
+"approved."
+msgstr ""
+"Job proposal successfully created! It will become active after it has been "
+"approved."
+
+msgid "Job successfully created!"
+msgstr "Job successfully created!"
+
+msgid "Job successfully deleted."
+msgstr "Job successfully deleted."
+
+msgid "Job successfully edited!"
+msgstr "Job successfully edited!"
+
+msgid "Job update has been rejected!"
+msgstr "Job update has been rejected!"
+
+msgid "Jobs"
+msgstr "Jobs"
+
+msgid "Jobs (Active)"
+msgstr "Jobs (Active)"
+
+msgid "Jobs (Active) / Type"
+msgstr "Jobs (Active) / Type"
+
+msgid "Jobs successfully transferred"
+msgstr "Jobs successfully transferred"
+
+msgid "Key Policy"
+msgstr "Key Policy"
+
+msgid "Labels"
+msgstr "Labels"
+
+msgid "Language"
+msgstr "Language"
+
+msgid "Language settings"
+msgstr "Language settings"
+
+msgid "Last authentication"
+msgstr "Last authentication"
+
+msgid "Last membership change"
+msgstr "Last membership change"
+
+msgid "Last name"
+msgstr "Last name"
+
+msgid "Lid"
+msgstr "Member"
+
+msgid "Links"
+msgstr "Links"
+
+msgid "Loading an infimum..."
+msgstr "Loading an infimum..."
+
+msgid "Loading tags..."
+msgstr "Loading tags..."
+
+msgid "Location"
+msgstr "Location"
+
+msgid "Log in"
+msgstr "Log in"
+
+msgid "Log in as company"
+msgstr "Log in as company"
+
+msgid "Log in as member"
+msgstr "Log in as member"
+
+msgid "Login"
+msgstr "Login"
+
+msgid "Login to subscribe"
+msgstr "Login to subscribe"
+
+msgid "Login to view more information"
+msgstr "Login to view more information"
+
+msgid "Login to view the subscribed members."
+msgstr "Login to view the subscribed members."
+
+msgid "Logo"
+msgstr "Logo"
+
+msgid "Logo of"
+msgstr "Logo of"
+
+msgid "Logout"
+msgstr "Logout"
+
+msgid "Long dutch description"
+msgstr "Long dutch description"
+
+msgid "Long english description"
+msgstr "Long english description"
+
+msgid ""
+"Looking for a specific decision but forgot the numbers? Try dropping the "
+"decision point and/or number"
+msgstr ""
+"Looking for a specific decision but forgot the numbers? Try dropping the "
+"decision point and/or number"
+
+msgid "Lunch break"
+msgstr "Lunch break"
+
+msgid "MMM d"
+msgstr "MMM d"
+
+msgid ""
+"Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
+"2022)."
+msgstr ""
+"Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
+"2022)."
+
+msgid "Mail address"
+msgstr "Mail address"
+
+msgid "Mail everybody"
+msgstr "Mail everybody"
+
+msgid "Mail the education officer"
+msgstr "Mail the education officer"
+
+msgid ""
+"Make this page available at the following URL. Providing a category is "
+"required."
+msgstr ""
+"Make this page available at the following URL. Providing a category is "
+"required."
+
+msgid "Max Activities"
+msgstr "Max Activities"
+
+msgid "Max. value"
+msgstr "Max. value"
+
+msgid "Meeting"
+msgstr "Meeting"
+
+msgid "Meeting document uploaded"
+msgstr "Meeting document uploaded"
+
+msgid "Meeting minutes uploaded"
+msgstr "Meeting minutes uploaded"
+
+msgid "Meeting number"
+msgstr "Meeting number"
+
+msgid "Meetings"
+msgstr "Meetings"
+
+msgid "Member"
+msgstr "Member"
+
+msgid "Member number"
+msgstr "Member number"
+
+msgid "Members"
+msgstr "Members"
+
+msgid "Membership number"
+msgstr "Membership number"
+
+msgid "Membership number or email address"
+msgstr "Membership number or email address"
+
+msgid "Membership type"
+msgstr "Membership type"
+
+msgid "Memberships of committees and fraternities"
+msgstr "Memberships of committees and fraternities"
+
+msgid "Message"
+msgstr "Message"
+
+msgid "Middle name"
+msgstr "Middle name"
+
+msgid "Min. value"
+msgstr "Min. value"
+
+msgid "Minutes"
+msgstr "Minutes"
+
+msgid "Minutes to upload"
+msgstr "Minutes to upload"
+
+msgid "Modified by"
+msgstr "Modified by"
+
+msgid "More information about this activity is available below."
+msgstr "More information about this activity is available below."
+
+msgid "More of my photo's"
+msgstr "More of my photo's"
+
+msgid "Morning"
+msgstr "Morning"
+
+msgid "Most recent"
+msgstr "Most recent"
+
+msgid "Move"
+msgstr "Move"
+
+msgid "Move %i photos"
+msgstr "Move %i photos"
+
+msgid "Move Jobs"
+msgstr "Move Jobs"
+
+msgid "Move album"
+msgstr "Move album"
+
+msgid "Move down"
+msgstr "Move down"
+
+msgid "Move photo"
+msgstr "Move photo"
+
+msgid "Move the album"
+msgstr "Move the album"
+
+msgid "Move the photo to another album"
+msgstr "Move the photo to another album"
+
+msgid "Move the photos to another album"
+msgstr "Move the photos to another album"
+
+msgid "Move up"
+msgstr "Move up"
+
+msgid "Multiple days"
+msgstr "Multiple days"
+
+msgid "My Activities"
+msgstr "My Activities"
+
+msgid "My Company"
+msgstr "My Company"
+
+msgid "My Information"
+msgstr "My Information"
+
+msgid "My activities"
+msgstr "My activities"
+
+msgid "My information"
+msgstr "My information"
+
+msgid "My options"
+msgstr "My options"
+
+msgid "My photo's"
+msgstr "My photos"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "NEW"
+msgstr "NEW"
+
+msgid "Naam"
+msgstr "Name"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Name (Plural)"
+msgstr "Name (Plural)"
+
+msgid "New password"
+msgstr "New password"
+
+msgid "News"
+msgstr "News"
+
+msgid "News items"
+msgstr "News items"
+
+msgid "Next"
+msgstr "Next"
+
+msgid "No"
+msgstr "No"
+
+msgid "No Company"
+msgstr "No Company"
+
+msgid "No Exception available"
+msgstr "No Exception available"
+
+msgid "No GMM available."
+msgstr "No GMM available."
+
+msgid "No date"
+msgstr "No date"
+
+msgid "No decisions were found."
+msgstr "No decisions were found."
+
+msgid "No documents have been added."
+msgstr "No documents have been added."
+
+msgid "No meeting available."
+msgstr "No meeting available."
+
+msgid "No notifications"
+msgstr "No notifications"
+
+msgid ""
+"No one has been tagged in this photo yet. Tag someone you recognise now!"
+msgstr ""
+"No one has been tagged in this photo yet. Tag someone you recognise now!"
+
+msgid "No organ"
+msgstr "No organ"
+
+msgid "None"
+msgstr "None"
+
+msgid "Not allowed to add photos."
+msgstr "Not allowed to add photos."
+
+msgid "Not allowed to add tags."
+msgstr "Not allowed to add tags."
+
+msgid "Not allowed to create albums"
+msgstr "Not allowed to create albums"
+
+msgid "Not allowed to create albums."
+msgstr "Not allowed to create albums."
+
+msgid "Not allowed to delete albums."
+msgstr "Not allowed to delete albums."
+
+msgid "Not allowed to delete photos."
+msgstr "Not allowed to delete photos."
+
+msgid "Not allowed to download photos"
+msgstr "Not allowed to download photos"
+
+msgid "Not allowed to edit albums"
+msgstr "Not allowed to edit albums"
+
+msgid "Not allowed to edit albums."
+msgstr "Not allowed to edit albums."
+
+msgid "Not allowed to generate album covers."
+msgstr "Not allowed to generate album covers."
+
+msgid "Not allowed to move albums"
+msgstr "Not allowed to move albums"
+
+msgid "Not allowed to move photos"
+msgstr "Not allowed to move photos"
+
+msgid "Not allowed to remove tags."
+msgstr "Not allowed to remove tags."
+
+msgid "Not allowed to search for members."
+msgstr "Not allowed to search for members."
+
+msgid "Not allowed to upload photos."
+msgstr "Not allowed to upload photos."
+
+msgid "Not allowed to view albums"
+msgstr "Not allowed to view albums"
+
+msgid "Not allowed to view albums without dates"
+msgstr "Not allowed to view albums without dates"
+
+msgid "Not allowed to view organ information"
+msgstr "Not allowed to view organ information"
+
+msgid "Not allowed to view photo details"
+msgstr "Not allowed to view photo details"
+
+msgid "Not allowed to view photos"
+msgstr "Not allowed to view photos"
+
+msgid "Not allowed to view previous photos of the week"
+msgstr "Not allowed to view previous photos of the week"
+
+msgid "Not allowed to view tags."
+msgstr "Not allowed to view tags."
+
+msgid "Not allowed to view the list of organs"
+msgstr "Not allowed to view the list of organs"
+
+msgid "Not allowed to vote for a photo of the week"
+msgstr "Not allowed to vote for a photo of the week"
+
+msgid "Notifications"
+msgstr "Notifications"
+
+msgid "Number"
+msgstr "Number"
+
+msgid "Old activities"
+msgstr "Old activities"
+
+msgid "Old members"
+msgstr "Old members"
+
+msgid "Old password"
+msgstr "Old password"
+
+msgid "Old photos of the week"
+msgstr "Old photos of the week"
+
+msgid "Old polls"
+msgstr "Old polls"
+
+msgid "Older"
+msgstr "Older"
+
+msgid "Onderwijscommissaris"
+msgstr "Educational Officer"
+
+msgid "Only allow GEWIS members"
+msgstr "Only allow GEWIS members"
+
+msgid "Open date and time"
+msgstr "Open date and time"
+
+msgid "Option 1, Option 2, ..."
+msgstr "Option 1, Option 2, ..."
+
+msgid "Option Calendar"
+msgstr "Option Calendar"
+
+msgid "Option Period"
+msgstr "Option Period"
+
+msgid "Option calendar"
+msgstr "Option calendar"
+
+msgid "Option does not fall within option period (also check the end date)."
+msgstr "Option does not fall within option period (also check the end date)."
+
+msgid "Option planning period created successfully."
+msgstr "Option planning period created successfully."
+
+msgid "Option planning period deleted."
+msgstr "Option planning period deleted."
+
+msgid "Option planning period has been updated."
+msgstr "Option planning period has been updated."
+
+msgid "Option should end after it starts."
+msgstr "Option should end after it starts."
+
+msgid "Optional message..."
+msgstr "Optional message..."
+
+msgid "Options"
+msgstr "Options"
+
+msgid "Or select a page to edit below."
+msgstr "Or select a page to edit below."
+
+msgid "Or subscribe without a GEWIS membership: "
+msgstr "Or subscribe without a GEWIS membership: "
+
+msgid ""
+"Order your course books via GEWIS to receive a discount. Specific ordering "
+"deadlines and pickup dates will be timely communicated to you via an email."
+msgstr ""
+"Order your course books via GEWIS to receive a discount. Specific ordering "
+"deadlines and pickup dates will be timely communicated to you via an email."
+
+msgid "Ordinary"
+msgstr "Ordinary"
+
+msgid "Organ"
+msgstr "Organ"
+
+msgid "Organ Regulations"
+msgstr "Organ Regulations"
+
+msgid "Organ list"
+msgstr "Organ list"
+
+msgid "Organ mutations"
+msgstr "Organ mutations"
+
+msgid "Organisation"
+msgstr "Organisation"
+
+msgid "Organizer"
+msgstr "Organizer"
+
+msgid "Organs"
+msgstr "Organs"
+
+msgid ""
+"Original job and proposed update do not have any job labels applied to them."
+msgstr ""
+"Original job and proposed update do not have any job labels applied to them."
+
+msgid "Other"
+msgstr "Other"
+
+msgid "Other albums"
+msgstr "Other albums"
+
+#, php-format
+msgid "Other exam material from %s (%s)"
+msgstr "Other exam material from %s (%s)"
+
+msgid "Overview"
+msgstr "Overview"
+
+msgid "PR-Functionaris"
+msgstr "PR-Functionaris"
+
+msgid "Packages"
+msgstr "Packages"
+
+msgid "Pages"
+msgstr "Pages"
+
+msgid "Participants"
+msgstr "Participants"
+
+msgid "Password"
+msgstr "Password"
+
+msgid "Password changed successfully"
+msgstr "Password changed successfully"
+
+msgid "Password incorrect"
+msgstr "Password incorrect"
+
+msgid "Past option planning periods cannot be deleted."
+msgstr "Past option planning periods cannot be deleted."
+
+msgid "Penningmeester"
+msgstr "Treasurer"
+
+msgid "Period"
+msgstr "Period"
+
+msgid "Permissions"
+msgstr "Permissions"
+
+msgid "Personal"
+msgstr "Personal"
+
+msgid "Phone Number"
+msgstr "Phone Number"
+
+msgid "Phone number"
+msgstr "Phone number"
+
+#, php-format
+msgid "Photo #%d"
+msgstr "Photo #%d"
+
+msgid "Photo admin"
+msgstr "Photo admin"
+
+msgid "Photo of the Week:<br> Week"
+msgstr "Photo of the Week:<br> Week"
+
+msgid "Photo of the week"
+msgstr "Photo of the week"
+
+#, php-format
+msgid "Photo's of %s"
+msgstr "Photo's of %s"
+
+msgid "Photos"
+msgstr "Photos"
+
+msgid "Photos of the Week"
+msgstr "Photos of the Week"
+
+#, php-format
+msgid "Photos of the Week in %d/%d"
+msgstr "Photos of the Week in %d/%d"
+
+msgid "Pin news item"
+msgstr "Pin news item"
+
+msgid "Plan activity"
+msgstr "Plan activity"
+
+msgid "Planned Activities"
+msgstr "Planned Activities"
+
+msgid "Planned Option Planning Periods"
+msgstr "Planned Option Planning Periods"
+
+msgid "Planning Period"
+msgstr "Planning Period"
+
+#, php-format
+msgid ""
+"Please contact %s or the board (%s) with any questions or concerns. Have fun!"
+msgstr ""
+"Please contact %s or the board (%s) with any questions or concerns. Have fun!"
+
+#, php-format
+msgid ""
+"Please contact %s or the board (%s) with any questions, concerns or if you "
+"are unable to attend after the deadline for unsubscribing has passed. Have "
+"fun!"
+msgstr ""
+"Please contact %s or the board (%s) with any questions, concerns or if you "
+"are unable to attend after the deadline for unsubscribing has passed. Have "
+"fun!"
+
+msgid "Please fill in this CAPTCHA:"
+msgstr "Please fill in this CAPTCHA:"
+
+msgid "Please note that numbers are not dependant on the selected language(s)."
+msgstr ""
+"Please note that numbers are not dependant on the selected language(s)."
+
+msgid "Please select a GMM to view authorizations."
+msgstr "Please select a GMM to view authorizations."
+
+msgid "Please wait while the album is being deleted."
+msgstr "Please wait while the album is being deleted."
+
+msgid "Please wait while the photos are being deleted."
+msgstr "Please wait while the photos are being deleted."
+
+msgid "Please wait while your photo is being deleted."
+msgstr "Please wait while your photo is being deleted."
+
+msgid "Poll"
+msgstr "Poll"
+
+msgid "Poll history"
+msgstr "Poll history"
+
+msgid "Polls"
+msgstr "Polls"
+
+msgid "Polls awaiting approval"
+msgstr "Polls awaiting approval"
+
+msgid "Poster Policy"
+msgstr "Poster Policy"
+
+msgid "Previous"
+msgstr "Previous"
+
+msgid "Previous exceptions"
+msgstr "Previous exceptions"
+
+msgid "Privacy Policy"
+msgstr "Privacy Policy"
+
+msgid "Profile"
+msgstr "Profile"
+
+msgid "Proposals"
+msgstr "Proposals"
+
+msgid "Propose options for an activity"
+msgstr "Propose options for an activity"
+
+msgid "Public Archive"
+msgstr "Public Archive"
+
+msgid "Public archive"
+msgstr "Public archive"
+
+msgid "Published"
+msgstr "Published"
+
+msgid "Random"
+msgstr "Random"
+
+msgid "Recent changes"
+msgstr "Recent changes"
+
+msgid "Recently Approved Jobs"
+msgstr "Recently Approved Jobs"
+
+msgid "Recently Rejected Jobs"
+msgstr "Recently Rejected Jobs"
+
+msgid "Recently Unapproved Jobs"
+msgstr "Recently Unapproved Jobs"
+
+msgid "Recipient"
+msgstr "Recipient"
+
+msgid "Regenerate"
+msgstr "Regenerate"
+
+msgid "Regenerate album cover"
+msgstr "Regenerate album cover"
+
+msgid "Register"
+msgstr "Register"
+
+msgid "Regulations"
+msgstr "Regulations"
+
+msgid "Reject Update"
+msgstr "Reject Update"
+
+msgid "Remember me"
+msgstr "Remember me"
+
+msgid "Remove"
+msgstr "Remove"
+
+msgid "Remove Token"
+msgstr "Remove Token"
+
+msgid "Remove option"
+msgstr "Remove option"
+
+msgid "Remove the last option"
+msgstr "Remove the last option"
+
+msgid "Remove the last sign-up list"
+msgstr "Remove the last sign-up list"
+
+msgid "Remove the last sign-up list field"
+msgstr "Remove the last sign-up list field"
+
+msgid "Remove this picture as your profile picture"
+msgstr "Remove this picture as your profile picture"
+
+msgid "Rename"
+msgstr "Rename"
+
+msgid "Rename Meeting Document"
+msgstr "Rename Meeting Document"
+
+msgid "Representative Information"
+msgstr "Representative Information"
+
+msgid "Request a poll"
+msgstr "Request a poll"
+
+msgid "Request password reset"
+msgstr "Request password reset"
+
+msgid "Request poll"
+msgstr "Request poll"
+
+msgid "Required role"
+msgstr "Required role"
+
+msgid "Reset Approval Status"
+msgstr "Reset Approval Status"
+
+msgid "Reset password"
+msgstr "Reset password"
+
+msgid "Retired fraternities"
+msgstr "Retired fraternities"
+
+msgid "Revoke authorization"
+msgstr "Revoke authorization"
+
+msgid "Revoked"
+msgstr "Revoked"
+
+#, php-format
+msgid "Revoked authorizations for GMM %d"
+msgstr "Revoked authorizations for GMM %d"
+
+msgid "Root"
+msgstr "Root"
+
+msgid ""
+"S.v. GEWIS uses cookies on this website, these are required for the website "
+"to function. Additionally, we may collection information about how you use "
+"our website in order to improve your experience. If you do not want your "
+"behaviour to be tracked please opt out below."
+msgstr ""
+"S.v. GEWIS uses cookies on this website, these are required for the website "
+"to function. Additionally, we may collection information about how you use "
+"our website in order to improve your experience. If you do not want your "
+"behaviour to be tracked please opt out below."
+
+msgid "Save"
+msgstr "Save"
+
+msgid "Scanned?"
+msgstr "Scanned?"
+
+msgid "Search"
+msgstr "Search"
+
+msgid "Search by keyword or meeting number"
+msgstr "Search by keyword or meeting number"
+
+msgid "Search for decision"
+msgstr "Search for decision"
+
+msgid "Search query"
+msgstr "Search query"
+
+msgid "Search through the list of decisions accumulated from past meetings:"
+msgstr "Search through the list of decisions accumulated from past meetings:"
+
+msgid "Secretaris"
+msgstr "Secretary"
+
+msgid "Select a job category"
+msgstr "Select a job category"
+
+msgid "Select a new parent album"
+msgstr "Select a new parent album"
+
+msgid "Select a new parent for the album"
+msgstr "Select a new parent for the album"
+
+msgid "Select a period"
+msgstr "Select a period"
+
+msgid "Select a target job package"
+msgstr "Select a target job package"
+
+msgid "Select a type"
+msgstr "Select a type"
+
+msgid "Select an option"
+msgstr "Select an option"
+
+msgid ""
+"Select an organ to edit its information. Changes will not be displayed until "
+"they have been approved."
+msgstr ""
+"Select an organ to edit its information. Changes will not be displayed until "
+"they have been approved."
+
+msgid "Select the jobs that you want to transfer to another job package."
+msgstr "Select the jobs that you want to transfer to another job package."
+
+msgid ""
+"Select the organ for which the options are and in which option period the "
+"options should be planned."
+msgstr ""
+"Select the organ for which the options are and in which option period the "
+"options should be planned."
+
+msgid ""
+"Select this if this sign-up list has limited capacity or is expected to have "
+"limited capacity. Please ensure that you also write this in the description "
+"of the activity."
+msgstr ""
+"Select this if this sign-up list has limited capacity or is expected to have "
+"limited capacity. Please ensure that you also write this in the description "
+"of the activity."
+
+msgid "Select this if you want this news item to stay at the top of the page."
+msgstr "Select this if you want this news item to stay at the top of the page."
+
+msgid ""
+"Select this to display the number of subscribed GEWIS members to external "
+"visitors."
+msgstr ""
+"Select this to display the number of subscribed GEWIS members to external "
+"visitors."
+
+msgid ""
+"Select whether an organ (committee, fraternity, etc.) or a company is "
+"responsible for this activity, or both."
+msgstr ""
+"Select whether an organ (committee, fraternity, etc.) or a company is "
+"responsible for this activity, or both."
+
+msgid "Set as profile picture"
+msgstr "Set as profile picture"
+
+msgid "Set as profile picture!"
+msgstr "Set as profile picture!"
+
+msgid "Settings"
+msgstr "Settings"
+
+msgid "Share"
+msgstr "Share"
+
+msgid "Short dutch description"
+msgstr "Short dutch description"
+
+msgid "Short english description"
+msgstr "Short english description"
+
+msgid "Shutter speed"
+msgstr "Shutter speed"
+
+msgid "Sign-up List"
+msgstr "Sign-up List"
+
+msgid "Sign-up Lists"
+msgstr "Sign-up Lists"
+
+msgid "Slogan"
+msgstr "Slogan"
+
+msgid "Slug"
+msgstr "Slug"
+
+msgid "Some of the required fields for this type are empty"
+msgstr "Some of the required fields for this type are empty"
+
+msgid "Sort on"
+msgstr "Sort on"
+
+msgid ""
+"Specify the permanent link for this company, it should be unique across all "
+"companies."
+msgstr ""
+"Specify the permanent link for this company, it should be unique across all "
+"companies."
+
+msgid ""
+"Specify the permanent link for this job, it should be unique for this "
+"company."
+msgstr ""
+"Specify the permanent link for this job, it should be unique for this "
+"company."
+
+msgid "Stack trace"
+msgstr "Stack trace"
+
+msgid "Start"
+msgstr "Start"
+
+msgid "Start Date"
+msgstr "Start Date"
+
+msgid "Start date"
+msgstr "Start date"
+
+msgid "Start date and time"
+msgstr "Start date and time"
+
+msgid "Start date and time of option period"
+msgstr "Start date and time of option period"
+
+msgid "Start date and time of planning period"
+msgstr "Start date and time of planning period"
+
+#, php-format
+msgid "Still haven't found what you're looking for? Take a look at %s."
+msgstr "Still haven't found what you're looking for? Take a look at %s."
+
+msgid "Street and number"
+msgstr "Street and number"
+
+msgid "Student address"
+msgstr "Student address"
+
+msgid "Studievereniging GEWIS"
+msgstr "Study Association GEWIS"
+
+msgid "Study Association GEWIS"
+msgstr "Study Association GEWIS"
+
+msgid ""
+"Study association GEWIS obviously has several fraternities which contribute "
+"to the atmosphere at GEWIS and organize fun activities. Some fraternities "
+"have retired, but luckily new fraternities continue to be founded."
+msgstr ""
+"Study association GEWIS obviously has several fraternities which contribute "
+"to the atmosphere at GEWIS and organize fun activities. Some fraternities "
+"have retired, but luckily new fraternities continue to be founded."
+
+msgid "Submit"
+msgstr "Submit"
+
+msgid "Submitter"
+msgstr "Submitter"
+
+msgid "Subscribe"
+msgstr "Subscribe"
+
+msgid "Subscribe an external participant"
+msgstr "Subscribe an external participant"
+
+msgid "Subscribe as external participant"
+msgstr "Subscribe as external participant"
+
+msgid "Subscribe now"
+msgstr "Subscribe now"
+
+msgid "Subscribe yourself"
+msgstr "Subscribe yourself"
+
+msgid "Subscription closed"
+msgstr "Subscription closed"
+
+msgid "Successfully added course!"
+msgstr "Successfully added course!"
+
+msgid "Successfully removed external participant"
+msgstr "Successfully removed external participant"
+
+msgid "Successfully subscribed"
+msgstr "Successfully subscribed"
+
+msgid "Successfully subscribed as external participant"
+msgstr "Successfully subscribed as external participant"
+
+msgid "Successfully subscribed external participant"
+msgstr "Successfully subscribed external participant"
+
+msgid "Successfully unsubscribed"
+msgstr "Successfully unsubscribed"
+
+msgid "Successfully updated course information!"
+msgstr "Successfully updated course information!"
+
+msgid "SudoSOS"
+msgstr "SudoSOS"
+
+msgid "Summaries"
+msgstr "Summaries"
+
+#, php-format
+msgid "Summary by %s on %s (%s)"
+msgstr "Summary by %s on %s (%s)"
+
+msgid "Summary date"
+msgstr "Summary date"
+
+#, php-format
+msgid "Summary on %s (%s)"
+msgstr "Summary on %s (%s)"
+
+msgid "Tafelvoetbalcoordinator"
+msgstr "Tafelvoetbalcoordinator"
+
+msgid "Tag someone"
+msgstr "Tag someone"
+
+msgid "Terms"
+msgstr "Terms"
+
+msgid "Text"
+msgstr "Text"
+
+#, php-format
+msgid "The %s%s %s%s will be held on %s."
+msgstr "The %s%s %s%s will be held on %s."
+
+msgid "The activity category was created successfully!"
+msgstr "The activity category was created successfully!"
+
+msgid "The activity category was successfully updated!"
+msgstr "The activity category was successfully updated!"
+
+msgid "The activity does now have an acceptable amount of options"
+msgstr "The activity does now have an acceptable amount of options"
+
+msgid "The activity has been successfully created."
+msgstr "The activity has been successfully created."
+
+msgid "The activity must start after today"
+msgstr "The activity must start after today"
+
+msgid "The activity must start before it ends"
+msgstr "The activity must start before it ends"
+
+msgid "The activity must start before it ends."
+msgstr "The activity must start before it ends."
+
+msgid "The album has been deleted"
+msgstr "The album has been deleted"
+
+msgid "The album has been moved"
+msgstr "The album has been moved"
+
+msgid "The application will get the following information:"
+msgstr "The application will get the following information:"
+
+msgid ""
+"The board can always decide to make an exception to the rules written above, "
+"for example in case of dependence on a third party, or when it concerns very "
+"big activities or weekends."
+msgstr ""
+"The board can always decide to make an exception to the rules written above, "
+"for example in case of dependence on a third party, or when it concerns very "
+"big activities or weekends."
+
+msgid "The currently active fraternities of GEWIS (in arbitrary order)"
+msgstr "The currently active fraternities of GEWIS (in arbitrary order)"
+
+msgid "The e-mail address must be unique across companies."
+msgstr "The e-mail address must be unique across companies."
+
+msgid ""
+"The exams on the website of GEWIS are provided by Education & Student "
+"Affairs of the department of Mathematics and Computer Science of the TU/e."
+msgstr ""
+"The exams on the website of GEWIS are provided by Education & Student "
+"Affairs of the department of Mathematics and Computer Science of the TU/e."
+
+msgid ""
+"The first to put an option for an activity on a particular date, has the "
+"first dibs to let the activity take place on this date. Five weeks before "
+"the activity takes place, the budget must have been presented to the board. "
+"When this has not been done, the option will only stay in the calendar for "
+"two more weeks. In case the entity involved does not present their budget "
+"within these two weeks nontheless, the option lapses and the next one in "
+"line gets the chance to use this date for an activity."
+msgstr ""
+"The first to put an option for an activity on a particular date, has the "
+"first dibs to let the activity take place on this date. Five weeks before "
+"the activity takes place, the budget must have been presented to the board. "
+"When this has not been done, the option will only stay in the calendar for "
+"two more weeks. In case the entity involved does not present their budget "
+"within these two weeks nontheless, the option lapses and the next one in "
+"line gets the chance to use this date for an activity."
+
+msgid "The following fraternities have retired:"
+msgstr "The following fraternities have retired:"
+
+msgid "The image could not be loaded."
+msgstr "The image could not be loaded."
+
+#, php-format
+msgid "The latest %s that took place:"
+msgstr "The latest %s that took place:"
+
+msgid "The login and password combination is incorrect."
+msgstr "The login and password combination is incorrect."
+
+msgid "The number of English options must equal the number of Dutch options"
+msgstr "The number of English options must equal the number of Dutch options"
+
+#, php-format
+msgid "The number of subscribed members is currently %d."
+msgstr "The number of subscribed members is currently %d."
+
+msgid "The option period must end after it starts."
+msgstr "The option period must end after it starts."
+
+msgid "The option period must start after the planning period ends."
+msgstr "The option period must start after the planning period ends."
+
+msgid "The photo has been deleted"
+msgstr "The photo has been deleted"
+
+msgid "The photo has been moved"
+msgstr "The photo has been moved"
+
+msgid "The photos have been been deleted"
+msgstr "The photos have been been deleted"
+
+msgid "The photos have been moved"
+msgstr "The photos have been moved"
+
+msgid "The planning period must end after it starts."
+msgstr "The planning period must end after it starts."
+
+msgid "The requested URL could not be matched by routing."
+msgstr "The requested URL could not be matched by routing."
+
+msgid ""
+"The requested controller could not be mapped to an existing controller class."
+msgstr ""
+"The requested controller could not be mapped to an existing controller class."
+
+msgid "The requested controller was not dispatchable."
+msgstr "The requested controller was not dispatchable."
+
+msgid "The requested controller was unable to dispatch the request."
+msgstr "The requested controller was unable to dispatch the request."
+
+msgid ""
+"The sign-up list closing date and time must be before the activity starts."
+msgstr ""
+"The sign-up list closing date and time must be before the activity starts."
+
+msgid ""
+"The sign-up list opening date and time must be before the sign-up list "
+"closes."
+msgstr ""
+"The sign-up list opening date and time must be before the sign-up list "
+"closes."
+
+msgid "The uploaded file does not have a valid extension"
+msgstr "The uploaded file does not have a valid extension"
+
+msgid "The uploaded file is not a valid image"
+msgstr "The uploaded file is not a valid image"
+
+#, php-format
+msgid ""
+"The uploaded file is not a valid image \n"
+"Error: %s"
+msgstr ""
+"The uploaded file is not a valid image \n"
+"Error: %s"
+
+msgid "There already are minutes for this meeting"
+msgstr "There already are minutes for this meeting"
+
+msgid "There already exists a course with this code"
+msgstr "There already exists a course with this code"
+
+msgid "There are a few rules:"
+msgstr "There are a few rules:"
+
+msgid "There are currently no activity categories..."
+msgstr "There are currently no activity categories..."
+
+msgid "There are currently no job labels..."
+msgstr "There are currently no job labels..."
+
+msgid "There are no activities in the archive."
+msgstr "There are no activities in the archive."
+
+msgid "There are no activities."
+msgstr "There are no activities."
+
+msgid "There are no exams to be edited. Upload exams to edit them."
+msgstr "There are no exams to be edited. Upload exams to edit them."
+
+msgid "There are no jobs that you can transfer..."
+msgstr "There are no jobs that you can transfer..."
+
+msgid "There are no meetings for which you can upload documents."
+msgstr "There are no meetings for which you can upload documents."
+
+msgid "There are no options."
+msgstr "There are no options."
+
+msgid "There are no photos in this year."
+msgstr "There are no photos in this year."
+
+msgid "There are no planned option creation periods in the future."
+msgstr "There are no planned option creation periods in the future."
+
+msgid "There are no revoked authorizations for this GMM."
+msgstr "There are no revoked authorizations for this GMM."
+
+msgid "There are no summaries to be edited. Upload exams to edit them."
+msgstr "There are no summaries to be edited. Upload exams to edit them."
+
+msgid ""
+"There are no upcoming meetings for which you can authorize someone.\n"
+"You may still be able to authorize someone or revoke an authorization by "
+"contacting the board."
+msgstr ""
+"There are no upcoming meetings for which you can authorize someone.\n"
+"You may still be able to authorize someone or revoke an authorization by "
+"contacting the board."
+
+msgid "There are no valid authorizations for this GMM."
+msgstr "There are no valid authorizations for this GMM."
+
+msgid "There currently is no poll."
+msgstr "There currently is no poll."
+
+msgid "There is currently no option creation period planned."
+msgstr "There is currently no option creation period planned."
+
+msgid "There is no company or update proposal that requires your approval."
+msgstr "There is no company or update proposal that requires your approval."
+
+msgid "There is no job or update proposal that requires your approval."
+msgstr "There is no job or update proposal that requires your approval."
+
+msgid "There is no member with this membership number."
+msgstr "There is no member with this membership number."
+
+msgid "This activity has already started/ended and can no longer be updated."
+msgstr "This activity has already started/ended and can no longer be updated."
+
+msgid "This activity needs a GEFLITST member to take photos"
+msgstr "This activity needs a GEFLITST member to take photos"
+
+#, php-format
+msgid "This activity was approved by <strong>%s</strong>."
+msgstr "This activity was approved by <strong>%s</strong>."
+
+#, php-format
+msgid "This activity was disapproved by <strong>%s</strong>."
+msgstr "This activity was disapproved by <strong>%s</strong>."
+
+msgid "This album does not contain any photos."
+msgstr "This album does not contain any photos."
+
+msgid "This course does not have any exams."
+msgstr "This course does not have any exams."
+
+msgid ""
+"This functionality is currently unavailable. Our apologies for the "
+"inconvenience."
+msgstr ""
+"This functionality is currently unavailable. Our apologies for the "
+"inconvenience."
+
+msgid "This is a career related activity"
+msgstr "This is a career related activity"
+
+#, php-format
+msgid ""
+"This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
+"it will start on <strong>%s</strong> and end on <strong>%s</strong>."
+msgstr ""
+"This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
+"it will start on <strong>%s</strong> and end on <strong>%s</strong>."
+
+#, php-format
+msgid "This job is proposed by <strong>%s</strong> as part of job package %s."
+msgstr "This job is proposed by <strong>%s</strong> as part of job package %s."
+
+msgid "This job package does not contain any jobs."
+msgstr "This job package does not contain any jobs."
+
+#, php-format
+msgid ""
+"This job update is proposed by <strong>%s</strong> as part of job package "
+"%s. Changes in the job's attributes are shown like this: %s. If there are no "
+"changes to a certain attribute, you will see the existing data."
+msgstr ""
+"This job update is proposed by <strong>%s</strong> as part of job package "
+"%s. Changes in the job's attributes are shown like this: %s. If there are no "
+"changes to a certain attribute, you will see the existing data."
+
+#, php-format
+msgid "This job was approved by <strong>%s</strong>."
+msgstr "This job was approved by <strong>%s</strong>."
+
+#, php-format
+msgid ""
+"This job was disapproved by <strong>%s</strong> with the message \"%s\"."
+msgstr ""
+"This job was disapproved by <strong>%s</strong> with the message \"%s\"."
+
+#, php-format
+msgid "This job was disapproved by <strong>%s</strong>."
+msgstr "This job was disapproved by <strong>%s</strong>."
+
+msgid "This meeting does not have any associated documents."
+msgstr "This meeting does not have any associated documents."
+
+msgid "This member already has an account."
+msgstr "This member already has an account."
+
+msgid ""
+"This member cannot create an account, please contact the secretary for more "
+"information."
+msgstr ""
+"This member cannot create an account, please contact the secretary for more "
+"information."
+
+msgid ""
+"This member has already received 2 or more authorizations through the "
+"website. Since you can only use two authorizations at the same time, this "
+"member may have to choose which 2 authorizations they use. This may "
+"<strong>not</strong> include yours. If you want to authorize someone else "
+"instead, click on \"cancel\". If you want to continue with the authorization "
+"click on \"confirm authorization\"."
+msgstr ""
+"This member has already received 2 or more authorizations through the "
+"website. Since you can only use two authorizations at the same time, this "
+"member may have to choose which 2 authorizations they use. This may "
+"<strong>not</strong> include yours. If you want to authorize someone else "
+"instead, click on \"cancel\". If you want to continue with the authorization "
+"click on \"confirm authorization\"."
+
+msgid "This option planning period cannot be edited."
+msgstr "This option planning period cannot be edited."
+
+msgid "This poll has no comments"
+msgstr "This poll has no comments"
+
+msgid ""
+"This sign-up list contains additional fields which require input from "
+"subscribers, they are shown below."
+msgstr ""
+"This sign-up list contains additional fields which require input from "
+"subscribers, they are shown below."
+
+#, php-format
+msgid ""
+"This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
+msgstr ""
+"This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
+
+msgid "This slug contains invalid characters"
+msgstr "This slug contains invalid characters"
+
+msgid "This slug is already taken"
+msgstr "This slug is already taken"
+
+msgid "Thumbnail photo to upload"
+msgstr "Thumbnail photo to upload"
+
+msgid ""
+"To optimally display your image on the overview page, please crop it below"
+msgstr ""
+"To optimally display your image on the overview page, please crop it below"
+
+msgid "To optimally display your image your page, please crop it below"
+msgstr "To optimally display your image your page, please crop it below"
+
+#, php-format
+msgid ""
+"To read more about the benefits of becoming a member and how to become a "
+"member, go to this %sinformation page%s."
+msgstr ""
+"To read more about the benefits of becoming a member and how to become a "
+"member, go to this %sinformation page%s."
+
+msgid "Toggle navigation"
+msgstr "Toggle navigation"
+
+msgid "Token"
+msgstr "Token"
+
+msgid "Token was successfully generated"
+msgstr "Token was successfully generated"
+
+msgid "Too many login attempts, try again later."
+msgstr "Too many login attempts, try again later."
+
+msgid "Tracking is currently"
+msgstr "Tracking is currently"
+
+msgid "Transfer Jobs"
+msgstr "Transfer Jobs"
+
+msgid "Try alternate words or selections"
+msgstr "Try alternate words or selections"
+
+msgid "Try entering fewer keywords"
+msgstr "Try entering fewer keywords"
+
+msgid "Try using a more generic search term"
+msgstr "Try using a more generic search term"
+
+msgid "Type"
+msgstr "Type"
+
+msgid "URL options"
+msgstr "URL options"
+
+msgid "Unable to retrieve infimum."
+msgstr "Unable to retrieve infimum."
+
+msgid "Unapproved Activities"
+msgstr "Unapproved Activities"
+
+msgid "Unapproved Companies"
+msgstr "Unapproved Companies"
+
+msgid "Unapproved Jobs"
+msgstr "Unapproved Jobs"
+
+msgid "Unfortunately there currently is no poll :("
+msgstr "Unfortunately there currently is no poll :("
+
+#, php-format
+msgid "Unfortunately, there aren't any %s at the moment."
+msgstr "Unfortunately, there aren't any %s at the moment."
+
+msgid "Unknown"
+msgstr "Unknown"
+
+msgid "Unsubscribe yourself"
+msgstr "Unsubscribe yourself"
+
+msgid "Until"
+msgstr "Until"
+
+msgid "Upcoming Activities"
+msgstr "Upcoming Activities"
+
+msgid "Upcoming meeting"
+msgid_plural "Upcoming meetings"
+msgstr[0] "Upcoming meeting"
+msgstr[1] "Upcoming meetings"
+
+msgid "Update Activity"
+msgstr "Update Activity"
+
+msgid "Update Activity Category"
+msgstr "Update Activity Category"
+
+msgid "Update Album"
+msgstr "Update Album"
+
+msgid "Update Company"
+msgstr "Update Company"
+
+msgid "Update Job"
+msgstr "Update Job"
+
+msgid "Update Job Category"
+msgstr "Update Job Category"
+
+msgid "Update Job Label"
+msgstr "Update Job Label"
+
+msgid "Update Package"
+msgstr "Update Package"
+
+msgid "Update Proposal"
+msgstr "Update Proposal"
+
+msgid "Update pending"
+msgstr "Update pending"
+
+msgid ""
+"Update proposal for job successfully created! It will become active after it "
+"has been approved."
+msgstr ""
+"Update proposal for job successfully created! It will become active after it "
+"has been approved."
+
+msgid "Update status"
+msgstr "Update status"
+
+msgid "Upload"
+msgstr "Upload"
+
+msgid "Upload Exams"
+msgstr "Upload Exams"
+
+msgid "Upload Photos"
+msgstr "Upload Photos"
+
+msgid "Upload Summaries"
+msgstr "Upload Summaries"
+
+msgid "Upload document"
+msgstr "Upload document"
+
+msgid "Upload exams"
+msgstr "Upload exams"
+
+msgid "Upload of all exams was finished."
+msgstr "Upload of all exams was finished."
+
+msgid "Upload of all summaries was finished."
+msgstr "Upload of all summaries was finished."
+
+msgid "Upload summaries"
+msgstr "Upload summaries"
+
+#, php-format
+msgid "Uploading photos to %s"
+msgstr "Uploading photos to %s"
+
+msgid "Use the form to subscribe"
+msgstr "Use the form to subscribe"
+
+msgid "Use the form to unsubscribe"
+msgstr "Use the form to unsubscribe"
+
+msgid "Use the form to unsubscribe an external participant"
+msgstr "Use the form to unsubscribe an external participant"
+
+msgid "Useful Information"
+msgstr "Useful Information"
+
+msgid "Useful links"
+msgstr "Useful links"
+
+#, php-format
+msgid "User (%s)"
+msgstr "User (%s)"
+
+msgid "Users"
+msgstr "Users"
+
+msgid "VIRT"
+msgstr "VIRT"
+
+#, php-format
+msgid "Valid authorizations for GMM %d"
+msgstr "Valid authorizations for GMM %d"
+
+msgid "Value is required and can't be empty"
+msgstr "Value is required and can't be empty"
+
+msgid "Verify new password"
+msgstr "Verify new password"
+
+msgid "Verify password"
+msgstr "Verify password"
+
+msgid "Verify your password"
+msgstr "Verify your password"
+
+msgid "Verjaardagen"
+msgstr "Birthdays"
+
+msgid "Vice-Voorzitter"
+msgstr "Vice-Chair"
+
+msgid "Vicevoorzitter"
+msgstr "Vice-Chair"
+
+msgid "View"
+msgstr "View"
+
+msgid "View Attachment"
+msgstr "View Attachment"
+
+msgid "View New Attachment"
+msgstr "View New Attachment"
+
+msgid "View Original Attachment"
+msgstr "View Original Attachment"
+
+msgid "View Proposal"
+msgstr "View Proposal"
+
+msgid "View Update"
+msgstr "View Update"
+
+msgid "View Website"
+msgstr "View Website"
+
+msgid "View all meetings"
+msgstr "View all meetings"
+
+msgid "View available documents"
+msgstr "View available documents"
+
+msgid "View current attachment"
+msgstr "View current attachment"
+
+msgid "View current logo"
+msgstr "View current logo"
+
+msgid "View details"
+msgstr "View details"
+
+msgid "View details / subscriptions"
+msgstr "View details / subscriptions"
+
+msgid "View details of the new activity"
+msgstr "View details of the new activity"
+
+msgid "View details of the old activity"
+msgstr "View details of the old activity"
+
+msgid "View on map"
+msgstr "View on map"
+
+#, php-format
+msgid "View the minutes of the %s"
+msgstr "View the minutes of the %s"
+
+msgid "View user profile"
+msgstr "View user profile"
+
+msgid "Virtual Meeting"
+msgstr "Virtual Meeting"
+
+msgid "Visit Website"
+msgstr "Visit Website"
+
+msgid "Visit the webshop"
+msgstr "Visit the webshop"
+
+msgid "Visit webshop"
+msgstr "Visit webshop"
+
+msgid "Voorzitter"
+msgstr "Chair"
+
+msgid "Vote for photo of the week"
+msgstr "Vote for photo of the week"
+
+msgid "Voted!"
+msgstr "Voted!"
+
+msgid ""
+"Warning! This is an update to an unapproved job. Applying this update will "
+"approve the job."
+msgstr ""
+"Warning! This is an update to an unapproved job. Applying this update will "
+"approve the job."
+
+msgid ""
+"Warning! This is an update to rejected job. Applying this update will "
+"approve the job."
+msgstr ""
+"Warning! This is an update to rejected job. Applying this update will "
+"approve the job."
+
+msgid "We cannot determine at this time why a 404 was generated."
+msgstr "We cannot determine at this time why a 404 was generated."
+
+msgid "Webmail"
+msgstr "Webmail"
+
+msgid "Website"
+msgstr "Website"
+
+#, php-format
+msgid ""
+"Welcome %s. Create your password for the website and activate your account."
+msgstr ""
+"Welcome %s. Create your password for the website and activate your account."
+
+msgid ""
+"Welcome on the page of the digital Option Calendar. In the calendar below "
+"you can place options for GEWIS activities, just like you were used to do in "
+"the paper version of the option calendar before. The red dots indicate "
+"activities that are already fixed in the GEWIS agenda, the blue dots are "
+"options for activities. If you insert an option, please give it a clear "
+"name, so it is clear what the option is for."
+msgstr ""
+"Welcome on the page of the digital Option Calendar. In the calendar below "
+"you can place options for GEWIS activities, just like you were used to do in "
+"the paper version of the option calendar before. The red dots indicate "
+"activities that are already fixed in the GEWIS agenda, the blue dots are "
+"options for activities. If you insert an option, please give it a clear "
+"name, so it is clear what the option is for."
+
+msgid ""
+"Welcome to the admin interface of the GEWIS website. If you are experiencing "
+"any issues or have a question, please contact the ApplicatieBeheerCommissie."
+msgstr ""
+"Welcome to the admin interface of the GEWIS website. If you are experiencing "
+"any issues or have a question, please contact the ApplicatieBeheerCommissie."
+
+msgid ""
+"Welcome to the website of Study association GEWIS, the study association of "
+"the department of Mathematics & Computer Science of the Eindhoven University "
+"of Technology."
+msgstr ""
+"Welcome to the website of Study association GEWIS, the study association of "
+"the department of Mathematics & Computer Science of the Eindhoven University "
+"of Technology."
+
+msgid "Well-being"
+msgstr "Well-being"
+
+msgid "What are you looking for?"
+msgstr "What are you looking for?"
+
+msgid ""
+"What is this activity about? Fill in the blanks below, please note that at "
+"least one language must be used."
+msgstr ""
+"What is this activity about? Fill in the blanks below, please note that at "
+"least one language must be used."
+
+msgid ""
+"What is this company about? Fill in the blanks below, please note that at "
+"least one language must be used."
+msgstr ""
+"What is this company about? Fill in the blanks below, please note that at "
+"least one language must be used."
+
+msgid ""
+"When this is checked, GEFLITST will be notified that this activity needs a "
+"photographer."
+msgstr ""
+"When this is checked, GEFLITST will be notified that this activity needs a "
+"photographer."
+
+msgid "Wrong form"
+msgstr "Wrong form"
+
+msgid "Yes"
+msgstr "Yes"
+
+msgid "Yes/No"
+msgstr "Yes/No"
+
+msgid ""
+"You already attempted to register, please check your email or try again "
+"after 20 minutes."
+msgstr ""
+"You already attempted to register, please check your email or try again "
+"after 20 minutes."
+
+#, php-format
+msgid "You are being redirected to %s"
+msgstr "You are being redirected to %s"
+
+msgid "You are currently a member of:"
+msgstr "You are currently a member of:"
+
+#, php-format
+msgid ""
+"You are currently updating a job that was previously rejected for the "
+"following reason: %s"
+msgstr ""
+"You are currently updating a job that was previously rejected for the "
+"following reason: %s"
+
+msgid ""
+"You are currently updating a job that was previously rejected, however, no "
+"reason was provided."
+msgstr ""
+"You are currently updating a job that was previously rejected, however, no "
+"reason was provided."
+
+#, php-format
+msgid ""
+"You are currently updating an update proposal that was previously rejected "
+"for the following reason: %s"
+msgstr ""
+"You are currently updating an update proposal that was previously rejected "
+"for the following reason: %s"
+
+msgid ""
+"You are currently updating an update proposal that was previously rejected, "
+"however, no reason was provided."
+msgstr ""
+"You are currently updating an update proposal that was previously rejected, "
+"however, no reason was provided."
+
+msgid "You are currently using administrator privileges to use the website!"
+msgstr "You are currently using administrator privileges to use the website!"
+
+msgid "You are logged out."
+msgstr "You are logged out."
+
+msgid "You are not allowed authorize people."
+msgstr "You are not allowed authorize people."
+
+msgid "You are not allowed to access the activities through the API"
+msgstr "You are not allowed to access the activities through the API"
+
+msgid "You are not allowed to access the admin interface"
+msgstr "You are not allowed to access the admin interface"
+
+msgid "You are not allowed to add API tokens"
+msgstr "You are not allowed to add API tokens"
+
+msgid "You are not allowed to add courses"
+msgstr "You are not allowed to add courses"
+
+msgid "You are not allowed to administer activities"
+msgstr "You are not allowed to administer activities"
+
+msgid "You are not allowed to administer career settings"
+msgstr "You are not allowed to administer career settings"
+
+msgid "You are not allowed to administer courses"
+msgstr "You are not allowed to administer courses"
+
+msgid "You are not allowed to administer education settings"
+msgstr "You are not allowed to administer education settings"
+
+msgid "You are not allowed to administer option calendar periods"
+msgstr "You are not allowed to administer option calendar periods"
+
+msgid "You are not allowed to administer polls"
+msgstr "You are not allowed to administer polls"
+
+msgid "You are not allowed to approve polls"
+msgstr "You are not allowed to approve polls"
+
+msgid "You are not allowed to approve this option"
+msgstr "You are not allowed to approve this option"
+
+msgid "You are not allowed to approve update proposals of jobs"
+msgstr "You are not allowed to approve update proposals of jobs"
+
+msgid "You are not allowed to authorize someone"
+msgstr "You are not allowed to authorize someone"
+
+msgid "You are not allowed to browse files."
+msgstr "You are not allowed to browse files."
+
+msgid "You are not allowed to change passwords"
+msgstr "You are not allowed to change passwords"
+
+msgid "You are not allowed to change the approval status of jobs"
+msgstr "You are not allowed to change the approval status of jobs"
+
+msgid "You are not allowed to change the status of the activity"
+msgstr "You are not allowed to change the status of the activity"
+
+msgid "You are not allowed to change your password"
+msgstr "You are not allowed to change your password"
+
+msgid "You are not allowed to create a company"
+msgstr "You are not allowed to create a company"
+
+msgid "You are not allowed to create activity option proposals"
+msgstr "You are not allowed to create activity option proposals"
+
+msgid "You are not allowed to create activity proposals"
+msgstr "You are not allowed to create activity proposals"
+
+msgid "You are not allowed to create an activity"
+msgstr "You are not allowed to create an activity"
+
+msgid "You are not allowed to create an activity category"
+msgstr "You are not allowed to create an activity category"
+
+msgid "You are not allowed to create an activity for this organ"
+msgstr "You are not allowed to create an activity for this organ"
+
+msgid "You are not allowed to create comments on this poll"
+msgstr "You are not allowed to create comments on this poll"
+
+msgid "You are not allowed to create companies"
+msgstr "You are not allowed to create companies"
+
+msgid "You are not allowed to create job categories"
+msgstr "You are not allowed to create job categories"
+
+msgid "You are not allowed to create job labels"
+msgstr "You are not allowed to create job labels"
+
+msgid "You are not allowed to create jobs"
+msgstr "You are not allowed to create jobs"
+
+msgid "You are not allowed to create new pages."
+msgstr "You are not allowed to create new pages."
+
+msgid "You are not allowed to create news items"
+msgstr "You are not allowed to create news items"
+
+msgid "You are not allowed to create option calendar periods"
+msgstr "You are not allowed to create option calendar periods"
+
+msgid "You are not allowed to create packages"
+msgstr "You are not allowed to create packages"
+
+msgid "You are not allowed to delete an activity category"
+msgstr "You are not allowed to delete an activity category"
+
+msgid "You are not allowed to delete companies"
+msgstr "You are not allowed to delete companies"
+
+msgid "You are not allowed to delete course documents"
+msgstr "You are not allowed to delete course documents"
+
+msgid "You are not allowed to delete courses"
+msgstr "You are not allowed to delete courses"
+
+msgid "You are not allowed to delete exams"
+msgstr "You are not allowed to delete exams"
+
+msgid "You are not allowed to delete jobs"
+msgstr "You are not allowed to delete jobs"
+
+msgid "You are not allowed to delete meeting documents."
+msgstr "You are not allowed to delete meeting documents."
+
+msgid "You are not allowed to delete news items"
+msgstr "You are not allowed to delete news items"
+
+msgid "You are not allowed to delete option calendar periods"
+msgstr "You are not allowed to delete option calendar periods"
+
+msgid "You are not allowed to delete packages"
+msgstr "You are not allowed to delete packages"
+
+msgid "You are not allowed to delete pages."
+msgstr "You are not allowed to delete pages."
+
+msgid "You are not allowed to delete polls"
+msgstr "You are not allowed to delete polls"
+
+msgid "You are not allowed to delete this option"
+msgstr "You are not allowed to delete this option"
+
+msgid "You are not allowed to download course documents"
+msgstr "You are not allowed to download course documents"
+
+msgid "You are not allowed to edit an activity category"
+msgstr "You are not allowed to edit an activity category"
+
+msgid "You are not allowed to edit categories"
+msgstr "You are not allowed to edit categories"
+
+msgid "You are not allowed to edit companies"
+msgstr "You are not allowed to edit companies"
+
+msgid "You are not allowed to edit courses"
+msgstr "You are not allowed to edit courses"
+
+msgid "You are not allowed to edit job categories"
+msgstr "You are not allowed to edit job categories"
+
+msgid "You are not allowed to edit job labels"
+msgstr "You are not allowed to edit job labels"
+
+msgid "You are not allowed to edit jobs"
+msgstr "You are not allowed to edit jobs"
+
+msgid "You are not allowed to edit labels"
+msgstr "You are not allowed to edit labels"
+
+msgid "You are not allowed to edit news items"
+msgstr "You are not allowed to edit news items"
+
+msgid "You are not allowed to edit option calendar periods"
+msgstr "You are not allowed to edit option calendar periods"
+
+msgid "You are not allowed to edit organ information"
+msgstr "You are not allowed to edit organ information"
+
+msgid "You are not allowed to edit packages"
+msgstr "You are not allowed to edit packages"
+
+msgid "You are not allowed to edit pages."
+msgstr "You are not allowed to edit pages."
+
+msgid "You are not allowed to edit this organ's information"
+msgstr "You are not allowed to edit this organ's information"
+
+msgid "You are not allowed to list all job categories"
+msgstr "You are not allowed to list all job categories"
+
+msgid "You are not allowed to list all job labels"
+msgstr "You are not allowed to list all job labels"
+
+msgid "You are not allowed to list all news items."
+msgstr "You are not allowed to list all news items."
+
+msgid "You are not allowed to list job categories"
+msgstr "You are not allowed to list job categories"
+
+msgid "You are not allowed to list job labels"
+msgstr "You are not allowed to list job labels"
+
+msgid "You are not allowed to list meetings."
+msgstr "You are not allowed to list meetings."
+
+msgid "You are not allowed to list the companies"
+msgstr "You are not allowed to list the companies"
+
+msgid ""
+"You are not allowed to perform this action. If you are not logged in please "
+"do so before continuing. If you are already logged in this action may "
+"require you to login in with a different account."
+msgstr ""
+"You are not allowed to perform this action. If you are not logged in please "
+"do so before continuing. If you are already logged in this action may "
+"require you to login in with a different account."
+
+msgid "You are not allowed to remove API tokens"
+msgstr "You are not allowed to remove API tokens"
+
+msgid "You are not allowed to remove external signups for this activity"
+msgstr "You are not allowed to remove external signups for this activity"
+
+msgid "You are not allowed to rename meeting documents"
+msgstr "You are not allowed to rename meeting documents"
+
+msgid "You are not allowed to request polls"
+msgstr "You are not allowed to request polls"
+
+msgid "You are not allowed to revoke authorizations."
+msgstr "You are not allowed to revoke authorizations."
+
+msgid "You are not allowed to search decisions."
+msgstr "You are not allowed to search decisions."
+
+msgid "You are not allowed to subscribe an external user to this sign-up list"
+msgstr "You are not allowed to subscribe an external user to this sign-up list"
+
+msgid "You are not allowed to subscribe to this sign-up list"
+msgstr "You are not allowed to subscribe to this sign-up list"
+
+msgid "You are not allowed to transfer jobs"
+msgstr "You are not allowed to transfer jobs"
+
+msgid "You are not allowed to unsubscribe after the deadline!"
+msgstr "You are not allowed to unsubscribe after the deadline!"
+
+msgid "You are not allowed to update this activity"
+msgstr "You are not allowed to update this activity"
+
+msgid "You are not allowed to upload exams"
+msgstr "You are not allowed to upload exams"
+
+msgid "You are not allowed to upload images."
+msgstr "You are not allowed to upload images."
+
+msgid "You are not allowed to upload meeting documents."
+msgstr "You are not allowed to upload meeting documents."
+
+msgid "You are not allowed to upload meeting minutes."
+msgstr "You are not allowed to upload meeting minutes."
+
+msgid "You are not allowed to use the external admin signup"
+msgstr "You are not allowed to use the external admin signup"
+
+msgid "You are not allowed to use the external signup"
+msgstr "You are not allowed to use the external signup"
+
+msgid "You are not allowed to use this form"
+msgstr "You are not allowed to use this form"
+
+msgid "You are not allowed to view API tokens"
+msgstr "You are not allowed to view API tokens"
+
+msgid "You are not allowed to view activities"
+msgstr "You are not allowed to view activities"
+
+msgid "You are not allowed to view activity categories"
+msgstr "You are not allowed to view activity categories"
+
+msgid "You are not allowed to view all authorizations."
+msgstr "You are not allowed to view all authorizations."
+
+msgid "You are not allowed to view authorizations."
+msgstr "You are not allowed to view authorizations."
+
+msgid "You are not allowed to view infima"
+msgstr "You are not allowed to view infima"
+
+msgid "You are not allowed to view meeting documents."
+msgstr "You are not allowed to view meeting documents."
+
+msgid "You are not allowed to view meeting minutes."
+msgstr "You are not allowed to view meeting minutes."
+
+msgid "You are not allowed to view meetings."
+msgstr "You are not allowed to view meetings."
+
+msgid "You are not allowed to view members."
+msgstr "You are not allowed to view members."
+
+msgid "You are not allowed to view membership info."
+msgstr "You are not allowed to view membership info."
+
+msgid "You are not allowed to view sign-up lists"
+msgstr "You are not allowed to view sign-up lists"
+
+msgid "You are not allowed to view the activities"
+msgstr "You are not allowed to view the activities"
+
+msgid "You are not allowed to view the approval of this activity"
+msgstr "You are not allowed to view the approval of this activity"
+
+msgid "You are not allowed to view the approval status of jobs"
+msgstr "You are not allowed to view the approval status of jobs"
+
+msgid "You are not allowed to view the banner"
+msgstr "You are not allowed to view the banner"
+
+msgid "You are not allowed to view the company accounts"
+msgstr "You are not allowed to view the company accounts"
+
+msgid "You are not allowed to view the disapproved activities"
+msgstr "You are not allowed to view the disapproved activities"
+
+msgid "You are not allowed to view the featured company"
+msgstr "You are not allowed to view the featured company"
+
+msgid "You are not allowed to view the list of birthdays."
+msgstr "You are not allowed to view the list of birthdays."
+
+msgid "You are not allowed to view the list of pages."
+msgstr "You are not allowed to view the list of pages."
+
+msgid "You are not allowed to view the participants of this activity"
+msgstr "You are not allowed to view the participants of this activity"
+
+msgid "You are not allowed to view the sign up data"
+msgstr "You are not allowed to view the sign up data"
+
+msgid "You are not allowed to view the status of a job"
+msgstr "You are not allowed to view the status of a job"
+
+msgid "You are not allowed to view this activity"
+msgstr "You are not allowed to view this activity"
+
+msgid "You are not allowed to view this page."
+msgstr "You are not allowed to view this page."
+
+msgid "You are not allowed to view unapproved activities"
+msgstr "You are not allowed to view unapproved activities"
+
+msgid "You are not allowed to view unapproved polls"
+msgstr "You are not allowed to view unapproved polls"
+
+msgid ""
+"You are not allowed to view upcoming activities coupled to a member account"
+msgstr ""
+"You are not allowed to view upcoming activities coupled to a member account"
+
+msgid "You are not allowed to view upcoming the activities"
+msgstr "You are not allowed to view upcoming the activities"
+
+msgid "You are not allowed to vote on this poll."
+msgstr "You are not allowed to vote on this poll."
+
+msgid "You are not subscribed to this activity!"
+msgstr "You are not subscribed to this activity!"
+
+msgid "You cannot create new jobs in expired job packages."
+msgstr "You cannot create new jobs in expired job packages."
+
+msgid "You cannot sign in to this account at this moment."
+msgstr "You cannot sign in to this account at this moment."
+
+msgid "You cannot subscribe to this activity at this moment in time"
+msgstr "You cannot subscribe to this activity at this moment in time"
+
+msgid "You cannot unsubscribe from this activity at this moment in time"
+msgstr "You cannot unsubscribe from this activity at this moment in time"
+
+msgid "You cannot update jobs in expired job packages."
+msgstr "You cannot update jobs in expired job packages."
+
+msgid ""
+"You cannot use this password, it was found in a public data breach and is "
+"therefore considered insecure. We recommend using a password generated by a "
+"good password manager, such as Bitwarden or 1Password."
+msgstr ""
+"You cannot use this password, it was found in a public data breach and is "
+"therefore considered insecure. We recommend using a password generated by a "
+"good password manager, such as Bitwarden or 1Password."
+
+msgid "You do not have any recent jobs pending approval."
+msgstr "You do not have any recent jobs pending approval."
+
+msgid "You do not have recently approved jobs."
+msgstr "You do not have recently approved jobs."
+
+msgid "You do not have recently rejected jobs."
+msgstr "You do not have recently rejected jobs."
+
+msgid "You do not have the required privileges to view this page"
+msgstr "You do not have the required privileges to view this page"
+
+msgid "You have already been subscribed for this activity"
+msgstr "You have already been subscribed for this activity"
+
+#, php-format
+msgid "You have authorized %s for the %s GMM (%s)."
+msgstr "You have authorized %s for the %s GMM (%s)."
+
+msgid "You have not been a member of a committee or fraternity."
+msgstr "You have not been a member of a committee or fraternity."
+
+msgid ""
+"You have successfully created an update proposal for the activity! If the "
+"activity was already approved, the proposal will be applied after it has "
+"been approved by the board. Otherwise, the update has already been applied "
+"to the activity."
+msgstr ""
+"You have successfully created an update proposal for the activity! If the "
+"activity was already approved, the proposal will be applied after it has "
+"been approved by the board. Otherwise, the update has already been applied "
+"to the activity."
+
+msgid "You have to be logged in to subscribe for this activity"
+msgstr "You have to be logged in to subscribe for this activity"
+
+msgid "You might be able to view this page by logging in"
+msgstr "You might be able to view this page by logging in"
+
+msgid "You need to be logged in to sign off for this activity"
+msgstr "You need to be logged in to sign off for this activity"
+
+msgid "You need to be logged in to sign up for this activity"
+msgstr "You need to be logged in to sign up for this activity"
+
+msgid "You need to log in to subscribe"
+msgstr "You need to log in to subscribe"
+
+msgid "You were a member of:"
+msgstr "You were a member of:"
+
+msgid ""
+"Your account for the GEWIS website has been registered, check your inbox for "
+"an activation e-mail."
+msgstr ""
+"Your account for the GEWIS website has been registered, check your inbox for "
+"an activation e-mail."
+
+msgid "Your account has been activated. You are now able to login."
+msgstr "Your account has been activated. You are now able to login."
+
+msgid "Your option has been added successfully"
+msgstr "Your option has been added successfully"
+
+msgid "Your password"
+msgstr "Your password"
+
+msgid ""
+"Your password was found in a public data breach and is therefore considered "
+"insecure. Please request a password reset before continuing. We recommend "
+"using a password generated by a good password manager, such as Bitwarden or "
+"1Password."
+msgstr ""
+"Your password was found in a public data breach and is therefore considered "
+"insecure. Please request a password reset before continuing. We recommend "
+"using a password generated by a good password manager, such as Bitwarden or "
+"1Password."
+
+msgid "Your poll request has been received and will be reviewed shortly."
+msgstr "Your poll request has been received and will be reviewed shortly."
+
+msgid "Your profile picture will be chosen automatically instead."
+msgstr "Your profile picture will be chosen automatically instead."
+
+msgid "Zoek"
+msgstr "Search"
+
+msgid "Zoeken op lid"
+msgstr "Search for a member"
+
+msgid "Zoom (z)"
+msgstr "Zoom (z)"
+
+msgid "and"
+msgstr "and"
+
+msgid "at"
+msgstr "at"
+
 msgid "course"
 msgid_plural "courses"
 msgstr[0] "course"
 msgstr[1] "courses"
 
-#: module/Education/view/education/education/index.phtml:92
-msgid "Course name"
-msgstr "Course name"
+msgid "disabled"
+msgstr "disabled"
 
-#: module/Education/view/education/education/index.phtml:93
-msgid "Available documents"
-msgstr "Available documents"
+msgid "disabled (Do Not Track)"
+msgstr "disabled (Do Not Track)"
 
-#: module/Education/view/education/education/index.phtml:104
-msgid "View available documents"
-msgstr "View available documents"
+msgid "edit"
+msgstr "edit"
 
-#: module/Education/view/education/education/index.phtml:123
-#, php-format
-msgid ""
-"Do you want to contribute to the collection of old exams and summaries? Send "
-"them to the %seducation officer%s so that your (future) peers can benefit."
-msgstr ""
-"Do you want to contribute to the collection of old exams and summaries? Send "
-"them to the %seducation officer%s so that your (future) peers can benefit."
-
-#: module/Education/view/education/education/index.phtml:124
-#: module/Education/view/education/education/index.phtml:182
-msgid "Mail the education officer"
-msgstr "Mail the education officer"
-
-#: module/Education/view/education/education/index.phtml:132
-msgid "For old exams of minor courses, you can also look at:"
-msgstr "For old exams of minor courses, you can also look at:"
-
-#: module/Education/view/education/education/index.phtml:135
-msgid "Applied Physics"
-msgstr "Applied Physics"
-
-#: module/Education/view/education/education/index.phtml:138
-msgid "Biomedical Engineering"
-msgstr "Biomedical Engineering"
-
-#: module/Education/view/education/education/index.phtml:141
-msgid "Electrical Engineering"
-msgstr "Electrical Engineering"
-
-#: module/Education/view/education/education/index.phtml:144
-msgid "Chemical Engineering"
-msgstr "Chemical Engineering"
-
-#: module/Education/view/education/education/index.phtml:147
-msgid "Innovation Sciences"
-msgstr "Innovation Sciences"
-
-#: module/Education/view/education/education/index.phtml:154
-msgid "Useful links"
-msgstr "Useful links"
-
-#: module/Education/view/education/education/index.phtml:159
-msgid "Books"
-msgstr "Books"
-
-#: module/Education/view/education/education/index.phtml:162
-msgid ""
-"Order your course books via GEWIS to receive a discount. Specific ordering "
-"deadlines and pickup dates will be timely communicated to you via an email."
-msgstr ""
-"Order your course books via GEWIS to receive a discount. Specific ordering "
-"deadlines and pickup dates will be timely communicated to you via an email."
-
-#: module/Education/view/education/education/index.phtml:165
-msgid "Visit the webshop"
-msgstr "Visit the webshop"
-
-#: module/Education/view/education/education/index.phtml:167
-msgid "Visit webshop"
-msgstr "Visit webshop"
-
-#: module/Education/view/education/education/index.phtml:175
-msgid "Complaint or suggestion about TU/e education?"
-msgstr "Complaint or suggestion about TU/e education?"
-
-#: module/Education/view/education/education/index.phtml:181
-#, php-format
-msgid ""
-"Do you have a complaint or suggestion concerning the education at the TU/e? "
-"Contact the %seducation officer%s to share your ideas."
-msgstr ""
-"Do you have a complaint or suggestion concerning the education at the TU/e? "
-"Contact the %seducation officer%s to share your ideas."
-
-#: module/Education/view/education/education/index.phtml:192
-msgid "Disclaimer on educational content"
-msgstr "Disclaimer on educational content"
-
-#: module/Education/view/education/education/index.phtml:197
-msgid ""
-"The exams on the website of GEWIS are provided by Education & Student "
-"Affairs of the department of Mathematics and Computer Science of the TU/e."
-msgstr ""
-"The exams on the website of GEWIS are provided by Education & Student "
-"Affairs of the department of Mathematics and Computer Science of the TU/e."
-
-#: module/Education/view/education/education/index.phtml:198
-msgid ""
-"If an exam has been put online without the intention of the author, please "
-"let the board of GEWIS know by sending an"
-msgstr ""
-"If an exam has been put online without the intention of the author, please "
-"let the board of GEWIS know by sending an"
-
-#: module/Education/view/education/education/index.phtml:199
-msgid "Email the board of GEWIS"
-msgstr "Email the board of GEWIS"
-
-#: module/Education/view/education/education/index.phtml:199
 msgid "email to the board of GEWIS"
 msgstr "email to the board of GEWIS"
 
-#: module/Education/view/education/education/index.phtml:200
-msgid ""
-"then this exam will be removed from the website. Using the summaries or "
-"exams on this website for commercial goals without the permission of the "
-"author is illegal."
-msgstr ""
-"then this exam will be removed from the website. Using the summaries or "
-"exams on this website for commercial goals without the permission of the "
-"author is illegal."
+msgid "enabled"
+msgstr "enabled"
 
-#: module/Frontpage/src/Controller/InfimumController.php:26
-msgid "You are not allowed to view infima"
-msgstr "You are not allowed to view infima"
+msgid "in the spotlight"
+msgstr "in the spotlight"
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:51
-msgid "You are not allowed to create news items"
-msgstr "You are not allowed to create news items"
+msgid "new"
+msgstr "new"
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:88
-msgid "You are not allowed to edit news items"
-msgstr "You are not allowed to edit news items"
-
-#: module/Frontpage/src/Controller/NewsAdminController.php:133
-msgid "You are not allowed to delete news items"
-msgstr "You are not allowed to delete news items"
-
-#: module/Frontpage/src/Controller/PageAdminController.php:31
-#: module/Frontpage/src/Service/Page.php:107
-msgid "You are not allowed to view the list of pages."
-msgstr "You are not allowed to view the list of pages."
-
-#: module/Frontpage/src/Controller/PageAdminController.php:46
-#: module/Frontpage/src/Service/Page.php:260
-msgid "You are not allowed to create new pages."
-msgstr "You are not allowed to create new pages."
-
-#: module/Frontpage/src/Controller/PageAdminController.php:77
-#: module/Frontpage/src/Service/Page.php:193
-msgid "You are not allowed to edit pages."
-msgstr "You are not allowed to edit pages."
-
-#: module/Frontpage/src/Controller/PageAdminController.php:104
-msgid "You are not allowed to delete pages."
-msgstr "You are not allowed to delete pages."
-
-#: module/Frontpage/src/Controller/PageAdminController.php:121
-msgid "You are not allowed to upload images."
-msgstr "You are not allowed to upload images."
-
-#: module/Frontpage/src/Controller/PollAdminController.php:32
-msgid "You are not allowed to administer polls"
-msgstr "You are not allowed to administer polls"
-
-#: module/Frontpage/src/Controller/PollAdminController.php:64
-msgid "You are not allowed to approve polls"
-msgstr "You are not allowed to approve polls"
-
-#: module/Frontpage/src/Controller/PollAdminController.php:96
-msgid "You are not allowed to delete polls"
-msgstr "You are not allowed to delete polls"
-
-#: module/Frontpage/src/Controller/PollController.php:96
-msgid "You are not allowed to create comments on this poll"
-msgstr "You are not allowed to create comments on this poll"
-
-#: module/Frontpage/src/Form/NewsItem.php:27
-#: module/Frontpage/src/Form/Page.php:49
-msgid "Dutch title"
-msgstr "Dutch title"
-
-#: module/Frontpage/src/Form/NewsItem.php:37
-#: module/Frontpage/src/Form/Page.php:59
-msgid "English title"
-msgstr "English title"
-
-#: module/Frontpage/src/Form/NewsItem.php:47
-#: module/Frontpage/src/Form/Page.php:69
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:73
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:104
-msgid "Dutch content"
-msgstr "Dutch content"
-
-#: module/Frontpage/src/Form/NewsItem.php:57
-#: module/Frontpage/src/Form/Page.php:79
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:49
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:80
-msgid "English content"
-msgstr "English content"
-
-#: module/Frontpage/src/Form/Page.php:89
-msgid "Required role"
-msgstr "Required role"
-
-#: module/Frontpage/src/Form/Poll.php:28
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:51
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:124
-msgid "Dutch question"
-msgstr "Dutch question"
-
-#: module/Frontpage/src/Form/Poll.php:38
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:40
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:54
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:113
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:127
-msgid "English question"
-msgstr "English question"
-
-#: module/Frontpage/src/Form/PollApproval.php:25
-msgid "Expiration date for the poll (YYYY-MM-DD)"
-msgstr "Expiration date for the poll (YYYY-MM-DD)"
-
-#: module/Frontpage/src/Form/PollApproval.php:36
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:201
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:227
-msgid "Approve poll"
-msgstr "Approve poll"
-
-#: module/Frontpage/src/Form/PollComment.php:37
-msgid "Content"
-msgstr "Content"
-
-#: module/Frontpage/src/Form/PollComment.php:47
-msgid "Comment"
-msgstr "Comment"
-
-#: module/Frontpage/src/Service/News.php:45
-msgid "You are not allowed to list all news items."
-msgstr "You are not allowed to list all news items."
-
-#: module/Frontpage/src/Service/Page.php:56
-msgid "You are not allowed to view this page."
-msgstr "You are not allowed to view this page."
-
-#: module/Frontpage/src/Service/Page.php:244
-#: module/Photo/src/Service/Admin.php:212
-msgid "The uploaded file does not have a valid extension"
-msgstr "The uploaded file does not have a valid extension"
-
-#: module/Frontpage/src/Service/Page.php:249
-msgid "The uploaded file is not a valid image"
-msgstr "The uploaded file is not a valid image"
-
-#: module/Frontpage/src/Service/Poll.php:71
-msgid "You are not allowed to view unapproved polls"
-msgstr "You are not allowed to view unapproved polls"
-
-#: module/Frontpage/src/Service/Poll.php:183
-msgid "You are not allowed to vote on this poll."
-msgstr "You are not allowed to vote on this poll."
-
-#: module/Frontpage/src/Service/Poll.php:329
-msgid "You are not allowed to request polls"
-msgstr "You are not allowed to request polls"
-
-#: module/Frontpage/view/frontpage/admin/index.phtml:10
-msgid ""
-"Welcome to the admin interface of the GEWIS website. If you are experiencing "
-"any issues or have a question, please contact the ApplicatieBeheerCommissie."
-msgstr ""
-"Welcome to the admin interface of the GEWIS website. If you are experiencing "
-"any issues or have a question, please contact the ApplicatieBeheerCommissie."
-
-#: module/Frontpage/view/frontpage/admin/index.phtml:12
-msgid "Recent changes"
-msgstr "Recent changes"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:47
-msgid "Studievereniging GEWIS"
-msgstr "Study Association GEWIS"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:49
-msgid ""
-"Welcome to the website of Study association GEWIS, the study association of "
-"the department of Mathematics & Computer Science of the Eindhoven University "
-"of Technology."
-msgstr ""
-"Welcome to the website of Study association GEWIS, the study association of "
-"the department of Mathematics & Computer Science of the Eindhoven University "
-"of Technology."
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:148
-msgid "Verjaardagen"
-msgstr "Birthdays"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:153
-#, php-format
-msgid "%s wil be %s years old today!"
-msgstr "%s will be %s years old today!"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:168
-msgid "Agenda"
-msgstr "Agenda"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:185
-#, php-format
-msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
-msgstr "Thursdays there is a %ssocial drink%s from 16.30 till 19.00."
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:194
-#: module/Frontpage/view/frontpage/organ/organ.phtml:136
-msgid "Complete agenda"
-msgstr "Complete agenda"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:198
-msgid "Google Calendar"
-msgstr "Google Calendar"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
-msgid "Poll"
-msgstr "Poll"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:296
-msgid "View details"
-msgstr "View details"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:301
-msgid "There currently is no poll."
-msgstr "There currently is no poll."
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:305
-#: module/Frontpage/view/frontpage/poll/request.phtml:174
-msgid "Request poll"
-msgstr "Request poll"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:308
-#: module/Frontpage/view/frontpage/poll/index.phtml:39
-msgid "Old polls"
-msgstr "Old polls"
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:101
-msgid "Pin news item"
-msgstr "Pin news item"
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:103
-msgid "Select this if you want this news item to stay at the top of the page."
-msgstr "Select this if you want this news item to stay at the top of the page."
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:118
-msgid "Delete this news item"
-msgstr "Delete this news item"
-
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:16
-msgid "News items"
-msgstr "News items"
-
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:17
-msgid "Create news item"
-msgstr "Create news item"
-
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:21
-msgid "GEWIS has many different committees, learn more about them below!"
-msgstr "GEWIS has many different committees, learn more about them below!"
-
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:27
-msgid "Information for committees"
-msgstr "Information for committees"
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:20
-msgid ""
-"Study association GEWIS obviously has several fraternities which contribute "
-"to the atmosphere at GEWIS and organize fun activities. Some fraternities "
-"have retired, but luckily new fraternities continue to be founded."
-msgstr ""
-"Study association GEWIS obviously has several fraternities which contribute "
-"to the atmosphere at GEWIS and organize fun activities. Some fraternities "
-"have retired, but luckily new fraternities continue to be founded."
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:21
-msgid "The currently active fraternities of GEWIS (in arbitrary order)"
-msgstr "The currently active fraternities of GEWIS (in arbitrary order)"
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:36
-msgid "Retired fraternities"
-msgstr "Retired fraternities"
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:37
-msgid "The following fraternities have retired:"
-msgstr "The following fraternities have retired:"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:67
-msgid "GMM Committees"
-msgstr "GMM Committees"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:69
-msgid "GMM Taskforces"
-msgstr "GMM Taskforces"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:71
-msgid "Financial Audit Committees"
-msgstr "Financial Audit Committees"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:73
-msgid "Advisory Boards"
-msgstr "Advisory Boards"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:122
-#, php-format
-msgid "%s's activities"
-msgstr "%s's activities"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:168
-msgid "Login to view more information"
-msgstr "Login to view more information"
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:48
-msgid "URL options"
-msgstr "URL options"
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:49
-msgid ""
-"Make this page available at the following URL. Providing a category is "
-"required."
-msgstr ""
-"Make this page available at the following URL. Providing a category is "
-"required."
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:128
-msgid "Permissions"
-msgstr "Permissions"
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:151
-msgid "Delete this page"
-msgstr "Delete this page"
-
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:29
-msgid "Create a new page"
-msgstr "Create a new page"
-
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:31
-msgid "Or select a page to edit below."
-msgstr "Or select a page to edit below."
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:34
-msgid "Polls awaiting approval"
-msgstr "Polls awaiting approval"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:43
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:116
-msgid "Approver"
-msgstr "Approver"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:60
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:133
-msgid "Dutch option"
-msgstr "Dutch option"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:61
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:134
-msgid "English option"
-msgstr "English option"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:95
-msgid "Approved polls"
-msgstr "Approved polls"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:178
-msgid "Are you sure you want to delete this poll?"
-msgstr "Are you sure you want to delete this poll?"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:184
-msgid "Delete poll"
-msgstr "Delete poll"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:204
-msgid "Are you sure that you want to approve this poll?"
-msgstr "Are you sure that you want to approve this poll?"
-
-#: module/Frontpage/view/frontpage/poll/history.phtml:14
-msgid "Poll history"
-msgstr "Poll history"
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:41
-#, php-format
-msgid "%sRequest a poll%s"
-msgstr "%sRequest a poll%s"
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:56
-msgid "Unfortunately there currently is no poll :("
-msgstr "Unfortunately there currently is no poll :("
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:61
-msgid "Comments"
-msgstr "Comments"
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:63
-msgid "This poll has no comments"
-msgstr "This poll has no comments"
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:84
-msgid "Comment on this poll"
-msgstr "Comment on this poll"
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:14
-#: module/Frontpage/view/frontpage/poll/request.phtml:19
-msgid "Request a poll"
-msgstr "Request a poll"
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:21
-msgid "Your poll request has been received and will be reviewed shortly."
-msgstr "Your poll request has been received and will be reviewed shortly."
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:158
-msgid "Remove option"
-msgstr "Remove option"
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:163
-msgid "Add option"
-msgstr "Add option"
-
-#: module/Frontpage/view/partial/poll.phtml:61
-#: module/Frontpage/view/partial/poll.phtml:72
-#, php-format
-msgid "%d votes"
-msgstr "%d votes"
-
-#: module/Frontpage/view/partial/poll.phtml:61
-#: module/Frontpage/view/partial/poll.phtml:72
-msgid "1 vote"
-msgstr "1 vote"
-
-#: module/Photo/src/Controller/AlbumController.php:50
-#: module/Photo/src/Service/Album.php:122
-msgid "Not allowed to view albums without dates"
-msgstr "Not allowed to view albums without dates"
-
-#: module/Photo/src/Controller/ApiController.php:50
-msgid "Not allowed to view photo details"
-msgstr "Not allowed to view photo details"
-
-#: module/Photo/src/Controller/PhotoController.php:44
-#: module/Photo/src/Service/Album.php:67 module/Photo/src/Service/Album.php:99
-#: module/Photo/src/Service/Album.php:234
-#: module/Photo/src/Service/Album.php:248
-msgid "Not allowed to view albums"
-msgstr "Not allowed to view albums"
-
-#: module/Photo/src/Controller/PhotoController.php:91
-#: module/Photo/src/Service/Photo.php:95
-msgid "Not allowed to download photos"
-msgstr "Not allowed to download photos"
-
-#: module/Photo/src/Controller/PhotoController.php:106
-msgid "Not allowed to view previous photos of the week"
-msgstr "Not allowed to view previous photos of the week"
-
-#: module/Photo/src/Controller/PhotoController.php:163
-msgid "Not allowed to vote for a photo of the week"
-msgstr "Not allowed to vote for a photo of the week"
-
-#: module/Photo/src/Controller/TagController.php:27
-msgid "Not allowed to add tags."
-msgstr "Not allowed to add tags."
-
-#: module/Photo/src/Controller/TagController.php:53
-msgid "Not allowed to remove tags."
-msgstr "Not allowed to remove tags."
-
-#: module/Photo/src/Form/CreateAlbum.php:25
-#: module/Photo/src/Form/EditAlbum.php:27
-#: module/Photo/view/photo/album-admin/create.phtml:28
-msgid "Album title"
-msgstr "Album title"
-
-#: module/Photo/src/Form/CreateAlbum.php:35
-msgid "Create"
-msgstr "Create"
-
-#: module/Photo/src/Form/EditAlbum.php:48
-msgid "End date"
-msgstr "End date"
-
-#: module/Photo/src/Service/Admin.php:66
-msgid "Not allowed to add photos."
-msgstr "Not allowed to add photos."
-
-#: module/Photo/src/Service/Admin.php:185
-msgid "An unknown error occurred during uploading ("
-msgstr "An unknown error occurred during uploading ("
-
-#: module/Photo/src/Service/Admin.php:201
-#, php-format
-msgid ""
-"The uploaded file is not a valid image \n"
-"Error: %s"
-msgstr ""
-"The uploaded file is not a valid image \n"
-"Error: %s"
-
-#: module/Photo/src/Service/Admin.php:225
-msgid "Not allowed to upload photos."
-msgstr "Not allowed to upload photos."
-
-#: module/Photo/src/Service/Album.php:191
-msgid "Not allowed to create albums"
-msgstr "Not allowed to create albums"
-
-#: module/Photo/src/Service/Album.php:213
-msgid "Not allowed to create albums."
-msgstr "Not allowed to create albums."
-
-#: module/Photo/src/Service/Album.php:327
-#, php-format
-msgid "Photos of the Week in %d/%d"
-msgstr "Photos of the Week in %d/%d"
-
-#: module/Photo/src/Service/Album.php:358
-msgid "Not allowed to edit albums"
-msgstr "Not allowed to edit albums"
-
-#: module/Photo/src/Service/Album.php:376
-msgid "Not allowed to edit albums."
-msgstr "Not allowed to edit albums."
-
-#: module/Photo/src/Service/Album.php:401
-msgid "Not allowed to move albums"
-msgstr "Not allowed to move albums"
-
-#: module/Photo/src/Service/Album.php:435
-msgid "Not allowed to delete albums."
-msgstr "Not allowed to delete albums."
-
-#: module/Photo/src/Service/Album.php:456
-msgid "Not allowed to generate album covers."
-msgstr "Not allowed to generate album covers."
-
-#: module/Photo/src/Service/Album.php:504
-msgid "Not allowed to move photos"
-msgstr "Not allowed to move photos"
-
-#: module/Photo/src/Service/Photo.php:73 module/Photo/src/Service/Photo.php:114
-#: module/Photo/src/Service/Photo.php:159
-#: module/Photo/src/Service/Photo.php:210
-#: module/Photo/src/Service/Photo.php:226
-msgid "Not allowed to view photos"
-msgstr "Not allowed to view photos"
-
-#: module/Photo/src/Service/Photo.php:245
-msgid "Not allowed to delete photos."
-msgstr "Not allowed to delete photos."
-
-#: module/Photo/src/Service/Photo.php:623
-#: module/Photo/src/Service/Photo.php:672
-msgid "Not allowed to view tags."
-msgstr "Not allowed to view tags."
-
-#: module/Photo/view/partial/metadata.phtml:19
-msgid "Artist"
-msgstr "Artist"
-
-#: module/Photo/view/partial/metadata.phtml:26
-msgid "Camera"
-msgstr "Camera"
-
-#: module/Photo/view/partial/metadata.phtml:33
-msgid "Date/time"
-msgstr "Date/time"
-
-#: module/Photo/view/partial/metadata.phtml:40
-msgid "Flash"
-msgstr "Flash"
-
-#: module/Photo/view/partial/metadata.phtml:47
-msgid "Focal length"
-msgstr "Focal length"
-
-#: module/Photo/view/partial/metadata.phtml:54
-msgid "Exposure time"
-msgstr "Exposure time"
-
-#: module/Photo/view/partial/metadata.phtml:61
-msgid "Shutter speed"
-msgstr "Shutter speed"
-
-#: module/Photo/view/partial/metadata.phtml:68
-msgid "Aperture"
-msgstr "Aperture"
-
-#: module/Photo/view/partial/metadata.phtml:75
-msgid "ISO"
-msgstr "ISO"
-
-#: module/Photo/view/partial/metadata.phtml:95
-msgid "View on map"
-msgstr "View on map"
-
-#: module/Photo/view/partial/tags.phtml:22
-#: module/Photo/view/photo/album/index.phtml:674
-msgid "In this photo:"
-msgstr "In this photo:"
-
-#: module/Photo/view/partial/tags.phtml:23
-#: module/Photo/view/photo/album/index.phtml:675
-msgid ""
-"No one has been tagged in this photo yet. Tag someone you recognise now!"
-msgstr ""
-"No one has been tagged in this photo yet. Tag someone you recognise now!"
-
-#: module/Photo/view/partial/tags.phtml:61
-#: module/Photo/view/photo/album/index.phtml:703
-msgid "Tag someone"
-msgstr "Tag someone"
-
-#: module/Photo/view/photo/album-admin/add.phtml:41
-msgid "Upload Photos"
-msgstr "Upload Photos"
-
-#: module/Photo/view/photo/album-admin/add.phtml:43
-#, php-format
-msgid "Uploading photos to %s"
-msgstr "Uploading photos to %s"
-
-#: module/Photo/view/photo/album-admin/create.phtml:16
-msgid "Create Album"
-msgstr "Create Album"
-
-#: module/Photo/view/photo/album-admin/create.phtml:37
-msgid "Create album"
-msgstr "Create album"
-
-#: module/Photo/view/photo/album-admin/edit.phtml:16
-msgid "Edit Album"
-msgstr "Edit Album"
-
-#: module/Photo/view/photo/album-admin/edit.phtml:22
-msgid "Update Album"
-msgstr "Update Album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:55
-#: module/Photo/view/photo/photo-admin/index.phtml:62
-msgid "Photo admin"
-msgstr "Photo admin"
-
-#: module/Photo/view/photo/album-admin/index.phtml:104
-msgid "Other albums"
-msgstr "Other albums"
-
-#: module/Photo/view/photo/album-admin/index.phtml:117
-msgid "Create new album"
-msgstr "Create new album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:122
-msgid "Edit album"
-msgstr "Edit album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:125
-msgid "Add photos"
-msgstr "Add photos"
-
-#: module/Photo/view/photo/album-admin/index.phtml:127
-msgid "Move album"
-msgstr "Move album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:130
-msgid "Move %i photos"
-msgstr "Move %i photos"
-
-#: module/Photo/view/photo/album-admin/index.phtml:133
-msgid "Regenerate album cover"
-msgstr "Regenerate album cover"
-
-#: module/Photo/view/photo/album-admin/index.phtml:137
-#: module/Photo/view/photo/album-admin/index.phtml:231
-msgid "Delete album"
-msgstr "Delete album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:140
-msgid "Delete %i photos"
-msgstr "Delete %i photos"
-
-#: module/Photo/view/photo/album-admin/index.phtml:158
-msgid "Generate a new cover photo"
-msgstr "Generate a new cover photo"
-
-#: module/Photo/view/photo/album-admin/index.phtml:164
-msgid "An error occurred while trying to generate an album photo."
-msgstr "An error occurred while trying to generate an album photo."
-
-#: module/Photo/view/photo/album-admin/index.phtml:171
-msgid "Regenerate"
-msgstr "Regenerate"
-
-#: module/Photo/view/photo/album-admin/index.phtml:173
-#: module/Photo/view/photo/album/index.phtml:435
-msgid "Close"
-msgstr "Close"
-
-#: module/Photo/view/photo/album-admin/index.phtml:186
-msgid "Move the album"
-msgstr "Move the album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:191
-msgid "Select a new parent for the album"
-msgstr "Select a new parent for the album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:195
-msgid "The album has been moved"
-msgstr "The album has been moved"
-
-#: module/Photo/view/photo/album-admin/index.phtml:200
-#: module/Photo/view/photo/album-admin/index.phtml:291
-#: module/Photo/view/photo/photo-admin/index.phtml:126
-msgid "Move"
-msgstr "Move"
-
-#: module/Photo/view/photo/album-admin/index.phtml:217
-msgid ""
-"Are you sure you want to delete this album including all photos inside of "
-"it? <strong>This action can not be reverted.</strong>"
-msgstr ""
-"Are you sure you want to delete this album including all photos inside of "
-"it? <strong>This action can not be reverted.</strong>"
-
-#: module/Photo/view/photo/album-admin/index.phtml:220
-msgid "Please wait while the album is being deleted."
-msgstr "Please wait while the album is being deleted."
-
-#: module/Photo/view/photo/album-admin/index.phtml:226
-msgid "The album has been deleted"
-msgstr "The album has been deleted"
-
-#: module/Photo/view/photo/album-admin/index.phtml:249
-msgid ""
-"Are you sure you want to delete the selected items? <strong>This action can "
-"not be reverted.</strong>"
-msgstr ""
-"Are you sure you want to delete the selected items? <strong>This action can "
-"not be reverted.</strong>"
-
-#: module/Photo/view/photo/album-admin/index.phtml:252
-msgid "Please wait while the photos are being deleted."
-msgstr "Please wait while the photos are being deleted."
-
-#: module/Photo/view/photo/album-admin/index.phtml:258
-msgid "The photos have been been deleted"
-msgstr "The photos have been been deleted"
-
-#: module/Photo/view/photo/album-admin/index.phtml:263
-msgid "Delete photos"
-msgstr "Delete photos"
-
-#: module/Photo/view/photo/album-admin/index.phtml:277
-msgid "Move the photos to another album"
-msgstr "Move the photos to another album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:282
-#: module/Photo/view/photo/photo-admin/index.phtml:117
-msgid "Select a new parent album"
-msgstr "Select a new parent album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:286
-msgid "The photos have been moved"
-msgstr "The photos have been moved"
-
-#: module/Photo/view/photo/album/index.phtml:86
-#: module/Photo/view/photo/photo/weekly.phtml:13
-#: module/Photo/view/photo/photo/weekly.phtml:20
-msgid "Photos of the Week"
-msgstr "Photos of the Week"
-
-#: module/Photo/view/photo/album/index.phtml:140
-msgid "View user profile"
-msgstr "View user profile"
-
-#: module/Photo/view/photo/album/index.phtml:152
-msgid "No date"
-msgstr "No date"
-
-#: module/Photo/view/photo/album/index.phtml:201
-#: module/Photo/view/photo/photo/index.phtml:71
-msgid "NEW"
-msgstr "NEW"
-
-#: module/Photo/view/photo/album/index.phtml:225
-msgid "This album does not contain any photos."
-msgstr "This album does not contain any photos."
-
-#: module/Photo/view/photo/album/index.phtml:398
-msgid "Already voted!"
-msgstr "Already voted!"
-
-#: module/Photo/view/photo/album/index.phtml:401
-#: module/Photo/view/photo/album/index.phtml:572
-msgid "Vote for photo of the week"
-msgstr "Vote for photo of the week"
-
-#: module/Photo/view/photo/album/index.phtml:436
-msgid "Zoom (z)"
-msgstr "Zoom (z)"
-
-#: module/Photo/view/photo/album/index.phtml:439
-msgid "The image could not be loaded."
-msgstr "The image could not be loaded."
-
-#: module/Photo/view/photo/album/index.phtml:452
-msgid "Download"
-msgstr "Download"
-
-#: module/Photo/view/photo/album/index.phtml:476
-msgid "Share"
-msgstr "Share"
-
-#: module/Photo/view/photo/album/index.phtml:487
-msgid "Copied URL!"
-msgstr "Copied URL!"
-
-#: module/Photo/view/photo/album/index.phtml:498
-msgid "Go to album"
-msgstr "Go to album"
-
-#: module/Photo/view/photo/album/index.phtml:541
-msgid "Set as profile picture"
-msgstr "Set as profile picture"
-
-#: module/Photo/view/photo/album/index.phtml:558
-msgid "Set as profile picture!"
-msgstr "Set as profile picture!"
-
-#: module/Photo/view/photo/album/index.phtml:561
-msgid "Could not set as profile photo, try again"
-msgstr "Could not set as profile photo, try again"
-
-#: module/Photo/view/photo/album/index.phtml:594
-msgid "Cannot load vote"
-msgstr "Cannot load vote"
-
-#: module/Photo/view/photo/album/index.phtml:614
-msgid "Voted!"
-msgstr "Voted!"
-
-#: module/Photo/view/photo/album/index.phtml:626
-msgid "Could not vote, try again"
-msgstr "Could not vote, try again"
-
-#: module/Photo/view/photo/album/index.phtml:641
-msgid "Loading tags..."
-msgstr "Loading tags..."
-
-#: module/Photo/view/photo/album/index.phtml:662
-msgid "Cannot load tags"
-msgstr "Cannot load tags"
-
-#: module/Photo/view/photo/album/index.phtml:757
-msgid "Cannot load metadata"
-msgstr "Cannot load metadata"
-
-#: module/Photo/view/photo/album/index.phtml:783
-msgid "Photo of the Week:<br> Week"
-msgstr "Photo of the Week:<br> Week"
-
-#: module/Photo/view/photo/album/index.phtml:783
 msgid "of"
 msgstr "of"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:51
+msgid "old"
+msgstr "old"
+
 #, php-format
-msgid "Photo #%d"
-msgstr "Photo #%d"
+msgid "resolves to %s"
+msgstr "resolves to %s"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:89
-msgid "Move photo"
-msgstr "Move photo"
+msgid "the organizing party"
+msgstr "the organizing party"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:91
-#: module/Photo/view/photo/photo-admin/index.phtml:157
-msgid "Delete photo"
-msgstr "Delete photo"
+msgid "the secretary of GEWIS"
+msgstr "the secretary of GEWIS"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:112
-msgid "Move the photo to another album"
-msgstr "Move the photo to another album"
-
-#: module/Photo/view/photo/photo-admin/index.phtml:121
-msgid "The photo has been moved"
-msgstr "The photo has been moved"
-
-#: module/Photo/view/photo/photo-admin/index.phtml:143
 msgid ""
-"Are you sure you want to delete this photo? <strong>This action can not be "
-"reverted.</strong>"
+"then this exam will be removed from the website. Using the summaries or "
+"exams on this website for commercial goals without the permission of the "
+"author is illegal."
 msgstr ""
-"Are you sure you want to delete this photo? <strong>This action can not be "
-"reverted.</strong>"
-
-#: module/Photo/view/photo/photo-admin/index.phtml:146
-msgid "Please wait while your photo is being deleted."
-msgstr "Please wait while your photo is being deleted."
-
-#: module/Photo/view/photo/photo-admin/index.phtml:152
-msgid "The photo has been deleted"
-msgstr "The photo has been deleted"
-
-#: module/Photo/view/photo/photo/index.phtml:82
-msgid "There are no photos in this year."
-msgstr "There are no photos in this year."
-
-#: module/Photo/view/photo/photo/weekly.phtml:18
-msgid "Currently, no pictures of the week are available."
-msgstr "Currently, no pictures of the week are available."
-
-#: module/Photo/view/photo/photo/weekly.phtml:21
-msgid "Current photo of the week"
-msgstr "Current photo of the week"
-
-#: module/Photo/view/photo/photo/weekly.phtml:52
-msgid "Old photos of the week"
-msgstr "Old photos of the week"
-
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:43
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:65
-#: module/User/src/Authentication/Adapter/UserAdapter.php:43
-#: module/User/src/Authentication/Adapter/UserAdapter.php:79
-msgid "The login and password combination is incorrect."
-msgstr "The login and password combination is incorrect."
-
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:53
-#: module/User/src/Authentication/Adapter/UserAdapter.php:67
-msgid "Too many login attempts, try again later."
-msgstr "Too many login attempts, try again later."
-
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:78
-#: module/User/src/Authentication/Adapter/UserAdapter.php:92
-msgid ""
-"Your password was found in a public data breach and is therefore considered "
-"insecure. Please request a password reset before continuing. We recommend "
-"using a password generated by a good password manager, such as Bitwarden or "
-"1Password."
-msgstr ""
-"Your password was found in a public data breach and is therefore considered "
-"insecure. Please request a password reset before continuing. We recommend "
-"using a password generated by a good password manager, such as Bitwarden or "
-"1Password."
-
-#: module/User/src/Authentication/Adapter/UserAdapter.php:57
-msgid "You cannot sign in to this account at this moment."
-msgstr "You cannot sign in to this account at this moment."
-
-#: module/User/src/Authorization/GenericAclService.php:108
-#: module/User/src/Authorization/GenericAclService.php:135
-msgid ""
-"You are not allowed to perform this action. If you are not logged in please "
-"do so before continuing. If you are already logged in this action may "
-"require you to login in with a different account."
-msgstr ""
-"You are not allowed to perform this action. If you are not logged in please "
-"do so before continuing. If you are already logged in this action may "
-"require you to login in with a different account."
-
-#: module/User/src/Controller/UserController.php:178
-msgid "You are not allowed to change passwords"
-msgstr "You are not allowed to change passwords"
-
-#: module/User/src/Form/Activate.php:29 module/User/src/Form/UserLogin.php:43
-msgid "Your password"
-msgstr "Your password"
-
-#: module/User/src/Form/Activate.php:39
-msgid "Verify your password"
-msgstr "Verify your password"
-
-#: module/User/src/Form/Activate.php:49
-#: module/User/view/user/user/activate.phtml:20
-#: module/User/view/user/user/activate.phtml:40
-msgid "Activate"
-msgstr "Activate"
-
-#: module/User/src/Form/ApiAppAuthorisation.php:37
-msgid "Authorise"
-msgstr "Authorise"
-
-#: module/User/src/Form/ApiToken.php:35
-#: module/User/view/user/api-admin/add.phtml:45
-msgid "Create API token"
-msgstr "Create API token"
-
-#: module/User/src/Form/CompanyUserLogin.php:34
-#: module/User/src/Form/CompanyUserReset.php:27
-msgid "Email address"
-msgstr "Email address"
-
-#: module/User/src/Form/CompanyUserLogin.php:44
-#: module/User/view/user/user/activate.phtml:58
-msgid "Password"
-msgstr "Password"
-
-#: module/User/src/Form/CompanyUserLogin.php:54
-msgid "Log in as company"
-msgstr "Log in as company"
-
-#: module/User/src/Form/CompanyUserReset.php:37
-msgid "Request password reset"
-msgstr "Request password reset"
-
-#: module/User/src/Form/Password.php:29
-msgid "Old password"
-msgstr "Old password"
-
-#: module/User/src/Form/Password.php:39
-msgid "New password"
-msgstr "New password"
-
-#: module/User/src/Form/Password.php:49
-msgid "Verify new password"
-msgstr "Verify new password"
-
-#: module/User/src/Form/Register.php:42
-#: module/User/view/user/user/register.phtml:14
-#: module/User/view/user/user/register.phtml:34
-msgid "Register"
-msgstr "Register"
-
-#: module/User/src/Form/Register.php:65
-msgid ""
-"This member cannot create an account, please contact the secretary for more "
-"information."
-msgstr ""
-"This member cannot create an account, please contact the secretary for more "
-"information."
-
-#: module/User/src/Form/Register.php:73
-msgid "There is no member with this membership number."
-msgstr "There is no member with this membership number."
-
-#: module/User/src/Form/Register.php:81
-msgid ""
-"You already attempted to register, please check your email or try again "
-"after 20 minutes."
-msgstr ""
-"You already attempted to register, please check your email or try again "
-"after 20 minutes."
-
-#: module/User/src/Form/Register.php:89
-msgid "This member already has an account."
-msgstr "This member already has an account."
-
-#: module/User/src/Form/UserLogin.php:33
-msgid "Membership number or email address"
-msgstr "Membership number or email address"
-
-#: module/User/src/Form/UserLogin.php:53
-msgid "Log in as member"
-msgstr "Log in as member"
-
-#: module/User/src/Form/UserLogin.php:63
-msgid "Remember me"
-msgstr "Remember me"
-
-#: module/User/src/Form/UserReset.php:50
-#: module/User/view/partial/reset/company.phtml:46
-#: module/User/view/partial/reset/member.phtml:59
-#: module/User/view/user/user/reset-password.phtml:18
-#: module/User/view/user/user/reset-password.phtml:29
-msgid "Reset password"
-msgstr "Reset password"
-
-#: module/User/src/Model/Enums/JWTClaims.php:40
-msgid "Family name"
-msgstr "Family name"
-
-#: module/User/src/Model/Enums/JWTClaims.php:41
-msgid "Given name"
-msgstr "Given name"
-
-#: module/User/src/Model/Enums/JWTClaims.php:42
-msgid "Is 18+?"
-msgstr "Is 18+?"
-
-#: module/User/src/Model/Enums/JWTClaims.php:43
-msgid "Member number"
-msgstr "Member number"
-
-#: module/User/src/Service/ApiUser.php:46
-#: module/User/src/Service/ApiUser.php:74
-msgid "You are not allowed to view API tokens"
-msgstr "You are not allowed to view API tokens"
-
-#: module/User/src/Service/ApiUser.php:60
-msgid "You are not allowed to remove API tokens"
-msgstr "You are not allowed to remove API tokens"
-
-#: module/User/src/Service/ApiUser.php:115
-msgid "You are not allowed to add API tokens"
-msgstr "You are not allowed to add API tokens"
-
-#: module/User/src/Service/User.php:105 module/User/src/Service/User.php:339
-msgid ""
-"You cannot use this password, it was found in a public data breach and is "
-"therefore considered insecure. We recommend using a password generated by a "
-"good password manager, such as Bitwarden or 1Password."
-msgstr ""
-"You cannot use this password, it was found in a public data breach and is "
-"therefore considered insecure. We recommend using a password generated by a "
-"good password manager, such as Bitwarden or 1Password."
-
-#: module/User/src/Service/User.php:326
-msgid "Password incorrect"
-msgstr "Password incorrect"
-
-#: module/User/src/Service/User.php:481
-msgid "You are not allowed to change your password"
-msgstr "You are not allowed to change your password"
-
-#: module/User/view/partial/login/company.phtml:77
-#: module/User/view/partial/login/member.phtml:87
-#, php-format
-msgid "If you forgot your password, go to the %sPassword reset page%s"
-msgstr "If you forgot your password, go to the %sPassword reset page%s"
-
-#: module/User/view/partial/login/member.phtml:83
-#, php-format
-msgid "If you don't have an account yet, go to the %sRegistration page%s"
-msgstr "If you don't have an account yet, go to the %sRegistration page%s"
-
-#: module/User/view/partial/reset/member.phtml:51
-msgid ""
-"Have you forgotten your e-mail address and do you want to change it? Ask the "
-"secretary by going to GEWIS (preferred) or by sending an e-mail."
-msgstr ""
-"Have you forgotten your e-mail address and do you want to change it? Ask the "
-"secretary by going to GEWIS (preferred) or by sending an e-mail."
-
-#: module/User/view/user/api-admin/add.phtml:15
-#: module/User/view/user/api-admin/index.phtml:15
-#: module/User/view/user/api-admin/index.phtml:17
-#: module/User/view/user/api-admin/remove.phtml:15
-msgid "API Tokens"
-msgstr "API Tokens"
-
-#: module/User/view/user/api-admin/add.phtml:16
-msgid "Add Token"
-msgstr "Add Token"
-
-#: module/User/view/user/api-admin/add.phtml:18
-msgid "Add a token"
-msgstr "Add a token"
-
-#: module/User/view/user/api-admin/add.phtml:53
-msgid "Token was successfully generated"
-msgstr "Token was successfully generated"
-
-#: module/User/view/user/api-admin/add.phtml:61
-#: module/User/view/user/api-admin/index.phtml:23
-msgid "Token"
-msgstr "Token"
-
-#: module/User/view/user/api-admin/index.phtml:42
-msgid "Add new Token"
-msgstr "Add new Token"
-
-#: module/User/view/user/api-admin/remove.phtml:16
-msgid "Remove Token"
-msgstr "Remove Token"
-
-#: module/User/view/user/api-authentication/redirect.phtml:21
-#, php-format
-msgid "You are being redirected to %s"
-msgstr "You are being redirected to %s"
-
-#: module/User/view/user/api-authentication/redirect.phtml:30
-#, php-format
-msgid ""
-"If your browser does not redirect you back, please <a href=\"%s\">click "
-"here</a> to continue."
-msgstr ""
-"If your browser does not redirect you back, please <a href=\"%s\">click "
-"here</a> to continue."
-
-#: module/User/view/user/api-authentication/token.phtml:28
-#, php-format
-msgid "Authorize %s to use your account?"
-msgstr "Authorize %s to use your account?"
-
-#: module/User/view/user/api-authentication/token.phtml:37
-#, php-format
-msgid ""
-"It has been more than 90 days since you last used <strong>%s</strong>. As a "
-"reminder, the application has access to:"
-msgstr ""
-"It has been more than 90 days since you last used <strong>%s</strong>. As a "
-"reminder, the application has access to:"
-
-#: module/User/view/user/api-authentication/token.phtml:42
-msgid "The application will get the following information:"
-msgstr "The application will get the following information:"
-
-#: module/User/view/user/user/activate.phtml:25
-msgid "Your account has been activated. You are now able to login."
-msgstr "Your account has been activated. You are now able to login."
-
-#: module/User/view/user/user/activate.phtml:53
-#, php-format
-msgid ""
-"Welcome %s. Create your password for the website and activate your account."
-msgstr ""
-"Welcome %s. Create your password for the website and activate your account."
-
-#: module/User/view/user/user/activate.phtml:72
-msgid "Verify password"
-msgstr "Verify password"
-
-#: module/User/view/user/user/change-password.phtml:20
-msgid "Password changed successfully"
-msgstr "Password changed successfully"
-
-#: module/User/view/user/user/login.phtml:16
-msgid "Log in"
-msgstr "Log in"
-
-#: module/User/view/user/user/logout.phtml:10
-msgid "You are logged out."
-msgstr "You are logged out."
-
-#: module/User/view/user/user/register.phtml:19
-msgid ""
-"Your account for the GEWIS website has been registered, check your inbox for "
-"an activation e-mail."
-msgstr ""
-"Your account for the GEWIS website has been registered, check your inbox for "
-"an activation e-mail."
-
-#: module/User/view/user/user/register.phtml:71
-#, php-format
-msgid ""
-"To read more about the benefits of becoming a member and how to become a "
-"member, go to this %sinformation page%s."
-msgstr ""
-"To read more about the benefits of becoming a member and how to become a "
-"member, go to this %sinformation page%s."
-
-#: module/User/view/user/user/reset-password.phtml:23
-msgid ""
-"An e-mail has been sent with instructions for resetting your password. If "
-"you have not received an e-mail, try again in 20 minutes."
-msgstr ""
-"An e-mail has been sent with instructions for resetting your password. If "
-"you have not received an e-mail, try again in 20 minutes."
+"then this exam will be removed from the website. Using the summaries or "
+"exams on this website for commercial goals without the permission of the "
+"author is illegal."
+
+msgid "unavailable"
+msgstr "unavailable"
+
+msgid "years"
+msgstr "years"

--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-22 13:08+0200\n"
-"PO-Revision-Date: 2023-04-22 13:14+0200\n"
+"POT-Creation-Date: 2023-06-25 00:26+0200\n"
+"PO-Revision-Date: 2023-06-25 00:27+0200\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: en\n"
@@ -19,109 +19,109 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: module/Activity/src/Controller/ActivityCalendarController.php:79
+#: module/Activity/src/Controller/ActivityCalendarController.php:82
 msgid "You are not allowed to create activity proposals"
 msgstr "You are not allowed to create activity proposals"
 
-#: module/Activity/src/Controller/ActivityController.php:236
-#: module/Activity/view/activity/activity/index.phtml:32
+#: module/Activity/src/Controller/ActivityController.php:228
+#: module/Activity/view/activity/activity/index.phtml:45
 msgid "Create Activity"
 msgstr "Create Activity"
 
-#: module/Activity/src/Controller/ActivityController.php:266
-#: module/Activity/src/Controller/ActivityController.php:363
-#: module/Activity/src/Controller/AdminController.php:304
-#: module/Activity/src/Controller/AdminController.php:397
+#: module/Activity/src/Controller/ActivityController.php:258
+#: module/Activity/src/Controller/ActivityController.php:351
+#: module/Activity/src/Controller/AdminController.php:294
+#: module/Activity/src/Controller/AdminController.php:381
 msgid "Invalid form"
 msgstr "Invalid form"
 
-#: module/Activity/src/Controller/ActivityController.php:275
-#: module/Activity/src/Controller/ActivityController.php:372
+#: module/Activity/src/Controller/ActivityController.php:267
+#: module/Activity/src/Controller/ActivityController.php:360
 msgid "You need to log in to subscribe"
 msgstr "You need to log in to subscribe"
 
-#: module/Activity/src/Controller/ActivityController.php:285
-#: module/Activity/src/Controller/ActivityController.php:382
+#: module/Activity/src/Controller/ActivityController.php:277
+#: module/Activity/src/Controller/ActivityController.php:370
 msgid "You cannot subscribe to this activity at this moment in time"
 msgstr "You cannot subscribe to this activity at this moment in time"
 
-#: module/Activity/src/Controller/ActivityController.php:294
+#: module/Activity/src/Controller/ActivityController.php:286
 msgid "You have already been subscribed for this activity"
 msgstr "You have already been subscribed for this activity"
 
-#: module/Activity/src/Controller/ActivityController.php:300
+#: module/Activity/src/Controller/ActivityController.php:292
 msgid "Successfully subscribed"
 msgstr "Successfully subscribed"
 
-#: module/Activity/src/Controller/ActivityController.php:305
-#: module/Activity/src/Controller/ActivityController.php:398
-#: module/Activity/src/Controller/AdminController.php:328
+#: module/Activity/src/Controller/ActivityController.php:297
+#: module/Activity/src/Controller/ActivityController.php:386
+#: module/Activity/src/Controller/AdminController.php:318
 msgid "Use the form to subscribe"
 msgstr "Use the form to subscribe"
 
-#: module/Activity/src/Controller/ActivityController.php:393
+#: module/Activity/src/Controller/ActivityController.php:381
 msgid "Successfully subscribed as external participant"
 msgstr "Successfully subscribed as external participant"
 
-#: module/Activity/src/Controller/ActivityController.php:425
+#: module/Activity/src/Controller/ActivityController.php:413
 msgid "Wrong form"
 msgstr "Wrong form"
 
-#: module/Activity/src/Controller/ActivityController.php:432
+#: module/Activity/src/Controller/ActivityController.php:420
 msgid "You have to be logged in to subscribe for this activity"
 msgstr "You have to be logged in to subscribe for this activity"
 
-#: module/Activity/src/Controller/ActivityController.php:443
+#: module/Activity/src/Controller/ActivityController.php:431
 msgid "You cannot unsubscribe from this activity at this moment in time"
 msgstr "You cannot unsubscribe from this activity at this moment in time"
 
-#: module/Activity/src/Controller/ActivityController.php:453
+#: module/Activity/src/Controller/ActivityController.php:441
 msgid "You are not subscribed to this activity!"
 msgstr "You are not subscribed to this activity!"
 
-#: module/Activity/src/Controller/ActivityController.php:459
+#: module/Activity/src/Controller/ActivityController.php:447
 msgid "Successfully unsubscribed"
 msgstr "Successfully unsubscribed"
 
-#: module/Activity/src/Controller/ActivityController.php:464
+#: module/Activity/src/Controller/ActivityController.php:452
 msgid "Use the form to unsubscribe"
 msgstr "Use the form to unsubscribe"
 
-#: module/Activity/src/Controller/AdminApprovalController.php:43
+#: module/Activity/src/Controller/AdminApprovalController.php:41
 msgid "You are not allowed to view the approval of this activity"
 msgstr "You are not allowed to view the approval of this activity"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:52
-#: module/Activity/src/Service/ActivityCategory.php:82
+#: module/Activity/src/Controller/AdminCategoryController.php:50
+#: module/Activity/src/Service/ActivityCategory.php:76
 msgid "You are not allowed to create an activity category"
 msgstr "You are not allowed to create an activity category"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:65
+#: module/Activity/src/Controller/AdminCategoryController.php:63
 msgid "The activity category was created successfully!"
 msgstr "The activity category was created successfully!"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:75
+#: module/Activity/src/Controller/AdminCategoryController.php:73
 #: module/Activity/src/Form/ActivityCategory.php:44
 msgid "Create Activity Category"
 msgstr "Create Activity Category"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:130
+#: module/Activity/src/Controller/AdminCategoryController.php:122
 msgid "You are not allowed to edit an activity category"
 msgstr "You are not allowed to edit an activity category"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:150
+#: module/Activity/src/Controller/AdminCategoryController.php:142
 msgid "The activity category was successfully updated!"
 msgstr "The activity category was successfully updated!"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:167
+#: module/Activity/src/Controller/AdminCategoryController.php:159
 msgid "Update Activity Category"
 msgstr "Update Activity Category"
 
-#: module/Activity/src/Controller/AdminController.php:65
+#: module/Activity/src/Controller/AdminController.php:62
 msgid "You are not allowed to update this activity"
 msgstr "You are not allowed to update this activity"
 
-#: module/Activity/src/Controller/AdminController.php:79
+#: module/Activity/src/Controller/AdminController.php:76
 msgid ""
 "Activities that have sign-up lists which are open or approved cannot be "
 "updated."
@@ -129,11 +129,11 @@ msgstr ""
 "Activities that have sign-up lists which are open or approved cannot be "
 "updated."
 
-#: module/Activity/src/Controller/AdminController.php:90
+#: module/Activity/src/Controller/AdminController.php:87
 msgid "This activity has already started/ended and can no longer be updated."
 msgstr "This activity has already started/ended and can no longer be updated."
 
-#: module/Activity/src/Controller/AdminController.php:108
+#: module/Activity/src/Controller/AdminController.php:106
 msgid ""
 "You have successfully created an update proposal for the activity! If the "
 "activity was already approved, the proposal will be applied after it has "
@@ -145,120 +145,120 @@ msgstr ""
 "been approved by the board. Otherwise, the update has already been applied "
 "to the activity."
 
-#: module/Activity/src/Controller/AdminController.php:145
+#: module/Activity/src/Controller/AdminController.php:143
 msgid "Update Activity"
 msgstr "Update Activity"
 
-#: module/Activity/src/Controller/AdminController.php:198
-#: module/Activity/src/Controller/AdminController.php:210
-#: module/Activity/src/Controller/AdminController.php:222
+#: module/Activity/src/Controller/AdminController.php:188
+#: module/Activity/src/Controller/AdminController.php:200
+#: module/Activity/src/Controller/AdminController.php:212
 msgid "You are not allowed to view the participants of this activity"
 msgstr "You are not allowed to view the participants of this activity"
 
-#: module/Activity/src/Controller/AdminController.php:244
-#: module/Activity/src/Controller/AdminController.php:388
-#: module/User/view/user/api-admin/index.phtml:23
+#: module/Activity/src/Controller/AdminController.php:234
+#: module/Activity/src/Controller/AdminController.php:372
+#: module/User/view/user/api-admin/index.phtml:35
 msgid "Remove"
 msgstr "Remove"
 
-#: module/Activity/src/Controller/AdminController.php:283
-#: module/Activity/src/Controller/AdminController.php:380
+#: module/Activity/src/Controller/AdminController.php:273
+#: module/Activity/src/Controller/AdminController.php:364
 msgid "You are not allowed to use this form"
 msgstr "You are not allowed to use this form"
 
-#: module/Activity/src/Controller/AdminController.php:320
+#: module/Activity/src/Controller/AdminController.php:310
 msgid "Successfully subscribed external participant"
 msgstr "Successfully subscribed external participant"
 
-#: module/Activity/src/Controller/AdminController.php:407
+#: module/Activity/src/Controller/AdminController.php:391
 msgid "Successfully removed external participant"
 msgstr "Successfully removed external participant"
 
-#: module/Activity/src/Controller/AdminController.php:415
+#: module/Activity/src/Controller/AdminController.php:399
 msgid "Use the form to unsubscribe an external participant"
 msgstr "Use the form to unsubscribe an external participant"
 
-#: module/Activity/src/Controller/AdminController.php:425
+#: module/Activity/src/Controller/AdminController.php:409
 msgid "You are not allowed to administer activities"
 msgstr "You are not allowed to administer activities"
 
-#: module/Activity/src/Controller/AdminOptionController.php:40
+#: module/Activity/src/Controller/AdminOptionController.php:41
 msgid "You are not allowed to administer option calendar periods"
 msgstr "You are not allowed to administer option calendar periods"
 
-#: module/Activity/src/Controller/AdminOptionController.php:54
+#: module/Activity/src/Controller/AdminOptionController.php:57
 msgid "You are not allowed to create option calendar periods"
 msgstr "You are not allowed to create option calendar periods"
 
-#: module/Activity/src/Controller/AdminOptionController.php:73
+#: module/Activity/src/Controller/AdminOptionController.php:77
 msgid "Option planning period created successfully."
 msgstr "Option planning period created successfully."
 
-#: module/Activity/src/Controller/AdminOptionController.php:97
-#: module/Activity/view/activity/admin-option/index.phtml:105
+#: module/Activity/src/Controller/AdminOptionController.php:101
+#: module/Activity/view/activity/admin-option/index.phtml:113
 msgid "Add Option Period"
 msgstr "Add Option Period"
 
-#: module/Activity/src/Controller/AdminOptionController.php:105
+#: module/Activity/src/Controller/AdminOptionController.php:109
 msgid "You are not allowed to delete option calendar periods"
 msgstr "You are not allowed to delete option calendar periods"
 
-#: module/Activity/src/Controller/AdminOptionController.php:120
+#: module/Activity/src/Controller/AdminOptionController.php:124
 msgid "Past option planning periods cannot be deleted."
 msgstr "Past option planning periods cannot be deleted."
 
-#: module/Activity/src/Controller/AdminOptionController.php:128
+#: module/Activity/src/Controller/AdminOptionController.php:132
 msgid "Option planning period deleted."
 msgstr "Option planning period deleted."
 
-#: module/Activity/src/Controller/AdminOptionController.php:140
+#: module/Activity/src/Controller/AdminOptionController.php:145
 msgid "You are not allowed to edit option calendar periods"
 msgstr "You are not allowed to edit option calendar periods"
 
-#: module/Activity/src/Controller/AdminOptionController.php:155
+#: module/Activity/src/Controller/AdminOptionController.php:161
 msgid "This option planning period cannot be edited."
 msgstr "This option planning period cannot be edited."
 
-#: module/Activity/src/Controller/AdminOptionController.php:174
+#: module/Activity/src/Controller/AdminOptionController.php:185
 msgid "Option planning period has been updated."
 msgstr "Option planning period has been updated."
 
-#: module/Activity/src/Controller/AdminOptionController.php:196
+#: module/Activity/src/Controller/AdminOptionController.php:207
 msgid "Edit Option Period"
 msgstr "Edit Option Period"
 
-#: module/Activity/src/Controller/ApiController.php:29
+#: module/Activity/src/Controller/ApiController.php:30
 msgid "You are not allowed to access the activities through the API"
 msgstr "You are not allowed to access the activities through the API"
 
-#: module/Activity/src/Form/Activity.php:34
+#: module/Activity/src/Form/Activity.php:35
 msgid "No organ"
 msgstr "No organ"
 
-#: module/Activity/src/Form/Activity.php:35
+#: module/Activity/src/Form/Activity.php:36
 msgid "No Company"
 msgstr "No Company"
 
-#: module/Activity/src/Form/Activity.php:289
-#: module/Activity/src/Form/Activity.php:301
-#: module/Activity/src/Form/Activity.php:315
-#: module/Activity/src/Form/Activity.php:327
-#: module/Activity/src/Form/Activity.php:339
-#: module/Activity/src/Form/Activity.php:351
-#: module/Activity/src/Form/ActivityCalendarProposal.php:130
-#: module/Activity/src/Form/ActivityCalendarProposal.php:141
-#: module/Activity/src/Form/ActivityCalendarProposal.php:149
-#: module/Education/src/Form/Bulk.php:59
+#: module/Activity/src/Form/Activity.php:282
+#: module/Activity/src/Form/Activity.php:294
+#: module/Activity/src/Form/Activity.php:308
+#: module/Activity/src/Form/Activity.php:320
+#: module/Activity/src/Form/Activity.php:335
+#: module/Activity/src/Form/Activity.php:350
+#: module/Activity/src/Form/ActivityCalendarProposal.php:128
+#: module/Activity/src/Form/ActivityCalendarProposal.php:142
+#: module/Activity/src/Form/ActivityCalendarProposal.php:150
+#: module/Education/src/Form/Bulk.php:57
 msgid "Value is required and can't be empty"
 msgstr "Value is required and can't be empty"
 
-#: module/Activity/src/Form/Activity.php:372
+#: module/Activity/src/Form/Activity.php:373
 msgid ""
 "The sign-up list closing date and time must be before the activity starts."
 msgstr ""
 "The sign-up list closing date and time must be before the activity starts."
 
-#: module/Activity/src/Form/Activity.php:407
+#: module/Activity/src/Form/Activity.php:409
 msgid "The activity must start before it ends."
 msgstr "The activity must start before it ends."
 
@@ -279,7 +279,7 @@ msgid "Evening"
 msgstr "Evening"
 
 #: module/Activity/src/Form/ActivityCalendarOption.php:30
-#: module/Activity/view/activity/activity-calendar/index.phtml:142
+#: module/Activity/view/activity/activity-calendar/index.phtml:160
 msgid "Day"
 msgstr "Day"
 
@@ -291,43 +291,43 @@ msgstr "Multiple days"
 msgid "Select a type"
 msgstr "Select a type"
 
-#: module/Activity/src/Form/ActivityCalendarOption.php:83
+#: module/Activity/src/Form/ActivityCalendarOption.php:84
 msgid "The activity must start before it ends"
 msgstr "The activity must start before it ends"
 
-#: module/Activity/src/Form/ActivityCalendarOption.php:94
+#: module/Activity/src/Form/ActivityCalendarOption.php:97
 msgid "The activity must start after today"
 msgstr "The activity must start after today"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:32
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:30
 msgid "Start date and time of planning period"
 msgstr "Start date and time of planning period"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:43
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:41
 msgid "End date and time of planning period"
 msgstr "End date and time of planning period"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:54
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:52
 msgid "Start date and time of option period"
 msgstr "Start date and time of option period"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:65
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:63
 msgid "End date and time of option period"
 msgstr "End date and time of option period"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:91
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:89
 msgid "Create Option Period"
 msgstr "Create Option Period"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:128
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:126
 msgid "The planning period must end after it starts."
 msgstr "The planning period must end after it starts."
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:151
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:149
 msgid "The option period must start after the planning period ends."
 msgstr "The option period must start after the planning period ends."
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:174
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:172
 msgid "The option period must end after it starts."
 msgstr "The option period must end after it starts."
 
@@ -339,83 +339,83 @@ msgstr "Select a period"
 msgid "Select an option"
 msgstr "Select an option"
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:161
+#: module/Activity/src/Form/ActivityCalendarProposal.php:165
 msgid "Option should end after it starts."
 msgstr "Option should end after it starts."
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:169
+#: module/Activity/src/Form/ActivityCalendarProposal.php:176
 msgid "Option does not fall within option period (also check the end date)."
 msgstr "Option does not fall within option period (also check the end date)."
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:216
+#: module/Activity/src/Form/ActivityCalendarProposal.php:220
 msgid "The activity does now have an acceptable amount of options"
 msgstr "The activity does now have an acceptable amount of options"
 
 #: module/Activity/src/Form/ActivityCategory.php:24
 #: module/Activity/src/Form/ActivityCategory.php:34
-#: module/Activity/src/Form/SignupList.php:36
-#: module/Activity/src/Form/SignupList.php:46
-#: module/Activity/src/Form/SignupListField.php:33
-#: module/Activity/src/Form/SignupListField.php:43
-#: module/Activity/view/activity/activity-calendar/create.phtml:81
-#: module/Activity/view/activity/activity-calendar/index.phtml:46
-#: module/Activity/view/activity/activity/view.phtml:248
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:112
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:117
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:129
-#: module/Activity/view/activity/admin-approval/view.phtml:64
-#: module/Activity/view/activity/admin-approval/view.phtml:69
-#: module/Activity/view/activity/admin-approval/view.phtml:76
-#: module/Activity/view/activity/admin-category/add.phtml:56
-#: module/Activity/view/activity/admin-category/add.phtml:93
-#: module/Activity/view/activity/admin/participantsTable.phtml:11
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:5
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:10
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:17
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:89
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:94
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:101
-#: module/Activity/view/partial/create.phtml:31
-#: module/Activity/view/partial/create.phtml:105
-#: module/Activity/view/partial/signuplist.phtml:41
-#: module/Activity/view/partial/signuplist.phtml:57
-#: module/Company/src/Form/Company.php:52
-#: module/Company/src/Form/Company.php:94
-#: module/Company/src/Form/Company.php:114 module/Company/src/Form/Job.php:102
-#: module/Company/src/Form/Job.php:133 module/Company/src/Form/Job.php:143
+#: module/Activity/src/Form/SignupList.php:35
+#: module/Activity/src/Form/SignupList.php:45
+#: module/Activity/src/Form/SignupListField.php:34
+#: module/Activity/src/Form/SignupListField.php:44
+#: module/Activity/view/activity/activity-calendar/create.phtml:90
+#: module/Activity/view/activity/activity-calendar/index.phtml:64
+#: module/Activity/view/activity/activity/view.phtml:268
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:133
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:138
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:150
+#: module/Activity/view/activity/admin-approval/view.phtml:80
+#: module/Activity/view/activity/admin-approval/view.phtml:85
+#: module/Activity/view/activity/admin-approval/view.phtml:92
+#: module/Activity/view/activity/admin-category/add.phtml:69
+#: module/Activity/view/activity/admin-category/add.phtml:106
+#: module/Activity/view/activity/admin/participantsTable.phtml:20
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:18
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:23
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:30
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:102
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:107
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:114
+#: module/Activity/view/partial/create.phtml:44
+#: module/Activity/view/partial/create.phtml:118
+#: module/Activity/view/partial/signuplist.phtml:54
+#: module/Activity/view/partial/signuplist.phtml:70
+#: module/Company/src/Form/Company.php:51
+#: module/Company/src/Form/Company.php:93
+#: module/Company/src/Form/Company.php:113 module/Company/src/Form/Job.php:106
+#: module/Company/src/Form/Job.php:137 module/Company/src/Form/Job.php:147
 #: module/Company/src/Form/JobCategory.php:45
 #: module/Company/src/Form/JobCategory.php:55
-#: module/Company/src/Form/JobLabel.php:32
-#: module/Company/src/Form/JobLabel.php:42
-#: module/Company/view/company/admin-approval/index.phtml:14
-#: module/Company/view/company/admin-approval/job-approval.phtml:52
-#: module/Company/view/company/admin-approval/job-approval.phtml:56
-#: module/Company/view/company/admin-approval/job-approval.phtml:105
-#: module/Company/view/company/admin-approval/job-approval.phtml:110
-#: module/Company/view/company/admin-approval/job-approval.phtml:117
-#: module/Company/view/company/admin-approval/job-proposal.phtml:87
-#: module/Company/view/company/admin-approval/job-proposal.phtml:91
-#: module/Company/view/company/admin-approval/job-proposal.phtml:149
-#: module/Company/view/company/admin-approval/job-proposal.phtml:154
+#: module/Company/src/Form/JobLabel.php:31
+#: module/Company/src/Form/JobLabel.php:41
+#: module/Company/view/company/admin-approval/index.phtml:30
+#: module/Company/view/company/admin-approval/job-approval.phtml:66
+#: module/Company/view/company/admin-approval/job-approval.phtml:70
+#: module/Company/view/company/admin-approval/job-approval.phtml:119
+#: module/Company/view/company/admin-approval/job-approval.phtml:124
+#: module/Company/view/company/admin-approval/job-approval.phtml:131
+#: module/Company/view/company/admin-approval/job-proposal.phtml:97
+#: module/Company/view/company/admin-approval/job-proposal.phtml:101
+#: module/Company/view/company/admin-approval/job-proposal.phtml:159
 #: module/Company/view/company/admin-approval/job-proposal.phtml:164
-#: module/Company/view/company/admin/edit-package.phtml:69
-#: module/Company/view/company/admin/index.phtml:112
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:177
-#: module/Decision/view/decision/admin/document.phtml:57
-#: module/Decision/view/decision/member/birthdays.phtml:12
-#: module/Decision/view/decision/organ-admin/index.phtml:12
-#: module/Decision/view/decision/organ/index.phtml:14
-#: module/Education/src/Form/Course.php:42
-#: module/Education/view/education/admin/course.phtml:32
-#: module/Photo/view/photo/album-admin/edit.phtml:23
+#: module/Company/view/company/admin-approval/job-proposal.phtml:174
+#: module/Company/view/company/admin/edit-package.phtml:83
+#: module/Company/view/company/admin/index.phtml:126
+#: module/Company/view/company/admin/index.phtml:212
+#: module/Company/view/company/company-account/jobs.phtml:196
+#: module/Decision/view/decision/admin/document.phtml:71
+#: module/Decision/view/decision/member/birthdays.phtml:23
+#: module/Decision/view/decision/organ-admin/index.phtml:24
+#: module/Decision/view/decision/organ/index.phtml:23
+#: module/Education/src/Form/Course.php:43
+#: module/Education/view/education/admin/course.phtml:44
+#: module/Photo/view/photo/album-admin/edit.phtml:35
 #: module/User/src/Form/ApiToken.php:25
-#: module/User/view/user/api-admin/add.phtml:45
-#: module/User/view/user/api-admin/index.phtml:10
+#: module/User/view/user/api-admin/add.phtml:57
+#: module/User/view/user/api-admin/index.phtml:22
 msgid "Name"
 msgstr "Name"
 
-#: module/Activity/src/Form/SignupList.php:184
+#: module/Activity/src/Form/SignupList.php:180
 msgid ""
 "The sign-up list opening date and time must be before the sign-up list "
 "closes."
@@ -423,196 +423,196 @@ msgstr ""
 "The sign-up list opening date and time must be before the sign-up list "
 "closes."
 
-#: module/Activity/src/Form/SignupListField.php:54
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:115
+#: module/Activity/src/Form/SignupListField.php:55
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:128
 msgid "Text"
 msgstr "Text"
 
-#: module/Activity/src/Form/SignupListField.php:55
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:118
+#: module/Activity/src/Form/SignupListField.php:56
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:131
 msgid "Yes/No"
 msgstr "Yes/No"
 
-#: module/Activity/src/Form/SignupListField.php:56
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
+#: module/Activity/src/Form/SignupListField.php:57
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
 msgid "Number"
 msgstr "Number"
 
-#: module/Activity/src/Form/SignupListField.php:57
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:124
+#: module/Activity/src/Form/SignupListField.php:58
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:137
 msgid "Choice"
 msgstr "Choice"
 
-#: module/Activity/src/Form/SignupListField.php:59
-#: module/Activity/view/activity/activity-calendar/index.phtml:47
-#: module/Activity/view/activity/admin/participantsTable.phtml:13
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:108
-#: module/Activity/view/partial/option.phtml:10
-#: module/Decision/view/decision/decision/index.phtml:9
-#: module/Decision/view/decision/organ/index.phtml:15
-#: module/Education/src/Form/Fieldset/Exam.php:69
-#: module/Education/view/education/admin/course-documents.phtml:58
+#: module/Activity/src/Form/SignupListField.php:60
+#: module/Activity/view/activity/activity-calendar/index.phtml:65
+#: module/Activity/view/activity/admin/participantsTable.phtml:22
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
+#: module/Activity/view/partial/option.phtml:19
+#: module/Decision/view/decision/decision/index.phtml:23
+#: module/Decision/view/decision/organ/index.phtml:24
+#: module/Education/src/Form/Fieldset/Exam.php:68
+#: module/Education/view/education/admin/course-documents.phtml:68
 msgid "Type"
 msgstr "Type"
 
-#: module/Activity/src/Form/SignupListField.php:69
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
+#: module/Activity/src/Form/SignupListField.php:70
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:147
 msgid "Min. value"
 msgstr "Min. value"
 
-#: module/Activity/src/Form/SignupListField.php:79
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:144
+#: module/Activity/src/Form/SignupListField.php:80
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:157
 msgid "Max. value"
 msgstr "Max. value"
 
-#: module/Activity/src/Form/SignupListField.php:89
-#: module/Activity/src/Form/SignupListField.php:102
+#: module/Activity/src/Form/SignupListField.php:90
+#: module/Activity/src/Form/SignupListField.php:103
 msgid "Option 1, Option 2, ..."
 msgstr "Option 1, Option 2, ..."
 
-#: module/Activity/src/Form/SignupListField.php:92
-#: module/Activity/src/Form/SignupListField.php:105
-#: module/Activity/view/activity/activity-calendar/create.phtml:110
-#: module/Activity/view/activity/activity-calendar/index.phtml:175
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:156
-#: module/Activity/view/partial/create.phtml:157
+#: module/Activity/src/Form/SignupListField.php:93
+#: module/Activity/src/Form/SignupListField.php:106
+#: module/Activity/view/activity/activity-calendar/create.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:193
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:169
+#: module/Activity/view/partial/create.phtml:170
 msgid "Options"
 msgstr "Options"
 
-#: module/Activity/src/Form/SignupListField.php:159
+#: module/Activity/src/Form/SignupListField.php:160
 msgid "Some of the required fields for this type are empty"
 msgstr "Some of the required fields for this type are empty"
 
-#: module/Activity/src/Form/SignupListField.php:190
+#: module/Activity/src/Form/SignupListField.php:191
 msgid "The number of English options must equal the number of Dutch options"
 msgstr "The number of English options must equal the number of Dutch options"
 
-#: module/Activity/src/Service/Activity.php:57
-#: module/Activity/src/Service/Activity.php:98
+#: module/Activity/src/Service/Activity.php:66
+#: module/Activity/src/Service/Activity.php:105
 msgid "You are not allowed to create an activity"
 msgstr "You are not allowed to create an activity"
 
-#: module/Activity/src/Service/Activity.php:138
+#: module/Activity/src/Service/Activity.php:145
 msgid "You are not allowed to create an activity for this organ"
 msgstr "You are not allowed to create an activity for this organ"
 
-#: module/Activity/src/Service/Activity.php:398
+#: module/Activity/src/Service/Activity.php:406
 msgid "You are not allowed to create activity option proposals"
 msgstr "You are not allowed to create activity option proposals"
 
-#: module/Activity/src/Service/Activity.php:731
-#: module/Activity/src/Service/Activity.php:749
-#: module/Activity/src/Service/Activity.php:767
+#: module/Activity/src/Service/Activity.php:754
+#: module/Activity/src/Service/Activity.php:772
+#: module/Activity/src/Service/Activity.php:790
 msgid "You are not allowed to change the status of the activity"
 msgstr "You are not allowed to change the status of the activity"
 
-#: module/Activity/src/Service/ActivityCalendar.php:167
+#: module/Activity/src/Service/ActivityCalendar.php:169
 msgid "You are not allowed to approve this option"
 msgstr "You are not allowed to approve this option"
 
-#: module/Activity/src/Service/ActivityCalendar.php:215
+#: module/Activity/src/Service/ActivityCalendar.php:209
 msgid "You are not allowed to delete this option"
 msgstr "You are not allowed to delete this option"
 
-#: module/Activity/src/Service/ActivityCategory.php:35
-#: module/Activity/src/Service/ActivityCategory.php:51
+#: module/Activity/src/Service/ActivityCategory.php:31
+#: module/Activity/src/Service/ActivityCategory.php:47
 msgid "You are not allowed to view activity categories"
 msgstr "You are not allowed to view activity categories"
 
-#: module/Activity/src/Service/ActivityCategory.php:115
+#: module/Activity/src/Service/ActivityCategory.php:105
 msgid "You are not allowed to delete an activity category"
 msgstr "You are not allowed to delete an activity category"
 
-#: module/Activity/src/Service/ActivityQuery.php:91
+#: module/Activity/src/Service/ActivityQuery.php:86
 msgid "You are not allowed to view this activity"
 msgstr "You are not allowed to view this activity"
 
-#: module/Activity/src/Service/ActivityQuery.php:107
-#: module/Activity/src/Service/ActivityQuery.php:274
-#: module/Activity/src/Service/Signup.php:149
+#: module/Activity/src/Service/ActivityQuery.php:102
+#: module/Activity/src/Service/ActivityQuery.php:262
+#: module/Activity/src/Service/Signup.php:128
 msgid "You are not allowed to view the activities"
 msgstr "You are not allowed to view the activities"
 
-#: module/Activity/src/Service/ActivityQuery.php:122
+#: module/Activity/src/Service/ActivityQuery.php:117
 msgid "You are not allowed to view unapproved activities"
 msgstr "You are not allowed to view unapproved activities"
 
-#: module/Activity/src/Service/ActivityQuery.php:137
+#: module/Activity/src/Service/ActivityQuery.php:132
 msgid "You are not allowed to view activities"
 msgstr "You are not allowed to view activities"
 
-#: module/Activity/src/Service/ActivityQuery.php:167
+#: module/Activity/src/Service/ActivityQuery.php:159
 msgid "You are not allowed to view the disapproved activities"
 msgstr "You are not allowed to view the disapproved activities"
 
-#: module/Activity/src/Service/ActivityQuery.php:185
+#: module/Activity/src/Service/ActivityQuery.php:177
 msgid "You are not allowed to view upcoming the activities"
 msgstr "You are not allowed to view upcoming the activities"
 
-#: module/Activity/src/Service/ActivityQuery.php:193
+#: module/Activity/src/Service/ActivityQuery.php:185
 msgid ""
 "You are not allowed to view upcoming activities coupled to a member account"
 msgstr ""
 "You are not allowed to view upcoming activities coupled to a member account"
 
-#: module/Activity/src/Service/Signup.php:54
-#: module/Activity/src/Service/Signup.php:168
+#: module/Activity/src/Service/Signup.php:47
+#: module/Activity/src/Service/Signup.php:147
 msgid "You need to be logged in to sign up for this activity"
 msgstr "You need to be logged in to sign up for this activity"
 
-#: module/Activity/src/Service/Signup.php:73
+#: module/Activity/src/Service/Signup.php:61
 msgid "You are not allowed to use the external admin signup"
 msgstr "You are not allowed to use the external admin signup"
 
-#: module/Activity/src/Service/Signup.php:92
+#: module/Activity/src/Service/Signup.php:75
 msgid "You are not allowed to use the external signup"
 msgstr "You are not allowed to use the external signup"
 
-#: module/Activity/src/Service/Signup.php:112
+#: module/Activity/src/Service/Signup.php:96
 msgid "You are not allowed to view the sign up data"
 msgstr "You are not allowed to view the sign up data"
 
-#: module/Activity/src/Service/Signup.php:248
+#: module/Activity/src/Service/Signup.php:229
 msgid "You are not allowed to subscribe an external user to this sign-up list"
 msgstr "You are not allowed to subscribe an external user to this sign-up list"
 
-#: module/Activity/src/Service/Signup.php:301
+#: module/Activity/src/Service/Signup.php:276
 msgid "You are not allowed to subscribe to this sign-up list"
 msgstr "You are not allowed to subscribe to this sign-up list"
 
-#: module/Activity/src/Service/Signup.php:320
+#: module/Activity/src/Service/Signup.php:292
 msgid "You need to be logged in to sign off for this activity"
 msgstr "You need to be logged in to sign off for this activity"
 
-#: module/Activity/src/Service/Signup.php:369
+#: module/Activity/src/Service/Signup.php:333
 msgid "You are not allowed to remove external signups for this activity"
 msgstr "You are not allowed to remove external signups for this activity"
 
-#: module/Activity/src/Service/SignupListQuery.php:30
+#: module/Activity/src/Service/SignupListQuery.php:26
 msgid "You are not allowed to view sign-up lists"
 msgstr "You are not allowed to view sign-up lists"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:5
+#: module/Activity/view/activity/activity-calendar/create.phtml:14
 msgid "Create activity proposal"
 msgstr "Create activity proposal"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:21
-#: module/Activity/view/activity/activity-calendar/index.phtml:20
-#: module/Application/view/partial/main-nav.phtml:386
-#: module/Decision/view/decision/member/index.phtml:196
+#: module/Activity/view/activity/activity-calendar/create.phtml:30
+#: module/Activity/view/activity/activity-calendar/index.phtml:38
+#: module/Application/view/partial/main-nav.phtml:417
+#: module/Decision/view/decision/member/index.phtml:207
 msgid "Option calendar"
 msgstr "Option calendar"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:22
+#: module/Activity/view/activity/activity-calendar/create.phtml:31
 msgid "Propose options for an activity"
 msgstr "Propose options for an activity"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:30
+#: module/Activity/view/activity/activity-calendar/create.phtml:39
 msgid "Organisation"
 msgstr "Organisation"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:31
-#: module/Activity/view/activity/activity-calendar/create.phtml:69
+#: module/Activity/view/activity/activity-calendar/create.phtml:40
+#: module/Activity/view/activity/activity-calendar/create.phtml:78
 msgid ""
 "Select the organ for which the options are and in which option period the "
 "options should be planned."
@@ -620,66 +620,66 @@ msgstr ""
 "Select the organ for which the options are and in which option period the "
 "options should be planned."
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:40
+#: module/Activity/view/activity/activity-calendar/create.phtml:49
 msgid "Period"
 msgstr "Period"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:55
-#: module/Activity/view/activity/activity/create.phtml:49
+#: module/Activity/view/activity/activity-calendar/create.phtml:64
+#: module/Activity/view/activity/activity/create.phtml:62
 msgid "Committee / fraternity"
 msgstr "Committee / fraternity"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:68
-#: module/Activity/view/activity/admin/list.phtml:59
-#: module/Company/view/company/admin-approval/job-approval.phtml:86
-#: module/Company/view/company/admin-approval/job-proposal.phtml:130
-#: module/Company/view/company/admin/edit-package.phtml:97
-#: module/Company/view/company/company-account/jobs.phtml:215
+#: module/Activity/view/activity/activity-calendar/create.phtml:77
+#: module/Activity/view/activity/admin/list.phtml:67
+#: module/Company/view/company/admin-approval/job-approval.phtml:100
+#: module/Company/view/company/admin-approval/job-proposal.phtml:140
+#: module/Company/view/company/admin/edit-package.phtml:111
+#: module/Company/view/company/company-account/jobs.phtml:234
 msgid "Details"
 msgstr "Details"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:97
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:199
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:204
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:216
-#: module/Activity/view/activity/admin-approval/view.phtml:121
-#: module/Activity/view/activity/admin-approval/view.phtml:126
-#: module/Activity/view/activity/admin-approval/view.phtml:133
-#: module/Activity/view/partial/create.phtml:74
-#: module/Activity/view/partial/create.phtml:148
-#: module/Company/src/Form/Company.php:199
-#: module/Company/src/Form/Company.php:209 module/Company/src/Form/Job.php:197
-#: module/Company/src/Form/Job.php:207
-#: module/Company/view/company/admin-approval/job-approval.phtml:162
-#: module/Company/view/company/admin-approval/job-approval.phtml:167
-#: module/Company/view/company/admin-approval/job-approval.phtml:174
-#: module/Company/view/company/admin-approval/job-proposal.phtml:224
-#: module/Company/view/company/admin-approval/job-proposal.phtml:229
+#: module/Activity/view/activity/activity-calendar/create.phtml:106
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:220
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:225
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:237
+#: module/Activity/view/activity/admin-approval/view.phtml:137
+#: module/Activity/view/activity/admin-approval/view.phtml:142
+#: module/Activity/view/activity/admin-approval/view.phtml:149
+#: module/Activity/view/partial/create.phtml:87
+#: module/Activity/view/partial/create.phtml:161
+#: module/Company/src/Form/Company.php:198
+#: module/Company/src/Form/Company.php:208 module/Company/src/Form/Job.php:201
+#: module/Company/src/Form/Job.php:211
+#: module/Company/view/company/admin-approval/job-approval.phtml:176
+#: module/Company/view/company/admin-approval/job-approval.phtml:181
+#: module/Company/view/company/admin-approval/job-approval.phtml:188
+#: module/Company/view/company/admin-approval/job-proposal.phtml:234
 #: module/Company/view/company/admin-approval/job-proposal.phtml:239
-#: module/Company/view/company/company/jobs.phtml:128
-#: module/Company/view/partial/company/company/list/company.phtml:89
+#: module/Company/view/company/admin-approval/job-proposal.phtml:249
+#: module/Company/view/company/company/jobs.phtml:140
+#: module/Company/view/partial/company/company/list/company.phtml:99
 msgid "Description"
 msgstr "Description"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:111
+#: module/Activity/view/activity/activity-calendar/create.phtml:120
 msgid "Add options for your activity proposal."
 msgstr "Add options for your activity proposal."
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:133
+#: module/Activity/view/activity/activity-calendar/create.phtml:142
 msgid "Add an option"
 msgstr "Add an option"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:137
+#: module/Activity/view/activity/activity-calendar/create.phtml:146
 msgid "Remove the last option"
 msgstr "Remove the last option"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:145
-#: module/Decision/src/Form/Minutes.php:53
+#: module/Activity/view/activity/activity-calendar/create.phtml:154
+#: module/Decision/src/Form/Minutes.php:55
 #: module/Frontpage/src/Form/Poll.php:63
 msgid "Submit"
 msgstr "Submit"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:21
+#: module/Activity/view/activity/activity-calendar/index.phtml:39
 msgid ""
 "Welcome on the page of the digital Option Calendar. In the calendar below "
 "you can place options for GEWIS activities, just like you were used to do in "
@@ -695,11 +695,11 @@ msgstr ""
 "options for activities. If you insert an option, please give it a clear "
 "name, so it is clear what the option is for."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:23
+#: module/Activity/view/activity/activity-calendar/index.phtml:41
 msgid "There are a few rules:"
 msgstr "There are a few rules:"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:25
+#: module/Activity/view/activity/activity-calendar/index.phtml:43
 msgid ""
 "It is not allowed to put more than 3 options for the same activity in the "
 "calendar."
@@ -707,7 +707,7 @@ msgstr ""
 "It is not allowed to put more than 3 options for the same activity in the "
 "calendar."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:26
+#: module/Activity/view/activity/activity-calendar/index.phtml:44
 msgid ""
 "The first to put an option for an activity on a particular date, has the "
 "first dibs to let the activity take place on this date. Five weeks before "
@@ -725,7 +725,7 @@ msgstr ""
 "within these two weeks nontheless, the option lapses and the next one in "
 "line gets the chance to use this date for an activity."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:27
+#: module/Activity/view/activity/activity-calendar/index.phtml:45
 msgid ""
 "The board can always decide to make an exception to the rules written above, "
 "for example in case of dependence on a third party, or when it concerns very "
@@ -735,134 +735,134 @@ msgstr ""
 "for example in case of dependence on a third party, or when it concerns very "
 "big activities or weekends."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:33
+#: module/Activity/view/activity/activity-calendar/index.phtml:51
 msgid "Your option has been added successfully"
 msgstr "Your option has been added successfully"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:41
+#: module/Activity/view/activity/activity-calendar/index.phtml:59
 msgid "My options"
 msgstr "My options"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:45
+#: module/Activity/view/activity/activity-calendar/index.phtml:63
 msgid "Creator"
 msgstr "Creator"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:48
-#: module/Activity/view/activity/activity/list.phtml:37
-#: module/Activity/view/activity/activity/view.phtml:70
+#: module/Activity/view/activity/activity-calendar/index.phtml:66
+#: module/Activity/view/activity/activity/list.phtml:50
+#: module/Activity/view/activity/activity/view.phtml:90
 msgid "Start"
 msgstr "Start"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:49
-#: module/Activity/view/activity/activity/list.phtml:39
-#: module/Activity/view/activity/activity/view.phtml:73
+#: module/Activity/view/activity/activity-calendar/index.phtml:67
+#: module/Activity/view/activity/activity/list.phtml:52
+#: module/Activity/view/activity/activity/view.phtml:93
 msgid "End"
 msgstr "End"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:70
-#: module/Activity/view/activity/activity-calendar/index.phtml:103
-#: module/Activity/view/activity/admin-option/index.phtml:40
-#: module/Activity/view/activity/admin-option/index.phtml:90
-#: module/Activity/view/activity/admin-option/index.phtml:130
-#: module/Company/view/company/admin/edit-company.phtml:150
-#: module/Company/view/company/admin/edit-package.phtml:112
-#: module/Company/view/company/admin/index.phtml:190
-#: module/Company/view/company/company-account/jobs.phtml:235
-#: module/Decision/view/decision/admin/document.phtml:136
-#: module/Decision/view/decision/admin/document.phtml:167
-#: module/Education/view/education/admin/course-documents.phtml:82
-#: module/Education/view/education/admin/course-documents.phtml:131
-#: module/Education/view/education/admin/course-documents.phtml:166
-#: module/Education/view/education/admin/course.phtml:58
-#: module/Education/view/education/admin/course.phtml:93
-#: module/Education/view/education/admin/edit-exam.phtml:49
-#: module/Education/view/education/admin/edit-summary.phtml:49
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:73
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:143
+#: module/Activity/view/activity/activity-calendar/index.phtml:88
+#: module/Activity/view/activity/activity-calendar/index.phtml:121
+#: module/Activity/view/activity/admin-option/index.phtml:48
+#: module/Activity/view/activity/admin-option/index.phtml:98
+#: module/Activity/view/activity/admin-option/index.phtml:138
+#: module/Company/view/company/admin/edit-company.phtml:162
+#: module/Company/view/company/admin/edit-package.phtml:126
+#: module/Company/view/company/admin/index.phtml:204
+#: module/Company/view/company/company-account/jobs.phtml:254
+#: module/Decision/view/decision/admin/document.phtml:150
+#: module/Decision/view/decision/admin/document.phtml:181
+#: module/Education/view/education/admin/course-documents.phtml:92
+#: module/Education/view/education/admin/course-documents.phtml:141
+#: module/Education/view/education/admin/course-documents.phtml:176
+#: module/Education/view/education/admin/course.phtml:70
+#: module/Education/view/education/admin/course.phtml:105
+#: module/Education/view/education/admin/edit-exam.phtml:62
+#: module/Education/view/education/admin/edit-summary.phtml:62
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:88
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:158
 msgid "Delete"
 msgstr "Delete"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:74
-#: module/Activity/view/activity/activity-calendar/index.phtml:127
-#: module/Activity/view/activity/admin-approval/view.phtml:192
-#: module/Decision/view/decision/organ-admin/edit.phtml:170
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:69
+#: module/Activity/view/activity/activity-calendar/index.phtml:92
+#: module/Activity/view/activity/activity-calendar/index.phtml:145
+#: module/Activity/view/activity/admin-approval/view.phtml:208
+#: module/Decision/view/decision/organ-admin/edit.phtml:181
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:84
 msgid "Approve"
 msgstr "Approve"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:78
+#: module/Activity/view/activity/activity-calendar/index.phtml:96
 msgid "Modified by"
 msgstr "Modified by"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:92
+#: module/Activity/view/activity/activity-calendar/index.phtml:110
 msgid "Delete option"
 msgstr "Delete option"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:95
+#: module/Activity/view/activity/activity-calendar/index.phtml:113
 msgid "Are you sure you want to delete this option?"
 msgstr "Are you sure you want to delete this option?"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:101
-#: module/Activity/view/activity/activity-calendar/index.phtml:125
-#: module/Activity/view/activity/admin-category/index.phtml:56
-#: module/Activity/view/activity/admin-option/index.phtml:127
-#: module/Company/view/company/admin/edit-company.phtml:202
-#: module/Company/view/company/admin/edit-package.phtml:146
-#: module/Company/view/company/admin/index.phtml:230
-#: module/Company/view/company/company-account/jobs.phtml:285
-#: module/Decision/view/decision/admin/document.phtml:164
-#: module/Decision/view/decision/admin/document.phtml:191
-#: module/Decision/view/decision/decision/authorizations.phtml:167
-#: module/Education/view/education/admin/course-documents.phtml:163
-#: module/Education/view/education/admin/course.phtml:90
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:171
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:217
-#: module/Photo/view/photo/album-admin/index.phtml:221
-#: module/Photo/view/photo/album-admin/index.phtml:253
-#: module/Photo/view/photo/photo-admin/index.phtml:140
+#: module/Activity/view/activity/activity-calendar/index.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:143
+#: module/Activity/view/activity/admin-category/index.phtml:64
+#: module/Activity/view/activity/admin-option/index.phtml:135
+#: module/Company/view/company/admin/edit-company.phtml:214
+#: module/Company/view/company/admin/edit-package.phtml:160
+#: module/Company/view/company/admin/index.phtml:244
+#: module/Company/view/company/company-account/jobs.phtml:304
+#: module/Decision/view/decision/admin/document.phtml:178
+#: module/Decision/view/decision/admin/document.phtml:205
+#: module/Decision/view/decision/decision/authorizations.phtml:185
+#: module/Education/view/education/admin/course-documents.phtml:173
+#: module/Education/view/education/admin/course.phtml:102
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:231
+#: module/Photo/view/photo/album-admin/index.phtml:232
+#: module/Photo/view/photo/album-admin/index.phtml:264
+#: module/Photo/view/photo/photo-admin/index.phtml:158
 #: module/User/src/Form/ApiAppAuthorisation.php:26
 msgid "Cancel"
 msgstr "Cancel"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:116
+#: module/Activity/view/activity/activity-calendar/index.phtml:134
 msgid "Approve option"
 msgstr "Approve option"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:137
 msgid "Are you sure you want to approve this option?"
 msgstr "Are you sure you want to approve this option?"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:162
+#: module/Activity/view/activity/activity-calendar/index.phtml:180
 msgid "Planned Activities"
 msgstr "Planned Activities"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:163
-#: module/Activity/view/activity/activity/list.phtml:55
+#: module/Activity/view/activity/activity-calendar/index.phtml:181
+#: module/Activity/view/activity/activity/list.phtml:68
 msgid "There are no activities."
 msgstr "There are no activities."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:176
+#: module/Activity/view/activity/activity-calendar/index.phtml:194
 msgid "There are no options."
 msgstr "There are no options."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:218
+#: module/Activity/view/activity/activity-calendar/index.phtml:236
 msgid "Plan activity"
 msgstr "Plan activity"
 
-#: module/Activity/view/activity/activity/archive.phtml:20
-#: module/Photo/view/photo/photo/index.phtml:23
+#: module/Activity/view/activity/activity/archive.phtml:34
+#: module/Photo/view/photo/photo/index.phtml:36
 msgid "Older"
 msgstr "Older"
 
-#: module/Activity/view/activity/activity/archive.phtml:40
+#: module/Activity/view/activity/activity/archive.phtml:54
 msgid "There are no activities in the archive."
 msgstr "There are no activities in the archive."
 
-#: module/Activity/view/activity/activity/create.phtml:38
+#: module/Activity/view/activity/activity/create.phtml:51
 msgid "Organizer"
 msgstr "Organizer"
 
-#: module/Activity/view/activity/activity/create.phtml:39
+#: module/Activity/view/activity/activity/create.phtml:52
 msgid ""
 "Select whether an organ (committee, fraternity, etc.) or a company is "
 "responsible for this activity, or both."
@@ -870,43 +870,43 @@ msgstr ""
 "Select whether an organ (committee, fraternity, etc.) or a company is "
 "responsible for this activity, or both."
 
-#: module/Activity/view/activity/activity/create.phtml:63
-#: module/Activity/view/activity/admin/list.phtml:17
-#: module/Activity/view/activity/admin/view.phtml:57
-#: module/Company/view/company/admin-approval/index.phtml:42
-#: module/Company/view/company/company/job-list.phtml:71
-#: module/User/view/user/user/login.phtml:20
+#: module/Activity/view/activity/activity/create.phtml:76
+#: module/Activity/view/activity/admin/list.phtml:25
+#: module/Activity/view/activity/admin/view.phtml:74
+#: module/Company/view/company/admin-approval/index.phtml:58
+#: module/Company/view/company/company/job-list.phtml:85
+#: module/User/view/user/user/login.phtml:34
 msgid "Company"
 msgstr "Company"
 
-#: module/Activity/view/activity/activity/create.phtml:74
-#: module/Activity/view/activity/admin/participantsTable.phtml:16
+#: module/Activity/view/activity/activity/create.phtml:87
+#: module/Activity/view/activity/admin/participantsTable.phtml:25
 msgid "Date and time"
 msgstr "Date and time"
 
-#: module/Activity/view/activity/activity/create.phtml:75
+#: module/Activity/view/activity/activity/create.phtml:88
 msgid "Enter the start and end date and time of this activity."
 msgstr "Enter the start and end date and time of this activity."
 
-#: module/Activity/view/activity/activity/create.phtml:88
+#: module/Activity/view/activity/activity/create.phtml:101
 msgid "Start date and time"
 msgstr "Start date and time"
 
-#: module/Activity/view/activity/activity/create.phtml:103
+#: module/Activity/view/activity/activity/create.phtml:116
 msgid "End date and time"
 msgstr "End date and time"
 
-#: module/Activity/view/activity/activity/create.phtml:117
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:242
-#: module/Activity/view/activity/admin-approval/view.phtml:149
-#: module/Activity/view/activity/admin-category/add.phtml:4
-#: module/Activity/view/activity/admin-category/index.phtml:2
-#: module/Activity/view/activity/admin-category/index.phtml:6
-#: module/Activity/view/activity/admin-category/index.phtml:11
+#: module/Activity/view/activity/activity/create.phtml:130
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:263
+#: module/Activity/view/activity/admin-approval/view.phtml:165
+#: module/Activity/view/activity/admin-category/add.phtml:17
+#: module/Activity/view/activity/admin-category/index.phtml:10
+#: module/Activity/view/activity/admin-category/index.phtml:14
+#: module/Activity/view/activity/admin-category/index.phtml:19
 msgid "Activity Categories"
 msgstr "Activity Categories"
 
-#: module/Activity/view/activity/activity/create.phtml:118
+#: module/Activity/view/activity/activity/create.phtml:131
 msgid ""
 "Add activity categories to your activity to give potential subscribers a "
 "better understanding of the activity."
@@ -914,19 +914,19 @@ msgstr ""
 "Add activity categories to your activity to give potential subscribers a "
 "better understanding of the activity."
 
-#: module/Activity/view/activity/activity/create.phtml:138
-#: module/Activity/view/activity/admin-category/index.phtml:16
+#: module/Activity/view/activity/activity/create.phtml:151
+#: module/Activity/view/activity/admin-category/index.phtml:24
 msgid "There are currently no activity categories..."
 msgstr "There are currently no activity categories..."
 
-#: module/Activity/view/activity/activity/create.phtml:164
-#: module/Activity/view/activity/activity/view.phtml:114
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:269
-#: module/Activity/view/activity/admin-approval/view.phtml:163
+#: module/Activity/view/activity/activity/create.phtml:177
+#: module/Activity/view/activity/activity/view.phtml:134
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:290
+#: module/Activity/view/activity/admin-approval/view.phtml:179
 msgid "Sign-up Lists"
 msgstr "Sign-up Lists"
 
-#: module/Activity/view/activity/activity/create.phtml:165
+#: module/Activity/view/activity/activity/create.phtml:178
 msgid ""
 "Add sign-up lists to allow people to sign up for this activity. Each list "
 "can have optional fields to collect specific information from the "
@@ -936,134 +936,134 @@ msgstr ""
 "can have optional fields to collect specific information from the "
 "participants."
 
-#: module/Activity/view/activity/activity/create.phtml:171
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:99
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:279
-#: module/Activity/view/activity/admin-approval/view.phtml:51
-#: module/Activity/view/activity/admin-approval/view.phtml:169
-#: module/Activity/view/activity/admin-category/add.phtml:40
-#: module/Activity/view/partial/create.phtml:17
-#: module/Application/src/Model/Enums/Languages.php:19
-#: module/Company/view/company/admin-approval/job-approval.phtml:92
-#: module/Company/view/company/admin-approval/job-proposal.phtml:136
-#: module/Company/view/partial/company/admin/editors/category.phtml:7
-#: module/Company/view/partial/company/admin/editors/company.phtml:205
-#: module/Company/view/partial/company/admin/editors/job.phtml:133
-#: module/Company/view/partial/company/admin/editors/label.phtml:16
-#: module/Company/view/partial/company/admin/editors/package.phtml:87
+#: module/Activity/view/activity/activity/create.phtml:184
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:120
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:300
+#: module/Activity/view/activity/admin-approval/view.phtml:67
+#: module/Activity/view/activity/admin-approval/view.phtml:185
+#: module/Activity/view/activity/admin-category/add.phtml:53
+#: module/Activity/view/partial/create.phtml:30
+#: module/Application/src/Model/Enums/Languages.php:24
+#: module/Company/view/company/admin-approval/job-approval.phtml:106
+#: module/Company/view/company/admin-approval/job-proposal.phtml:146
+#: module/Company/view/partial/company/admin/editors/category.phtml:20
+#: module/Company/view/partial/company/admin/editors/company.phtml:218
+#: module/Company/view/partial/company/admin/editors/job.phtml:146
+#: module/Company/view/partial/company/admin/editors/label.phtml:29
+#: module/Company/view/partial/company/admin/editors/package.phtml:96
 msgid "Dutch"
 msgstr "Dutch"
 
-#: module/Activity/view/activity/activity/create.phtml:176
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:104
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:284
-#: module/Activity/view/activity/admin-approval/view.phtml:56
-#: module/Activity/view/activity/admin-approval/view.phtml:174
-#: module/Activity/view/activity/admin-category/add.phtml:77
-#: module/Activity/view/partial/create.phtml:91
-#: module/Application/src/Model/Enums/Languages.php:18
-#: module/Company/view/company/admin-approval/job-approval.phtml:97
-#: module/Company/view/company/admin-approval/job-proposal.phtml:141
-#: module/Company/view/partial/company/admin/editors/category.phtml:52
-#: module/Company/view/partial/company/admin/editors/company.phtml:266
-#: module/Company/view/partial/company/admin/editors/job.phtml:227
-#: module/Company/view/partial/company/admin/editors/label.phtml:61
-#: module/Company/view/partial/company/admin/editors/package.phtml:119
+#: module/Activity/view/activity/activity/create.phtml:189
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:125
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:305
+#: module/Activity/view/activity/admin-approval/view.phtml:72
+#: module/Activity/view/activity/admin-approval/view.phtml:190
+#: module/Activity/view/activity/admin-category/add.phtml:90
+#: module/Activity/view/partial/create.phtml:104
+#: module/Application/src/Model/Enums/Languages.php:23
+#: module/Company/view/company/admin-approval/job-approval.phtml:111
+#: module/Company/view/company/admin-approval/job-proposal.phtml:151
+#: module/Company/view/partial/company/admin/editors/category.phtml:65
+#: module/Company/view/partial/company/admin/editors/company.phtml:279
+#: module/Company/view/partial/company/admin/editors/job.phtml:240
+#: module/Company/view/partial/company/admin/editors/label.phtml:74
+#: module/Company/view/partial/company/admin/editors/package.phtml:128
 msgid "English"
 msgstr "English"
 
-#: module/Activity/view/activity/activity/create.phtml:204
+#: module/Activity/view/activity/activity/create.phtml:217
 msgid "Remove the last sign-up list"
 msgstr "Remove the last sign-up list"
 
-#: module/Activity/view/activity/activity/create.phtml:208
+#: module/Activity/view/activity/activity/create.phtml:221
 msgid "Add a sign-up list"
 msgstr "Add a sign-up list"
 
-#: module/Activity/view/activity/activity/createSuccess.phtml:6
+#: module/Activity/view/activity/activity/createSuccess.phtml:15
 msgid "The activity has been successfully created."
 msgstr "The activity has been successfully created."
 
-#: module/Activity/view/activity/activity/createSuccess.phtml:7
+#: module/Activity/view/activity/activity/createSuccess.phtml:16
 msgid "It will become visible after it has been approved by the board."
 msgstr "It will become visible after it has been approved by the board."
 
-#: module/Activity/view/activity/activity/index.phtml:2
-#: module/Activity/view/activity/activity/index.phtml:8
-#: module/Activity/view/activity/activity/view.phtml:10
-#: module/Activity/view/activity/activity/view.phtml:18
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:9
-#: module/Activity/view/activity/admin-approval/view.phtml:9
-#: module/Activity/view/activity/admin/participants.phtml:7
-#: module/Activity/view/activity/admin/view.phtml:3
-#: module/Application/view/partial/admin.phtml:32
-#: module/Application/view/partial/main-nav.phtml:350
-#: module/Application/view/partial/main-nav.phtml:354
-#: module/Application/view/partial/main-nav.phtml:359
-#: module/Decision/view/decision/member/index.phtml:192
+#: module/Activity/view/activity/activity/index.phtml:15
+#: module/Activity/view/activity/activity/index.phtml:21
+#: module/Activity/view/activity/activity/view.phtml:30
+#: module/Activity/view/activity/activity/view.phtml:38
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:24
+#: module/Activity/view/activity/admin-approval/view.phtml:22
+#: module/Activity/view/activity/admin/participants.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:19
+#: module/Application/view/partial/admin.phtml:38
+#: module/Application/view/partial/main-nav.phtml:374
+#: module/Application/view/partial/main-nav.phtml:378
+#: module/Application/view/partial/main-nav.phtml:383
+#: module/Decision/view/decision/member/index.phtml:203
 msgid "Activities"
 msgstr "Activities"
 
-#: module/Activity/view/activity/activity/index.phtml:14
+#: module/Activity/view/activity/activity/index.phtml:27
 msgid "All Activities"
 msgstr "All Activities"
 
-#: module/Activity/view/activity/activity/index.phtml:17
+#: module/Activity/view/activity/activity/index.phtml:30
 msgid "Career Activities"
 msgstr "Career Activities"
 
-#: module/Activity/view/activity/activity/index.phtml:21
+#: module/Activity/view/activity/activity/index.phtml:34
 msgid "My Activities"
 msgstr "My Activities"
 
-#: module/Activity/view/activity/activity/list.phtml:9
+#: module/Activity/view/activity/activity/list.phtml:22
 msgid "MMM d"
 msgstr "MMM d"
 
-#: module/Activity/view/activity/activity/list.phtml:33
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:61
+#: module/Activity/view/activity/activity/list.phtml:46
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:79
 msgid "Continue reading"
 msgstr "Continue reading"
 
-#: module/Activity/view/activity/activity/list.phtml:42
-#: module/Activity/view/activity/activity/view.phtml:76
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:141
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:146
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:158
-#: module/Activity/view/activity/admin-approval/view.phtml:83
-#: module/Activity/view/activity/admin-approval/view.phtml:88
-#: module/Activity/view/activity/admin-approval/view.phtml:95
-#: module/Activity/view/partial/create.phtml:45
-#: module/Activity/view/partial/create.phtml:119
-#: module/Company/src/Form/Job.php:177 module/Company/src/Form/Job.php:187
-#: module/Company/view/company/admin-approval/job-approval.phtml:143
-#: module/Company/view/company/admin-approval/job-approval.phtml:148
-#: module/Company/view/company/admin-approval/job-approval.phtml:155
-#: module/Company/view/company/admin-approval/job-proposal.phtml:199
-#: module/Company/view/company/admin-approval/job-proposal.phtml:204
+#: module/Activity/view/activity/activity/list.phtml:55
+#: module/Activity/view/activity/activity/view.phtml:96
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:162
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:167
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:179
+#: module/Activity/view/activity/admin-approval/view.phtml:99
+#: module/Activity/view/activity/admin-approval/view.phtml:104
+#: module/Activity/view/activity/admin-approval/view.phtml:111
+#: module/Activity/view/partial/create.phtml:58
+#: module/Activity/view/partial/create.phtml:132
+#: module/Company/src/Form/Job.php:181 module/Company/src/Form/Job.php:191
+#: module/Company/view/company/admin-approval/job-approval.phtml:157
+#: module/Company/view/company/admin-approval/job-approval.phtml:162
+#: module/Company/view/company/admin-approval/job-approval.phtml:169
+#: module/Company/view/company/admin-approval/job-proposal.phtml:209
 #: module/Company/view/company/admin-approval/job-proposal.phtml:214
-#: module/Photo/view/partial/metadata.phtml:69
+#: module/Company/view/company/admin-approval/job-proposal.phtml:224
+#: module/Photo/view/partial/metadata.phtml:82
 msgid "Location"
 msgstr "Location"
 
-#: module/Activity/view/activity/activity/list.phtml:45
-#: module/Activity/view/activity/activity/view.phtml:79
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:170
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:175
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:187
-#: module/Activity/view/activity/admin-approval/view.phtml:102
-#: module/Activity/view/activity/admin-approval/view.phtml:107
-#: module/Activity/view/activity/admin-approval/view.phtml:114
-#: module/Activity/view/partial/create.phtml:59
-#: module/Activity/view/partial/create.phtml:133
+#: module/Activity/view/activity/activity/list.phtml:58
+#: module/Activity/view/activity/activity/view.phtml:99
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:191
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:196
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:208
+#: module/Activity/view/activity/admin-approval/view.phtml:118
+#: module/Activity/view/activity/admin-approval/view.phtml:123
+#: module/Activity/view/activity/admin-approval/view.phtml:130
+#: module/Activity/view/partial/create.phtml:72
+#: module/Activity/view/partial/create.phtml:146
 msgid "Costs"
 msgstr "Costs"
 
-#: module/Activity/view/activity/activity/view.phtml:130
+#: module/Activity/view/activity/activity/view.phtml:150
 msgid "the organizing party"
 msgstr "the organizing party"
 
-#: module/Activity/view/activity/activity/view.phtml:142
+#: module/Activity/view/activity/activity/view.phtml:162
 #, php-format
 msgid ""
 "Please contact %s or the board (%s) with any questions, concerns or if you "
@@ -1074,90 +1074,90 @@ msgstr ""
 "are unable to attend after the deadline for unsubscribing has passed. Have "
 "fun!"
 
-#: module/Activity/view/activity/activity/view.phtml:145
+#: module/Activity/view/activity/activity/view.phtml:165
 #, php-format
 msgid ""
 "Please contact %s or the board (%s) with any questions or concerns. Have fun!"
 msgstr ""
 "Please contact %s or the board (%s) with any questions or concerns. Have fun!"
 
-#: module/Activity/view/activity/activity/view.phtml:160
+#: module/Activity/view/activity/activity/view.phtml:180
 #, php-format
 msgid ""
 "This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
 msgstr ""
 "This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
 
-#: module/Activity/view/activity/activity/view.phtml:161
+#: module/Activity/view/activity/activity/view.phtml:181
 msgid " <strong>has a limited capacity</strong> and "
 msgstr " <strong>has a limited capacity</strong> and "
 
-#: module/Activity/view/activity/activity/view.phtml:173
+#: module/Activity/view/activity/activity/view.phtml:193
 msgid "Already subscribed"
 msgstr "Already subscribed"
 
-#: module/Activity/view/activity/activity/view.phtml:180
+#: module/Activity/view/activity/activity/view.phtml:200
 msgid "Subscription closed"
 msgstr "Subscription closed"
 
-#: module/Activity/view/activity/activity/view.phtml:186
+#: module/Activity/view/activity/activity/view.phtml:206
 msgid "Subscribe now"
 msgstr "Subscribe now"
 
-#: module/Activity/view/activity/activity/view.phtml:193
+#: module/Activity/view/activity/activity/view.phtml:213
 msgid "Unsubscribe yourself"
 msgstr "Unsubscribe yourself"
 
-#: module/Activity/view/activity/activity/view.phtml:196
+#: module/Activity/view/activity/activity/view.phtml:216
 msgid "You are not allowed to unsubscribe after the deadline!"
 msgstr "You are not allowed to unsubscribe after the deadline!"
 
-#: module/Activity/view/activity/activity/view.phtml:215
-#: module/Activity/view/activity/activity/view.phtml:232
+#: module/Activity/view/activity/activity/view.phtml:235
+#: module/Activity/view/activity/activity/view.phtml:252
 msgid "Subscribe yourself"
 msgstr "Subscribe yourself"
 
-#: module/Activity/view/activity/activity/view.phtml:218
+#: module/Activity/view/activity/activity/view.phtml:238
 msgid "Login to subscribe"
 msgstr "Login to subscribe"
 
-#: module/Activity/view/activity/activity/view.phtml:222
+#: module/Activity/view/activity/activity/view.phtml:242
 msgid "Or subscribe without a GEWIS membership: "
 msgstr "Or subscribe without a GEWIS membership: "
 
-#: module/Activity/view/activity/activity/view.phtml:243
+#: module/Activity/view/activity/activity/view.phtml:263
 msgid "Current subscriptions"
 msgstr "Current subscriptions"
 
-#: module/Activity/view/activity/activity/view.phtml:261
+#: module/Activity/view/activity/activity/view.phtml:281
 #, php-format
 msgid "The number of subscribed members is currently %d."
 msgstr "The number of subscribed members is currently %d."
 
-#: module/Activity/view/activity/activity/view.phtml:265
+#: module/Activity/view/activity/activity/view.phtml:285
 msgid "Login to view the subscribed members."
 msgstr "Login to view the subscribed members."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:6
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:16
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:21
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:31
 msgid "Update Proposal"
 msgstr "Update Proposal"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:41
-#: module/Activity/view/activity/admin-approval/view.phtml:20
-#: module/Activity/view/partial/create.phtml:3
-#: module/Company/view/company/admin-approval/job-approval.phtml:16
-#: module/Company/view/company/admin-approval/job-proposal.phtml:44
-#: module/Company/view/partial/company/admin/editors/category.phtml:3
-#: module/Company/view/partial/company/admin/editors/company.phtml:191
-#: module/Company/view/partial/company/admin/editors/job.phtml:119
-#: module/Company/view/partial/company/admin/editors/label.phtml:3
-#: module/Company/view/partial/company/admin/editors/package.phtml:9
-#: module/Photo/view/photo/album/index.phtml:510
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:56
+#: module/Activity/view/activity/admin-approval/view.phtml:33
+#: module/Activity/view/partial/create.phtml:16
+#: module/Company/view/company/admin-approval/job-approval.phtml:30
+#: module/Company/view/company/admin-approval/job-proposal.phtml:54
+#: module/Company/view/partial/company/admin/editors/category.phtml:16
+#: module/Company/view/partial/company/admin/editors/company.phtml:204
+#: module/Company/view/partial/company/admin/editors/job.phtml:132
+#: module/Company/view/partial/company/admin/editors/label.phtml:16
+#: module/Company/view/partial/company/admin/editors/package.phtml:18
+#: module/Photo/view/photo/album/index.phtml:519
 msgid "Information"
 msgstr "Information"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:45
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:60
 #, php-format
 msgid ""
 "Changes in activity attributes are shown like this: %s. If there are no "
@@ -1172,28 +1172,28 @@ msgstr ""
 "up list(s) and the new sign-up list(s) are shown. There might not be "
 "difference between the two!"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:46
-#: module/Company/view/company/admin-approval/job-proposal.phtml:52
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
+#: module/Company/view/company/admin-approval/job-proposal.phtml:62
 msgid "new"
 msgstr "new"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:46
-#: module/Company/view/company/admin-approval/job-proposal.phtml:52
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
+#: module/Company/view/company/admin-approval/job-proposal.phtml:62
 msgid "old"
 msgstr "old"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:55
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:68
-#: module/Activity/view/activity/admin-approval/view.phtml:26
-#: module/Activity/view/partial/signupForm.phtml:72
-#: module/Photo/view/partial/tags.phtml:40
-#: module/Photo/view/photo/album/index.phtml:333
-#: module/Photo/view/photo/album/index.phtml:678
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:73
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:89
+#: module/Activity/view/activity/admin-approval/view.phtml:42
+#: module/Activity/view/partial/signupForm.phtml:86
+#: module/Photo/view/partial/tags.phtml:52
+#: module/Photo/view/photo/album/index.phtml:342
+#: module/Photo/view/photo/album/index.phtml:687
 msgid "and"
 msgstr "and"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:79
-#: module/Activity/view/activity/admin-approval/view.phtml:37
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:100
+#: module/Activity/view/activity/admin-approval/view.phtml:53
 #, php-format
 msgid ""
 "This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
@@ -1202,61 +1202,61 @@ msgstr ""
 "This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
 "it will start on <strong>%s</strong> and end on <strong>%s</strong>."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:92
-#: module/Activity/view/activity/admin-approval/view.phtml:44
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:113
+#: module/Activity/view/activity/admin-approval/view.phtml:60
 msgid "More information about this activity is available below."
 msgstr "More information about this activity is available below."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:229
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:250
 msgid "View details of the old activity"
 msgstr "View details of the old activity"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:234
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:255
 msgid "View details of the new activity"
 msgstr "View details of the new activity"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:293
-#: module/Activity/view/activity/admin-approval/view.phtml:6
-#: module/Activity/view/activity/admin-approval/view.phtml:16
-#: module/Activity/view/activity/admin-approval/view.phtml:182
-#: module/Company/view/company/admin-approval/job-approval.phtml:7
-#: module/Company/view/company/admin-approval/job-approval.phtml:224
-#: module/Company/view/company/admin-approval/job-proposal.phtml:13
-#: module/Company/view/company/admin-approval/job-proposal.phtml:323
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:314
+#: module/Activity/view/activity/admin-approval/view.phtml:19
+#: module/Activity/view/activity/admin-approval/view.phtml:29
+#: module/Activity/view/activity/admin-approval/view.phtml:198
+#: module/Company/view/company/admin-approval/job-approval.phtml:21
+#: module/Company/view/company/admin-approval/job-approval.phtml:238
+#: module/Company/view/company/admin-approval/job-proposal.phtml:23
+#: module/Company/view/company/admin-approval/job-proposal.phtml:333
 msgid "Approval"
 msgstr "Approval"
 
-#: module/Activity/view/activity/admin-approval/view.phtml:141
+#: module/Activity/view/activity/admin-approval/view.phtml:157
 msgid "View details / subscriptions"
 msgstr "View details / subscriptions"
 
-#: module/Activity/view/activity/admin-approval/view.phtml:204
+#: module/Activity/view/activity/admin-approval/view.phtml:220
 msgid "Disapprove"
 msgstr "Disapprove"
 
-#: module/Activity/view/activity/admin-approval/view.phtml:214
+#: module/Activity/view/activity/admin-approval/view.phtml:230
 #, php-format
 msgid "This activity was approved by <strong>%s</strong>."
 msgstr "This activity was approved by <strong>%s</strong>."
 
-#: module/Activity/view/activity/admin-approval/view.phtml:236
+#: module/Activity/view/activity/admin-approval/view.phtml:252
 #, php-format
 msgid "This activity was disapproved by <strong>%s</strong>."
 msgstr "This activity was disapproved by <strong>%s</strong>."
 
-#: module/Activity/view/activity/admin-category/add.phtml:37
-#: module/Activity/view/partial/create.phtml:14
-#: module/Application/src/Form/Localisable.php:27
+#: module/Activity/view/activity/admin-category/add.phtml:50
+#: module/Activity/view/partial/create.phtml:27
+#: module/Application/src/Form/Localisable.php:32
 msgid "Enable Dutch Translations"
 msgstr "Enable Dutch Translations"
 
-#: module/Activity/view/activity/admin-category/add.phtml:74
-#: module/Activity/view/partial/create.phtml:88
-#: module/Application/src/Form/Localisable.php:39
+#: module/Activity/view/activity/admin-category/add.phtml:87
+#: module/Activity/view/partial/create.phtml:101
+#: module/Application/src/Form/Localisable.php:44
 msgid "Enable English Translations"
 msgstr "Enable English Translations"
 
-#: module/Activity/view/activity/admin-category/index.phtml:12
+#: module/Activity/view/activity/admin-category/index.phtml:20
 msgid ""
 "Here you can add, edit, or remove activity categories. Click on 'Add "
 "Category' to add a new category or click on a category to edit/remove it."
@@ -1264,62 +1264,62 @@ msgstr ""
 "Here you can add, edit, or remove activity categories. Click on 'Add "
 "Category' to add a new category or click on a category to edit/remove it."
 
-#: module/Activity/view/activity/admin-category/index.phtml:34
-#: module/Company/view/company/admin/categories.phtml:4
+#: module/Activity/view/activity/admin-category/index.phtml:42
+#: module/Company/view/company/admin/categories.phtml:17
 msgid "Add Category"
 msgstr "Add Category"
 
-#: module/Activity/view/activity/admin-category/index.phtml:45
-#: module/Company/view/company/admin/edit-company.phtml:191
-#: module/Company/view/company/admin/edit-package.phtml:137
-#: module/Company/view/company/admin/index.phtml:217
-#: module/Company/view/company/company-account/jobs.phtml:275
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:160
-#: module/Photo/view/photo/album-admin/index.phtml:202
-#: module/Photo/view/photo/album-admin/index.phtml:234
-#: module/Photo/view/photo/photo-admin/index.phtml:121
+#: module/Activity/view/activity/admin-category/index.phtml:53
+#: module/Company/view/company/admin/edit-company.phtml:203
+#: module/Company/view/company/admin/edit-package.phtml:151
+#: module/Company/view/company/admin/index.phtml:231
+#: module/Company/view/company/company-account/jobs.phtml:294
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:175
+#: module/Photo/view/photo/album-admin/index.phtml:213
+#: module/Photo/view/photo/album-admin/index.phtml:245
+#: module/Photo/view/photo/photo-admin/index.phtml:139
 msgid "Delete confirmation"
 msgstr "Delete confirmation"
 
-#: module/Activity/view/activity/admin-category/index.phtml:48
+#: module/Activity/view/activity/admin-category/index.phtml:56
 msgid "Are you sure you want to delete this activity category?"
 msgstr "Are you sure you want to delete this activity category?"
 
-#: module/Activity/view/activity/admin-category/index.phtml:54
+#: module/Activity/view/activity/admin-category/index.phtml:62
 msgid "Delete Activity Category"
 msgstr "Delete Activity Category"
 
-#: module/Activity/view/activity/admin-option/add.phtml:3
-#: module/Activity/view/activity/admin-option/index.phtml:5
-#: module/Application/view/partial/admin.phtml:45
+#: module/Activity/view/activity/admin-option/add.phtml:16
+#: module/Activity/view/activity/admin-option/index.phtml:13
+#: module/Application/view/partial/admin.phtml:62
 msgid "Option Calendar"
 msgstr "Option Calendar"
 
-#: module/Activity/view/activity/admin-option/add.phtml:12
-#: module/Activity/view/activity/admin-option/index.phtml:15
-#: module/Activity/view/activity/admin-option/index.phtml:57
+#: module/Activity/view/activity/admin-option/add.phtml:25
+#: module/Activity/view/activity/admin-option/index.phtml:23
+#: module/Activity/view/activity/admin-option/index.phtml:65
 msgid "Planning Period"
 msgstr "Planning Period"
 
-#: module/Activity/view/activity/admin-option/add.phtml:13
+#: module/Activity/view/activity/admin-option/add.phtml:26
 msgid "Enter the start and end date and time of the planning period."
 msgstr "Enter the start and end date and time of the planning period."
 
-#: module/Activity/view/activity/admin-option/add.phtml:52
-#: module/Activity/view/activity/admin-option/index.phtml:16
-#: module/Activity/view/activity/admin-option/index.phtml:58
+#: module/Activity/view/activity/admin-option/add.phtml:65
+#: module/Activity/view/activity/admin-option/index.phtml:24
+#: module/Activity/view/activity/admin-option/index.phtml:66
 msgid "Option Period"
 msgstr "Option Period"
 
-#: module/Activity/view/activity/admin-option/add.phtml:53
+#: module/Activity/view/activity/admin-option/add.phtml:66
 msgid "Enter the start and end date and time of the option period."
 msgstr "Enter the start and end date and time of the option period."
 
-#: module/Activity/view/activity/admin-option/add.phtml:92
+#: module/Activity/view/activity/admin-option/add.phtml:105
 msgid "Max Activities"
 msgstr "Max Activities"
 
-#: module/Activity/view/activity/admin-option/add.phtml:93
+#: module/Activity/view/activity/admin-option/add.phtml:106
 msgid ""
 "Enter the maximum number of activities for which options can be created. You "
 "can either set the number globally or individually for each organ."
@@ -1327,67 +1327,67 @@ msgstr ""
 "Enter the maximum number of activities for which options can be created. You "
 "can either set the number globally or individually for each organ."
 
-#: module/Activity/view/activity/admin-option/add.phtml:100
+#: module/Activity/view/activity/admin-option/add.phtml:113
 msgid "Global Value"
 msgstr "Global Value"
 
-#: module/Activity/view/activity/admin-option/index.phtml:6
-#: module/Activity/view/activity/admin/view.phtml:4
-#: module/Application/view/partial/admin.phtml:36
+#: module/Activity/view/activity/admin-option/index.phtml:14
+#: module/Activity/view/activity/admin/view.phtml:20
+#: module/Application/view/partial/admin.phtml:43
 msgid "Overview"
 msgstr "Overview"
 
-#: module/Activity/view/activity/admin-option/index.phtml:10
+#: module/Activity/view/activity/admin-option/index.phtml:18
 msgid "Active Option Planning Periods"
 msgstr "Active Option Planning Periods"
 
-#: module/Activity/view/activity/admin-option/index.phtml:17
-#: module/Activity/view/activity/admin-option/index.phtml:59
-#: module/Company/view/company/admin-approval/index.phtml:15
-#: module/Company/view/company/admin-approval/index.phtml:43
-#: module/Company/view/company/admin/edit-company.phtml:104
-#: module/Company/view/company/admin/edit-package.phtml:72
-#: module/Company/view/company/admin/index.phtml:163
-#: module/Company/view/company/admin/index.phtml:204
-#: module/Company/view/company/company-account/jobs.phtml:47
-#: module/Company/view/company/company-account/jobs.phtml:180
-#: module/Education/view/education/admin/course-documents.phtml:64
-#: module/Education/view/education/admin/course-documents.phtml:115
-#: module/Education/view/education/admin/course.phtml:35
+#: module/Activity/view/activity/admin-option/index.phtml:25
+#: module/Activity/view/activity/admin-option/index.phtml:67
+#: module/Company/view/company/admin-approval/index.phtml:31
+#: module/Company/view/company/admin-approval/index.phtml:59
+#: module/Company/view/company/admin/edit-company.phtml:116
+#: module/Company/view/company/admin/edit-package.phtml:86
+#: module/Company/view/company/admin/index.phtml:177
+#: module/Company/view/company/admin/index.phtml:218
+#: module/Company/view/company/company-account/jobs.phtml:66
+#: module/Company/view/company/company-account/jobs.phtml:199
+#: module/Education/view/education/admin/course-documents.phtml:74
+#: module/Education/view/education/admin/course-documents.phtml:125
+#: module/Education/view/education/admin/course.phtml:47
 msgid "Actions"
 msgstr "Actions"
 
-#: module/Activity/view/activity/admin-option/index.phtml:48
+#: module/Activity/view/activity/admin-option/index.phtml:56
 msgid "There is currently no option creation period planned."
 msgstr "There is currently no option creation period planned."
 
-#: module/Activity/view/activity/admin-option/index.phtml:52
+#: module/Activity/view/activity/admin-option/index.phtml:60
 msgid "Planned Option Planning Periods"
 msgstr "Planned Option Planning Periods"
 
-#: module/Activity/view/activity/admin-option/index.phtml:86
-#: module/Activity/view/activity/admin/list.phtml:55
-#: module/Company/view/company/admin/edit-company.phtml:145
-#: module/Company/view/company/admin/edit-package.phtml:108
-#: module/Company/view/company/company-account/jobs.phtml:226
-#: module/Decision/view/decision/organ-admin/edit.phtml:37
-#: module/Education/view/education/admin/course-documents.phtml:24
-#: module/Education/view/education/admin/course.phtml:53
-#: module/Education/view/education/admin/edit-course.phtml:10
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:26
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:26
+#: module/Activity/view/activity/admin-option/index.phtml:94
+#: module/Activity/view/activity/admin/list.phtml:63
+#: module/Company/view/company/admin/edit-company.phtml:157
+#: module/Company/view/company/admin/edit-package.phtml:122
+#: module/Company/view/company/company-account/jobs.phtml:245
+#: module/Decision/view/decision/organ-admin/edit.phtml:49
+#: module/Education/view/education/admin/course-documents.phtml:34
+#: module/Education/view/education/admin/course.phtml:65
+#: module/Education/view/education/admin/edit-course.phtml:24
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:40
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:38
 msgid "Edit"
 msgstr "Edit"
 
-#: module/Activity/view/activity/admin-option/index.phtml:98
+#: module/Activity/view/activity/admin-option/index.phtml:106
 msgid "There are no planned option creation periods in the future."
 msgstr "There are no planned option creation periods in the future."
 
-#: module/Activity/view/activity/admin-option/index.phtml:117
+#: module/Activity/view/activity/admin-option/index.phtml:125
 msgid "Delete period"
 msgstr "Delete period"
 
-#: module/Activity/view/activity/admin-option/index.phtml:121
+#: module/Activity/view/activity/admin-option/index.phtml:129
 msgid ""
 "Are you sure you want to delete this option planning period? This will "
 "<strong>not</strong> delete proposed options."
@@ -1395,71 +1395,71 @@ msgstr ""
 "Are you sure you want to delete this option planning period? This will "
 "<strong>not</strong> delete proposed options."
 
-#: module/Activity/view/activity/admin/list.phtml:13
-#: module/Activity/view/activity/admin/view.phtml:53
+#: module/Activity/view/activity/admin/list.phtml:21
+#: module/Activity/view/activity/admin/view.phtml:70
 msgid "Dutch name"
 msgstr "Dutch name"
 
-#: module/Activity/view/activity/admin/list.phtml:14
-#: module/Activity/view/activity/admin/view.phtml:54
+#: module/Activity/view/activity/admin/list.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:71
 msgid "English name"
 msgstr "English name"
 
-#: module/Activity/view/activity/admin/list.phtml:15
-#: module/Activity/view/activity/admin/view.phtml:55
-#: module/Company/view/company/admin/edit-company.phtml:95
-#: module/Company/view/company/company-account/jobs.phtml:38
+#: module/Activity/view/activity/admin/list.phtml:23
+#: module/Activity/view/activity/admin/view.phtml:72
+#: module/Company/view/company/admin/edit-company.phtml:107
+#: module/Company/view/company/company-account/jobs.phtml:57
 #: module/Photo/src/Form/EditAlbum.php:37
 msgid "Start date"
 msgstr "Start date"
 
-#: module/Activity/view/activity/admin/list.phtml:16
-#: module/Activity/view/activity/admin/view.phtml:56
+#: module/Activity/view/activity/admin/list.phtml:24
+#: module/Activity/view/activity/admin/view.phtml:73
 msgid "Organ"
 msgstr "Organ"
 
-#: module/Activity/view/activity/admin/list.phtml:18
-#: module/Activity/view/activity/admin/view.phtml:58
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:27
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:100
+#: module/Activity/view/activity/admin/list.phtml:26
+#: module/Activity/view/activity/admin/view.phtml:75
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:42
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:115
 msgid "Submitter"
 msgstr "Submitter"
 
-#: module/Activity/view/activity/admin/list.phtml:19
+#: module/Activity/view/activity/admin/list.phtml:27
 msgid "Update status"
 msgstr "Update status"
 
-#: module/Activity/view/activity/admin/list.phtml:21
-#: module/Company/view/company/admin/edit-package.phtml:71
+#: module/Activity/view/activity/admin/list.phtml:29
+#: module/Company/view/company/admin/edit-package.phtml:85
 msgid "Approved"
 msgstr "Approved"
 
-#: module/Activity/view/activity/admin/list.phtml:37
-#: module/Activity/view/activity/admin/list.phtml:38
-#: module/Activity/view/activity/admin/view.phtml:76
-#: module/Activity/view/activity/admin/view.phtml:77
-#: module/Education/view/education/education/index.phtml:86
+#: module/Activity/view/activity/admin/list.phtml:45
+#: module/Activity/view/activity/admin/list.phtml:46
+#: module/Activity/view/activity/admin/view.phtml:91
+#: module/Activity/view/activity/admin/view.phtml:92
+#: module/Education/view/education/education/index.phtml:112
 msgid "None"
 msgstr "None"
 
-#: module/Activity/view/activity/admin/list.phtml:42
-#: module/Activity/view/activity/admin/list.phtml:44
+#: module/Activity/view/activity/admin/list.phtml:50
+#: module/Activity/view/activity/admin/list.phtml:52
 msgid "Update pending"
 msgstr "Update pending"
 
-#: module/Activity/view/activity/admin/list.phtml:63
-#: module/Activity/view/activity/admin/participants.phtml:4
-#: module/Activity/view/activity/admin/participants.phtml:14
-#: module/Activity/view/activity/admin/participants.phtml:46
-#: module/Activity/view/activity/admin/view.phtml:82
+#: module/Activity/view/activity/admin/list.phtml:71
+#: module/Activity/view/activity/admin/participants.phtml:19
+#: module/Activity/view/activity/admin/participants.phtml:29
+#: module/Activity/view/activity/admin/participants.phtml:61
+#: module/Activity/view/activity/admin/view.phtml:97
 msgid "Participants"
 msgstr "Participants"
 
-#: module/Activity/view/activity/admin/participants.phtml:26
+#: module/Activity/view/activity/admin/participants.phtml:41
 msgid "General"
 msgstr "General"
 
-#: module/Activity/view/activity/admin/participants.phtml:40
+#: module/Activity/view/activity/admin/participants.phtml:55
 msgid ""
 "Here you can find everyone who signed up for this activity (may contain "
 "duplicates). Using the tabs above you can navigate to the different sign-up "
@@ -1471,7 +1471,7 @@ msgstr ""
 "lists of this activity. From there you can remove external participants and "
 "(when supplied) view additional signup information from each participant."
 
-#: module/Activity/view/activity/admin/participants.phtml:42
+#: module/Activity/view/activity/admin/participants.phtml:57
 msgid ""
 "Here you can find everyone who signed up to this sign-up list. Here you can "
 "add or remove external participants and view detailed information regarding "
@@ -1481,142 +1481,142 @@ msgstr ""
 "add or remove external participants and view detailed information regarding "
 "the signup of all participants."
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:12
-#: module/Decision/src/Form/OrganInformation.php:34
-#: module/Decision/view/decision/member/self.phtml:39
-#: module/Decision/view/decision/member/view.phtml:34
-#: module/Frontpage/view/frontpage/organ/organ.phtml:83
+#: module/Activity/view/activity/admin/participantsTable.phtml:21
+#: module/Decision/src/Form/OrganInformation.php:32
+#: module/Decision/view/decision/member/self.phtml:49
+#: module/Decision/view/decision/member/view.phtml:33
+#: module/Frontpage/view/frontpage/organ/organ.phtml:99
 msgid "Email"
 msgstr "Email"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:14
-#: module/Decision/view/decision/member/self.phtml:54
-#: module/Decision/view/decision/member/view.phtml:50
+#: module/Activity/view/activity/admin/participantsTable.phtml:23
+#: module/Decision/view/decision/member/self.phtml:64
+#: module/Decision/view/decision/member/view.phtml:49
 msgid "Generation"
 msgstr "Generation"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:19
+#: module/Activity/view/activity/admin/participantsTable.phtml:28
 msgid "Sign-up List"
 msgstr "Sign-up List"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:61
-#: module/Decision/view/decision/member/self.phtml:45
-#: module/Decision/view/decision/member/view.phtml:40
-#: module/Photo/view/partial/metadata.phtml:8
-#: module/Photo/view/partial/metadata.phtml:15
-#: module/Photo/view/partial/metadata.phtml:36
-#: module/Photo/view/partial/metadata.phtml:43
-#: module/Photo/view/partial/metadata.phtml:50
-#: module/Photo/view/partial/metadata.phtml:57
-#: module/Photo/view/partial/metadata.phtml:64
-#: module/Photo/view/partial/metadata.phtml:73
+#: module/Activity/view/activity/admin/participantsTable.phtml:70
+#: module/Decision/view/decision/member/self.phtml:55
+#: module/Decision/view/decision/member/view.phtml:39
+#: module/Photo/view/partial/metadata.phtml:21
+#: module/Photo/view/partial/metadata.phtml:28
+#: module/Photo/view/partial/metadata.phtml:49
+#: module/Photo/view/partial/metadata.phtml:56
+#: module/Photo/view/partial/metadata.phtml:63
+#: module/Photo/view/partial/metadata.phtml:70
+#: module/Photo/view/partial/metadata.phtml:77
+#: module/Photo/view/partial/metadata.phtml:86
 msgid "Unknown"
 msgstr "Unknown"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:67
+#: module/Activity/view/activity/admin/participantsTable.phtml:76
 #, php-format
 msgid "User (%s)"
 msgstr "User (%s)"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:74
-#: module/Decision/src/Model/Enums/MembershipTypes.php:21
+#: module/Activity/view/activity/admin/participantsTable.phtml:83
+#: module/Decision/src/Model/Enums/MembershipTypes.php:23
 msgid "External"
 msgstr "External"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:87
-#: module/Education/view/education/admin/course-documents.phtml:123
+#: module/Activity/view/activity/admin/participantsTable.phtml:96
+#: module/Education/view/education/admin/course-documents.phtml:133
 msgid "N/A"
 msgstr "N/A"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:107
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:49
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:52
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:60
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:63
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:71
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:74
+#: module/Activity/view/activity/admin/participantsTable.phtml:116
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
 #: module/Application/language/additional-strings:20
-#: module/Company/view/company/admin/edit-company.phtml:114
-#: module/Company/view/company/admin/edit-package.phtml:78
-#: module/Company/view/company/admin/index.phtml:183
-#: module/Company/view/company/admin/index.phtml:184
-#: module/Company/view/company/company-account/jobs.phtml:195
-#: module/Company/view/company/company-account/jobs.phtml:203
-#: module/Decision/view/decision/member/view.phtml:60
-#: module/Photo/view/partial/metadata.phtml:29
+#: module/Company/view/company/admin/edit-company.phtml:126
+#: module/Company/view/company/admin/edit-package.phtml:92
+#: module/Company/view/company/admin/index.phtml:197
+#: module/Company/view/company/admin/index.phtml:198
+#: module/Company/view/company/company-account/jobs.phtml:214
+#: module/Company/view/company/company-account/jobs.phtml:222
+#: module/Decision/view/decision/member/view.phtml:59
+#: module/Photo/view/partial/metadata.phtml:42
 msgid "Yes"
 msgstr "Yes"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:109
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:49
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:52
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:60
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:63
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:71
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:74
+#: module/Activity/view/activity/admin/participantsTable.phtml:118
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
 #: module/Application/language/additional-strings:21
-#: module/Company/view/company/admin/edit-company.phtml:114
-#: module/Company/view/company/admin/edit-package.phtml:78
-#: module/Company/view/company/admin/index.phtml:183
-#: module/Company/view/company/admin/index.phtml:184
-#: module/Company/view/company/company-account/jobs.phtml:195
-#: module/Decision/view/decision/member/view.phtml:60
-#: module/Photo/view/partial/metadata.phtml:29
+#: module/Company/view/company/admin/edit-company.phtml:126
+#: module/Company/view/company/admin/edit-package.phtml:92
+#: module/Company/view/company/admin/index.phtml:197
+#: module/Company/view/company/admin/index.phtml:198
+#: module/Company/view/company/company-account/jobs.phtml:214
+#: module/Decision/view/decision/member/view.phtml:59
+#: module/Photo/view/partial/metadata.phtml:42
 msgid "No"
 msgstr "No"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:132
+#: module/Activity/view/activity/admin/participantsTable.phtml:141
 msgid "Additional actions"
 msgstr "Additional actions"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:136
+#: module/Activity/view/activity/admin/participantsTable.phtml:145
 msgid "Mail everybody"
 msgstr "Mail everybody"
 
-#: module/Activity/view/activity/admin/view.phtml:8
+#: module/Activity/view/activity/admin/view.phtml:24
 msgid "Unapproved Activities"
 msgstr "Unapproved Activities"
 
-#: module/Activity/view/activity/admin/view.phtml:15
+#: module/Activity/view/activity/admin/view.phtml:31
 msgid "Approved Activities"
 msgstr "Approved Activities"
 
-#: module/Activity/view/activity/admin/view.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:38
 msgid "Disapproved Activities"
 msgstr "Disapproved Activities"
 
-#: module/Activity/view/activity/admin/view.phtml:30
+#: module/Activity/view/activity/admin/view.phtml:46
 msgid "Upcoming Activities"
 msgstr "Upcoming Activities"
 
-#: module/Activity/view/activity/admin/view.phtml:37
+#: module/Activity/view/activity/admin/view.phtml:53
 msgid "Old activities"
 msgstr "Old activities"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:24
-#: module/Activity/view/partial/signuplist.phtml:12
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:37
+#: module/Activity/view/partial/signuplist.phtml:25
 msgid "Open date and time"
 msgstr "Open date and time"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:35
-#: module/Activity/view/partial/signuplist.phtml:26
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:48
+#: module/Activity/view/partial/signuplist.phtml:39
 msgid "Close date and time"
 msgstr "Close date and time"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:46
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:59
 msgid "GEWIS members only"
 msgstr "GEWIS members only"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:57
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:70
 msgid "Display GEWIS member count"
 msgstr "Display GEWIS member count"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:68
-#: module/Activity/view/partial/signuplist.phtml:107
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:81
+#: module/Activity/view/partial/signuplist.phtml:120
 msgid "Has limited capacity"
 msgstr "Has limited capacity"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:80
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:93
 msgid ""
 "This sign-up list contains additional fields which require input from "
 "subscribers, they are shown below."
@@ -1624,7 +1624,7 @@ msgstr ""
 "This sign-up list contains additional fields which require input from "
 "subscribers, they are shown below."
 
-#: module/Activity/view/partial/create.phtml:4
+#: module/Activity/view/partial/create.phtml:17
 msgid ""
 "What is this activity about? Fill in the blanks below, please note that at "
 "least one language must be used."
@@ -1632,15 +1632,15 @@ msgstr ""
 "What is this activity about? Fill in the blanks below, please note that at "
 "least one language must be used."
 
-#: module/Activity/view/partial/create.phtml:158
+#: module/Activity/view/partial/create.phtml:171
 msgid "Choose which options are applicable to this activity."
 msgstr "Choose which options are applicable to this activity."
 
-#: module/Activity/view/partial/create.phtml:168
+#: module/Activity/view/partial/create.phtml:181
 msgid "This is a career related activity"
 msgstr "This is a career related activity"
 
-#: module/Activity/view/partial/create.phtml:170
+#: module/Activity/view/partial/create.phtml:183
 msgid ""
 "If this is checked the My Future logo will be displayed on the activity page "
 "and the activity will be included on the career activities page."
@@ -1648,11 +1648,11 @@ msgstr ""
 "If this is checked the My Future logo will be displayed on the activity page "
 "and the activity will be included on the career activities page."
 
-#: module/Activity/view/partial/create.phtml:182
+#: module/Activity/view/partial/create.phtml:195
 msgid "This activity needs a GEFLITST member to take photos"
 msgstr "This activity needs a GEFLITST member to take photos"
 
-#: module/Activity/view/partial/create.phtml:184
+#: module/Activity/view/partial/create.phtml:197
 msgid ""
 "When this is checked, GEFLITST will be notified that this activity needs a "
 "photographer."
@@ -1660,29 +1660,29 @@ msgstr ""
 "When this is checked, GEFLITST will be notified that this activity needs a "
 "photographer."
 
-#: module/Activity/view/partial/option.phtml:24
+#: module/Activity/view/partial/option.phtml:33
 msgid "From"
 msgstr "From"
 
-#: module/Activity/view/partial/option.phtml:38
+#: module/Activity/view/partial/option.phtml:47
 msgid "Until"
 msgstr "Until"
 
-#: module/Activity/view/partial/signupForm.phtml:7
-#: module/Activity/view/partial/signupForm.phtml:12
+#: module/Activity/view/partial/signupForm.phtml:21
+#: module/Activity/view/partial/signupForm.phtml:26
 msgid "By subscribing to this activity, you agree to the terms outlined in the"
 msgstr ""
 "By subscribing to this activity, you agree to the terms outlined in the"
 
-#: module/Activity/view/partial/signupForm.phtml:9
+#: module/Activity/view/partial/signupForm.phtml:23
 msgid "Confirm subscription"
 msgstr "Confirm subscription"
 
-#: module/Activity/view/partial/signupForm.phtml:14
+#: module/Activity/view/partial/signupForm.phtml:28
 msgid "Subscribe as external participant"
 msgstr "Subscribe as external participant"
 
-#: module/Activity/view/partial/signupForm.phtml:19
+#: module/Activity/view/partial/signupForm.phtml:33
 msgid ""
 "By subscribing an external participant to this activity, they must agree to "
 "the terms outlined in the"
@@ -1690,50 +1690,50 @@ msgstr ""
 "By subscribing an external participant to this activity, they must agree to "
 "the terms outlined in the"
 
-#: module/Activity/view/partial/signupForm.phtml:21
+#: module/Activity/view/partial/signupForm.phtml:35
 msgid "Subscribe an external participant"
 msgstr "Subscribe an external participant"
 
-#: module/Activity/view/partial/signupForm.phtml:53
+#: module/Activity/view/partial/signupForm.phtml:67
 msgid "Full name:"
 msgstr "Full name:"
 
-#: module/Activity/view/partial/signupForm.phtml:54
+#: module/Activity/view/partial/signupForm.phtml:68
 msgid "Email address:"
 msgstr "Email address:"
 
-#: module/Activity/view/partial/signupForm.phtml:58
+#: module/Activity/view/partial/signupForm.phtml:72
 msgid "Please fill in this CAPTCHA:"
 msgstr "Please fill in this CAPTCHA:"
 
-#: module/Activity/view/partial/signupForm.phtml:72
-#: module/Decision/view/decision/member/index.phtml:243
+#: module/Activity/view/partial/signupForm.phtml:86
+#: module/Decision/view/decision/member/index.phtml:254
 msgid "Activity Policy"
 msgstr "Activity Policy"
 
-#: module/Activity/view/partial/signupForm.phtml:74
-#: module/Decision/view/decision/member/index.phtml:248
+#: module/Activity/view/partial/signupForm.phtml:88
+#: module/Decision/view/decision/member/index.phtml:259
 msgid "Alcohol Policy"
 msgstr "Alcohol Policy"
 
-#: module/Activity/view/partial/signuplist-fields.phtml:86
+#: module/Activity/view/partial/signuplist-fields.phtml:95
 msgid "Please note that numbers are not dependant on the selected language(s)."
 msgstr ""
 "Please note that numbers are not dependant on the selected language(s)."
 
-#: module/Activity/view/partial/signuplist.phtml:75
+#: module/Activity/view/partial/signuplist.phtml:88
 msgid "Only allow GEWIS members"
 msgstr "Only allow GEWIS members"
 
-#: module/Activity/view/partial/signuplist.phtml:77
+#: module/Activity/view/partial/signuplist.phtml:90
 msgid "Deselect this to allow people without a GEWIS account to subscribe."
 msgstr "Deselect this to allow people without a GEWIS account to subscribe."
 
-#: module/Activity/view/partial/signuplist.phtml:90
+#: module/Activity/view/partial/signuplist.phtml:103
 msgid "Display number of subscribed members"
 msgstr "Display number of subscribed members"
 
-#: module/Activity/view/partial/signuplist.phtml:92
+#: module/Activity/view/partial/signuplist.phtml:105
 msgid ""
 "Select this to display the number of subscribed GEWIS members to external "
 "visitors."
@@ -1741,7 +1741,7 @@ msgstr ""
 "Select this to display the number of subscribed GEWIS members to external "
 "visitors."
 
-#: module/Activity/view/partial/signuplist.phtml:109
+#: module/Activity/view/partial/signuplist.phtml:122
 msgid ""
 "Select this if this sign-up list has limited capacity or is expected to have "
 "limited capacity. Please ensure that you also write this in the description "
@@ -1751,11 +1751,11 @@ msgstr ""
 "limited capacity. Please ensure that you also write this in the description "
 "of the activity."
 
-#: module/Activity/view/partial/signuplist.phtml:140
+#: module/Activity/view/partial/signuplist.phtml:153
 msgid "Remove the last sign-up list field"
 msgstr "Remove the last sign-up list field"
 
-#: module/Activity/view/partial/signuplist.phtml:145
+#: module/Activity/view/partial/signuplist.phtml:158
 msgid "Add a sign-up list field"
 msgstr "Add a sign-up list field"
 
@@ -1835,342 +1835,342 @@ msgstr "Inkoper"
 msgid "Inactief Lid"
 msgstr "Inactive Member"
 
-#: module/Application/src/Service/FileStorage.php:62
+#: module/Application/src/Service/FileStorage.php:91
 msgid "An unknown error occurred during uploading (%i)"
 msgstr "An unknown error occurred during uploading (%i)"
 
-#: module/Application/src/Service/Infimum.php:62
-#: module/Application/view/partial/footer.phtml:26
-#: module/Application/view/partial/footer.phtml:31
+#: module/Application/src/Service/Infimum.php:66
+#: module/Application/view/partial/footer.phtml:36
+#: module/Application/view/partial/footer.phtml:41
 msgid "Unable to retrieve infimum."
 msgstr "Unable to retrieve infimum."
 
-#: module/Application/view/error/403.phtml:6
+#: module/Application/view/error/403.phtml:17
 msgid "You do not have the required privileges to view this page"
 msgstr "You do not have the required privileges to view this page"
 
-#: module/Application/view/error/403.phtml:9
+#: module/Application/view/error/403.phtml:22
 msgid "You might be able to view this page by logging in"
 msgstr "You might be able to view this page by logging in"
 
-#: module/Application/view/error/403.phtml:15
-#: module/Application/view/partial/admin.phtml:24
-#: module/Application/view/partial/main-nav.phtml:74
-#: module/User/view/user/user/login.phtml:25
+#: module/Application/view/error/403.phtml:28
+#: module/Application/view/partial/admin.phtml:28
+#: module/Application/view/partial/main-nav.phtml:87
+#: module/User/view/user/user/login.phtml:39
 msgid "Login"
 msgstr "Login"
 
-#: module/Application/view/error/404.phtml:3
-#: module/Application/view/error/debug/404.phtml:3
+#: module/Application/view/error/404.phtml:12
+#: module/Application/view/error/debug/404.phtml:12
 msgid "A 404 error occurred"
 msgstr "A 404 error occurred"
 
-#: module/Application/view/error/500.phtml:3
-#: module/Application/view/error/debug/500.phtml:3
+#: module/Application/view/error/500.phtml:12
+#: module/Application/view/error/debug/500.phtml:13
 msgid "An error occurred"
 msgstr "An error occurred"
 
-#: module/Application/view/error/500.phtml:4
+#: module/Application/view/error/500.phtml:13
 msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
 msgstr "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
 
-#: module/Application/view/error/debug/403.phtml:3
+#: module/Application/view/error/debug/403.phtml:12
 msgid "403 Forbidden"
 msgstr "403 Forbidden"
 
-#: module/Application/view/error/debug/404.phtml:12
+#: module/Application/view/error/debug/404.phtml:22
 msgid "The requested controller was unable to dispatch the request."
 msgstr "The requested controller was unable to dispatch the request."
 
-#: module/Application/view/error/debug/404.phtml:15
+#: module/Application/view/error/debug/404.phtml:26
 msgid ""
 "The requested controller could not be mapped to an existing controller class."
 msgstr ""
 "The requested controller could not be mapped to an existing controller class."
 
-#: module/Application/view/error/debug/404.phtml:18
+#: module/Application/view/error/debug/404.phtml:30
 msgid "The requested controller was not dispatchable."
 msgstr "The requested controller was not dispatchable."
 
-#: module/Application/view/error/debug/404.phtml:21
+#: module/Application/view/error/debug/404.phtml:33
 msgid "The requested URL could not be matched by routing."
 msgstr "The requested URL could not be matched by routing."
 
-#: module/Application/view/error/debug/404.phtml:24
+#: module/Application/view/error/debug/404.phtml:36
 msgid "We cannot determine at this time why a 404 was generated."
 msgstr "We cannot determine at this time why a 404 was generated."
 
-#: module/Application/view/error/debug/404.phtml:36
+#: module/Application/view/error/debug/404.phtml:50
 msgid "Controller"
 msgstr "Controller"
 
-#: module/Application/view/error/debug/404.phtml:43
+#: module/Application/view/error/debug/404.phtml:58
 #, php-format
 msgid "resolves to %s"
 msgstr "resolves to %s"
 
-#: module/Application/view/error/debug/404.phtml:55
-#: module/Application/view/error/debug/500.phtml:10
+#: module/Application/view/error/debug/404.phtml:75
+#: module/Application/view/error/debug/500.phtml:24
 msgid "Additional information"
 msgstr "Additional information"
 
-#: module/Application/view/error/debug/404.phtml:58
-#: module/Application/view/error/debug/404.phtml:83
-#: module/Application/view/error/debug/500.phtml:13
-#: module/Application/view/error/debug/500.phtml:40
+#: module/Application/view/error/debug/404.phtml:78
+#: module/Application/view/error/debug/404.phtml:104
+#: module/Application/view/error/debug/500.phtml:29
+#: module/Application/view/error/debug/500.phtml:69
 msgid "File"
 msgstr "File"
 
-#: module/Application/view/error/debug/404.phtml:63
-#: module/Application/view/error/debug/404.phtml:88
-#: module/Application/view/error/debug/500.phtml:18
-#: module/Application/view/error/debug/500.phtml:45
+#: module/Application/view/error/debug/404.phtml:83
+#: module/Application/view/error/debug/404.phtml:109
+#: module/Application/view/error/debug/500.phtml:38
+#: module/Application/view/error/debug/500.phtml:78
 msgid "Message"
 msgstr "Message"
 
-#: module/Application/view/error/debug/404.phtml:67
-#: module/Application/view/error/debug/404.phtml:92
-#: module/Application/view/error/debug/500.phtml:23
-#: module/Application/view/error/debug/500.phtml:50
+#: module/Application/view/error/debug/404.phtml:87
+#: module/Application/view/error/debug/404.phtml:113
+#: module/Application/view/error/debug/500.phtml:46
+#: module/Application/view/error/debug/500.phtml:86
 msgid "Stack trace"
 msgstr "Stack trace"
 
-#: module/Application/view/error/debug/404.phtml:77
-#: module/Application/view/error/debug/500.phtml:34
+#: module/Application/view/error/debug/404.phtml:97
+#: module/Application/view/error/debug/500.phtml:60
 msgid "Previous exceptions"
 msgstr "Previous exceptions"
 
-#: module/Application/view/error/debug/404.phtml:107
-#: module/Application/view/error/debug/500.phtml:66
+#: module/Application/view/error/debug/404.phtml:130
+#: module/Application/view/error/debug/500.phtml:107
 msgid "No Exception available"
 msgstr "No Exception available"
 
-#: module/Application/view/layout/layout.phtml:6
+#: module/Application/view/layout/layout.phtml:15
 msgid "Study Association GEWIS"
 msgstr "Study Association GEWIS"
 
-#: module/Application/view/partial/admin.phtml:40
-#: module/Application/view/partial/admin.phtml:80
-#: module/Company/view/company/admin/categories.phtml:10
-#: module/Company/view/company/admin/categories.phtml:30
+#: module/Application/view/partial/admin.phtml:50
+#: module/Application/view/partial/admin.phtml:105
+#: module/Company/view/company/admin/categories.phtml:23
+#: module/Company/view/company/admin/categories.phtml:43
 msgid "Categories"
 msgstr "Categories"
 
-#: module/Application/view/partial/admin.phtml:55
-#: module/Application/view/partial/main-nav.phtml:305
-#: module/Application/view/partial/main-nav.phtml:309
-#: module/Application/view/partial/main-nav.phtml:314
-#: module/Company/view/company/admin-approval/index.phtml:3
-#: module/Company/view/company/admin-approval/job-approval.phtml:10
-#: module/Company/view/company/admin-approval/job-proposal.phtml:16
-#: module/Company/view/company/admin/edit-company.phtml:7
-#: module/Company/view/company/admin/index.phtml:6
+#: module/Application/view/partial/admin.phtml:76
+#: module/Application/view/partial/main-nav.phtml:326
+#: module/Application/view/partial/main-nav.phtml:330
+#: module/Application/view/partial/main-nav.phtml:335
+#: module/Company/view/company/admin-approval/index.phtml:19
+#: module/Company/view/company/admin-approval/job-approval.phtml:24
+#: module/Company/view/company/admin-approval/job-proposal.phtml:26
+#: module/Company/view/company/admin/edit-company.phtml:19
+#: module/Company/view/company/admin/index.phtml:20
 msgid "Career"
 msgstr "Career"
 
-#: module/Application/view/partial/admin.phtml:61
-#: module/Company/view/company/admin/index.phtml:7
-#: module/Company/view/company/company/job-list.phtml:22
-#: module/Company/view/company/company/jobs.phtml:22
-#: module/Company/view/company/company/list.phtml:4
-#: module/Company/view/company/company/show.phtml:5
-#: module/Company/view/company/company/show.phtml:12
-#: module/Company/view/company/company/spotlight.phtml:17
+#: module/Application/view/partial/admin.phtml:83
+#: module/Company/view/company/admin/index.phtml:21
+#: module/Company/view/company/company/job-list.phtml:36
+#: module/Company/view/company/company/jobs.phtml:34
+#: module/Company/view/company/company/list.phtml:21
+#: module/Company/view/company/company/show.phtml:17
+#: module/Company/view/company/company/show.phtml:24
+#: module/Company/view/company/company/spotlight.phtml:33
 msgid "Companies"
 msgstr "Companies"
 
-#: module/Application/view/partial/admin.phtml:73
-#: module/Company/view/company/admin-approval/index.phtml:4
-#: module/Company/view/company/admin-approval/job-approval.phtml:11
+#: module/Application/view/partial/admin.phtml:96
+#: module/Company/view/company/admin-approval/index.phtml:20
+#: module/Company/view/company/admin-approval/job-approval.phtml:25
 msgid "Approvals"
 msgstr "Approvals"
 
-#: module/Application/view/partial/admin.phtml:87
-#: module/Company/src/Form/Job.php:237
-#: module/Company/view/company/admin-approval/job-approval.phtml:210
-#: module/Company/view/company/admin/labels.phtml:10
-#: module/Company/view/company/admin/labels.phtml:29
+#: module/Application/view/partial/admin.phtml:114
+#: module/Company/src/Form/Job.php:241
+#: module/Company/view/company/admin-approval/job-approval.phtml:224
+#: module/Company/view/company/admin/labels.phtml:23
+#: module/Company/view/company/admin/labels.phtml:42
 msgid "Labels"
 msgstr "Labels"
 
-#: module/Application/view/partial/admin.phtml:98
-#: module/Application/view/partial/main-nav.phtml:344
-#: module/Education/view/education/admin/add-course.phtml:3
-#: module/Education/view/education/admin/bulk-exam.phtml:11
-#: module/Education/view/education/admin/bulk-summary.phtml:11
-#: module/Education/view/education/admin/course-documents.phtml:17
-#: module/Education/view/education/admin/course.phtml:5
-#: module/Education/view/education/admin/edit-course.phtml:3
-#: module/Education/view/education/admin/edit-exam.phtml:18
-#: module/Education/view/education/admin/edit-summary.phtml:18
-#: module/Education/view/education/admin/index.phtml:3
-#: module/Education/view/education/education/course.phtml:11
-#: module/Education/view/education/education/index.phtml:2
-#: module/Education/view/education/education/index.phtml:17
+#: module/Application/view/partial/admin.phtml:128
+#: module/Application/view/partial/main-nav.phtml:368
+#: module/Education/view/education/admin/add-course.phtml:15
+#: module/Education/view/education/admin/bulk-exam.phtml:19
+#: module/Education/view/education/admin/bulk-summary.phtml:19
+#: module/Education/view/education/admin/course-documents.phtml:27
+#: module/Education/view/education/admin/course.phtml:17
+#: module/Education/view/education/admin/edit-course.phtml:17
+#: module/Education/view/education/admin/edit-exam.phtml:31
+#: module/Education/view/education/admin/edit-summary.phtml:31
+#: module/Education/view/education/admin/index.phtml:11
+#: module/Education/view/education/education/course.phtml:21
+#: module/Education/view/education/education/index.phtml:16
+#: module/Education/view/education/education/index.phtml:31
 msgid "Education"
 msgstr "Education"
 
-#: module/Application/view/partial/admin.phtml:103
-#: module/Education/view/education/admin/add-course.phtml:4
-#: module/Education/view/education/admin/course-documents.phtml:18
-#: module/Education/view/education/admin/course.phtml:6
-#: module/Education/view/education/admin/edit-course.phtml:4
+#: module/Application/view/partial/admin.phtml:133
+#: module/Education/view/education/admin/add-course.phtml:16
+#: module/Education/view/education/admin/course-documents.phtml:28
+#: module/Education/view/education/admin/course.phtml:18
+#: module/Education/view/education/admin/edit-course.phtml:18
 msgid "Courses"
 msgstr "Courses"
 
-#: module/Application/view/partial/admin.phtml:108
-#: module/Education/view/education/admin/bulk-exam.phtml:16
+#: module/Application/view/partial/admin.phtml:138
+#: module/Education/view/education/admin/bulk-exam.phtml:24
 msgid "Upload exams"
 msgstr "Upload exams"
 
-#: module/Application/view/partial/admin.phtml:113
-#: module/Education/view/education/admin/bulk-summary.phtml:16
+#: module/Application/view/partial/admin.phtml:143
+#: module/Education/view/education/admin/bulk-summary.phtml:24
 msgid "Upload summaries"
 msgstr "Upload summaries"
 
-#: module/Application/view/partial/admin.phtml:123
-#: module/Decision/view/decision/admin/authorizations.phtml:3
-#: module/Decision/view/decision/admin/document.phtml:14
-#: module/Decision/view/decision/admin/minutes.phtml:3
-#: module/Decision/view/decision/decision/index.phtml:3
-#: module/Decision/view/decision/member/index.phtml:89
+#: module/Application/view/partial/admin.phtml:155
+#: module/Decision/view/decision/admin/authorizations.phtml:14
+#: module/Decision/view/decision/admin/document.phtml:29
+#: module/Decision/view/decision/admin/minutes.phtml:15
+#: module/Decision/view/decision/decision/index.phtml:17
+#: module/Decision/view/decision/member/index.phtml:100
 msgid "Meetings"
 msgstr "Meetings"
 
-#: module/Application/view/partial/admin.phtml:127
-#: module/Decision/view/decision/admin/minutes.phtml:4
-#: module/Decision/view/decision/decision/view.phtml:41
+#: module/Application/view/partial/admin.phtml:160
+#: module/Decision/view/decision/admin/minutes.phtml:16
+#: module/Decision/view/decision/decision/view.phtml:53
 msgid "Minutes"
 msgstr "Minutes"
 
-#: module/Application/view/partial/admin.phtml:130
-#: module/Decision/view/decision/admin/document.phtml:15
-#: module/Decision/view/decision/decision/view.phtml:19
-#: module/Education/view/education/admin/course.phtml:48
+#: module/Application/view/partial/admin.phtml:165
+#: module/Decision/view/decision/admin/document.phtml:30
+#: module/Decision/view/decision/decision/view.phtml:31
+#: module/Education/view/education/admin/course.phtml:60
 msgid "Documents"
 msgstr "Documents"
 
-#: module/Application/view/partial/admin.phtml:133
-#: module/Decision/view/decision/admin/authorizations.phtml:4
-#: module/Decision/view/decision/decision/authorizations.phtml:3
-#: module/Decision/view/decision/decision/authorizations.phtml:16
-#: module/Decision/view/decision/member/index.phtml:50
+#: module/Application/view/partial/admin.phtml:170
+#: module/Decision/view/decision/admin/authorizations.phtml:15
+#: module/Decision/view/decision/decision/authorizations.phtml:27
+#: module/Decision/view/decision/decision/authorizations.phtml:34
+#: module/Decision/view/decision/member/index.phtml:61
 msgid "Authorizations"
 msgstr "Authorizations"
 
-#: module/Application/view/partial/admin.phtml:141
-#: module/Decision/view/decision/member/index.phtml:62
-#: module/Decision/view/decision/organ-admin/edit.phtml:36
-#: module/Decision/view/decision/organ-admin/index.phtml:3
+#: module/Application/view/partial/admin.phtml:181
+#: module/Decision/view/decision/member/index.phtml:73
+#: module/Decision/view/decision/organ-admin/edit.phtml:48
+#: module/Decision/view/decision/organ-admin/index.phtml:15
 msgid "Organs"
 msgstr "Organs"
 
-#: module/Application/view/partial/admin.phtml:147
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:36
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:25
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:3
+#: module/Application/view/partial/admin.phtml:189
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:54
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:39
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:14
 msgid "News"
 msgstr "News"
 
-#: module/Application/view/partial/admin.phtml:152
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:25
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:11
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:13
+#: module/Application/view/partial/admin.phtml:196
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:23
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:25
 msgid "Pages"
 msgstr "Pages"
 
-#: module/Application/view/partial/admin.phtml:157
-#: module/Application/view/partial/main-nav.phtml:401
-#: module/Application/view/partial/main-nav.phtml:405
-#: module/Application/view/partial/main-nav.phtml:409
-#: module/Application/view/partial/main-nav.phtml:416
-#: module/Photo/view/photo/album-admin/add.phtml:21
-#: module/Photo/view/photo/album-admin/create.phtml:3
-#: module/Photo/view/photo/album-admin/edit.phtml:3
-#: module/Photo/view/photo/album-admin/index.phtml:22
-#: module/Photo/view/photo/album/index.phtml:20
-#: module/Photo/view/photo/album/index.phtml:60
-#: module/Photo/view/photo/photo-admin/index.phtml:20
-#: module/Photo/view/photo/photo/index.phtml:3
+#: module/Application/view/partial/admin.phtml:203
+#: module/Application/view/partial/main-nav.phtml:434
+#: module/Application/view/partial/main-nav.phtml:438
+#: module/Application/view/partial/main-nav.phtml:443
+#: module/Application/view/partial/main-nav.phtml:452
+#: module/Photo/view/photo/album-admin/add.phtml:33
+#: module/Photo/view/photo/album-admin/create.phtml:15
+#: module/Photo/view/photo/album-admin/edit.phtml:15
+#: module/Photo/view/photo/album-admin/index.phtml:33
+#: module/Photo/view/photo/album/index.phtml:29
+#: module/Photo/view/photo/album/index.phtml:69
+#: module/Photo/view/photo/photo-admin/index.phtml:38
+#: module/Photo/view/photo/photo/index.phtml:15
 msgid "Photos"
 msgstr "Photos"
 
-#: module/Application/view/partial/admin.phtml:162
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:17
-#: module/Frontpage/view/frontpage/poll/index.phtml:3
-#: module/Frontpage/view/frontpage/poll/index.phtml:11
+#: module/Application/view/partial/admin.phtml:210
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:32
+#: module/Frontpage/view/frontpage/poll/index.phtml:22
+#: module/Frontpage/view/frontpage/poll/index.phtml:30
 msgid "Polls"
 msgstr "Polls"
 
-#: module/Application/view/partial/admin.phtml:169
+#: module/Application/view/partial/admin.phtml:219
 msgid "Users"
 msgstr "Users"
 
-#: module/Application/view/partial/admin.phtml:173
+#: module/Application/view/partial/admin.phtml:224
 msgid "API Users"
 msgstr "API Users"
 
-#: module/Application/view/partial/admin.phtml:192
-#: module/Application/view/partial/main-nav.phtml:143
+#: module/Application/view/partial/admin.phtml:245
+#: module/Application/view/partial/main-nav.phtml:161
 msgid "Admin"
 msgstr "Admin"
 
-#: module/Application/view/partial/company.phtml:23
-#: module/Frontpage/view/frontpage/page/page.phtml:5
+#: module/Application/view/partial/company.phtml:26
+#: module/Frontpage/view/frontpage/page/page.phtml:20
 msgid "Home"
 msgstr "Home"
 
-#: module/Application/view/partial/company.phtml:28
-#: module/Company/src/Form/JobsTransfer.php:29
-#: module/Company/view/company/admin/edit-package.phtml:65
-#: module/Company/view/company/admin/index.phtml:121
-#: module/Company/view/company/admin/index.phtml:199
-#: module/Company/view/company/company-account/jobs.phtml:7
-#: module/Company/view/company/company-account/jobs.phtml:11
-#: module/Company/view/company/company-account/jobs.phtml:14
-#: module/Company/view/company/company-account/jobs.phtml:169
-#: module/Company/view/company/company-account/transfer-jobs.phtml:5
+#: module/Application/view/partial/company.phtml:31
+#: module/Company/src/Form/JobsTransfer.php:27
+#: module/Company/view/company/admin/edit-package.phtml:79
+#: module/Company/view/company/admin/index.phtml:135
+#: module/Company/view/company/admin/index.phtml:213
+#: module/Company/view/company/company-account/jobs.phtml:26
+#: module/Company/view/company/company-account/jobs.phtml:30
+#: module/Company/view/company/company-account/jobs.phtml:33
+#: module/Company/view/company/company-account/jobs.phtml:188
+#: module/Company/view/company/company-account/transfer-jobs.phtml:17
 msgid "Jobs"
 msgstr "Jobs"
 
-#: module/Application/view/partial/company.phtml:33
-#: module/Company/view/company/company-account/highlights.phtml:2
-#: module/Company/view/company/company-account/highlights.phtml:5
+#: module/Application/view/partial/company.phtml:36
+#: module/Company/view/company/company-account/highlights.phtml:10
+#: module/Company/view/company/company-account/highlights.phtml:13
 msgid "Highlights"
 msgstr "Highlights"
 
-#: module/Application/view/partial/company.phtml:38
-#: module/Company/src/Form/Package.php:115
-#: module/Company/view/company/admin/edit-package.phtml:57
-#: module/Company/view/company/company-account/banner.phtml:2
-#: module/Company/view/company/company-account/banner.phtml:5
+#: module/Application/view/partial/company.phtml:41
+#: module/Company/src/Form/Package.php:112
+#: module/Company/view/company/admin/edit-package.phtml:70
+#: module/Company/view/company/company-account/banner.phtml:10
+#: module/Company/view/company/company-account/banner.phtml:13
 msgid "Banner"
 msgstr "Banner"
 
-#: module/Application/view/partial/company.phtml:43
+#: module/Application/view/partial/company.phtml:46
 msgid "Settings"
 msgstr "Settings"
 
-#: module/Application/view/partial/company.phtml:55
-#: module/Application/view/partial/main-nav.phtml:101
+#: module/Application/view/partial/company.phtml:58
+#: module/Application/view/partial/main-nav.phtml:116
 msgid "My Company"
 msgstr "My Company"
 
-#: module/Application/view/partial/footer.phtml:11
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:255
+#: module/Application/view/partial/footer.phtml:21
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:273
 msgid "Infimum"
 msgstr "Infimum"
 
-#: module/Application/view/partial/footer.phtml:12
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:258
+#: module/Application/view/partial/footer.phtml:22
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:276
 msgid "Loading an infimum..."
 msgstr "Loading an infimum..."
 
-#: module/Application/view/partial/footer.phtml:38
+#: module/Application/view/partial/footer.phtml:50
 msgid "All rights reserved."
 msgstr "All rights reserved."
 
-#: module/Application/view/partial/footer.phtml:39
+#: module/Application/view/partial/footer.phtml:52
 msgid ""
 "Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
 "2022)."
@@ -2178,170 +2178,170 @@ msgstr ""
 "Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
 "2022)."
 
-#: module/Application/view/partial/footer.phtml:44
-#: module/Application/view/partial/main-nav.phtml:297
-#: module/Company/view/company/company/companyStory.phtml:21
-#: module/Company/view/company/company/jobs.phtml:93
-#: module/Company/view/partial/company/company/list/company.phtml:31
+#: module/Application/view/partial/footer.phtml:58
+#: module/Application/view/partial/main-nav.phtml:318
+#: module/Company/view/company/company/companyStory.phtml:37
+#: module/Company/view/company/company/jobs.phtml:105
+#: module/Company/view/partial/company/company/list/company.phtml:41
 msgid "Contact"
 msgstr "Contact"
 
-#: module/Application/view/partial/main-nav.phtml:42
+#: module/Application/view/partial/main-nav.phtml:53
 msgid "Language settings"
 msgstr "Language settings"
 
-#: module/Application/view/partial/main-nav.phtml:68
-#: module/Application/view/partial/main-nav.phtml:445
-#: module/Decision/view/decision/member/birthdays.phtml:4
-#: module/Decision/view/decision/member/index.phtml:8
-#: module/Decision/view/decision/member/index.phtml:17
-#: module/Decision/view/decision/member/search.phtml:4
-#: module/Decision/view/decision/member/view.phtml:13
+#: module/Application/view/partial/main-nav.phtml:81
+#: module/Application/view/partial/main-nav.phtml:485
+#: module/Decision/view/decision/member/birthdays.phtml:15
+#: module/Decision/view/decision/member/index.phtml:22
+#: module/Decision/view/decision/member/index.phtml:28
+#: module/Decision/view/decision/member/search.phtml:11
+#: module/Decision/view/decision/member/view.phtml:23
 msgid "Members"
 msgstr "Members"
 
-#: module/Application/view/partial/main-nav.phtml:85
+#: module/Application/view/partial/main-nav.phtml:98
 msgid "Subscribe"
 msgstr "Subscribe"
 
-#: module/Application/view/partial/main-nav.phtml:106
-#: module/Application/view/partial/main-nav.phtml:137
-#: module/Decision/view/decision/member/index.phtml:31
-#: module/User/src/Form/Password.php:61
-#: module/User/view/user/user/change-password.phtml:2
-#: module/User/view/user/user/change-password.phtml:23
+#: module/Application/view/partial/main-nav.phtml:121
+#: module/Application/view/partial/main-nav.phtml:154
+#: module/Decision/view/decision/member/index.phtml:42
+#: module/User/src/Form/Password.php:59
+#: module/User/view/user/user/change-password.phtml:15
+#: module/User/view/user/user/change-password.phtml:36
 msgid "Change password"
 msgstr "Change password"
 
-#: module/Application/view/partial/main-nav.phtml:111
-#: module/Application/view/partial/main-nav.phtml:149
+#: module/Application/view/partial/main-nav.phtml:126
+#: module/Application/view/partial/main-nav.phtml:168
 msgid "Logout"
 msgstr "Logout"
 
-#: module/Application/view/partial/main-nav.phtml:127
+#: module/Application/view/partial/main-nav.phtml:144
 msgid "My information"
 msgstr "My information"
 
-#: module/Application/view/partial/main-nav.phtml:132
-#: module/Decision/view/decision/member/index.phtml:45
+#: module/Application/view/partial/main-nav.phtml:149
+#: module/Decision/view/decision/member/index.phtml:56
 msgid "SudoSOS"
 msgstr "SudoSOS"
 
-#: module/Application/view/partial/main-nav.phtml:157
+#: module/Application/view/partial/main-nav.phtml:177
 msgid "Toggle navigation"
 msgstr "Toggle navigation"
 
-#: module/Application/view/partial/main-nav.phtml:170
-#: module/Application/view/partial/main-nav.phtml:175
-#: module/Application/view/partial/main-nav.phtml:180
-#: module/Decision/view/decision/member/index.phtml:58
+#: module/Application/view/partial/main-nav.phtml:191
+#: module/Application/view/partial/main-nav.phtml:196
+#: module/Application/view/partial/main-nav.phtml:201
+#: module/Decision/view/decision/member/index.phtml:69
 msgid "Association"
 msgstr "Association"
 
-#: module/Application/view/partial/main-nav.phtml:191
-#: module/Decision/view/decision/member/view.phtml:82
+#: module/Application/view/partial/main-nav.phtml:212
+#: module/Decision/view/decision/member/view.phtml:72
 msgid "Board"
 msgstr "Board"
 
-#: module/Application/view/partial/main-nav.phtml:196
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:3
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:9
-#: module/Frontpage/view/frontpage/organ/organ.phtml:48
+#: module/Application/view/partial/main-nav.phtml:217
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:14
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:20
+#: module/Frontpage/view/frontpage/organ/organ.phtml:64
 msgid "Committees"
 msgstr "Committees"
 
-#: module/Application/view/partial/main-nav.phtml:201
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:3
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:7
-#: module/Frontpage/view/frontpage/organ/organ.phtml:44
+#: module/Application/view/partial/main-nav.phtml:222
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:15
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:19
+#: module/Frontpage/view/frontpage/organ/organ.phtml:60
 msgid "Fraternities"
 msgstr "Fraternities"
 
-#: module/Application/view/partial/main-nav.phtml:212
+#: module/Application/view/partial/main-nav.phtml:233
 msgid "Exceptional Members"
 msgstr "Exceptional Members"
 
-#: module/Application/view/partial/main-nav.phtml:223
+#: module/Application/view/partial/main-nav.phtml:244
 msgid "GEWIS song"
 msgstr "GEWIS song"
 
-#: module/Application/view/partial/main-nav.phtml:234
-#: module/Decision/view/decision/member/index.phtml:215
+#: module/Application/view/partial/main-nav.phtml:255
+#: module/Decision/view/decision/member/index.phtml:226
 msgid "Regulations"
 msgstr "Regulations"
 
-#: module/Application/view/partial/main-nav.phtml:241
-#: module/Application/view/partial/main-nav.phtml:246
+#: module/Application/view/partial/main-nav.phtml:262
+#: module/Application/view/partial/main-nav.phtml:267
 msgid "Useful Information"
 msgstr "Useful Information"
 
-#: module/Application/view/partial/main-nav.phtml:252
-#: module/Decision/view/decision/member/index.phtml:82
+#: module/Application/view/partial/main-nav.phtml:273
+#: module/Decision/view/decision/member/index.phtml:93
 msgid "Links"
 msgstr "Links"
 
-#: module/Application/view/partial/main-nav.phtml:257
+#: module/Application/view/partial/main-nav.phtml:278
 msgid "Well-being"
 msgstr "Well-being"
 
-#: module/Application/view/partial/main-nav.phtml:268
+#: module/Application/view/partial/main-nav.phtml:289
 msgid "Confidential Contact Person (CCP)"
 msgstr "Confidential Contact Person (CCP)"
 
-#: module/Application/view/partial/main-nav.phtml:273
+#: module/Application/view/partial/main-nav.phtml:294
 msgid "FAQ"
 msgstr "FAQ"
 
-#: module/Application/view/partial/main-nav.phtml:284
+#: module/Application/view/partial/main-nav.phtml:305
 msgid "Housing"
 msgstr "Housing"
 
-#: module/Application/view/partial/main-nav.phtml:321
-#: module/Company/view/company/admin/index.phtml:147
+#: module/Application/view/partial/main-nav.phtml:343
+#: module/Company/view/company/admin/index.phtml:161
 msgid "Featured"
 msgstr "Featured"
 
-#: module/Application/view/partial/main-nav.phtml:365
+#: module/Application/view/partial/main-nav.phtml:390
 msgid "My activities"
 msgstr "My activities"
 
-#: module/Application/view/partial/main-nav.phtml:372
+#: module/Application/view/partial/main-nav.phtml:399
 msgid "Activity Archive"
 msgstr "Activity Archive"
 
-#: module/Application/view/partial/main-nav.phtml:379
+#: module/Application/view/partial/main-nav.phtml:408
 msgid "Create an activity"
 msgstr "Create an activity"
 
-#: module/Application/view/partial/main-nav.phtml:392
+#: module/Application/view/partial/main-nav.phtml:424
 msgid "Career related"
 msgstr "Career related"
 
-#: module/Application/view/partial/main-nav.phtml:421
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:200
+#: module/Application/view/partial/main-nav.phtml:457
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:218
 msgid "Photo of the week"
 msgstr "Photo of the week"
 
-#: module/Application/view/partial/main-nav.phtml:433
-#: module/Decision/view/decision/member/index.phtml:41
+#: module/Application/view/partial/main-nav.phtml:470
+#: module/Decision/view/decision/member/index.phtml:52
 msgid "My photo's"
 msgstr "My photos"
 
-#: module/Application/view/partial/main-nav.phtml:457
+#: module/Application/view/partial/main-nav.phtml:499
 msgid "You are currently using administrator privileges to use the website!"
 msgstr "You are currently using administrator privileges to use the website!"
 
-#: module/Application/view/partial/paginator.phtml:8
-#: module/Photo/view/photo/album/index.phtml:428
+#: module/Application/view/partial/paginator.phtml:19
+#: module/Photo/view/photo/album/index.phtml:437
 msgid "Previous"
 msgstr "Previous"
 
-#: module/Application/view/partial/paginator.phtml:22
-#: module/Photo/view/photo/album/index.phtml:429
+#: module/Application/view/partial/paginator.phtml:37
+#: module/Photo/view/photo/album/index.phtml:438
 msgid "Next"
 msgstr "Next"
 
-#: module/Application/view/partial/privacy-widget.phtml:3
+#: module/Application/view/partial/privacy-widget.phtml:13
 msgid ""
 "S.v. GEWIS uses cookies on this website, these are required for the website "
 "to function. Additionally, we may collection information about how you use "
@@ -2353,54 +2353,54 @@ msgstr ""
 "our website in order to improve your experience. If you do not want your "
 "behaviour to be tracked please opt out below."
 
-#: module/Application/view/partial/privacy-widget.phtml:8
+#: module/Application/view/partial/privacy-widget.phtml:19
 msgid "Tracking is currently"
 msgstr "Tracking is currently"
 
-#: module/Application/view/partial/privacy-widget.phtml:9
+#: module/Application/view/partial/privacy-widget.phtml:20
 msgid "enabled"
 msgstr "enabled"
 
-#: module/Application/view/partial/privacy-widget.phtml:10
+#: module/Application/view/partial/privacy-widget.phtml:21
 msgid "disabled"
 msgstr "disabled"
 
-#: module/Application/view/partial/privacy-widget.phtml:11
+#: module/Application/view/partial/privacy-widget.phtml:23
 msgid "disabled (Do Not Track)"
 msgstr "disabled (Do Not Track)"
 
-#: module/Application/view/partial/privacy-widget.phtml:12
+#: module/Application/view/partial/privacy-widget.phtml:25
 msgid "unavailable"
 msgstr "unavailable"
 
-#: module/Application/view/partial/privacy-widget.phtml:17
-#: module/Decision/view/decision/member/index.phtml:283
+#: module/Application/view/partial/privacy-widget.phtml:31
+#: module/Decision/view/decision/member/index.phtml:294
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: module/Application/view/partial/privacy-widget.phtml:18
+#: module/Application/view/partial/privacy-widget.phtml:33
 #: module/User/src/Form/ApiAppAuthorisation.php:48
 msgid "Continue"
 msgstr "Continue"
 
-#: module/Company/src/Controller/AdminApprovalController.php:46
-#: module/Company/src/Controller/AdminApprovalController.php:72
+#: module/Company/src/Controller/AdminApprovalController.php:45
+#: module/Company/src/Controller/AdminApprovalController.php:71
 msgid "You are not allowed to view the approval status of jobs"
 msgstr "You are not allowed to view the approval status of jobs"
 
-#: module/Company/src/Controller/AdminApprovalController.php:90
+#: module/Company/src/Controller/AdminApprovalController.php:89
 msgid "Approve Job"
 msgstr "Approve Job"
 
-#: module/Company/src/Controller/AdminApprovalController.php:94
+#: module/Company/src/Controller/AdminApprovalController.php:93
 msgid "Disapprove Job"
 msgstr "Disapprove Job"
 
-#: module/Company/src/Controller/AdminApprovalController.php:98
+#: module/Company/src/Controller/AdminApprovalController.php:97
 msgid "Reset Approval Status"
 msgstr "Reset Approval Status"
 
-#: module/Company/src/Controller/AdminApprovalController.php:108
+#: module/Company/src/Controller/AdminApprovalController.php:107
 msgid "You are not allowed to change the approval status of jobs"
 msgstr "You are not allowed to change the approval status of jobs"
 
@@ -2429,7 +2429,7 @@ msgstr "Apply Update"
 msgid "Reject Update"
 msgstr "Reject Update"
 
-#: module/Company/src/Controller/AdminApprovalController.php:213
+#: module/Company/src/Controller/AdminApprovalController.php:218
 msgid ""
 "An unknown error occurred while try to change the status of a job update "
 "proposal. Please try again."
@@ -2437,107 +2437,107 @@ msgstr ""
 "An unknown error occurred while try to change the status of a job update "
 "proposal. Please try again."
 
-#: module/Company/src/Controller/AdminApprovalController.php:223
+#: module/Company/src/Controller/AdminApprovalController.php:230
 msgid "Job has been updated!"
 msgstr "Job has been updated!"
 
-#: module/Company/src/Controller/AdminApprovalController.php:230
+#: module/Company/src/Controller/AdminApprovalController.php:238
 msgid "Job update has been rejected!"
 msgstr "Job update has been rejected!"
 
-#: module/Company/src/Controller/AdminController.php:44
+#: module/Company/src/Controller/AdminController.php:47
 msgid "You are not allowed to administer career settings"
 msgstr "You are not allowed to administer career settings"
 
-#: module/Company/src/Controller/AdminController.php:77
+#: module/Company/src/Controller/AdminController.php:80
 msgid "You are not allowed to create companies"
 msgstr "You are not allowed to create companies"
 
-#: module/Company/src/Controller/AdminController.php:120
+#: module/Company/src/Controller/AdminController.php:123
 msgid "You are not allowed to edit companies"
 msgstr "You are not allowed to edit companies"
 
-#: module/Company/src/Controller/AdminController.php:187
-#: module/Company/src/Service/Company.php:852
+#: module/Company/src/Controller/AdminController.php:190
+#: module/Company/src/Service/Company.php:856
 msgid "You are not allowed to delete companies"
 msgstr "You are not allowed to delete companies"
 
-#: module/Company/src/Controller/AdminController.php:212
+#: module/Company/src/Controller/AdminController.php:215
 msgid "You are not allowed to create packages"
 msgstr "You are not allowed to create packages"
 
-#: module/Company/src/Controller/AdminController.php:281
-#: module/Company/src/Service/Company.php:917
+#: module/Company/src/Controller/AdminController.php:284
+#: module/Company/src/Service/Company.php:905
 msgid "You are not allowed to edit packages"
 msgstr "You are not allowed to edit packages"
 
-#: module/Company/src/Controller/AdminController.php:366
-#: module/Company/src/Service/Company.php:749
+#: module/Company/src/Controller/AdminController.php:372
+#: module/Company/src/Service/Company.php:741
 msgid "You are not allowed to delete packages"
 msgstr "You are not allowed to delete packages"
 
-#: module/Company/src/Controller/AdminController.php:408
-#: module/Company/src/Controller/CompanyAccountController.php:116
+#: module/Company/src/Controller/AdminController.php:414
+#: module/Company/src/Controller/CompanyAccountController.php:120
 msgid "You are not allowed to create jobs"
 msgstr "You are not allowed to create jobs"
 
-#: module/Company/src/Controller/AdminController.php:447
+#: module/Company/src/Controller/AdminController.php:453
 msgid "Job successfully created!"
 msgstr "Job successfully created!"
 
-#: module/Company/src/Controller/AdminController.php:487
-#: module/Company/src/Controller/CompanyAccountController.php:193
-#: module/Company/src/Service/Company.php:944
-#: module/Company/src/Service/Company.php:1015
+#: module/Company/src/Controller/AdminController.php:493
+#: module/Company/src/Controller/CompanyAccountController.php:203
+#: module/Company/src/Service/Company.php:931
+#: module/Company/src/Service/Company.php:1002
 msgid "You are not allowed to edit jobs"
 msgstr "You are not allowed to edit jobs"
 
-#: module/Company/src/Controller/AdminController.php:526
+#: module/Company/src/Controller/AdminController.php:532
 msgid "Job successfully edited!"
 msgstr "Job successfully edited!"
 
-#: module/Company/src/Controller/AdminController.php:562
-#: module/Company/src/Controller/CompanyAccountController.php:296
+#: module/Company/src/Controller/AdminController.php:568
+#: module/Company/src/Controller/CompanyAccountController.php:310
 msgid "You are not allowed to delete jobs"
 msgstr "You are not allowed to delete jobs"
 
-#: module/Company/src/Controller/AdminController.php:604
+#: module/Company/src/Controller/AdminController.php:610
 msgid "You are not allowed to create job categories"
 msgstr "You are not allowed to create job categories"
 
-#: module/Company/src/Controller/AdminController.php:623
+#: module/Company/src/Controller/AdminController.php:629
 msgid "Job category successfully created!"
 msgstr "Job category successfully created!"
 
-#: module/Company/src/Controller/AdminController.php:658
-#: module/Company/src/Service/Company.php:885
+#: module/Company/src/Controller/AdminController.php:665
+#: module/Company/src/Service/Company.php:881
 msgid "You are not allowed to edit job categories"
 msgstr "You are not allowed to edit job categories"
 
-#: module/Company/src/Controller/AdminController.php:698
+#: module/Company/src/Controller/AdminController.php:705
 msgid "You are not allowed to create job labels"
 msgstr "You are not allowed to create job labels"
 
-#: module/Company/src/Controller/AdminController.php:717
+#: module/Company/src/Controller/AdminController.php:724
 msgid "Job label successfully created!"
 msgstr "Job label successfully created!"
 
-#: module/Company/src/Controller/AdminController.php:751
-#: module/Company/src/Service/Company.php:901
+#: module/Company/src/Controller/AdminController.php:758
+#: module/Company/src/Service/Company.php:893
 msgid "You are not allowed to edit job labels"
 msgstr "You are not allowed to edit job labels"
 
-#: module/Company/src/Controller/CompanyAccountController.php:46
-#: module/Company/src/Controller/CompanyAccountController.php:57
-#: module/Company/src/Controller/CompanyAccountController.php:68
+#: module/Company/src/Controller/CompanyAccountController.php:47
+#: module/Company/src/Controller/CompanyAccountController.php:58
+#: module/Company/src/Controller/CompanyAccountController.php:69
 msgid "You are not allowed to view the company accounts"
 msgstr "You are not allowed to view the company accounts"
 
-#: module/Company/src/Controller/CompanyAccountController.php:136
+#: module/Company/src/Controller/CompanyAccountController.php:143
 msgid "You cannot create new jobs in expired job packages."
 msgstr "You cannot create new jobs in expired job packages."
 
-#: module/Company/src/Controller/CompanyAccountController.php:157
+#: module/Company/src/Controller/CompanyAccountController.php:166
 msgid ""
 "Job proposal successfully created! It will become active after it has been "
 "approved."
@@ -2545,11 +2545,11 @@ msgstr ""
 "Job proposal successfully created! It will become active after it has been "
 "approved."
 
-#: module/Company/src/Controller/CompanyAccountController.php:213
+#: module/Company/src/Controller/CompanyAccountController.php:223
 msgid "You cannot update jobs in expired job packages."
 msgstr "You cannot update jobs in expired job packages."
 
-#: module/Company/src/Controller/CompanyAccountController.php:236
+#: module/Company/src/Controller/CompanyAccountController.php:249
 msgid ""
 "Update proposal for job successfully created! It will become active after it "
 "has been approved."
@@ -2557,125 +2557,125 @@ msgstr ""
 "Update proposal for job successfully created! It will become active after it "
 "has been approved."
 
-#: module/Company/src/Controller/CompanyAccountController.php:319
+#: module/Company/src/Controller/CompanyAccountController.php:335
 msgid "Job successfully deleted."
 msgstr "Job successfully deleted."
 
-#: module/Company/src/Controller/CompanyAccountController.php:328
+#: module/Company/src/Controller/CompanyAccountController.php:344
 msgid "You are not allowed to view the status of a job"
 msgstr "You are not allowed to view the status of a job"
 
-#: module/Company/src/Controller/CompanyAccountController.php:353
+#: module/Company/src/Controller/CompanyAccountController.php:369
 msgid "You are not allowed to transfer jobs"
 msgstr "You are not allowed to transfer jobs"
 
-#: module/Company/src/Controller/CompanyAccountController.php:386
+#: module/Company/src/Controller/CompanyAccountController.php:406
 msgid "Jobs successfully transferred"
 msgstr "Jobs successfully transferred"
 
-#: module/Company/src/Controller/CompanyAccountController.php:396
+#: module/Company/src/Controller/CompanyAccountController.php:417
 msgid ""
 "An unknown error occurred while trying to transfer jobs, please try again."
 msgstr ""
 "An unknown error occurred while trying to transfer jobs, please try again."
 
-#: module/Company/src/Form/Company.php:62 module/Company/src/Form/Job.php:65
+#: module/Company/src/Form/Company.php:61 module/Company/src/Form/Job.php:69
 #: module/Company/src/Form/JobCategory.php:85
 #: module/Company/src/Form/JobCategory.php:95
-#: module/Company/view/company/admin-approval/job-approval.phtml:30
-#: module/Company/view/company/admin-approval/job-approval.phtml:34
-#: module/Company/view/company/admin-approval/job-proposal.phtml:59
-#: module/Company/view/company/admin-approval/job-proposal.phtml:63
-#: module/Company/view/partial/company/admin/editors/company.phtml:5
-#: module/Company/view/partial/company/admin/editors/job.phtml:5
+#: module/Company/view/company/admin-approval/job-approval.phtml:44
+#: module/Company/view/company/admin-approval/job-approval.phtml:48
+#: module/Company/view/company/admin-approval/job-proposal.phtml:69
+#: module/Company/view/company/admin-approval/job-proposal.phtml:73
+#: module/Company/view/partial/company/admin/editors/company.phtml:18
+#: module/Company/view/partial/company/admin/editors/job.phtml:18
 msgid "Slug"
 msgstr "Slug"
 
-#: module/Company/src/Form/Company.php:72
+#: module/Company/src/Form/Company.php:71
 msgid "Logo"
 msgstr "Logo"
 
-#: module/Company/src/Form/Company.php:82 module/Company/src/Form/Job.php:87
-#: module/Company/src/Form/Package.php:69
+#: module/Company/src/Form/Company.php:81 module/Company/src/Form/Job.php:91
+#: module/Company/src/Form/Package.php:66
 msgid "Published"
 msgstr "Published"
 
-#: module/Company/src/Form/Company.php:104
-#: module/Company/src/Form/Company.php:134 module/Company/src/Form/Job.php:112
+#: module/Company/src/Form/Company.php:103
+#: module/Company/src/Form/Company.php:133 module/Company/src/Form/Job.php:116
 msgid "E-mail Address"
 msgstr "E-mail Address"
 
-#: module/Company/src/Form/Company.php:124
+#: module/Company/src/Form/Company.php:123
 msgid "Address"
 msgstr "Address"
 
-#: module/Company/src/Form/Company.php:144 module/Company/src/Form/Job.php:122
+#: module/Company/src/Form/Company.php:143 module/Company/src/Form/Job.php:126
 msgid "Phone Number"
 msgstr "Phone Number"
 
-#: module/Company/src/Form/Company.php:155
-#: module/Company/src/Form/Company.php:165
+#: module/Company/src/Form/Company.php:154
+#: module/Company/src/Form/Company.php:164
 msgid "Slogan"
 msgstr "Slogan"
 
-#: module/Company/src/Form/Company.php:179
-#: module/Company/src/Form/Company.php:189 module/Company/src/Form/Job.php:157
-#: module/Company/src/Form/Job.php:167
-#: module/Company/view/company/admin-approval/job-approval.phtml:124
-#: module/Company/view/company/admin-approval/job-approval.phtml:129
-#: module/Company/view/company/admin-approval/job-approval.phtml:136
-#: module/Company/view/company/admin-approval/job-proposal.phtml:174
-#: module/Company/view/company/admin-approval/job-proposal.phtml:179
+#: module/Company/src/Form/Company.php:178
+#: module/Company/src/Form/Company.php:188 module/Company/src/Form/Job.php:161
+#: module/Company/src/Form/Job.php:171
+#: module/Company/view/company/admin-approval/job-approval.phtml:138
+#: module/Company/view/company/admin-approval/job-approval.phtml:143
+#: module/Company/view/company/admin-approval/job-approval.phtml:150
+#: module/Company/view/company/admin-approval/job-proposal.phtml:184
 #: module/Company/view/company/admin-approval/job-proposal.phtml:189
-#: module/Decision/src/Form/OrganInformation.php:44
-#: module/Frontpage/view/frontpage/organ/organ.phtml:94
+#: module/Company/view/company/admin-approval/job-proposal.phtml:199
+#: module/Decision/src/Form/OrganInformation.php:42
+#: module/Frontpage/view/frontpage/organ/organ.phtml:110
 msgid "Website"
 msgstr "Website"
 
-#: module/Company/src/Form/Company.php:261 module/Company/src/Form/Job.php:283
+#: module/Company/src/Form/Company.php:261 module/Company/src/Form/Job.php:282
 #: module/Company/src/Form/JobCategory.php:194
 msgid "This slug is already taken"
 msgstr "This slug is already taken"
 
-#: module/Company/src/Form/Company.php:270 module/Company/src/Form/Job.php:292
-#: module/Company/src/Form/JobCategory.php:203
+#: module/Company/src/Form/Company.php:272 module/Company/src/Form/Job.php:293
+#: module/Company/src/Form/JobCategory.php:204
 msgid "This slug contains invalid characters"
 msgstr "This slug contains invalid characters"
 
-#: module/Company/src/Form/Company.php:338
+#: module/Company/src/Form/Company.php:346
 msgid "E-mail address format is not valid."
 msgstr "E-mail address format is not valid."
 
-#: module/Company/src/Form/Company.php:348
+#: module/Company/src/Form/Company.php:356
 msgid "The e-mail address must be unique across companies."
 msgstr "The e-mail address must be unique across companies."
 
-#: module/Company/src/Form/Company.php:392 module/Company/src/Form/Job.php:339
-#: module/User/src/Form/CompanyUserLogin.php:127
-#: module/User/src/Form/CompanyUserReset.php:71
-#: module/User/src/Form/UserReset.php:95
+#: module/Company/src/Form/Company.php:400 module/Company/src/Form/Job.php:341
+#: module/User/src/Form/CompanyUserLogin.php:125
+#: module/User/src/Form/CompanyUserReset.php:64
+#: module/User/src/Form/UserReset.php:93
 msgid "E-mail address format is not valid"
 msgstr "E-mail address format is not valid"
 
-#: module/Company/src/Form/Job.php:75
-#: module/Company/view/company/admin-approval/job-approval.phtml:41
-#: module/Company/view/company/admin-approval/job-approval.phtml:45
-#: module/Company/view/company/admin-approval/job-proposal.phtml:73
-#: module/Company/view/company/admin-approval/job-proposal.phtml:77
+#: module/Company/src/Form/Job.php:79
+#: module/Company/view/company/admin-approval/job-approval.phtml:55
+#: module/Company/view/company/admin-approval/job-approval.phtml:59
+#: module/Company/view/company/admin-approval/job-proposal.phtml:83
+#: module/Company/view/company/admin-approval/job-proposal.phtml:87
 msgid "Category"
 msgstr "Category"
 
-#: module/Company/src/Form/Job.php:76
+#: module/Company/src/Form/Job.php:80
 msgid "Select a job category"
 msgstr "Select a job category"
 
-#: module/Company/src/Form/Job.php:217 module/Company/src/Form/Job.php:227
-#: module/Company/view/company/admin-approval/job-approval.phtml:181
-#: module/Company/view/company/admin-approval/job-approval.phtml:186
-#: module/Company/view/company/admin-approval/job-approval.phtml:197
-#: module/Company/view/company/admin-approval/job-proposal.phtml:249
-#: module/Company/view/company/admin-approval/job-proposal.phtml:254
-#: module/Company/view/company/admin-approval/job-proposal.phtml:270
+#: module/Company/src/Form/Job.php:221 module/Company/src/Form/Job.php:231
+#: module/Company/view/company/admin-approval/job-approval.phtml:195
+#: module/Company/view/company/admin-approval/job-approval.phtml:200
+#: module/Company/view/company/admin-approval/job-approval.phtml:211
+#: module/Company/view/company/admin-approval/job-proposal.phtml:259
+#: module/Company/view/company/admin-approval/job-proposal.phtml:264
+#: module/Company/view/company/admin-approval/job-proposal.phtml:280
 msgid "Attachment"
 msgstr "Attachment"
 
@@ -2688,161 +2688,161 @@ msgstr "Name (Plural)"
 msgid "Hidden"
 msgstr "Hidden"
 
-#: module/Company/src/Form/JobLabel.php:52
-#: module/Company/src/Form/JobLabel.php:62
-#: module/Decision/view/decision/organ-admin/index.phtml:11
-#: module/Decision/view/decision/organ/index.phtml:13
+#: module/Company/src/Form/JobLabel.php:51
+#: module/Company/src/Form/JobLabel.php:61
+#: module/Decision/view/decision/organ-admin/index.phtml:23
+#: module/Decision/view/decision/organ/index.phtml:22
 msgid "Abbreviation"
 msgstr "Abbreviation"
 
-#: module/Company/src/Form/JobsTransfer.php:40
+#: module/Company/src/Form/JobsTransfer.php:38
 msgid "Select a target job package"
 msgstr "Select a target job package"
 
-#: module/Company/src/Form/JobsTransfer.php:41
-#: module/Company/view/company/admin/edit-company.phtml:47
+#: module/Company/src/Form/JobsTransfer.php:39
+#: module/Company/view/company/admin/edit-company.phtml:59
 msgid "Packages"
 msgstr "Packages"
 
-#: module/Company/src/Form/JobsTransfer.php:52
-#: module/Company/view/company/company-account/jobs.phtml:253
-#: module/Company/view/company/company-account/transfer-jobs.phtml:2
-#: module/Company/view/company/company-account/transfer-jobs.phtml:12
+#: module/Company/src/Form/JobsTransfer.php:50
+#: module/Company/view/company/company-account/jobs.phtml:272
+#: module/Company/view/company/company-account/transfer-jobs.phtml:14
+#: module/Company/view/company/company-account/transfer-jobs.phtml:24
 msgid "Transfer Jobs"
 msgstr "Transfer Jobs"
 
-#: module/Company/src/Form/Package.php:41
+#: module/Company/src/Form/Package.php:38
 msgid "Start Date"
 msgstr "Start Date"
 
-#: module/Company/src/Form/Package.php:55
+#: module/Company/src/Form/Package.php:52
 msgid "Expiration Date"
 msgstr "Expiration Date"
 
-#: module/Company/src/Form/Package.php:82
-#: module/Company/view/company/admin/edit-company.phtml:89
-#: module/Company/view/company/company-account/jobs.phtml:35
+#: module/Company/src/Form/Package.php:79
+#: module/Company/view/company/admin/edit-company.phtml:101
+#: module/Company/view/company/company-account/jobs.phtml:54
 msgid "Contract Number"
 msgstr "Contract Number"
 
-#: module/Company/src/Form/Package.php:93
-#: module/Company/src/Form/Package.php:103
+#: module/Company/src/Form/Package.php:90
+#: module/Company/src/Form/Package.php:100
 msgid "Article"
 msgstr "Article"
 
-#: module/Company/src/Form/Package.php:182
+#: module/Company/src/Form/Package.php:179
 msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
 msgstr ""
 "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
 
-#: module/Company/src/Service/Company.php:83
+#: module/Company/src/Service/Company.php:92
 msgid "You are not allowed to view the banner"
 msgstr "You are not allowed to view the banner"
 
-#: module/Company/src/Service/Company.php:96
+#: module/Company/src/Service/Company.php:102
 msgid "You are not allowed to view the featured company"
 msgstr "You are not allowed to view the featured company"
 
-#: module/Company/src/Service/Company.php:165
-#: module/Company/src/Service/Company.php:185
-#: module/Company/src/Service/Company.php:217
+#: module/Company/src/Service/Company.php:170
+#: module/Company/src/Service/Company.php:190
+#: module/Company/src/Service/Company.php:218
 msgid "You are not allowed to list the companies"
 msgstr "You are not allowed to list the companies"
 
-#: module/Company/src/Service/Company.php:200
+#: module/Company/src/Service/Company.php:205
 msgid "You are not allowed to access the admin interface"
 msgstr "You are not allowed to access the admin interface"
 
-#: module/Company/src/Service/Company.php:961
+#: module/Company/src/Service/Company.php:948
 msgid "You are not allowed to edit categories"
 msgstr "You are not allowed to edit categories"
 
-#: module/Company/src/Service/Company.php:978
+#: module/Company/src/Service/Company.php:965
 msgid "You are not allowed to edit labels"
 msgstr "You are not allowed to edit labels"
 
-#: module/Company/src/Service/Company.php:1031
+#: module/Company/src/Service/Company.php:1015
 msgid "You are not allowed to create a company"
 msgstr "You are not allowed to create a company"
 
-#: module/Company/src/Service/CompanyQuery.php:109
+#: module/Company/src/Service/CompanyQuery.php:98
 msgid "You are not allowed to list all job categories"
 msgstr "You are not allowed to list all job categories"
 
-#: module/Company/src/Service/CompanyQuery.php:117
+#: module/Company/src/Service/CompanyQuery.php:106
 msgid "You are not allowed to list job categories"
 msgstr "You are not allowed to list job categories"
 
-#: module/Company/src/Service/CompanyQuery.php:157
+#: module/Company/src/Service/CompanyQuery.php:146
 msgid "You are not allowed to list all job labels"
 msgstr "You are not allowed to list all job labels"
 
-#: module/Company/src/Service/CompanyQuery.php:165
+#: module/Company/src/Service/CompanyQuery.php:154
 msgid "You are not allowed to list job labels"
 msgstr "You are not allowed to list job labels"
 
-#: module/Company/view/company/admin-approval/index.phtml:8
+#: module/Company/view/company/admin-approval/index.phtml:24
 msgid "Unapproved Companies"
 msgstr "Unapproved Companies"
 
-#: module/Company/view/company/admin-approval/index.phtml:22
+#: module/Company/view/company/admin-approval/index.phtml:38
 msgid "There is no company or update proposal that requires your approval."
 msgstr "There is no company or update proposal that requires your approval."
 
-#: module/Company/view/company/admin-approval/index.phtml:34
+#: module/Company/view/company/admin-approval/index.phtml:50
 msgid "Unapproved Jobs"
 msgstr "Unapproved Jobs"
 
-#: module/Company/view/company/admin-approval/index.phtml:40
+#: module/Company/view/company/admin-approval/index.phtml:56
 msgid "Dutch Name"
 msgstr "Dutch Name"
 
-#: module/Company/view/company/admin-approval/index.phtml:41
+#: module/Company/view/company/admin-approval/index.phtml:57
 msgid "English Name"
 msgstr "English Name"
 
-#: module/Company/view/company/admin-approval/index.phtml:50
+#: module/Company/view/company/admin-approval/index.phtml:66
 msgid "There is no job or update proposal that requires your approval."
 msgstr "There is no job or update proposal that requires your approval."
 
-#: module/Company/view/company/admin-approval/index.phtml:66
+#: module/Company/view/company/admin-approval/index.phtml:82
 msgid "View Update"
 msgstr "View Update"
 
-#: module/Company/view/company/admin-approval/index.phtml:74
+#: module/Company/view/company/admin-approval/index.phtml:90
 msgid "View Proposal"
 msgstr "View Proposal"
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:21
+#: module/Company/view/company/admin-approval/job-approval.phtml:35
 #, php-format
 msgid "This job is proposed by <strong>%s</strong> as part of job package %s."
 msgstr "This job is proposed by <strong>%s</strong> as part of job package %s."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:63
-#: module/Company/view/company/admin-approval/job-approval.phtml:67
-#: module/Company/view/company/admin-approval/job-proposal.phtml:101
-#: module/Company/view/company/admin-approval/job-proposal.phtml:105
-#: module/Decision/view/decision/member/self.phtml:158
+#: module/Company/view/company/admin-approval/job-approval.phtml:77
+#: module/Company/view/company/admin-approval/job-approval.phtml:81
+#: module/Company/view/company/admin-approval/job-proposal.phtml:111
+#: module/Company/view/company/admin-approval/job-proposal.phtml:115
+#: module/Decision/view/decision/member/self.phtml:174
 msgid "Phone number"
 msgstr "Phone number"
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:74
-#: module/Company/view/company/admin-approval/job-approval.phtml:78
-#: module/Company/view/company/admin-approval/job-proposal.phtml:115
-#: module/Company/view/company/admin-approval/job-proposal.phtml:119
-#: module/User/src/Form/UserReset.php:42
-#: module/User/src/Model/Enums/JWTClaims.php:37
+#: module/Company/view/company/admin-approval/job-approval.phtml:88
+#: module/Company/view/company/admin-approval/job-approval.phtml:92
+#: module/Company/view/company/admin-approval/job-proposal.phtml:125
+#: module/Company/view/company/admin-approval/job-proposal.phtml:129
+#: module/User/src/Form/UserReset.php:40
+#: module/User/src/Model/Enums/JWTClaims.php:39
 msgid "E-mail address"
 msgstr "E-mail address"
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:190
-#: module/Company/view/company/admin-approval/job-approval.phtml:201
-#: module/Company/view/company/admin-approval/job-proposal.phtml:274
-#: module/Company/view/company/company/jobs.phtml:121
+#: module/Company/view/company/admin-approval/job-approval.phtml:204
+#: module/Company/view/company/admin-approval/job-approval.phtml:215
+#: module/Company/view/company/admin-approval/job-proposal.phtml:284
+#: module/Company/view/company/company/jobs.phtml:133
 msgid "View Attachment"
 msgstr "View Attachment"
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:230
+#: module/Company/view/company/admin-approval/job-approval.phtml:244
 msgid ""
 "If approved, this job will be <strong>published</strong>, however, its "
 "actual visiblity depends on the company and associated job package."
@@ -2850,37 +2850,37 @@ msgstr ""
 "If approved, this job will be <strong>published</strong>, however, its "
 "actual visiblity depends on the company and associated job package."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:232
+#: module/Company/view/company/admin-approval/job-approval.phtml:246
 msgid "If approved, this job will be <strong>hidden</strong>."
 msgstr "If approved, this job will be <strong>hidden</strong>."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:277
-#: module/Company/view/company/admin-approval/job-proposal.phtml:387
+#: module/Company/view/company/admin-approval/job-approval.phtml:291
+#: module/Company/view/company/admin-approval/job-proposal.phtml:397
 msgid "Optional message..."
 msgstr "Optional message..."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:298
+#: module/Company/view/company/admin-approval/job-approval.phtml:312
 #, php-format
 msgid "This job was approved by <strong>%s</strong>."
 msgstr "This job was approved by <strong>%s</strong>."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:327
+#: module/Company/view/company/admin-approval/job-approval.phtml:341
 #, php-format
 msgid ""
 "This job was disapproved by <strong>%s</strong> with the message \"%s\"."
 msgstr ""
 "This job was disapproved by <strong>%s</strong> with the message \"%s\"."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:333
+#: module/Company/view/company/admin-approval/job-approval.phtml:347
 #, php-format
 msgid "This job was disapproved by <strong>%s</strong>."
 msgstr "This job was disapproved by <strong>%s</strong>."
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:17
+#: module/Company/view/company/admin-approval/job-proposal.phtml:27
 msgid "Proposals"
 msgstr "Proposals"
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:49
+#: module/Company/view/company/admin-approval/job-proposal.phtml:59
 #, php-format
 msgid ""
 "This job update is proposed by <strong>%s</strong> as part of job package "
@@ -2891,181 +2891,181 @@ msgstr ""
 "%s. Changes in the job's attributes are shown like this: %s. If there are no "
 "changes to a certain attribute, you will see the existing data."
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:258
+#: module/Company/view/company/admin-approval/job-proposal.phtml:268
 msgid "View Original Attachment"
 msgstr "View Original Attachment"
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:263
-#: module/Company/view/company/admin-approval/job-proposal.phtml:279
+#: module/Company/view/company/admin-approval/job-proposal.phtml:273
+#: module/Company/view/company/admin-approval/job-proposal.phtml:289
 msgid "View New Attachment"
 msgstr "View New Attachment"
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:287
-#: module/Company/view/partial/company/admin/editors/job.phtml:315
+#: module/Company/view/company/admin-approval/job-proposal.phtml:297
+#: module/Company/view/partial/company/admin/editors/job.phtml:328
 msgid "Job Labels"
 msgstr "Job Labels"
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:318
+#: module/Company/view/company/admin-approval/job-proposal.phtml:328
 msgid ""
 "Original job and proposed update do not have any job labels applied to them."
 msgstr ""
 "Original job and proposed update do not have any job labels applied to them."
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:330
-msgid ""
-"Warning! This is an update to an unapproved job. Applying this update will "
-"approve the job."
-msgstr ""
-"Warning! This is an update to an unapproved job. Applying this update will "
-"approve the job."
 
 #: module/Company/view/company/admin-approval/job-proposal.phtml:340
 msgid ""
+"Warning! This is an update to an unapproved job. Applying this update will "
+"approve the job."
+msgstr ""
+"Warning! This is an update to an unapproved job. Applying this update will "
+"approve the job."
+
+#: module/Company/view/company/admin-approval/job-proposal.phtml:350
+msgid ""
 "Warning! This is an update to rejected job. Applying this update will "
 "approve the job."
 msgstr ""
 "Warning! This is an update to rejected job. Applying this update will "
 "approve the job."
 
-#: module/Company/view/company/admin/add-category.phtml:2
-#: module/Company/view/company/admin/add-category.phtml:10
-#: module/Company/view/company/admin/add-category.phtml:25
+#: module/Company/view/company/admin/add-category.phtml:14
+#: module/Company/view/company/admin/add-category.phtml:22
+#: module/Company/view/company/admin/add-category.phtml:37
 msgid "Create Job Category"
 msgstr "Create Job Category"
 
-#: module/Company/view/company/admin/add-company.phtml:2
-#: module/Company/view/company/admin/add-company.phtml:16
-#: module/Company/view/company/admin/add-company.phtml:31
+#: module/Company/view/company/admin/add-company.phtml:14
+#: module/Company/view/company/admin/add-company.phtml:28
+#: module/Company/view/company/admin/add-company.phtml:43
 msgid "Create Company"
 msgstr "Create Company"
 
-#: module/Company/view/company/admin/add-job.phtml:2
-#: module/Company/view/company/admin/add-job.phtml:21
-#: module/Company/view/company/admin/add-job.phtml:36
-#: module/Company/view/company/admin/edit-package.phtml:126
-#: module/Company/view/company/company-account/jobs.phtml:78
-#: module/Company/view/company/company-account/jobs.phtml:263
+#: module/Company/view/company/admin/add-job.phtml:14
+#: module/Company/view/company/admin/add-job.phtml:33
+#: module/Company/view/company/admin/add-job.phtml:48
+#: module/Company/view/company/admin/edit-package.phtml:140
+#: module/Company/view/company/company-account/jobs.phtml:97
+#: module/Company/view/company/company-account/jobs.phtml:282
 msgid "Add Job"
 msgstr "Add Job"
 
-#: module/Company/view/company/admin/add-label.phtml:2
-#: module/Company/view/company/admin/add-label.phtml:16
-#: module/Company/view/company/admin/add-label.phtml:31
+#: module/Company/view/company/admin/add-label.phtml:14
+#: module/Company/view/company/admin/add-label.phtml:28
+#: module/Company/view/company/admin/add-label.phtml:43
 msgid "Create Job Label"
 msgstr "Create Job Label"
 
-#: module/Company/view/company/admin/add-package.phtml:2
-#: module/Company/view/company/admin/add-package.phtml:16
-#: module/Company/view/company/admin/add-package.phtml:32
+#: module/Company/view/company/admin/add-package.phtml:15
+#: module/Company/view/company/admin/add-package.phtml:29
+#: module/Company/view/company/admin/add-package.phtml:45
 msgid "Add Package"
 msgstr "Add Package"
 
-#: module/Company/view/company/admin/categories.phtml:23
-#: module/Company/view/company/admin/labels.phtml:22
+#: module/Company/view/company/admin/categories.phtml:36
+#: module/Company/view/company/admin/labels.phtml:35
 msgid "edit"
 msgstr "edit"
 
-#: module/Company/view/company/admin/edit-category.phtml:2
-#: module/Company/view/company/admin/edit-category.phtml:9
+#: module/Company/view/company/admin/edit-category.phtml:14
+#: module/Company/view/company/admin/edit-category.phtml:21
 msgid "Edit Job Category"
 msgstr "Edit Job Category"
 
-#: module/Company/view/company/admin/edit-category.phtml:24
+#: module/Company/view/company/admin/edit-category.phtml:36
 msgid "Update Job Category"
 msgstr "Update Job Category"
 
-#: module/Company/view/company/admin/edit-company.phtml:5
+#: module/Company/view/company/admin/edit-company.phtml:17
 msgid "Edit Company"
 msgstr "Edit Company"
 
-#: module/Company/view/company/admin/edit-company.phtml:41
+#: module/Company/view/company/admin/edit-company.phtml:53
 #, php-format
 msgid "Edit %s"
 msgstr "Edit %s"
 
-#: module/Company/view/company/admin/edit-company.phtml:58
+#: module/Company/view/company/admin/edit-company.phtml:70
 msgid "Add Job Package"
 msgstr "Add Job Package"
 
-#: module/Company/view/company/admin/edit-company.phtml:68
+#: module/Company/view/company/admin/edit-company.phtml:80
 msgid "Add Spotlight Package"
 msgstr "Add Spotlight Package"
 
-#: module/Company/view/company/admin/edit-company.phtml:78
+#: module/Company/view/company/admin/edit-company.phtml:90
 msgid "Add Banner Package"
 msgstr "Add Banner Package"
 
-#: module/Company/view/company/admin/edit-company.phtml:92
-#: module/Company/view/company/admin/edit-package.phtml:70
-#: module/Company/view/company/company-account/jobs.phtml:178
+#: module/Company/view/company/admin/edit-company.phtml:104
+#: module/Company/view/company/admin/edit-package.phtml:84
+#: module/Company/view/company/company-account/jobs.phtml:197
 msgid "Active"
 msgstr "Active"
 
-#: module/Company/view/company/admin/edit-company.phtml:98
-#: module/Company/view/company/company-account/jobs.phtml:41
+#: module/Company/view/company/admin/edit-company.phtml:110
+#: module/Company/view/company/company-account/jobs.phtml:60
 msgid "Expiration date"
 msgstr "Expiration date"
 
-#: module/Company/view/company/admin/edit-company.phtml:101
+#: module/Company/view/company/admin/edit-company.phtml:113
 msgid "Jobs (Active) / Type"
 msgstr "Jobs (Active) / Type"
 
-#: module/Company/view/company/admin/edit-company.phtml:124
-#: module/Company/view/company/admin/index.phtml:36
-#: module/Company/view/company/admin/index.phtml:68
+#: module/Company/view/company/admin/edit-company.phtml:136
+#: module/Company/view/company/admin/index.phtml:50
+#: module/Company/view/company/admin/index.phtml:82
 msgid "Banner Package"
 msgstr "Banner Package"
 
-#: module/Company/view/company/admin/edit-company.phtml:127
-#: module/Company/view/company/admin/index.phtml:39
-#: module/Company/view/company/admin/index.phtml:71
+#: module/Company/view/company/admin/edit-company.phtml:139
+#: module/Company/view/company/admin/index.phtml:53
+#: module/Company/view/company/admin/index.phtml:85
 msgid "Featured Package"
 msgstr "Featured Package"
 
-#: module/Company/view/company/admin/edit-company.phtml:175
+#: module/Company/view/company/admin/edit-company.phtml:187
 msgid "Update Company"
 msgstr "Update Company"
 
-#: module/Company/view/company/admin/edit-company.phtml:194
+#: module/Company/view/company/admin/edit-company.phtml:206
 msgid "Are you sure you want to delete this package?"
 msgstr "Are you sure you want to delete this package?"
 
-#: module/Company/view/company/admin/edit-company.phtml:200
+#: module/Company/view/company/admin/edit-company.phtml:212
 msgid "Delete package"
 msgstr "Delete package"
 
-#: module/Company/view/company/admin/edit-job.phtml:2
-#: module/Company/view/company/admin/edit-job.phtml:21
+#: module/Company/view/company/admin/edit-job.phtml:19
+#: module/Company/view/company/admin/edit-job.phtml:38
 msgid "Edit Job"
 msgstr "Edit Job"
 
-#: module/Company/view/company/admin/edit-job.phtml:30
-#, php-format
-msgid ""
-"You are currently updating an update proposal that was previously rejected "
-"for the following reason: %s"
-msgstr ""
-"You are currently updating an update proposal that was previously rejected "
-"for the following reason: %s"
-
-#: module/Company/view/company/admin/edit-job.phtml:36
-msgid ""
-"You are currently updating an update proposal that was previously rejected, "
-"however, no reason was provided."
-msgstr ""
-"You are currently updating an update proposal that was previously rejected, "
-"however, no reason was provided."
-
-#: module/Company/view/company/admin/edit-job.phtml:41
-#, php-format
-msgid ""
-"You are currently updating a job that was previously rejected for the "
-"following reason: %s"
-msgstr ""
-"You are currently updating a job that was previously rejected for the "
-"following reason: %s"
-
 #: module/Company/view/company/admin/edit-job.phtml:47
+#, php-format
+msgid ""
+"You are currently updating an update proposal that was previously rejected "
+"for the following reason: %s"
+msgstr ""
+"You are currently updating an update proposal that was previously rejected "
+"for the following reason: %s"
+
+#: module/Company/view/company/admin/edit-job.phtml:53
+msgid ""
+"You are currently updating an update proposal that was previously rejected, "
+"however, no reason was provided."
+msgstr ""
+"You are currently updating an update proposal that was previously rejected, "
+"however, no reason was provided."
+
+#: module/Company/view/company/admin/edit-job.phtml:58
+#, php-format
+msgid ""
+"You are currently updating a job that was previously rejected for the "
+"following reason: %s"
+msgstr ""
+"You are currently updating a job that was previously rejected for the "
+"following reason: %s"
+
+#: module/Company/view/company/admin/edit-job.phtml:64
 msgid ""
 "You are currently updating a job that was previously rejected, however, no "
 "reason was provided."
@@ -3073,111 +3073,111 @@ msgstr ""
 "You are currently updating a job that was previously rejected, however, no "
 "reason was provided."
 
-#: module/Company/view/company/admin/edit-job.phtml:68
+#: module/Company/view/company/admin/edit-job.phtml:85
 msgid "Update Job"
 msgstr "Update Job"
 
-#: module/Company/view/company/admin/edit-label.phtml:2
-#: module/Company/view/company/admin/edit-label.phtml:16
+#: module/Company/view/company/admin/edit-label.phtml:14
+#: module/Company/view/company/admin/edit-label.phtml:28
 msgid "Edit Job Label"
 msgstr "Edit Job Label"
 
-#: module/Company/view/company/admin/edit-label.phtml:31
+#: module/Company/view/company/admin/edit-label.phtml:43
 msgid "Update Job Label"
 msgstr "Update Job Label"
 
-#: module/Company/view/company/admin/edit-package.phtml:7
-#: module/Company/view/company/admin/edit-package.phtml:28
+#: module/Company/view/company/admin/edit-package.phtml:19
+#: module/Company/view/company/admin/edit-package.phtml:40
 msgid "Edit Package"
 msgstr "Edit Package"
 
-#: module/Company/view/company/admin/edit-package.phtml:44
+#: module/Company/view/company/admin/edit-package.phtml:56
 msgid "Update Package"
 msgstr "Update Package"
 
-#: module/Company/view/company/admin/edit-package.phtml:87
+#: module/Company/view/company/admin/edit-package.phtml:101
 msgid "(Update Pending)"
 msgstr "(Update Pending)"
 
-#: module/Company/view/company/admin/edit-package.phtml:140
-#: module/Company/view/company/company-account/jobs.phtml:278
+#: module/Company/view/company/admin/edit-package.phtml:154
+#: module/Company/view/company/company-account/jobs.phtml:297
 msgid "Are you sure you want to delete this job?"
 msgstr "Are you sure you want to delete this job?"
 
-#: module/Company/view/company/admin/edit-package.phtml:145
-#: module/Company/view/company/company-account/jobs.phtml:283
+#: module/Company/view/company/admin/edit-package.phtml:159
+#: module/Company/view/company/company-account/jobs.phtml:302
 msgid "Delete job"
 msgstr "Delete job"
 
-#: module/Company/view/company/admin/index.phtml:22
-#: module/Company/view/company/company-account/jobs.phtml:20
+#: module/Company/view/company/admin/index.phtml:36
+#: module/Company/view/company/company-account/jobs.phtml:39
 msgid "Notifications"
 msgstr "Notifications"
 
-#: module/Company/view/company/admin/index.phtml:24
+#: module/Company/view/company/admin/index.phtml:38
 msgid "No notifications"
 msgstr "No notifications"
 
-#: module/Company/view/company/admin/index.phtml:42
-#: module/Company/view/company/admin/index.phtml:74
+#: module/Company/view/company/admin/index.phtml:56
+#: module/Company/view/company/admin/index.phtml:88
 #, php-format
 msgid "Job Package (%s active)"
 msgstr "Job Package (%s active)"
 
-#: module/Company/view/company/admin/index.phtml:49
+#: module/Company/view/company/admin/index.phtml:63
 #, php-format
 msgid "%s for company %s will start on %s"
 msgstr "%s for company %s will start on %s"
 
-#: module/Company/view/company/admin/index.phtml:81
+#: module/Company/view/company/admin/index.phtml:95
 #, php-format
 msgid "%s for company %s will expire on %s"
 msgstr "%s for company %s will expire on %s"
 
-#: module/Company/view/company/admin/index.phtml:96
-#: module/Education/view/education/admin/course.phtml:15
+#: module/Company/view/company/admin/index.phtml:110
+#: module/Education/view/education/admin/course.phtml:27
 msgid "Filter..."
 msgstr "Filter..."
 
-#: module/Company/view/company/admin/index.phtml:101
+#: module/Company/view/company/admin/index.phtml:115
 msgid "Add Company"
 msgstr "Add Company"
 
-#: module/Company/view/company/admin/index.phtml:130
-#: module/Company/view/company/admin/index.phtml:200
+#: module/Company/view/company/admin/index.phtml:144
+#: module/Company/view/company/admin/index.phtml:214
 msgid "Active jobs"
 msgstr "Active jobs"
 
-#: module/Company/view/company/admin/index.phtml:138
-#: module/Company/view/company/admin/index.phtml:201
+#: module/Company/view/company/admin/index.phtml:152
+#: module/Company/view/company/admin/index.phtml:215
 msgid "Banner active"
 msgstr "Banner active"
 
-#: module/Company/view/company/admin/index.phtml:155
-#: module/Company/view/company/admin/index.phtml:203
+#: module/Company/view/company/admin/index.phtml:169
+#: module/Company/view/company/admin/index.phtml:217
 msgid "Expired packages"
 msgstr "Expired packages"
 
-#: module/Company/view/company/admin/index.phtml:202
+#: module/Company/view/company/admin/index.phtml:216
 msgid "Featured in language"
 msgstr "Featured in language"
 
-#: module/Company/view/company/admin/index.phtml:220
-#: module/Decision/view/decision/admin/document.phtml:155
+#: module/Company/view/company/admin/index.phtml:234
+#: module/Decision/view/decision/admin/document.phtml:169
 #, php-format
 msgid "Are you sure you want to delete %s?"
 msgstr "Are you sure you want to delete %s?"
 
-#: module/Company/view/company/admin/index.phtml:227
+#: module/Company/view/company/admin/index.phtml:241
 msgid "Delete company"
 msgstr "Delete company"
 
-#: module/Company/view/company/admin/labels.phtml:4
+#: module/Company/view/company/admin/labels.phtml:17
 msgid "Add Label"
 msgstr "Add Label"
 
-#: module/Company/view/company/company-account/banner.phtml:12
-#: module/Company/view/company/company-account/highlights.phtml:12
+#: module/Company/view/company/company-account/banner.phtml:20
+#: module/Company/view/company/company-account/highlights.phtml:20
 msgid ""
 "This functionality is currently unavailable. Our apologies for the "
 "inconvenience."
@@ -3185,131 +3185,131 @@ msgstr ""
 "This functionality is currently unavailable. Our apologies for the "
 "inconvenience."
 
-#: module/Company/view/company/company-account/jobs.phtml:26
+#: module/Company/view/company/company-account/jobs.phtml:45
 msgid "Job Packages"
 msgstr "Job Packages"
 
-#: module/Company/view/company/company-account/jobs.phtml:44
+#: module/Company/view/company/company-account/jobs.phtml:63
 msgid "Jobs (Active)"
 msgstr "Jobs (Active)"
 
-#: module/Company/view/company/company-account/jobs.phtml:87
-#: module/Company/view/company/company/job-list.phtml:138
+#: module/Company/view/company/company-account/jobs.phtml:106
+#: module/Company/view/company/company/job-list.phtml:152
 msgid "View"
 msgstr "View"
 
-#: module/Company/view/company/company-account/jobs.phtml:99
+#: module/Company/view/company/company-account/jobs.phtml:118
 msgid "Recently Approved Jobs"
 msgstr "Recently Approved Jobs"
 
-#: module/Company/view/company/company-account/jobs.phtml:101
+#: module/Company/view/company/company-account/jobs.phtml:120
 msgid "You do not have recently approved jobs."
 msgstr "You do not have recently approved jobs."
 
-#: module/Company/view/company/company-account/jobs.phtml:121
+#: module/Company/view/company/company-account/jobs.phtml:140
 msgid "Recently Rejected Jobs"
 msgstr "Recently Rejected Jobs"
 
-#: module/Company/view/company/company-account/jobs.phtml:123
+#: module/Company/view/company/company-account/jobs.phtml:142
 msgid "You do not have recently rejected jobs."
 msgstr "You do not have recently rejected jobs."
 
-#: module/Company/view/company/company-account/jobs.phtml:143
+#: module/Company/view/company/company-account/jobs.phtml:162
 msgid "Recently Unapproved Jobs"
 msgstr "Recently Unapproved Jobs"
 
-#: module/Company/view/company/company-account/jobs.phtml:145
+#: module/Company/view/company/company-account/jobs.phtml:164
 msgid "You do not have any recent jobs pending approval."
 msgstr "You do not have any recent jobs pending approval."
 
-#: module/Company/view/company/company-account/jobs.phtml:179
+#: module/Company/view/company/company-account/jobs.phtml:198
 msgid "Approved (Has Updates)"
 msgstr "Approved (Has Updates)"
 
-#: module/Company/view/company/company-account/jobs.phtml:187
+#: module/Company/view/company/company-account/jobs.phtml:206
 msgid "This job package does not contain any jobs."
 msgstr "This job package does not contain any jobs."
 
-#: module/Company/view/company/company-account/self.phtml:2
+#: module/Company/view/company/company-account/self.phtml:10
 msgid "Company Account"
 msgstr "Company Account"
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:18
+#: module/Company/view/company/company-account/transfer-jobs.phtml:30
 msgid "Select the jobs that you want to transfer to another job package."
 msgstr "Select the jobs that you want to transfer to another job package."
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:36
+#: module/Company/view/company/company-account/transfer-jobs.phtml:48
 msgid "There are no jobs that you can transfer..."
 msgstr "There are no jobs that you can transfer..."
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:52
+#: module/Company/view/company/company-account/transfer-jobs.phtml:64
 msgid "Choose to which job package you want to transfer the selected jobs."
 msgstr "Choose to which job package you want to transfer the selected jobs."
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:69
+#: module/Company/view/company/company-account/transfer-jobs.phtml:81
 msgid "Move Jobs"
 msgstr "Move Jobs"
 
-#: module/Company/view/company/company/companyStory.phtml:18
-#: module/Company/view/company/company/jobs.phtml:83
-#: module/Company/view/partial/company/company/grid/company.phtml:16
-#: module/Company/view/partial/company/company/list/company.phtml:26
+#: module/Company/view/company/company/companyStory.phtml:34
+#: module/Company/view/company/company/jobs.phtml:95
+#: module/Company/view/partial/company/company/grid/company.phtml:32
+#: module/Company/view/partial/company/company/list/company.phtml:36
 msgid "Logo of"
 msgstr "Logo of"
 
-#: module/Company/view/company/company/companyStory.phtml:47
-#: module/Company/view/partial/company/company/list/company.phtml:52
+#: module/Company/view/company/company/companyStory.phtml:63
+#: module/Company/view/partial/company/company/list/company.phtml:62
 msgid "Visit Website"
 msgstr "Visit Website"
 
-#: module/Company/view/company/company/companyStory.phtml:52
+#: module/Company/view/company/company/companyStory.phtml:68
 msgid "Highlighted"
 msgstr "Highlighted"
 
-#: module/Company/view/company/company/job-list.phtml:60
+#: module/Company/view/company/company/job-list.phtml:74
 msgid "What are you looking for?"
 msgstr "What are you looking for?"
 
-#: module/Company/view/company/company/job-list.phtml:63
+#: module/Company/view/company/company/job-list.phtml:77
 msgid "Sort on"
 msgstr "Sort on"
 
-#: module/Company/view/company/company/job-list.phtml:65
+#: module/Company/view/company/company/job-list.phtml:79
 msgid "Random"
 msgstr "Random"
 
-#: module/Company/view/company/company/job-list.phtml:66
+#: module/Company/view/company/company/job-list.phtml:80
 msgid "Most recent"
 msgstr "Most recent"
 
-#: module/Company/view/company/company/job-list.phtml:94
+#: module/Company/view/company/company/job-list.phtml:108
 #, php-format
 msgid "Unfortunately, there aren't any %s at the moment."
 msgstr "Unfortunately, there aren't any %s at the moment."
 
-#: module/Company/view/company/company/job-list.phtml:169
+#: module/Company/view/company/company/job-list.phtml:183
 #, php-format
 msgid "Still haven't found what you're looking for? Take a look at %s."
 msgstr "Still haven't found what you're looking for? Take a look at %s."
 
-#: module/Company/view/company/company/jobs.phtml:64
+#: module/Company/view/company/company/jobs.phtml:76
 msgid "at"
 msgstr "at"
 
-#: module/Company/view/company/company/jobs.phtml:114
+#: module/Company/view/company/company/jobs.phtml:126
 msgid "View Website"
 msgstr "View Website"
 
-#: module/Company/view/company/company/list.phtml:23
-#: module/Company/view/company/company/spotlight.phtml:33
+#: module/Company/view/company/company/list.phtml:40
+#: module/Company/view/company/company/spotlight.phtml:49
 msgid "in the spotlight"
 msgstr "in the spotlight"
 
-#: module/Company/view/company/company/spotlight.phtml:21
+#: module/Company/view/company/company/spotlight.phtml:37
 msgid "Featured company"
 msgstr "Featured company"
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:8
+#: module/Company/view/partial/company/admin/editors/company.phtml:21
 msgid ""
 "Specify the permanent link for this company, it should be unique across all "
 "companies."
@@ -3317,24 +3317,24 @@ msgstr ""
 "Specify the permanent link for this company, it should be unique across all "
 "companies."
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:57
+#: module/Company/view/partial/company/admin/editors/company.phtml:70
 msgid "View current logo"
 msgstr "View current logo"
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:81
+#: module/Company/view/partial/company/admin/editors/company.phtml:94
 msgid "Representative Information"
 msgstr "Representative Information"
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:82
+#: module/Company/view/partial/company/admin/editors/company.phtml:95
 msgid "Enter information about the representative of this company."
 msgstr "Enter information about the representative of this company."
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:123
-#: module/Company/view/partial/company/admin/editors/job.phtml:65
+#: module/Company/view/partial/company/admin/editors/company.phtml:136
+#: module/Company/view/partial/company/admin/editors/job.phtml:78
 msgid "Contact Information"
 msgstr "Contact Information"
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:124
+#: module/Company/view/partial/company/admin/editors/company.phtml:137
 msgid ""
 "Enter how someone can contact this company and who is responsible for this "
 "company."
@@ -3342,8 +3342,8 @@ msgstr ""
 "Enter how someone can contact this company and who is responsible for this "
 "company."
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:192
-#: module/Company/view/partial/company/admin/editors/job.phtml:120
+#: module/Company/view/partial/company/admin/editors/company.phtml:205
+#: module/Company/view/partial/company/admin/editors/job.phtml:133
 msgid ""
 "What is this company about? Fill in the blanks below, please note that at "
 "least one language must be used."
@@ -3351,7 +3351,7 @@ msgstr ""
 "What is this company about? Fill in the blanks below, please note that at "
 "least one language must be used."
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:8
+#: module/Company/view/partial/company/admin/editors/job.phtml:21
 msgid ""
 "Specify the permanent link for this job, it should be unique for this "
 "company."
@@ -3359,71 +3359,71 @@ msgstr ""
 "Specify the permanent link for this job, it should be unique for this "
 "company."
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:66
+#: module/Company/view/partial/company/admin/editors/job.phtml:79
 msgid "Enter how someone can contact the person responsible for this job."
 msgstr "Enter how someone can contact the person responsible for this job."
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:211
-#: module/Company/view/partial/company/admin/editors/job.phtml:307
+#: module/Company/view/partial/company/admin/editors/job.phtml:224
+#: module/Company/view/partial/company/admin/editors/job.phtml:320
 msgid "View current attachment"
 msgstr "View current attachment"
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:316
+#: module/Company/view/partial/company/admin/editors/job.phtml:329
 msgid ""
 "Add job labels to your job to give viewers a better understanding of the job."
 msgstr ""
 "Add job labels to your job to give viewers a better understanding of the job."
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:336
+#: module/Company/view/partial/company/admin/editors/job.phtml:349
 msgid "There are currently no job labels..."
 msgstr "There are currently no job labels..."
 
-#: module/Decision/src/Controller/AdminController.php:53
+#: module/Decision/src/Controller/AdminController.php:55
 msgid "Meeting minutes uploaded"
 msgstr "Meeting minutes uploaded"
 
-#: module/Decision/src/Controller/AdminController.php:134
+#: module/Decision/src/Controller/AdminController.php:137
 msgid "You are not allowed to rename meeting documents"
 msgstr "You are not allowed to rename meeting documents"
 
-#: module/Decision/src/Controller/AdminController.php:168
-#: module/Decision/src/Service/Decision.php:293
+#: module/Decision/src/Controller/AdminController.php:177
+#: module/Decision/src/Service/Decision.php:279
 msgid "You are not allowed to delete meeting documents."
 msgstr "You are not allowed to delete meeting documents."
 
-#: module/Decision/src/Controller/DecisionController.php:102
+#: module/Decision/src/Controller/DecisionController.php:109
 msgid "You are not allowed to search decisions."
 msgstr "You are not allowed to search decisions."
 
-#: module/Decision/src/Controller/DecisionController.php:137
+#: module/Decision/src/Controller/DecisionController.php:142
 msgid "You are not allowed to authorize someone"
 msgstr "You are not allowed to authorize someone"
 
-#: module/Decision/src/Controller/DecisionController.php:184
-#: module/Decision/src/Service/Decision.php:595
+#: module/Decision/src/Controller/DecisionController.php:190
+#: module/Decision/src/Service/Decision.php:571
 msgid "You are not allowed to revoke authorizations."
 msgstr "You are not allowed to revoke authorizations."
 
-#: module/Decision/src/Controller/DecisionController.php:212
+#: module/Decision/src/Controller/DecisionController.php:219
 msgid "You are not allowed to browse files."
 msgstr "You are not allowed to browse files."
 
-#: module/Decision/src/Controller/MemberController.php:37
-#: module/Decision/src/Service/Decision.php:140
+#: module/Decision/src/Controller/MemberController.php:40
+#: module/Decision/src/Service/Decision.php:137
 msgid "You are not allowed to view meetings."
 msgstr "You are not allowed to view meetings."
 
-#: module/Decision/src/Controller/MemberController.php:95
+#: module/Decision/src/Controller/MemberController.php:98
 msgid "Not allowed to search for members."
 msgstr "Not allowed to search for members."
 
-#: module/Decision/src/Controller/MemberController.php:148
+#: module/Decision/src/Controller/MemberController.php:151
 msgid "You are not allowed to view the list of birthdays."
 msgstr "You are not allowed to view the list of birthdays."
 
 #: module/Decision/src/Form/Authorization.php:50
-#: module/Decision/view/decision/decision/authorizations.phtml:115
-#: module/Decision/view/decision/decision/authorizations.phtml:121
+#: module/Decision/view/decision/decision/authorizations.phtml:133
+#: module/Decision/view/decision/decision/authorizations.phtml:139
 msgid "Authorize"
 msgstr "Authorize"
 
@@ -3431,328 +3431,324 @@ msgstr "Authorize"
 msgid "Revoke authorization"
 msgstr "Revoke authorization"
 
-#: module/Decision/src/Form/Document.php:31
-#: module/Decision/src/Form/Minutes.php:31
-#: module/Decision/view/decision/admin/minutes.phtml:20
+#: module/Decision/src/Form/Document.php:29
+#: module/Decision/src/Form/Minutes.php:33
+#: module/Decision/view/decision/admin/minutes.phtml:31
 msgid "Meeting"
 msgstr "Meeting"
 
-#: module/Decision/src/Form/Document.php:41
+#: module/Decision/src/Form/Document.php:39
 msgid "Document name"
 msgstr "Document name"
 
-#: module/Decision/src/Form/Document.php:51
+#: module/Decision/src/Form/Document.php:49
 msgid "Document to upload"
 msgstr "Document to upload"
 
-#: module/Decision/src/Form/Document.php:61
+#: module/Decision/src/Form/Document.php:59
 msgid "Upload document"
 msgstr "Upload document"
 
-#: module/Decision/src/Form/Minutes.php:32
+#: module/Decision/src/Form/Minutes.php:34
 msgid "Choose a meeting"
 msgstr "Choose a meeting"
 
-#: module/Decision/src/Form/Minutes.php:43
+#: module/Decision/src/Form/Minutes.php:45
 msgid "Minutes to upload"
 msgstr "Minutes to upload"
 
-#: module/Decision/src/Form/Minutes.php:90
+#: module/Decision/src/Form/Minutes.php:94
 msgid "There already are minutes for this meeting"
 msgstr "There already are minutes for this meeting"
 
-#: module/Decision/src/Form/OrganInformation.php:54
+#: module/Decision/src/Form/OrganInformation.php:52
 msgid "Short dutch description"
 msgstr "Short dutch description"
 
-#: module/Decision/src/Form/OrganInformation.php:64
+#: module/Decision/src/Form/OrganInformation.php:62
 msgid "Short english description"
 msgstr "Short english description"
 
-#: module/Decision/src/Form/OrganInformation.php:74
+#: module/Decision/src/Form/OrganInformation.php:72
 msgid "Long dutch description"
 msgstr "Long dutch description"
 
-#: module/Decision/src/Form/OrganInformation.php:84
+#: module/Decision/src/Form/OrganInformation.php:82
 msgid "Long english description"
 msgstr "Long english description"
 
-#: module/Decision/src/Form/OrganInformation.php:94
+#: module/Decision/src/Form/OrganInformation.php:92
 msgid "Thumbnail photo to upload"
 msgstr "Thumbnail photo to upload"
 
-#: module/Decision/src/Form/OrganInformation.php:104
+#: module/Decision/src/Form/OrganInformation.php:102
 msgid "Cover photo to upload"
 msgstr "Cover photo to upload"
 
-#: module/Decision/src/Form/OrganInformation.php:125
-#: module/Decision/view/decision/organ-admin/edit.phtml:171
+#: module/Decision/src/Form/OrganInformation.php:123
+#: module/Decision/view/decision/organ-admin/edit.phtml:182
 #: module/Frontpage/src/Form/NewsItem.php:78
-#: module/Frontpage/src/Form/Page.php:102
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:97
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:131
+#: module/Frontpage/src/Form/Page.php:100
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:110
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:143
 #: module/Photo/src/Form/EditAlbum.php:59
 msgid "Save"
 msgstr "Save"
 
-#: module/Decision/src/Form/ReorderDocument.php:48
+#: module/Decision/src/Form/ReorderDocument.php:46
 msgid "Move up"
 msgstr "Move up"
 
-#: module/Decision/src/Form/ReorderDocument.php:52
+#: module/Decision/src/Form/ReorderDocument.php:50
 msgid "Move down"
 msgstr "Move down"
 
 #: module/Decision/src/Form/SearchDecision.php:25
-#: module/Decision/view/decision/decision/search.phtml:21
-#: module/Education/src/Form/SearchCourse.php:21
+#: module/Decision/view/decision/decision/search.phtml:32
+#: module/Education/src/Form/SearchCourse.php:23
 msgid "Search query"
 msgstr "Search query"
 
 #: module/Decision/src/Form/SearchDecision.php:35
 #: module/Decision/src/Form/SearchDecision.php:36
-#: module/Decision/view/decision/decision/search.phtml:30
-#: module/Decision/view/decision/member/index.phtml:146
-#: module/Education/view/education/education/index.phtml:46
+#: module/Decision/view/decision/decision/search.phtml:41
+#: module/Decision/view/decision/member/index.phtml:157
+#: module/Education/view/education/education/index.phtml:59
 msgid "Search"
 msgstr "Search"
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:19
+#: module/Decision/src/Model/Enums/AddressTypes.php:21
 msgid "Home address (parents)"
 msgstr "Home address (parents)"
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:20
+#: module/Decision/src/Model/Enums/AddressTypes.php:22
 msgid "Student address"
 msgstr "Student address"
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:21
+#: module/Decision/src/Model/Enums/AddressTypes.php:23
 msgid "Mail address"
 msgstr "Mail address"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:20
+#: module/Decision/src/Model/Enums/MeetingTypes.php:22
 msgid "Board Meeting"
 msgstr "Board Meeting"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:21
+#: module/Decision/src/Model/Enums/MeetingTypes.php:23
 msgid "General Members Meeting"
 msgstr "General Members Meeting"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:22
+#: module/Decision/src/Model/Enums/MeetingTypes.php:24
 msgid "Chair's Meeting"
 msgstr "Chair's Meeting"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:23
+#: module/Decision/src/Model/Enums/MeetingTypes.php:25
 msgid "Virtual Meeting"
 msgstr "Virtual Meeting"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:30
+#: module/Decision/src/Model/Enums/MeetingTypes.php:32
 msgid "BM"
 msgstr "BM"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:31
+#: module/Decision/src/Model/Enums/MeetingTypes.php:33
 msgid "GMM"
 msgstr "GMM"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:32
+#: module/Decision/src/Model/Enums/MeetingTypes.php:34
 msgid "CM"
 msgstr "CM"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:33
+#: module/Decision/src/Model/Enums/MeetingTypes.php:35
 msgid "VIRT"
 msgstr "VIRT"
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:20
+#: module/Decision/src/Model/Enums/MembershipTypes.php:22
 msgid "Ordinary"
 msgstr "Ordinary"
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:22
+#: module/Decision/src/Model/Enums/MembershipTypes.php:24
 msgid "Graduate"
 msgstr "Graduate"
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:23
+#: module/Decision/src/Model/Enums/MembershipTypes.php:25
 msgid "Honorary"
 msgstr "Honorary"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:22
+#: module/Decision/src/Model/Enums/OrganTypes.php:24
 msgid "Committee"
 msgstr "Committee"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:23
+#: module/Decision/src/Model/Enums/OrganTypes.php:25
 msgid "GMM Committee"
 msgstr "GMM Committee"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:24
+#: module/Decision/src/Model/Enums/OrganTypes.php:26
 msgid "Fraternity"
 msgstr "Fraternity"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:25
+#: module/Decision/src/Model/Enums/OrganTypes.php:27
 msgid "Financial Audit Committee"
 msgstr "Financial Audit Committee"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:26
+#: module/Decision/src/Model/Enums/OrganTypes.php:28
 msgid "GMM Taskforce"
 msgstr "GMM Taskforce"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:27
+#: module/Decision/src/Model/Enums/OrganTypes.php:29
 msgid "Advisory Board"
 msgstr "Advisory Board"
 
-#: module/Decision/src/Service/Decision.php:87
-#: module/Decision/src/Service/Decision.php:106
-#: module/Decision/src/Service/Decision.php:120
+#: module/Decision/src/Service/Decision.php:90
+#: module/Decision/src/Service/Decision.php:109
+#: module/Decision/src/Service/Decision.php:121
 msgid "You are not allowed to list meetings."
 msgstr "You are not allowed to list meetings."
 
-#: module/Decision/src/Service/Decision.php:191
+#: module/Decision/src/Service/Decision.php:178
 msgid "You are not allowed to view meeting documents."
 msgstr "You are not allowed to view meeting documents."
 
-#: module/Decision/src/Service/Decision.php:212
+#: module/Decision/src/Service/Decision.php:195
 msgid "You are not allowed to view meeting minutes."
 msgstr "You are not allowed to view meeting minutes."
 
-#: module/Decision/src/Service/Decision.php:399
+#: module/Decision/src/Service/Decision.php:388
 msgid "You are not allowed to view all authorizations."
 msgstr "You are not allowed to view all authorizations."
 
-#: module/Decision/src/Service/Decision.php:419
+#: module/Decision/src/Service/Decision.php:404
 msgid "You are not allowed to view authorizations."
 msgstr "You are not allowed to view authorizations."
 
-#: module/Decision/src/Service/Decision.php:529
+#: module/Decision/src/Service/Decision.php:514
 msgid "You are not allowed to upload meeting minutes."
 msgstr "You are not allowed to upload meeting minutes."
 
-#: module/Decision/src/Service/Decision.php:544
+#: module/Decision/src/Service/Decision.php:528
 msgid "You are not allowed to upload meeting documents."
 msgstr "You are not allowed to upload meeting documents."
 
-#: module/Decision/src/Service/Decision.php:581
+#: module/Decision/src/Service/Decision.php:558
 msgid "You are not allowed authorize people."
 msgstr "You are not allowed authorize people."
 
-#: module/Decision/src/Service/Member.php:56
-#: module/Decision/src/Service/MemberInfo.php:45
+#: module/Decision/src/Service/Member.php:50
+#: module/Decision/src/Service/MemberInfo.php:69
 msgid "You are not allowed to view members."
 msgstr "You are not allowed to view members."
 
-#: module/Decision/src/Service/Member.php:100
-msgid "Name must be at least "
-msgstr "Name must be at least "
-
-#: module/Decision/src/Service/MemberInfo.php:43
+#: module/Decision/src/Service/MemberInfo.php:65
 msgid "You are not allowed to view membership info."
 msgstr "You are not allowed to view membership info."
 
-#: module/Decision/src/Service/Organ.php:56
+#: module/Decision/src/Service/Organ.php:66
 msgid "Not allowed to view the list of organs"
 msgstr "Not allowed to view the list of organs"
 
-#: module/Decision/src/Service/Organ.php:72
+#: module/Decision/src/Service/Organ.php:78
 msgid "Not allowed to view organ information"
 msgstr "Not allowed to view organ information"
 
-#: module/Decision/src/Service/Organ.php:87
+#: module/Decision/src/Service/Organ.php:93
 msgid "You are not allowed to edit organ information"
 msgstr "You are not allowed to edit organ information"
 
-#: module/Decision/src/Service/Organ.php:317
+#: module/Decision/src/Service/Organ.php:305
 msgid "You are not allowed to edit this organ's information"
 msgstr "You are not allowed to edit this organ's information"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:20
+#: module/Decision/view/decision/admin/authorizations.phtml:31
 #, php-format
 msgid "GMM %d (%s)"
 msgstr "GMM %d (%s)"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:27
+#: module/Decision/view/decision/admin/authorizations.phtml:38
 msgid "No GMM available."
 msgstr "No GMM available."
 
-#: module/Decision/view/decision/admin/authorizations.phtml:32
+#: module/Decision/view/decision/admin/authorizations.phtml:43
 #, php-format
 msgid "Valid authorizations for GMM %d"
 msgstr "Valid authorizations for GMM %d"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:37
-#: module/Decision/view/decision/admin/authorizations.phtml:61
+#: module/Decision/view/decision/admin/authorizations.phtml:48
+#: module/Decision/view/decision/admin/authorizations.phtml:72
 msgid "Authorizer"
 msgstr "Authorizer"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:38
-#: module/Decision/view/decision/admin/authorizations.phtml:62
+#: module/Decision/view/decision/admin/authorizations.phtml:49
+#: module/Decision/view/decision/admin/authorizations.phtml:73
 msgid "Recipient"
 msgstr "Recipient"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:39
-#: module/Decision/view/decision/admin/authorizations.phtml:63
+#: module/Decision/view/decision/admin/authorizations.phtml:50
+#: module/Decision/view/decision/admin/authorizations.phtml:74
 msgid "Created"
 msgstr "Created"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:53
+#: module/Decision/view/decision/admin/authorizations.phtml:64
 msgid "There are no valid authorizations for this GMM."
 msgstr "There are no valid authorizations for this GMM."
 
-#: module/Decision/view/decision/admin/authorizations.phtml:56
+#: module/Decision/view/decision/admin/authorizations.phtml:67
 #, php-format
 msgid "Revoked authorizations for GMM %d"
 msgstr "Revoked authorizations for GMM %d"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:64
+#: module/Decision/view/decision/admin/authorizations.phtml:75
 msgid "Revoked"
 msgstr "Revoked"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:79
+#: module/Decision/view/decision/admin/authorizations.phtml:90
 msgid "There are no revoked authorizations for this GMM."
 msgstr "There are no revoked authorizations for this GMM."
 
-#: module/Decision/view/decision/admin/authorizations.phtml:82
+#: module/Decision/view/decision/admin/authorizations.phtml:93
 msgid "Please select a GMM to view authorizations."
 msgstr "Please select a GMM to view authorizations."
 
-#: module/Decision/view/decision/admin/document.phtml:18
+#: module/Decision/view/decision/admin/document.phtml:33
 msgid "There are no meetings for which you can upload documents."
 msgstr "There are no meetings for which you can upload documents."
 
-#: module/Decision/view/decision/admin/document.phtml:22
+#: module/Decision/view/decision/admin/document.phtml:37
 msgid "Meeting document uploaded"
 msgstr "Meeting document uploaded"
 
-#: module/Decision/view/decision/admin/document.phtml:48
+#: module/Decision/view/decision/admin/document.phtml:62
 msgid "No meeting available."
 msgstr "No meeting available."
 
-#: module/Decision/view/decision/admin/document.phtml:89
+#: module/Decision/view/decision/admin/document.phtml:103
 msgid "Documents for this meeting"
 msgstr "Documents for this meeting"
 
-#: module/Decision/view/decision/admin/document.phtml:92
+#: module/Decision/view/decision/admin/document.phtml:106
 msgid "This meeting does not have any associated documents."
 msgstr "This meeting does not have any associated documents."
 
-#: module/Decision/view/decision/admin/document.phtml:131
-#: module/Decision/view/decision/admin/document.phtml:194
+#: module/Decision/view/decision/admin/document.phtml:145
+#: module/Decision/view/decision/admin/document.phtml:208
 msgid "Rename"
 msgstr "Rename"
 
-#: module/Decision/view/decision/admin/document.phtml:149
-#: module/Education/view/education/admin/course-documents.phtml:153
+#: module/Decision/view/decision/admin/document.phtml:163
+#: module/Education/view/education/admin/course-documents.phtml:163
 msgid "Delete Document"
 msgstr "Delete Document"
 
-#: module/Decision/view/decision/admin/document.phtml:181
+#: module/Decision/view/decision/admin/document.phtml:195
 msgid "Rename Meeting Document"
 msgstr "Rename Meeting Document"
 
-#: module/Decision/view/decision/admin/document.phtml:184
+#: module/Decision/view/decision/admin/document.phtml:198
 msgid "Enter a new name for this document:"
 msgstr "Enter a new name for this document:"
 
-#: module/Decision/view/decision/admin/minutes.phtml:44
+#: module/Decision/view/decision/admin/minutes.phtml:55
 msgid "Upload"
 msgstr "Upload"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:18
+#: module/Decision/view/decision/decision/authorizations.phtml:36
 msgid ""
 "There are no upcoming meetings for which you can authorize someone.\n"
 "You may still be able to authorize someone or revoke an authorization by "
@@ -3762,12 +3758,12 @@ msgstr ""
 "You may still be able to authorize someone or revoke an authorization by "
 "contacting the board."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:22
+#: module/Decision/view/decision/decision/authorizations.phtml:40
 #, php-format
 msgid "You have authorized %s for the %s GMM (%s)."
 msgstr "You have authorized %s for the %s GMM (%s)."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:29
+#: module/Decision/view/decision/decision/authorizations.phtml:47
 #, php-format
 msgid ""
 "As per HR article 5 paragraph 4, you have the right to revoke your "
@@ -3782,12 +3778,12 @@ msgstr ""
 "only revoke an authorization that was granted via this website by using the "
 "form below."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:45
-#: module/Decision/view/decision/decision/authorizations.phtml:100
+#: module/Decision/view/decision/decision/authorizations.phtml:63
+#: module/Decision/view/decision/decision/authorizations.phtml:118
 msgid "Terms"
 msgstr "Terms"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:50
+#: module/Decision/view/decision/decision/authorizations.phtml:68
 #, php-format
 msgid ""
 "I, %s am fully aware that by revoking my authorization, %s cannot represent "
@@ -3796,17 +3792,17 @@ msgstr ""
 "I, %s am fully aware that by revoking my authorization, %s cannot represent "
 "me at the %s General Members Meeting (%s) of s.v. GEWIS."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:71
+#: module/Decision/view/decision/decision/authorizations.phtml:89
 #, php-format
 msgid "Authorize someone for the %s GMM (%s)"
 msgstr "Authorize someone for the %s GMM (%s)"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:87
-#: module/User/view/user/user/login.phtml:15
+#: module/Decision/view/decision/decision/authorizations.phtml:105
+#: module/User/view/user/user/login.phtml:29
 msgid "Member"
 msgstr "Member"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:105
+#: module/Decision/view/decision/decision/authorizations.phtml:123
 #, php-format
 msgid ""
 "I, %s I am fully aware that by filling in this form I authorize the person "
@@ -3817,11 +3813,11 @@ msgstr ""
 "in this form to represent me at the %s General Members Meeting (%s) of s.v. "
 "GEWIS."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:157
+#: module/Decision/view/decision/decision/authorizations.phtml:175
 msgid "Are you sure you would like to authorize"
 msgstr "Are you sure you would like to authorize"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:163
+#: module/Decision/view/decision/decision/authorizations.phtml:181
 msgid ""
 "This member has already received 2 or more authorizations through the "
 "website. Since you can only use two authorizations at the same time, this "
@@ -3837,110 +3833,144 @@ msgstr ""
 "instead, click on \"cancel\". If you want to continue with the authorization "
 "click on \"confirm authorization\"."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:169
+#: module/Decision/view/decision/decision/authorizations.phtml:187
 msgid "Confirm authorization"
 msgstr "Confirm authorization"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:193
+#: module/Decision/view/decision/decision/authorizations.phtml:211
 #, php-format
 msgid "Are you sure you would like to authorize %s"
 msgstr "Are you sure you would like to authorize %s"
 
-#: module/Decision/view/decision/decision/files.phtml:14
-#: module/Decision/view/decision/decision/files.phtml:16
-#: module/Decision/view/decision/decision/files.phtml:35
-#: module/Decision/view/decision/decision/files.phtml:39
+#: module/Decision/view/decision/decision/files.phtml:26
+#: module/Decision/view/decision/decision/files.phtml:28
+#: module/Decision/view/decision/decision/files.phtml:47
+#: module/Decision/view/decision/decision/files.phtml:51
 msgid "Root"
 msgstr "Root"
 
-#: module/Decision/view/decision/decision/files.phtml:35
+#: module/Decision/view/decision/decision/files.phtml:47
 msgid "Public Archive"
 msgstr "Public Archive"
 
-#: module/Decision/view/decision/decision/files.phtml:39
+#: module/Decision/view/decision/decision/files.phtml:51
 msgid "Browsing directory: "
 msgstr "Browsing directory: "
 
-#: module/Decision/view/decision/decision/files.phtml:66
+#: module/Decision/view/decision/decision/files.phtml:78
 msgid "Filename"
 msgstr "Filename"
 
-#: module/Decision/view/decision/decision/files.phtml:80
+#: module/Decision/view/decision/decision/files.phtml:92
 msgid ".. Move up a folder"
 msgstr ".. Move up a folder"
 
-#: module/Decision/view/decision/decision/files.phtml:89
+#: module/Decision/view/decision/decision/files.phtml:101
 msgid "Empty folder"
 msgstr "Empty folder"
 
-#: module/Decision/view/decision/decision/index.phtml:10
+#: module/Decision/view/decision/decision/index.phtml:24
 msgid "Meeting number"
 msgstr "Meeting number"
 
-#: module/Decision/view/decision/decision/index.phtml:11
-#: module/Decision/view/decision/member/birthdays.phtml:11
-#: module/Education/view/education/admin/course-documents.phtml:55
-#: module/Education/view/education/admin/course-documents.phtml:106
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:26
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:99
+#: module/Decision/view/decision/decision/index.phtml:25
+#: module/Decision/view/decision/member/birthdays.phtml:22
+#: module/Education/view/education/admin/course-documents.phtml:65
+#: module/Education/view/education/admin/course-documents.phtml:116
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:41
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:114
 msgid "Date"
 msgstr "Date"
 
-#: module/Decision/view/decision/decision/index.phtml:12
+#: module/Decision/view/decision/decision/index.phtml:26
 msgid "# Decisions"
 msgstr "# Decisions"
 
-#: module/Decision/view/decision/decision/search.phtml:3
+#: module/Decision/view/decision/decision/search.phtml:14
 msgid "Search for decision"
 msgstr "Search for decision"
 
-#: module/Decision/view/decision/decision/view.phtml:35
+#: module/Decision/view/decision/decision/search.phtml:50
+msgid "No decisions were found."
+msgstr "No decisions were found."
+
+#: module/Decision/view/decision/decision/search.phtml:52
+msgid "Check the spelling of your search term"
+msgstr "Check the spelling of your search term"
+
+#: module/Decision/view/decision/decision/search.phtml:53
+msgid "Try alternate words or selections"
+msgstr "Try alternate words or selections"
+
+#: module/Decision/view/decision/decision/search.phtml:54
+msgid "Try using a more generic search term"
+msgstr "Try using a more generic search term"
+
+#: module/Decision/view/decision/decision/search.phtml:55
+msgid "Try entering fewer keywords"
+msgstr "Try entering fewer keywords"
+
+#: module/Decision/view/decision/decision/search.phtml:56
+msgid ""
+"Looking for a specific decision but forgot the numbers? Try dropping the "
+"decision point and/or number"
+msgstr ""
+"Looking for a specific decision but forgot the numbers? Try dropping the "
+"decision point and/or number"
+
+#: module/Decision/view/decision/decision/view.phtml:47
 msgid "No documents have been added."
 msgstr "No documents have been added."
 
-#: module/Decision/view/decision/decision/view.phtml:50
+#: module/Decision/view/decision/decision/view.phtml:62
 #, php-format
 msgid "View the minutes of the %s"
 msgstr "View the minutes of the %s"
 
-#: module/Decision/view/decision/decision/view.phtml:59
+#: module/Decision/view/decision/decision/view.phtml:71
 msgid "Decisions"
 msgstr "Decisions"
 
-#: module/Decision/view/decision/member/birthdays.phtml:3
+#: module/Decision/view/decision/member/birthdays.phtml:14
 msgid "Birthdays"
 msgstr "Birthdays"
 
-#: module/Decision/view/decision/member/birthdays.phtml:13
+#: module/Decision/view/decision/member/birthdays.phtml:24
 msgid "Age"
 msgstr "Age"
 
-#: module/Decision/view/decision/member/birthdays.phtml:33
+#: module/Decision/view/decision/member/birthdays.phtml:44
 msgid "years"
 msgstr "years"
 
-#: module/Decision/view/decision/member/index.phtml:22
+#: module/Decision/view/decision/member/index.phtml:33
 msgid "Personal"
 msgstr "Personal"
 
-#: module/Decision/view/decision/member/index.phtml:26
+#: module/Decision/view/decision/member/index.phtml:37
 msgid "Profile"
 msgstr "Profile"
 
-#: module/Decision/view/decision/member/index.phtml:67
+#: module/Decision/view/decision/member/index.phtml:78
 msgid "Public archive"
 msgstr "Public archive"
 
-#: module/Decision/view/decision/member/index.phtml:72
+#: module/Decision/view/decision/member/index.phtml:83
 msgid "Find a member"
 msgstr "Find a member"
 
-#: module/Decision/view/decision/member/index.phtml:107
+#: module/Decision/view/decision/member/index.phtml:106
+msgid "Upcoming meeting"
+msgid_plural "Upcoming meetings"
+msgstr[0] "Upcoming meeting"
+msgstr[1] "Upcoming meetings"
+
+#: module/Decision/view/decision/member/index.phtml:118
 #, php-format
 msgid "The %s%s %s%s will be held on %s."
 msgstr "The %s%s %s%s will be held on %s."
 
-#: module/Decision/view/decision/member/index.phtml:133
+#: module/Decision/view/decision/member/index.phtml:144
 #, php-format
 msgid ""
 "If you aren't able to attend a GMM in person but you want your voice to be "
@@ -3949,108 +3979,108 @@ msgstr ""
 "If you aren't able to attend a GMM in person but you want your voice to be "
 "heard, consider %sauthorizing another member%s to act on your behalf."
 
-#: module/Decision/view/decision/member/index.phtml:141
+#: module/Decision/view/decision/member/index.phtml:152
 msgid "Search through the list of decisions accumulated from past meetings:"
 msgstr "Search through the list of decisions accumulated from past meetings:"
 
-#: module/Decision/view/decision/member/index.phtml:144
+#: module/Decision/view/decision/member/index.phtml:155
 msgid "Search by keyword or meeting number"
 msgstr "Search by keyword or meeting number"
 
-#: module/Decision/view/decision/member/index.phtml:151
+#: module/Decision/view/decision/member/index.phtml:162
 #, php-format
 msgid "The latest %s that took place:"
 msgstr "The latest %s that took place:"
 
-#: module/Decision/view/decision/member/index.phtml:163
+#: module/Decision/view/decision/member/index.phtml:174
 #, php-format
 msgid "%s %s on %s"
 msgstr "%s %s on %s"
 
-#: module/Decision/view/decision/member/index.phtml:178
+#: module/Decision/view/decision/member/index.phtml:189
 msgid "View all meetings"
 msgstr "View all meetings"
 
-#: module/Decision/view/decision/member/index.phtml:183
-#: module/Decision/view/decision/organ/show.phtml:9
-#: module/Frontpage/view/frontpage/organ/organ.phtml:129
+#: module/Decision/view/decision/member/index.phtml:194
+#: module/Decision/view/decision/organ/show.phtml:25
+#: module/Frontpage/view/frontpage/organ/organ.phtml:145
 msgid "Active members"
 msgstr "Active members"
 
-#: module/Decision/view/decision/member/index.phtml:184
+#: module/Decision/view/decision/member/index.phtml:195
 msgid "A list of helpful resources for active members."
 msgstr "A list of helpful resources for active members."
 
-#: module/Decision/view/decision/member/index.phtml:188
+#: module/Decision/view/decision/member/index.phtml:199
 msgid "Webmail"
 msgstr "Webmail"
 
-#: module/Decision/view/decision/member/index.phtml:200
+#: module/Decision/view/decision/member/index.phtml:211
 msgid "GEWIKI"
 msgstr "GEWIKI"
 
-#: module/Decision/view/decision/member/index.phtml:204
+#: module/Decision/view/decision/member/index.phtml:215
 msgid "Corporate Identity"
 msgstr "Corporate Identity"
 
-#: module/Decision/view/decision/member/index.phtml:208
+#: module/Decision/view/decision/member/index.phtml:219
 msgid "Administrator"
 msgstr "Administrator"
 
-#: module/Decision/view/decision/member/index.phtml:226
+#: module/Decision/view/decision/member/index.phtml:237
 msgid "Bylaws"
 msgstr "Bylaws"
 
-#: module/Decision/view/decision/member/index.phtml:238
+#: module/Decision/view/decision/member/index.phtml:249
 msgid "Internal Regulations"
 msgstr "Internal Regulations"
 
-#: module/Decision/view/decision/member/index.phtml:253
+#: module/Decision/view/decision/member/index.phtml:264
 msgid "Board Policies"
 msgstr "Board Policies"
 
-#: module/Decision/view/decision/member/index.phtml:258
+#: module/Decision/view/decision/member/index.phtml:269
 msgid "Borrel Policy"
 msgstr "Borrel Policy"
 
-#: module/Decision/view/decision/member/index.phtml:263
+#: module/Decision/view/decision/member/index.phtml:274
 msgid "House Rules"
 msgstr "House Rules"
 
-#: module/Decision/view/decision/member/index.phtml:268
+#: module/Decision/view/decision/member/index.phtml:279
 msgid "ICT Policy"
 msgstr "ICT Policy"
 
-#: module/Decision/view/decision/member/index.phtml:273
+#: module/Decision/view/decision/member/index.phtml:284
 msgid "Key Policy"
 msgstr "Key Policy"
 
-#: module/Decision/view/decision/member/index.phtml:278
+#: module/Decision/view/decision/member/index.phtml:289
 msgid "Poster Policy"
 msgstr "Poster Policy"
 
-#: module/Decision/view/decision/member/index.phtml:289
+#: module/Decision/view/decision/member/index.phtml:300
 msgid "Organ Regulations"
 msgstr "Organ Regulations"
 
-#: module/Decision/view/decision/member/search.phtml:3
-#: module/Decision/view/decision/member/search.phtml:9
+#: module/Decision/view/decision/member/search.phtml:10
+#: module/Decision/view/decision/member/search.phtml:16
 msgid "Zoeken op lid"
 msgstr "Search for a member"
 
-#: module/Decision/view/decision/member/search.phtml:13
+#: module/Decision/view/decision/member/search.phtml:20
 msgid "Zoek"
 msgstr "Search"
 
-#: module/Decision/view/decision/member/search.phtml:23
+#: module/Decision/view/decision/member/search.phtml:30
 msgid "Naam"
 msgstr "Name"
 
-#: module/Decision/view/decision/member/search.phtml:24
+#: module/Decision/view/decision/member/search.phtml:31
 msgid "Generatie"
 msgstr "Generation"
 
-#: module/Decision/view/decision/member/search.phtml:31
+#: module/Decision/view/decision/member/search.phtml:38
 msgid ""
 "Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
 "resultaten te zien."
@@ -4058,52 +4088,52 @@ msgstr ""
 "There are too many results to display. Try filtering in order to display "
 "other results."
 
-#: module/Decision/view/decision/member/self.phtml:10
+#: module/Decision/view/decision/member/self.phtml:20
 msgid "My Information"
 msgstr "My Information"
 
-#: module/Decision/view/decision/member/self.phtml:19
-#: module/User/src/Form/Register.php:34 module/User/src/Form/UserReset.php:32
+#: module/Decision/view/decision/member/self.phtml:29
+#: module/User/src/Form/Register.php:32 module/User/src/Form/UserReset.php:30
 msgid "Membership number"
 msgstr "Membership number"
 
-#: module/Decision/view/decision/member/self.phtml:23
+#: module/Decision/view/decision/member/self.phtml:33
 msgid "Initials"
 msgstr "Initials"
 
-#: module/Decision/view/decision/member/self.phtml:27
+#: module/Decision/view/decision/member/self.phtml:37
 msgid "First name"
 msgstr "First name"
 
-#: module/Decision/view/decision/member/self.phtml:31
-#: module/User/src/Model/Enums/JWTClaims.php:43
+#: module/Decision/view/decision/member/self.phtml:41
+#: module/User/src/Model/Enums/JWTClaims.php:45
 msgid "Middle name"
 msgstr "Middle name"
 
-#: module/Decision/view/decision/member/self.phtml:35
+#: module/Decision/view/decision/member/self.phtml:45
 msgid "Last name"
 msgstr "Last name"
 
-#: module/Decision/view/decision/member/self.phtml:50
-#: module/Decision/view/decision/member/view.phtml:46
+#: module/Decision/view/decision/member/self.phtml:60
+#: module/Decision/view/decision/member/view.phtml:45
 msgid "Birth date"
 msgstr "Birth date"
 
-#: module/Decision/view/decision/member/self.phtml:58
-#: module/Decision/view/decision/member/view.phtml:55
-#: module/User/src/Model/Enums/JWTClaims.php:42
+#: module/Decision/view/decision/member/self.phtml:68
+#: module/Decision/view/decision/member/view.phtml:54
+#: module/User/src/Model/Enums/JWTClaims.php:44
 msgid "Membership type"
 msgstr "Membership type"
 
-#: module/Decision/view/decision/member/self.phtml:62
+#: module/Decision/view/decision/member/self.phtml:72
 msgid "Last membership change"
 msgstr "Last membership change"
 
-#: module/Decision/view/decision/member/self.phtml:66
+#: module/Decision/view/decision/member/self.phtml:76
 msgid "End date of membership"
 msgstr "End date of membership"
 
-#: module/Decision/view/decision/member/self.phtml:73
+#: module/Decision/view/decision/member/self.phtml:83
 msgid ""
 "If your information is no longer up to date and you would like to change it, "
 "you can contact the secretary of GEWIS."
@@ -4111,145 +4141,145 @@ msgstr ""
 "If your information is no longer up to date and you would like to change it, "
 "you can contact the secretary of GEWIS."
 
-#: module/Decision/view/decision/member/self.phtml:74
+#: module/Decision/view/decision/member/self.phtml:84
 msgid "Also for data removal requests, you can contact"
 msgstr "Also for data removal requests, you can contact"
 
-#: module/Decision/view/decision/member/self.phtml:75
+#: module/Decision/view/decision/member/self.phtml:85
 msgid "Email the secretary of GEWIS"
 msgstr "Email the secretary of GEWIS"
 
-#: module/Decision/view/decision/member/self.phtml:75
+#: module/Decision/view/decision/member/self.phtml:85
 msgid "the secretary of GEWIS"
 msgstr "the secretary of GEWIS"
 
-#: module/Decision/view/decision/member/self.phtml:79
-#: module/Decision/view/decision/member/view.phtml:127
+#: module/Decision/view/decision/member/self.phtml:89
+#: module/Decision/view/decision/member/view.phtml:117
 msgid "Memberships of committees and fraternities"
 msgstr "Memberships of committees and fraternities"
 
-#: module/Decision/view/decision/member/self.phtml:84
+#: module/Decision/view/decision/member/self.phtml:94
 msgid "You have not been a member of a committee or fraternity."
 msgstr "You have not been a member of a committee or fraternity."
 
-#: module/Decision/view/decision/member/self.phtml:87
+#: module/Decision/view/decision/member/self.phtml:97
 msgid "You are currently a member of:"
 msgstr "You are currently a member of:"
 
-#: module/Decision/view/decision/member/self.phtml:108
+#: module/Decision/view/decision/member/self.phtml:121
 msgid "You were a member of:"
 msgstr "You were a member of:"
 
-#: module/Decision/view/decision/member/self.phtml:129
-#: module/Decision/view/decision/member/view.phtml:192
+#: module/Decision/view/decision/member/self.phtml:145
+#: module/Decision/view/decision/member/view.phtml:188
 msgid "Addresses"
 msgstr "Addresses"
 
-#: module/Decision/view/decision/member/self.phtml:134
-#: module/Decision/view/decision/member/view.phtml:197
+#: module/Decision/view/decision/member/self.phtml:150
+#: module/Decision/view/decision/member/view.phtml:193
 msgid "Country"
 msgstr "Country"
 
-#: module/Decision/view/decision/member/self.phtml:138
-#: module/Decision/view/decision/member/view.phtml:201
+#: module/Decision/view/decision/member/self.phtml:154
+#: module/Decision/view/decision/member/view.phtml:197
 msgid "Street and number"
 msgstr "Street and number"
 
-#: module/Decision/view/decision/member/self.phtml:141
-#: module/Decision/view/decision/member/self.phtml:151
-#: module/Decision/view/decision/member/view.phtml:204
-#: module/Decision/view/decision/member/view.phtml:214
+#: module/Decision/view/decision/member/self.phtml:157
+#: module/Decision/view/decision/member/self.phtml:167
+#: module/Decision/view/decision/member/view.phtml:200
+#: module/Decision/view/decision/member/view.phtml:210
 #, php-format
 msgid "%s %s"
 msgstr "%s %s"
 
-#: module/Decision/view/decision/member/self.phtml:148
-#: module/Decision/view/decision/member/view.phtml:211
+#: module/Decision/view/decision/member/self.phtml:164
+#: module/Decision/view/decision/member/view.phtml:207
 msgid "City and postal code"
 msgstr "City and postal code"
 
-#: module/Decision/view/decision/member/self.phtml:164
+#: module/Decision/view/decision/member/self.phtml:180
 msgid "External applications"
 msgstr "External applications"
 
-#: module/Decision/view/decision/member/self.phtml:167
+#: module/Decision/view/decision/member/self.phtml:183
 msgid "App"
 msgstr "App"
 
-#: module/Decision/view/decision/member/self.phtml:168
+#: module/Decision/view/decision/member/self.phtml:184
 msgid "First authentication"
 msgstr "First authentication"
 
-#: module/Decision/view/decision/member/self.phtml:169
+#: module/Decision/view/decision/member/self.phtml:185
 msgid "Last authentication"
 msgstr "Last authentication"
 
-#: module/Decision/view/decision/member/self.phtml:214
+#: module/Decision/view/decision/member/self.phtml:230
 msgid "Remove this picture as your profile picture"
 msgstr "Remove this picture as your profile picture"
 
-#: module/Decision/view/decision/member/self.phtml:216
+#: module/Decision/view/decision/member/self.phtml:232
 msgid "Your profile picture will be chosen automatically instead."
 msgstr "Your profile picture will be chosen automatically instead."
 
-#: module/Decision/view/decision/member/self.phtml:231
+#: module/Decision/view/decision/member/self.phtml:247
 msgid "More of my photo's"
 msgstr "More of my photo's"
 
-#: module/Decision/view/decision/member/view.phtml:59
+#: module/Decision/view/decision/member/view.phtml:58
 msgid "Has key code?"
 msgstr "Has key code?"
 
-#: module/Decision/view/decision/member/view.phtml:89
+#: module/Decision/view/decision/member/view.phtml:79
 #, php-format
 msgid "%s is the upcoming <strong>%s</strong>."
 msgstr "%s is the upcoming <strong>%s</strong>."
 
-#: module/Decision/view/decision/member/view.phtml:105
+#: module/Decision/view/decision/member/view.phtml:95
 #, php-format
 msgid "%s is currently the <strong>%s</strong>."
 msgstr "%s is currently the <strong>%s</strong>."
 
-#: module/Decision/view/decision/member/view.phtml:115
+#: module/Decision/view/decision/member/view.phtml:105
 #, php-format
 msgid "%s was the <strong>%s</strong> during the association year %d/%d."
 msgstr "%s was the <strong>%s</strong> during the association year %d/%d."
 
-#: module/Decision/view/decision/member/view.phtml:134
+#: module/Decision/view/decision/member/view.phtml:124
 #, php-format
 msgid "%s has never been part of a committee or fraternity."
 msgstr "%s has never been part of a committee or fraternity."
 
-#: module/Decision/view/decision/member/view.phtml:142
+#: module/Decision/view/decision/member/view.phtml:132
 #, php-format
 msgid "%s is currently a member of:"
 msgstr "%s is currently a member of:"
 
-#: module/Decision/view/decision/member/view.phtml:168
+#: module/Decision/view/decision/member/view.phtml:161
 #, php-format
 msgid "%s was a member of:"
 msgstr "%s was a member of:"
 
-#: module/Decision/view/decision/member/view.phtml:266
+#: module/Decision/view/decision/member/view.phtml:262
 #, php-format
 msgid "Photo's of %s"
 msgstr "Photo's of %s"
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:64
+#: module/Decision/view/decision/organ-admin/edit.phtml:75
 msgid "Edit organ information"
 msgstr "Edit organ information"
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:139
+#: module/Decision/view/decision/organ-admin/edit.phtml:150
 msgid ""
 "To optimally display your image on the overview page, please crop it below"
 msgstr ""
 "To optimally display your image on the overview page, please crop it below"
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:155
+#: module/Decision/view/decision/organ-admin/edit.phtml:166
 msgid "To optimally display your image your page, please crop it below"
 msgstr "To optimally display your image your page, please crop it below"
 
-#: module/Decision/view/decision/organ-admin/index.phtml:6
+#: module/Decision/view/decision/organ-admin/index.phtml:18
 msgid ""
 "Select an organ to edit its information. Changes will not be displayed until "
 "they have been approved."
@@ -4257,110 +4287,110 @@ msgstr ""
 "Select an organ to edit its information. Changes will not be displayed until "
 "they have been approved."
 
-#: module/Decision/view/decision/organ-admin/index.phtml:13
+#: module/Decision/view/decision/organ-admin/index.phtml:25
 msgid "Approval status"
 msgstr "Approval status"
 
-#: module/Decision/view/decision/organ/index.phtml:6
+#: module/Decision/view/decision/organ/index.phtml:15
 msgid "Organ list"
 msgstr "Organ list"
 
-#: module/Decision/view/decision/organ/show.phtml:32
+#: module/Decision/view/decision/organ/show.phtml:50
 msgid "Inactive members"
 msgstr "Inactive members"
 
-#: module/Decision/view/decision/organ/show.phtml:43
+#: module/Decision/view/decision/organ/show.phtml:61
 msgid "Old members"
 msgstr "Old members"
 
-#: module/Decision/view/decision/organ/show.phtml:52
+#: module/Decision/view/decision/organ/show.phtml:70
 msgid "Organ mutations"
 msgstr "Organ mutations"
 
-#: module/Education/src/Controller/AdminController.php:43
+#: module/Education/src/Controller/AdminController.php:41
 msgid "You are not allowed to administer education settings"
 msgstr "You are not allowed to administer education settings"
 
-#: module/Education/src/Controller/AdminController.php:53
+#: module/Education/src/Controller/AdminController.php:51
 msgid "You are not allowed to administer courses"
 msgstr "You are not allowed to administer courses"
 
-#: module/Education/src/Controller/AdminController.php:62
-#: module/Education/src/Service/Exam.php:482
+#: module/Education/src/Controller/AdminController.php:60
+#: module/Education/src/Service/Exam.php:473
 msgid "You are not allowed to add courses"
 msgstr "You are not allowed to add courses"
 
-#: module/Education/src/Controller/AdminController.php:78
+#: module/Education/src/Controller/AdminController.php:76
 msgid "Successfully added course!"
 msgstr "Successfully added course!"
 
-#: module/Education/src/Controller/AdminController.php:84
-#: module/Education/src/Controller/AdminController.php:127
+#: module/Education/src/Controller/AdminController.php:83
+#: module/Education/src/Controller/AdminController.php:125
 msgid "An error occurred while saving the course!"
 msgstr "An error occurred while saving the course!"
 
-#: module/Education/src/Controller/AdminController.php:100
-#: module/Education/src/Controller/AdminController.php:164
+#: module/Education/src/Controller/AdminController.php:98
+#: module/Education/src/Controller/AdminController.php:162
 msgid "You are not allowed to edit courses"
 msgstr "You are not allowed to edit courses"
 
-#: module/Education/src/Controller/AdminController.php:123
+#: module/Education/src/Controller/AdminController.php:121
 msgid "Successfully updated course information!"
 msgstr "Successfully updated course information!"
 
-#: module/Education/src/Controller/AdminController.php:142
+#: module/Education/src/Controller/AdminController.php:140
 msgid "You are not allowed to delete courses"
 msgstr "You are not allowed to delete courses"
 
-#: module/Education/src/Controller/AdminController.php:185
+#: module/Education/src/Controller/AdminController.php:183
 msgid "You are not allowed to delete course documents"
 msgstr "You are not allowed to delete course documents"
 
-#: module/Education/src/Form/Bulk.php:45
+#: module/Education/src/Form/Bulk.php:43
 msgid "Finalize uploads"
 msgstr "Finalize uploads"
 
-#: module/Education/src/Form/Bulk.php:66
+#: module/Education/src/Form/Bulk.php:64
 msgid "Course does not exist"
 msgstr "Course does not exist"
 
-#: module/Education/src/Form/Course.php:32
-#: module/Education/src/Form/Fieldset/Exam.php:48
-#: module/Education/src/Form/Fieldset/Summary.php:50
-#: module/Education/view/education/education/index.phtml:65
+#: module/Education/src/Form/Course.php:33
+#: module/Education/src/Form/Fieldset/Exam.php:47
+#: module/Education/src/Form/Fieldset/Summary.php:47
+#: module/Education/view/education/education/index.phtml:91
 msgid "Course code"
 msgstr "Course code"
 
-#: module/Education/src/Form/Course.php:52
+#: module/Education/src/Form/Course.php:53
 msgid "Add course"
 msgstr "Add course"
 
-#: module/Education/src/Form/Course.php:83
+#: module/Education/src/Form/Course.php:84
 msgid "There already exists a course with this code"
 msgstr "There already exists a course with this code"
 
-#: module/Education/src/Form/Fieldset/Exam.php:58
+#: module/Education/src/Form/Fieldset/Exam.php:57
 msgid "Exam date"
 msgstr "Exam date"
 
-#: module/Education/src/Form/Fieldset/Exam.php:85
-#: module/Education/src/Form/Fieldset/Summary.php:81
-#: module/Education/view/education/admin/course-documents.phtml:61
-#: module/Education/view/education/admin/course-documents.phtml:112
+#: module/Education/src/Form/Fieldset/Exam.php:84
+#: module/Education/src/Form/Fieldset/Summary.php:78
+#: module/Education/view/education/admin/course-documents.phtml:71
+#: module/Education/view/education/admin/course-documents.phtml:122
 msgid "Language"
 msgstr "Language"
 
-#: module/Education/src/Form/Fieldset/Exam.php:99
-#: module/Education/src/Form/Fieldset/Summary.php:95
+#: module/Education/src/Form/Fieldset/Exam.php:98
+#: module/Education/src/Form/Fieldset/Summary.php:92
 msgid "Scanned?"
 msgstr "Scanned?"
 
-#: module/Education/src/Form/Fieldset/Summary.php:60
+#: module/Education/src/Form/Fieldset/Summary.php:57
 msgid "Summary date"
 msgstr "Summary date"
 
-#: module/Education/src/Form/Fieldset/Summary.php:71
-#: module/Education/view/education/admin/course-documents.phtml:109
+#: module/Education/src/Form/Fieldset/Summary.php:68
+#: module/Education/view/education/admin/course-documents.phtml:119
 #: module/Frontpage/src/Form/PollComment.php:27
 msgid "Author"
 msgstr "Author"
@@ -4369,96 +4399,96 @@ msgstr "Author"
 msgid "Exam to upload"
 msgstr "Exam to upload"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:20
+#: module/Education/src/Model/Enums/ExamTypes.php:25
 msgid "Final"
 msgstr "Final"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:21
+#: module/Education/src/Model/Enums/ExamTypes.php:26
 msgid "Interim"
 msgstr "Interim"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:22
+#: module/Education/src/Model/Enums/ExamTypes.php:27
 msgid "Answers"
 msgstr "Answers"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:23
+#: module/Education/src/Model/Enums/ExamTypes.php:28
 msgid "Other"
 msgstr "Other"
 
-#: module/Education/src/Service/Exam.php:91
+#: module/Education/src/Service/Exam.php:98
 msgid "You are not allowed to download course documents"
 msgstr "You are not allowed to download course documents"
 
-#: module/Education/src/Service/Exam.php:320
+#: module/Education/src/Service/Exam.php:318
 msgid "You are not allowed to delete exams"
 msgstr "You are not allowed to delete exams"
 
-#: module/Education/src/Service/Exam.php:339
-#: module/Education/src/Service/Exam.php:464
+#: module/Education/src/Service/Exam.php:334
+#: module/Education/src/Service/Exam.php:456
 msgid "You are not allowed to upload exams"
 msgstr "You are not allowed to upload exams"
 
-#: module/Education/view/education/admin/add-course.phtml:5
+#: module/Education/view/education/admin/add-course.phtml:17
 msgid "Add"
 msgstr "Add"
 
-#: module/Education/view/education/admin/add-course.phtml:16
-#: module/Education/view/education/admin/course.phtml:19
+#: module/Education/view/education/admin/add-course.phtml:28
+#: module/Education/view/education/admin/course.phtml:31
 msgid "Add Course"
 msgstr "Add Course"
 
-#: module/Education/view/education/admin/bulk-exam.phtml:12
+#: module/Education/view/education/admin/bulk-exam.phtml:20
 msgid "Upload Exams"
 msgstr "Upload Exams"
 
-#: module/Education/view/education/admin/bulk-exam.phtml:27
+#: module/Education/view/education/admin/bulk-exam.phtml:35
 msgid "Finalize exam uploads"
 msgstr "Finalize exam uploads"
 
-#: module/Education/view/education/admin/bulk-summary.phtml:12
+#: module/Education/view/education/admin/bulk-summary.phtml:20
 msgid "Upload Summaries"
 msgstr "Upload Summaries"
 
-#: module/Education/view/education/admin/bulk-summary.phtml:27
+#: module/Education/view/education/admin/bulk-summary.phtml:35
 msgid "Finalize summary uploads"
 msgstr "Finalize summary uploads"
 
-#: module/Education/view/education/admin/course-documents.phtml:37
+#: module/Education/view/education/admin/course-documents.phtml:47
 #, php-format
 msgid "Course Documents of %s"
 msgstr "Course Documents of %s"
 
-#: module/Education/view/education/admin/course-documents.phtml:47
-#: module/Education/view/education/education/index.phtml:22
+#: module/Education/view/education/admin/course-documents.phtml:57
+#: module/Education/view/education/education/index.phtml:36
 msgid "Exams"
 msgstr "Exams"
 
-#: module/Education/view/education/admin/course-documents.phtml:90
-#: module/Education/view/education/admin/course-documents.phtml:139
+#: module/Education/view/education/admin/course-documents.phtml:100
+#: module/Education/view/education/admin/course-documents.phtml:149
 msgid "This course does not have any exams."
 msgstr "This course does not have any exams."
 
-#: module/Education/view/education/admin/course-documents.phtml:98
+#: module/Education/view/education/admin/course-documents.phtml:108
 msgid "Summaries"
 msgstr "Summaries"
 
-#: module/Education/view/education/admin/course-documents.phtml:157
+#: module/Education/view/education/admin/course-documents.phtml:167
 msgid "Are you sure you want to delete this document?"
 msgstr "Are you sure you want to delete this document?"
 
-#: module/Education/view/education/admin/course.phtml:10
+#: module/Education/view/education/admin/course.phtml:22
 msgid "Course Admin"
 msgstr "Course Admin"
 
-#: module/Education/view/education/admin/course.phtml:29
+#: module/Education/view/education/admin/course.phtml:41
 msgid "Code"
 msgstr "Code"
 
-#: module/Education/view/education/admin/course.phtml:75
+#: module/Education/view/education/admin/course.phtml:87
 msgid "Delete Course"
 msgstr "Delete Course"
 
-#: module/Education/view/education/admin/course.phtml:81
+#: module/Education/view/education/admin/course.phtml:93
 #, php-format
 msgid ""
 "Are you sure you want to delete %s? This will also delete all associated "
@@ -4467,24 +4497,24 @@ msgstr ""
 "Are you sure you want to delete %s? This will also delete all associated "
 "exams and summaries will be deleted."
 
-#: module/Education/view/education/admin/edit-course.phtml:23
+#: module/Education/view/education/admin/edit-course.phtml:37
 msgid "Edit Course"
 msgstr "Edit Course"
 
-#: module/Education/view/education/admin/edit-exam.phtml:19
+#: module/Education/view/education/admin/edit-exam.phtml:32
 msgid "Edit Exam"
 msgstr "Edit Exam"
 
-#: module/Education/view/education/admin/edit-exam.phtml:22
+#: module/Education/view/education/admin/edit-exam.phtml:35
 msgid "Upload of all exams was finished."
 msgstr "Upload of all exams was finished."
 
-#: module/Education/view/education/admin/edit-exam.phtml:24
+#: module/Education/view/education/admin/edit-exam.phtml:37
 msgid "There are no exams to be edited. Upload exams to edit them."
 msgstr "There are no exams to be edited. Upload exams to edit them."
 
-#: module/Education/view/education/admin/edit-exam.phtml:115
-#: module/Education/view/education/admin/edit-summary.phtml:117
+#: module/Education/view/education/admin/edit-exam.phtml:128
+#: module/Education/view/education/admin/edit-summary.phtml:130
 msgid ""
 "Check this if the document is scanned, as this will enable higher quality "
 "downloads. Please note that enabling setting this for non-scanned documents "
@@ -4494,78 +4524,84 @@ msgstr ""
 "downloads. Please note that enabling setting this for non-scanned documents "
 "will significantly impact the ability to download the document."
 
-#: module/Education/view/education/admin/edit-summary.phtml:19
+#: module/Education/view/education/admin/edit-summary.phtml:32
 msgid "Edit Summary"
 msgstr "Edit Summary"
 
-#: module/Education/view/education/admin/edit-summary.phtml:22
+#: module/Education/view/education/admin/edit-summary.phtml:35
 msgid "Upload of all summaries was finished."
 msgstr "Upload of all summaries was finished."
 
-#: module/Education/view/education/admin/edit-summary.phtml:24
+#: module/Education/view/education/admin/edit-summary.phtml:37
 msgid "There are no summaries to be edited. Upload exams to edit them."
 msgstr "There are no summaries to be edited. Upload exams to edit them."
 
-#: module/Education/view/education/admin/index.phtml:5
+#: module/Education/view/education/admin/index.phtml:13
 msgid "Education admin"
 msgstr "Education admin"
 
-#: module/Education/view/education/education/course.phtml:23
+#: module/Education/view/education/education/course.phtml:33
 msgid "Exams and summaries"
 msgstr "Exams and summaries"
 
-#: module/Education/view/education/education/course.phtml:34
+#: module/Education/view/education/education/course.phtml:44
 #, php-format
 msgid "Summary by %s on %s (%s)"
 msgstr "Summary by %s on %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:43
+#: module/Education/view/education/education/course.phtml:53
 #, php-format
 msgid "Summary on %s (%s)"
 msgstr "Summary on %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:54
+#: module/Education/view/education/education/course.phtml:64
 #, php-format
 msgid "Final test from %s (%s)"
 msgstr "Final test from %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:57
+#: module/Education/view/education/education/course.phtml:67
 #, php-format
 msgid "Interim test from %s (%s)"
 msgstr "Interim test from %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:60
+#: module/Education/view/education/education/course.phtml:70
 #, php-format
 msgid "Answers from %s (%s)"
 msgstr "Answers from %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:63
+#: module/Education/view/education/education/course.phtml:73
 #, php-format
 msgid "Other exam material from %s (%s)"
 msgstr "Other exam material from %s (%s)"
 
-#: module/Education/view/education/education/index.phtml:41
+#: module/Education/view/education/education/index.phtml:54
 msgid "Course code or course description"
 msgstr "Course code or course description"
 
-#: module/Education/view/education/education/index.phtml:58
+#: module/Education/view/education/education/index.phtml:76
 #, php-format
-msgid "Found %d course(s) matching your description"
-msgstr "Found %d course(s) matching your description"
+msgid "Found %d %s matching your description"
+msgstr "Found %d %s matching your description"
 
-#: module/Education/view/education/education/index.phtml:66
+#: module/Education/view/education/education/index.phtml:79
+msgid "course"
+msgid_plural "courses"
+msgstr[0] "course"
+msgstr[1] "courses"
+
+#: module/Education/view/education/education/index.phtml:92
 msgid "Course name"
 msgstr "Course name"
 
-#: module/Education/view/education/education/index.phtml:67
+#: module/Education/view/education/education/index.phtml:93
 msgid "Available documents"
 msgstr "Available documents"
 
-#: module/Education/view/education/education/index.phtml:78
+#: module/Education/view/education/education/index.phtml:104
 msgid "View available documents"
 msgstr "View available documents"
 
-#: module/Education/view/education/education/index.phtml:97
+#: module/Education/view/education/education/index.phtml:123
 #, php-format
 msgid ""
 "Do you want to contribute to the collection of old exams and summaries? Send "
@@ -4574,44 +4610,44 @@ msgstr ""
 "Do you want to contribute to the collection of old exams and summaries? Send "
 "them to the %seducation officer%s so that your (future) peers can benefit."
 
-#: module/Education/view/education/education/index.phtml:98
-#: module/Education/view/education/education/index.phtml:156
+#: module/Education/view/education/education/index.phtml:124
+#: module/Education/view/education/education/index.phtml:182
 msgid "Mail the education officer"
 msgstr "Mail the education officer"
 
-#: module/Education/view/education/education/index.phtml:106
+#: module/Education/view/education/education/index.phtml:132
 msgid "For old exams of minor courses, you can also look at:"
 msgstr "For old exams of minor courses, you can also look at:"
 
-#: module/Education/view/education/education/index.phtml:109
+#: module/Education/view/education/education/index.phtml:135
 msgid "Applied Physics"
 msgstr "Applied Physics"
 
-#: module/Education/view/education/education/index.phtml:112
+#: module/Education/view/education/education/index.phtml:138
 msgid "Biomedical Engineering"
 msgstr "Biomedical Engineering"
 
-#: module/Education/view/education/education/index.phtml:115
+#: module/Education/view/education/education/index.phtml:141
 msgid "Electrical Engineering"
 msgstr "Electrical Engineering"
 
-#: module/Education/view/education/education/index.phtml:118
+#: module/Education/view/education/education/index.phtml:144
 msgid "Chemical Engineering"
 msgstr "Chemical Engineering"
 
-#: module/Education/view/education/education/index.phtml:121
+#: module/Education/view/education/education/index.phtml:147
 msgid "Innovation Sciences"
 msgstr "Innovation Sciences"
 
-#: module/Education/view/education/education/index.phtml:128
+#: module/Education/view/education/education/index.phtml:154
 msgid "Useful links"
 msgstr "Useful links"
 
-#: module/Education/view/education/education/index.phtml:133
+#: module/Education/view/education/education/index.phtml:159
 msgid "Books"
 msgstr "Books"
 
-#: module/Education/view/education/education/index.phtml:136
+#: module/Education/view/education/education/index.phtml:162
 msgid ""
 "Order your course books via GEWIS to receive a discount. Specific ordering "
 "deadlines and pickup dates will be timely communicated to you via an email."
@@ -4619,19 +4655,19 @@ msgstr ""
 "Order your course books via GEWIS to receive a discount. Specific ordering "
 "deadlines and pickup dates will be timely communicated to you via an email."
 
-#: module/Education/view/education/education/index.phtml:139
+#: module/Education/view/education/education/index.phtml:165
 msgid "Visit the webshop"
 msgstr "Visit the webshop"
 
-#: module/Education/view/education/education/index.phtml:141
+#: module/Education/view/education/education/index.phtml:167
 msgid "Visit webshop"
 msgstr "Visit webshop"
 
-#: module/Education/view/education/education/index.phtml:149
+#: module/Education/view/education/education/index.phtml:175
 msgid "Complaint or suggestion about TU/e education?"
 msgstr "Complaint or suggestion about TU/e education?"
 
-#: module/Education/view/education/education/index.phtml:155
+#: module/Education/view/education/education/index.phtml:181
 #, php-format
 msgid ""
 "Do you have a complaint or suggestion concerning the education at the TU/e? "
@@ -4640,11 +4676,11 @@ msgstr ""
 "Do you have a complaint or suggestion concerning the education at the TU/e? "
 "Contact the %seducation officer%s to share your ideas."
 
-#: module/Education/view/education/education/index.phtml:166
+#: module/Education/view/education/education/index.phtml:192
 msgid "Disclaimer on educational content"
 msgstr "Disclaimer on educational content"
 
-#: module/Education/view/education/education/index.phtml:171
+#: module/Education/view/education/education/index.phtml:197
 msgid ""
 "The exams on the website of GEWIS are provided by Education & Student "
 "Affairs of the department of Mathematics and Computer Science of the TU/e."
@@ -4652,7 +4688,7 @@ msgstr ""
 "The exams on the website of GEWIS are provided by Education & Student "
 "Affairs of the department of Mathematics and Computer Science of the TU/e."
 
-#: module/Education/view/education/education/index.phtml:172
+#: module/Education/view/education/education/index.phtml:198
 msgid ""
 "If an exam has been put online without the intention of the author, please "
 "let the board of GEWIS know by sending an"
@@ -4660,15 +4696,15 @@ msgstr ""
 "If an exam has been put online without the intention of the author, please "
 "let the board of GEWIS know by sending an"
 
-#: module/Education/view/education/education/index.phtml:173
+#: module/Education/view/education/education/index.phtml:199
 msgid "Email the board of GEWIS"
 msgstr "Email the board of GEWIS"
 
-#: module/Education/view/education/education/index.phtml:173
+#: module/Education/view/education/education/index.phtml:199
 msgid "email to the board of GEWIS"
 msgstr "email to the board of GEWIS"
 
-#: module/Education/view/education/education/index.phtml:174
+#: module/Education/view/education/education/index.phtml:200
 msgid ""
 "then this exam will be removed from the website. Using the summaries or "
 "exams on this website for commercial goals without the permission of the "
@@ -4678,102 +4714,102 @@ msgstr ""
 "exams on this website for commercial goals without the permission of the "
 "author is illegal."
 
-#: module/Frontpage/src/Controller/InfimumController.php:24
+#: module/Frontpage/src/Controller/InfimumController.php:26
 msgid "You are not allowed to view infima"
 msgstr "You are not allowed to view infima"
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:53
+#: module/Frontpage/src/Controller/NewsAdminController.php:51
 msgid "You are not allowed to create news items"
 msgstr "You are not allowed to create news items"
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:90
+#: module/Frontpage/src/Controller/NewsAdminController.php:88
 msgid "You are not allowed to edit news items"
 msgstr "You are not allowed to edit news items"
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:135
+#: module/Frontpage/src/Controller/NewsAdminController.php:133
 msgid "You are not allowed to delete news items"
 msgstr "You are not allowed to delete news items"
 
-#: module/Frontpage/src/Controller/PageAdminController.php:35
-#: module/Frontpage/src/Service/Page.php:110
+#: module/Frontpage/src/Controller/PageAdminController.php:31
+#: module/Frontpage/src/Service/Page.php:107
 msgid "You are not allowed to view the list of pages."
 msgstr "You are not allowed to view the list of pages."
 
-#: module/Frontpage/src/Controller/PageAdminController.php:50
-#: module/Frontpage/src/Service/Page.php:270
+#: module/Frontpage/src/Controller/PageAdminController.php:46
+#: module/Frontpage/src/Service/Page.php:260
 msgid "You are not allowed to create new pages."
 msgstr "You are not allowed to create new pages."
 
-#: module/Frontpage/src/Controller/PageAdminController.php:81
-#: module/Frontpage/src/Service/Page.php:201
+#: module/Frontpage/src/Controller/PageAdminController.php:77
+#: module/Frontpage/src/Service/Page.php:193
 msgid "You are not allowed to edit pages."
 msgstr "You are not allowed to edit pages."
 
-#: module/Frontpage/src/Controller/PageAdminController.php:108
+#: module/Frontpage/src/Controller/PageAdminController.php:104
 msgid "You are not allowed to delete pages."
 msgstr "You are not allowed to delete pages."
 
-#: module/Frontpage/src/Controller/PageAdminController.php:125
+#: module/Frontpage/src/Controller/PageAdminController.php:121
 msgid "You are not allowed to upload images."
 msgstr "You are not allowed to upload images."
 
-#: module/Frontpage/src/Controller/PollAdminController.php:34
+#: module/Frontpage/src/Controller/PollAdminController.php:32
 msgid "You are not allowed to administer polls"
 msgstr "You are not allowed to administer polls"
 
-#: module/Frontpage/src/Controller/PollAdminController.php:66
+#: module/Frontpage/src/Controller/PollAdminController.php:64
 msgid "You are not allowed to approve polls"
 msgstr "You are not allowed to approve polls"
 
-#: module/Frontpage/src/Controller/PollAdminController.php:98
+#: module/Frontpage/src/Controller/PollAdminController.php:96
 msgid "You are not allowed to delete polls"
 msgstr "You are not allowed to delete polls"
 
-#: module/Frontpage/src/Controller/PollController.php:97
+#: module/Frontpage/src/Controller/PollController.php:96
 msgid "You are not allowed to create comments on this poll"
 msgstr "You are not allowed to create comments on this poll"
 
 #: module/Frontpage/src/Form/NewsItem.php:27
-#: module/Frontpage/src/Form/Page.php:51
+#: module/Frontpage/src/Form/Page.php:49
 msgid "Dutch title"
 msgstr "Dutch title"
 
 #: module/Frontpage/src/Form/NewsItem.php:37
-#: module/Frontpage/src/Form/Page.php:61
+#: module/Frontpage/src/Form/Page.php:59
 msgid "English title"
 msgstr "English title"
 
 #: module/Frontpage/src/Form/NewsItem.php:47
-#: module/Frontpage/src/Form/Page.php:71
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:60
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:92
+#: module/Frontpage/src/Form/Page.php:69
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:73
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:104
 msgid "Dutch content"
 msgstr "Dutch content"
 
 #: module/Frontpage/src/Form/NewsItem.php:57
-#: module/Frontpage/src/Form/Page.php:81
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:36
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:68
+#: module/Frontpage/src/Form/Page.php:79
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:49
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:80
 msgid "English content"
 msgstr "English content"
 
-#: module/Frontpage/src/Form/Page.php:91
+#: module/Frontpage/src/Form/Page.php:89
 msgid "Required role"
 msgstr "Required role"
 
 #: module/Frontpage/src/Form/Poll.php:28
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:24
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:36
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:97
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:109
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:51
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:124
 msgid "Dutch question"
 msgstr "Dutch question"
 
 #: module/Frontpage/src/Form/Poll.php:38
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:25
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:98
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:40
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:54
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:113
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:127
 msgid "English question"
 msgstr "English question"
 
@@ -4782,8 +4818,8 @@ msgid "Expiration date for the poll (YYYY-MM-DD)"
 msgstr "Expiration date for the poll (YYYY-MM-DD)"
 
 #: module/Frontpage/src/Form/PollApproval.php:36
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:213
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:201
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:227
 msgid "Approve poll"
 msgstr "Approve poll"
 
@@ -4795,36 +4831,36 @@ msgstr "Content"
 msgid "Comment"
 msgstr "Comment"
 
-#: module/Frontpage/src/Service/News.php:47
+#: module/Frontpage/src/Service/News.php:45
 msgid "You are not allowed to list all news items."
 msgstr "You are not allowed to list all news items."
 
-#: module/Frontpage/src/Service/Page.php:61
+#: module/Frontpage/src/Service/Page.php:56
 msgid "You are not allowed to view this page."
 msgstr "You are not allowed to view this page."
 
-#: module/Frontpage/src/Service/Page.php:250
-#: module/Photo/src/Service/Admin.php:189
+#: module/Frontpage/src/Service/Page.php:244
+#: module/Photo/src/Service/Admin.php:212
 msgid "The uploaded file does not have a valid extension"
 msgstr "The uploaded file does not have a valid extension"
 
-#: module/Frontpage/src/Service/Page.php:255
+#: module/Frontpage/src/Service/Page.php:249
 msgid "The uploaded file is not a valid image"
 msgstr "The uploaded file is not a valid image"
 
-#: module/Frontpage/src/Service/Poll.php:72
+#: module/Frontpage/src/Service/Poll.php:71
 msgid "You are not allowed to view unapproved polls"
 msgstr "You are not allowed to view unapproved polls"
 
-#: module/Frontpage/src/Service/Poll.php:192
+#: module/Frontpage/src/Service/Poll.php:183
 msgid "You are not allowed to vote on this poll."
 msgstr "You are not allowed to vote on this poll."
 
-#: module/Frontpage/src/Service/Poll.php:347
+#: module/Frontpage/src/Service/Poll.php:329
 msgid "You are not allowed to request polls"
 msgstr "You are not allowed to request polls"
 
-#: module/Frontpage/view/frontpage/admin/index.phtml:1
+#: module/Frontpage/view/frontpage/admin/index.phtml:10
 msgid ""
 "Welcome to the admin interface of the GEWIS website. If you are experiencing "
 "any issues or have a question, please contact the ApplicatieBeheerCommissie."
@@ -4832,15 +4868,15 @@ msgstr ""
 "Welcome to the admin interface of the GEWIS website. If you are experiencing "
 "any issues or have a question, please contact the ApplicatieBeheerCommissie."
 
-#: module/Frontpage/view/frontpage/admin/index.phtml:3
+#: module/Frontpage/view/frontpage/admin/index.phtml:12
 msgid "Recent changes"
 msgstr "Recent changes"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:29
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:47
 msgid "Studievereniging GEWIS"
 msgstr "Study Association GEWIS"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:31
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:49
 msgid ""
 "Welcome to the website of Study association GEWIS, the study association of "
 "the department of Mathematics & Computer Science of the Eindhoven University "
@@ -4850,84 +4886,84 @@ msgstr ""
 "the department of Mathematics & Computer Science of the Eindhoven University "
 "of Technology."
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:130
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:148
 msgid "Verjaardagen"
 msgstr "Birthdays"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:135
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:153
 #, php-format
 msgid "%s wil be %s years old today!"
 msgstr "%s will be %s years old today!"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:150
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:168
 msgid "Agenda"
 msgstr "Agenda"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:167
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:185
 #, php-format
 msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
 msgstr "Thursdays there is a %ssocial drink%s from 16.30 till 19.00."
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:176
-#: module/Frontpage/view/frontpage/organ/organ.phtml:120
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:194
+#: module/Frontpage/view/frontpage/organ/organ.phtml:136
 msgid "Complete agenda"
 msgstr "Complete agenda"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:180
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:198
 msgid "Google Calendar"
 msgstr "Google Calendar"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:264
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
 msgid "Poll"
 msgstr "Poll"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:277
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:296
 msgid "View details"
 msgstr "View details"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:301
 msgid "There currently is no poll."
 msgstr "There currently is no poll."
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:286
-#: module/Frontpage/view/frontpage/poll/request.phtml:162
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:305
+#: module/Frontpage/view/frontpage/poll/request.phtml:174
 msgid "Request poll"
 msgstr "Request poll"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:289
-#: module/Frontpage/view/frontpage/poll/index.phtml:20
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:308
+#: module/Frontpage/view/frontpage/poll/index.phtml:39
 msgid "Old polls"
 msgstr "Old polls"
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:88
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:101
 msgid "Pin news item"
 msgstr "Pin news item"
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:90
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:103
 msgid "Select this if you want this news item to stay at the top of the page."
 msgstr "Select this if you want this news item to stay at the top of the page."
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:105
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:118
 msgid "Delete this news item"
 msgstr "Delete this news item"
 
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:5
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:16
 msgid "News items"
 msgstr "News items"
 
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:6
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:17
 msgid "Create news item"
 msgstr "Create news item"
 
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:10
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:21
 msgid "GEWIS has many different committees, learn more about them below!"
 msgstr "GEWIS has many different committees, learn more about them below!"
 
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:16
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:27
 msgid "Information for committees"
 msgstr "Information for committees"
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:8
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:20
 msgid ""
 "Study association GEWIS obviously has several fraternities which contribute "
 "to the atmosphere at GEWIS and organize fun activities. Some fraternities "
@@ -4937,48 +4973,48 @@ msgstr ""
 "to the atmosphere at GEWIS and organize fun activities. Some fraternities "
 "have retired, but luckily new fraternities continue to be founded."
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:9
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:21
 msgid "The currently active fraternities of GEWIS (in arbitrary order)"
 msgstr "The currently active fraternities of GEWIS (in arbitrary order)"
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:24
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:36
 msgid "Retired fraternities"
 msgstr "Retired fraternities"
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:25
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:37
 msgid "The following fraternities have retired:"
 msgstr "The following fraternities have retired:"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:51
+#: module/Frontpage/view/frontpage/organ/organ.phtml:67
 msgid "GMM Committees"
 msgstr "GMM Committees"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:53
+#: module/Frontpage/view/frontpage/organ/organ.phtml:69
 msgid "GMM Taskforces"
 msgstr "GMM Taskforces"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:55
+#: module/Frontpage/view/frontpage/organ/organ.phtml:71
 msgid "Financial Audit Committees"
 msgstr "Financial Audit Committees"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:57
+#: module/Frontpage/view/frontpage/organ/organ.phtml:73
 msgid "Advisory Boards"
 msgstr "Advisory Boards"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:106
+#: module/Frontpage/view/frontpage/organ/organ.phtml:122
 #, php-format
 msgid "%s's activities"
 msgstr "%s's activities"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:152
+#: module/Frontpage/view/frontpage/organ/organ.phtml:168
 msgid "Login to view more information"
 msgstr "Login to view more information"
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:36
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:48
 msgid "URL options"
 msgstr "URL options"
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:49
 msgid ""
 "Make this page available at the following URL. Providing a category is "
 "required."
@@ -4986,136 +5022,136 @@ msgstr ""
 "Make this page available at the following URL. Providing a category is "
 "required."
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:116
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:128
 msgid "Permissions"
 msgstr "Permissions"
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:139
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:151
 msgid "Delete this page"
 msgstr "Delete this page"
 
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:17
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:29
 msgid "Create a new page"
 msgstr "Create a new page"
 
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:19
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:31
 msgid "Or select a page to edit below."
 msgstr "Or select a page to edit below."
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:19
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:34
 msgid "Polls awaiting approval"
 msgstr "Polls awaiting approval"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:28
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:101
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:43
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:116
 msgid "Approver"
 msgstr "Approver"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:45
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:118
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:60
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:133
 msgid "Dutch option"
 msgstr "Dutch option"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:46
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:119
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:61
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:134
 msgid "English option"
 msgstr "English option"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:80
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:95
 msgid "Approved polls"
 msgstr "Approved polls"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:163
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:178
 msgid "Are you sure you want to delete this poll?"
 msgstr "Are you sure you want to delete this poll?"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:169
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:184
 msgid "Delete poll"
 msgstr "Delete poll"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:189
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:204
 msgid "Are you sure that you want to approve this poll?"
 msgstr "Are you sure that you want to approve this poll?"
 
-#: module/Frontpage/view/frontpage/poll/history.phtml:3
+#: module/Frontpage/view/frontpage/poll/history.phtml:14
 msgid "Poll history"
 msgstr "Poll history"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:22
+#: module/Frontpage/view/frontpage/poll/index.phtml:41
 #, php-format
 msgid "%sRequest a poll%s"
 msgstr "%sRequest a poll%s"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:37
+#: module/Frontpage/view/frontpage/poll/index.phtml:56
 msgid "Unfortunately there currently is no poll :("
 msgstr "Unfortunately there currently is no poll :("
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:42
+#: module/Frontpage/view/frontpage/poll/index.phtml:61
 msgid "Comments"
 msgstr "Comments"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:44
+#: module/Frontpage/view/frontpage/poll/index.phtml:63
 msgid "This poll has no comments"
 msgstr "This poll has no comments"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:65
+#: module/Frontpage/view/frontpage/poll/index.phtml:84
 msgid "Comment on this poll"
 msgstr "Comment on this poll"
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:3
-#: module/Frontpage/view/frontpage/poll/request.phtml:7
+#: module/Frontpage/view/frontpage/poll/request.phtml:14
+#: module/Frontpage/view/frontpage/poll/request.phtml:19
 msgid "Request a poll"
 msgstr "Request a poll"
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:9
+#: module/Frontpage/view/frontpage/poll/request.phtml:21
 msgid "Your poll request has been received and will be reviewed shortly."
 msgstr "Your poll request has been received and will be reviewed shortly."
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:146
+#: module/Frontpage/view/frontpage/poll/request.phtml:158
 msgid "Remove option"
 msgstr "Remove option"
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:151
+#: module/Frontpage/view/frontpage/poll/request.phtml:163
 msgid "Add option"
 msgstr "Add option"
 
-#: module/Frontpage/view/partial/poll.phtml:40
-#: module/Frontpage/view/partial/poll.phtml:51
+#: module/Frontpage/view/partial/poll.phtml:61
+#: module/Frontpage/view/partial/poll.phtml:72
 #, php-format
 msgid "%d votes"
 msgstr "%d votes"
 
-#: module/Frontpage/view/partial/poll.phtml:40
-#: module/Frontpage/view/partial/poll.phtml:51
+#: module/Frontpage/view/partial/poll.phtml:61
+#: module/Frontpage/view/partial/poll.phtml:72
 msgid "1 vote"
 msgstr "1 vote"
 
-#: module/Photo/src/Controller/AlbumController.php:49
-#: module/Photo/src/Service/Album.php:123
+#: module/Photo/src/Controller/AlbumController.php:50
+#: module/Photo/src/Service/Album.php:122
 msgid "Not allowed to view albums without dates"
 msgstr "Not allowed to view albums without dates"
 
-#: module/Photo/src/Controller/ApiController.php:48
+#: module/Photo/src/Controller/ApiController.php:50
 msgid "Not allowed to view photo details"
 msgstr "Not allowed to view photo details"
 
-#: module/Photo/src/Controller/PhotoController.php:38
-#: module/Photo/src/Service/Album.php:70 module/Photo/src/Service/Album.php:100
-#: module/Photo/src/Service/Album.php:239
-#: module/Photo/src/Service/Album.php:253
+#: module/Photo/src/Controller/PhotoController.php:44
+#: module/Photo/src/Service/Album.php:67 module/Photo/src/Service/Album.php:99
+#: module/Photo/src/Service/Album.php:234
+#: module/Photo/src/Service/Album.php:248
 msgid "Not allowed to view albums"
 msgstr "Not allowed to view albums"
 
-#: module/Photo/src/Controller/PhotoController.php:85
-#: module/Photo/src/Service/Photo.php:93
+#: module/Photo/src/Controller/PhotoController.php:91
+#: module/Photo/src/Service/Photo.php:95
 msgid "Not allowed to download photos"
 msgstr "Not allowed to download photos"
 
-#: module/Photo/src/Controller/PhotoController.php:100
+#: module/Photo/src/Controller/PhotoController.php:106
 msgid "Not allowed to view previous photos of the week"
 msgstr "Not allowed to view previous photos of the week"
 
-#: module/Photo/src/Controller/PhotoController.php:157
+#: module/Photo/src/Controller/PhotoController.php:163
 msgid "Not allowed to vote for a photo of the week"
 msgstr "Not allowed to vote for a photo of the week"
 
@@ -5129,7 +5165,7 @@ msgstr "Not allowed to remove tags."
 
 #: module/Photo/src/Form/CreateAlbum.php:25
 #: module/Photo/src/Form/EditAlbum.php:27
-#: module/Photo/view/photo/album-admin/create.phtml:16
+#: module/Photo/view/photo/album-admin/create.phtml:28
 msgid "Album title"
 msgstr "Album title"
 
@@ -5141,15 +5177,15 @@ msgstr "Create"
 msgid "End date"
 msgstr "End date"
 
-#: module/Photo/src/Service/Admin.php:58
+#: module/Photo/src/Service/Admin.php:66
 msgid "Not allowed to add photos."
 msgstr "Not allowed to add photos."
 
-#: module/Photo/src/Service/Admin.php:172
+#: module/Photo/src/Service/Admin.php:185
 msgid "An unknown error occurred during uploading ("
 msgstr "An unknown error occurred during uploading ("
 
-#: module/Photo/src/Service/Admin.php:195
+#: module/Photo/src/Service/Admin.php:201
 #, php-format
 msgid ""
 "The uploaded file is not a valid image \n"
@@ -5158,223 +5194,223 @@ msgstr ""
 "The uploaded file is not a valid image \n"
 "Error: %s"
 
-#: module/Photo/src/Service/Admin.php:211
+#: module/Photo/src/Service/Admin.php:225
 msgid "Not allowed to upload photos."
 msgstr "Not allowed to upload photos."
 
-#: module/Photo/src/Service/Album.php:194
+#: module/Photo/src/Service/Album.php:191
 msgid "Not allowed to create albums"
 msgstr "Not allowed to create albums"
 
-#: module/Photo/src/Service/Album.php:218
+#: module/Photo/src/Service/Album.php:213
 msgid "Not allowed to create albums."
 msgstr "Not allowed to create albums."
 
-#: module/Photo/src/Service/Album.php:331
+#: module/Photo/src/Service/Album.php:327
 #, php-format
 msgid "Photos of the Week in %d/%d"
 msgstr "Photos of the Week in %d/%d"
 
-#: module/Photo/src/Service/Album.php:360
+#: module/Photo/src/Service/Album.php:358
 msgid "Not allowed to edit albums"
 msgstr "Not allowed to edit albums"
 
-#: module/Photo/src/Service/Album.php:379
+#: module/Photo/src/Service/Album.php:376
 msgid "Not allowed to edit albums."
 msgstr "Not allowed to edit albums."
 
-#: module/Photo/src/Service/Album.php:404
+#: module/Photo/src/Service/Album.php:401
 msgid "Not allowed to move albums"
 msgstr "Not allowed to move albums"
 
-#: module/Photo/src/Service/Album.php:438
+#: module/Photo/src/Service/Album.php:435
 msgid "Not allowed to delete albums."
 msgstr "Not allowed to delete albums."
 
-#: module/Photo/src/Service/Album.php:459
+#: module/Photo/src/Service/Album.php:456
 msgid "Not allowed to generate album covers."
 msgstr "Not allowed to generate album covers."
 
-#: module/Photo/src/Service/Album.php:507
+#: module/Photo/src/Service/Album.php:504
 msgid "Not allowed to move photos"
 msgstr "Not allowed to move photos"
 
-#: module/Photo/src/Service/Photo.php:67 module/Photo/src/Service/Photo.php:112
-#: module/Photo/src/Service/Photo.php:154
-#: module/Photo/src/Service/Photo.php:205
-#: module/Photo/src/Service/Photo.php:221
+#: module/Photo/src/Service/Photo.php:73 module/Photo/src/Service/Photo.php:114
+#: module/Photo/src/Service/Photo.php:159
+#: module/Photo/src/Service/Photo.php:210
+#: module/Photo/src/Service/Photo.php:226
 msgid "Not allowed to view photos"
 msgstr "Not allowed to view photos"
 
-#: module/Photo/src/Service/Photo.php:239
+#: module/Photo/src/Service/Photo.php:245
 msgid "Not allowed to delete photos."
 msgstr "Not allowed to delete photos."
 
-#: module/Photo/src/Service/Photo.php:669
-#: module/Photo/src/Service/Photo.php:731
+#: module/Photo/src/Service/Photo.php:623
+#: module/Photo/src/Service/Photo.php:672
 msgid "Not allowed to view tags."
 msgstr "Not allowed to view tags."
 
-#: module/Photo/view/partial/metadata.phtml:6
+#: module/Photo/view/partial/metadata.phtml:19
 msgid "Artist"
 msgstr "Artist"
 
-#: module/Photo/view/partial/metadata.phtml:13
+#: module/Photo/view/partial/metadata.phtml:26
 msgid "Camera"
 msgstr "Camera"
 
-#: module/Photo/view/partial/metadata.phtml:20
+#: module/Photo/view/partial/metadata.phtml:33
 msgid "Date/time"
 msgstr "Date/time"
 
-#: module/Photo/view/partial/metadata.phtml:27
+#: module/Photo/view/partial/metadata.phtml:40
 msgid "Flash"
 msgstr "Flash"
 
-#: module/Photo/view/partial/metadata.phtml:34
+#: module/Photo/view/partial/metadata.phtml:47
 msgid "Focal length"
 msgstr "Focal length"
 
-#: module/Photo/view/partial/metadata.phtml:41
+#: module/Photo/view/partial/metadata.phtml:54
 msgid "Exposure time"
 msgstr "Exposure time"
 
-#: module/Photo/view/partial/metadata.phtml:48
+#: module/Photo/view/partial/metadata.phtml:61
 msgid "Shutter speed"
 msgstr "Shutter speed"
 
-#: module/Photo/view/partial/metadata.phtml:55
+#: module/Photo/view/partial/metadata.phtml:68
 msgid "Aperture"
 msgstr "Aperture"
 
-#: module/Photo/view/partial/metadata.phtml:62
+#: module/Photo/view/partial/metadata.phtml:75
 msgid "ISO"
 msgstr "ISO"
 
-#: module/Photo/view/partial/metadata.phtml:75
+#: module/Photo/view/partial/metadata.phtml:95
 msgid "View on map"
 msgstr "View on map"
 
-#: module/Photo/view/partial/tags.phtml:10
-#: module/Photo/view/photo/album/index.phtml:665
+#: module/Photo/view/partial/tags.phtml:22
+#: module/Photo/view/photo/album/index.phtml:674
 msgid "In this photo:"
 msgstr "In this photo:"
 
-#: module/Photo/view/partial/tags.phtml:11
-#: module/Photo/view/photo/album/index.phtml:666
+#: module/Photo/view/partial/tags.phtml:23
+#: module/Photo/view/photo/album/index.phtml:675
 msgid ""
 "No one has been tagged in this photo yet. Tag someone you recognise now!"
 msgstr ""
 "No one has been tagged in this photo yet. Tag someone you recognise now!"
 
-#: module/Photo/view/partial/tags.phtml:49
-#: module/Photo/view/photo/album/index.phtml:694
+#: module/Photo/view/partial/tags.phtml:61
+#: module/Photo/view/photo/album/index.phtml:703
 msgid "Tag someone"
 msgstr "Tag someone"
 
-#: module/Photo/view/photo/album-admin/add.phtml:29
+#: module/Photo/view/photo/album-admin/add.phtml:41
 msgid "Upload Photos"
 msgstr "Upload Photos"
 
-#: module/Photo/view/photo/album-admin/add.phtml:31
+#: module/Photo/view/photo/album-admin/add.phtml:43
 #, php-format
 msgid "Uploading photos to %s"
 msgstr "Uploading photos to %s"
 
-#: module/Photo/view/photo/album-admin/create.phtml:4
+#: module/Photo/view/photo/album-admin/create.phtml:16
 msgid "Create Album"
 msgstr "Create Album"
 
-#: module/Photo/view/photo/album-admin/create.phtml:25
+#: module/Photo/view/photo/album-admin/create.phtml:37
 msgid "Create album"
 msgstr "Create album"
 
-#: module/Photo/view/photo/album-admin/edit.phtml:4
+#: module/Photo/view/photo/album-admin/edit.phtml:16
 msgid "Edit Album"
 msgstr "Edit Album"
 
-#: module/Photo/view/photo/album-admin/edit.phtml:10
+#: module/Photo/view/photo/album-admin/edit.phtml:22
 msgid "Update Album"
 msgstr "Update Album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:44
-#: module/Photo/view/photo/photo-admin/index.phtml:44
+#: module/Photo/view/photo/album-admin/index.phtml:55
+#: module/Photo/view/photo/photo-admin/index.phtml:62
 msgid "Photo admin"
 msgstr "Photo admin"
 
-#: module/Photo/view/photo/album-admin/index.phtml:93
+#: module/Photo/view/photo/album-admin/index.phtml:104
 msgid "Other albums"
 msgstr "Other albums"
 
-#: module/Photo/view/photo/album-admin/index.phtml:106
+#: module/Photo/view/photo/album-admin/index.phtml:117
 msgid "Create new album"
 msgstr "Create new album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:111
+#: module/Photo/view/photo/album-admin/index.phtml:122
 msgid "Edit album"
 msgstr "Edit album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:114
+#: module/Photo/view/photo/album-admin/index.phtml:125
 msgid "Add photos"
 msgstr "Add photos"
 
-#: module/Photo/view/photo/album-admin/index.phtml:116
+#: module/Photo/view/photo/album-admin/index.phtml:127
 msgid "Move album"
 msgstr "Move album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:119
+#: module/Photo/view/photo/album-admin/index.phtml:130
 msgid "Move %i photos"
 msgstr "Move %i photos"
 
-#: module/Photo/view/photo/album-admin/index.phtml:122
+#: module/Photo/view/photo/album-admin/index.phtml:133
 msgid "Regenerate album cover"
 msgstr "Regenerate album cover"
 
-#: module/Photo/view/photo/album-admin/index.phtml:126
-#: module/Photo/view/photo/album-admin/index.phtml:220
+#: module/Photo/view/photo/album-admin/index.phtml:137
+#: module/Photo/view/photo/album-admin/index.phtml:231
 msgid "Delete album"
 msgstr "Delete album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:129
+#: module/Photo/view/photo/album-admin/index.phtml:140
 msgid "Delete %i photos"
 msgstr "Delete %i photos"
 
-#: module/Photo/view/photo/album-admin/index.phtml:147
+#: module/Photo/view/photo/album-admin/index.phtml:158
 msgid "Generate a new cover photo"
 msgstr "Generate a new cover photo"
 
-#: module/Photo/view/photo/album-admin/index.phtml:153
+#: module/Photo/view/photo/album-admin/index.phtml:164
 msgid "An error occurred while trying to generate an album photo."
 msgstr "An error occurred while trying to generate an album photo."
 
-#: module/Photo/view/photo/album-admin/index.phtml:160
+#: module/Photo/view/photo/album-admin/index.phtml:171
 msgid "Regenerate"
 msgstr "Regenerate"
 
-#: module/Photo/view/photo/album-admin/index.phtml:162
-#: module/Photo/view/photo/album/index.phtml:426
+#: module/Photo/view/photo/album-admin/index.phtml:173
+#: module/Photo/view/photo/album/index.phtml:435
 msgid "Close"
 msgstr "Close"
 
-#: module/Photo/view/photo/album-admin/index.phtml:175
+#: module/Photo/view/photo/album-admin/index.phtml:186
 msgid "Move the album"
 msgstr "Move the album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:180
+#: module/Photo/view/photo/album-admin/index.phtml:191
 msgid "Select a new parent for the album"
 msgstr "Select a new parent for the album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:184
+#: module/Photo/view/photo/album-admin/index.phtml:195
 msgid "The album has been moved"
 msgstr "The album has been moved"
 
-#: module/Photo/view/photo/album-admin/index.phtml:189
-#: module/Photo/view/photo/album-admin/index.phtml:280
-#: module/Photo/view/photo/photo-admin/index.phtml:108
+#: module/Photo/view/photo/album-admin/index.phtml:200
+#: module/Photo/view/photo/album-admin/index.phtml:291
+#: module/Photo/view/photo/photo-admin/index.phtml:126
 msgid "Move"
 msgstr "Move"
 
-#: module/Photo/view/photo/album-admin/index.phtml:206
+#: module/Photo/view/photo/album-admin/index.phtml:217
 msgid ""
 "Are you sure you want to delete this album including all photos inside of "
 "it? <strong>This action can not be reverted.</strong>"
@@ -5382,15 +5418,15 @@ msgstr ""
 "Are you sure you want to delete this album including all photos inside of "
 "it? <strong>This action can not be reverted.</strong>"
 
-#: module/Photo/view/photo/album-admin/index.phtml:209
+#: module/Photo/view/photo/album-admin/index.phtml:220
 msgid "Please wait while the album is being deleted."
 msgstr "Please wait while the album is being deleted."
 
-#: module/Photo/view/photo/album-admin/index.phtml:215
+#: module/Photo/view/photo/album-admin/index.phtml:226
 msgid "The album has been deleted"
 msgstr "The album has been deleted"
 
-#: module/Photo/view/photo/album-admin/index.phtml:238
+#: module/Photo/view/photo/album-admin/index.phtml:249
 msgid ""
 "Are you sure you want to delete the selected items? <strong>This action can "
 "not be reverted.</strong>"
@@ -5398,154 +5434,154 @@ msgstr ""
 "Are you sure you want to delete the selected items? <strong>This action can "
 "not be reverted.</strong>"
 
-#: module/Photo/view/photo/album-admin/index.phtml:241
+#: module/Photo/view/photo/album-admin/index.phtml:252
 msgid "Please wait while the photos are being deleted."
 msgstr "Please wait while the photos are being deleted."
 
-#: module/Photo/view/photo/album-admin/index.phtml:247
+#: module/Photo/view/photo/album-admin/index.phtml:258
 msgid "The photos have been been deleted"
 msgstr "The photos have been been deleted"
 
-#: module/Photo/view/photo/album-admin/index.phtml:252
+#: module/Photo/view/photo/album-admin/index.phtml:263
 msgid "Delete photos"
 msgstr "Delete photos"
 
-#: module/Photo/view/photo/album-admin/index.phtml:266
+#: module/Photo/view/photo/album-admin/index.phtml:277
 msgid "Move the photos to another album"
 msgstr "Move the photos to another album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:271
-#: module/Photo/view/photo/photo-admin/index.phtml:99
+#: module/Photo/view/photo/album-admin/index.phtml:282
+#: module/Photo/view/photo/photo-admin/index.phtml:117
 msgid "Select a new parent album"
 msgstr "Select a new parent album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:275
+#: module/Photo/view/photo/album-admin/index.phtml:286
 msgid "The photos have been moved"
 msgstr "The photos have been moved"
 
-#: module/Photo/view/photo/album/index.phtml:77
-#: module/Photo/view/photo/photo/weekly.phtml:2
-#: module/Photo/view/photo/photo/weekly.phtml:8
+#: module/Photo/view/photo/album/index.phtml:86
+#: module/Photo/view/photo/photo/weekly.phtml:13
+#: module/Photo/view/photo/photo/weekly.phtml:20
 msgid "Photos of the Week"
 msgstr "Photos of the Week"
 
-#: module/Photo/view/photo/album/index.phtml:131
+#: module/Photo/view/photo/album/index.phtml:140
 msgid "View user profile"
 msgstr "View user profile"
 
-#: module/Photo/view/photo/album/index.phtml:143
+#: module/Photo/view/photo/album/index.phtml:152
 msgid "No date"
 msgstr "No date"
 
-#: module/Photo/view/photo/album/index.phtml:192
-#: module/Photo/view/photo/photo/index.phtml:58
+#: module/Photo/view/photo/album/index.phtml:201
+#: module/Photo/view/photo/photo/index.phtml:71
 msgid "NEW"
 msgstr "NEW"
 
-#: module/Photo/view/photo/album/index.phtml:216
+#: module/Photo/view/photo/album/index.phtml:225
 msgid "This album does not contain any photos."
 msgstr "This album does not contain any photos."
 
-#: module/Photo/view/photo/album/index.phtml:389
+#: module/Photo/view/photo/album/index.phtml:398
 msgid "Already voted!"
 msgstr "Already voted!"
 
-#: module/Photo/view/photo/album/index.phtml:392
-#: module/Photo/view/photo/album/index.phtml:563
+#: module/Photo/view/photo/album/index.phtml:401
+#: module/Photo/view/photo/album/index.phtml:572
 msgid "Vote for photo of the week"
 msgstr "Vote for photo of the week"
 
-#: module/Photo/view/photo/album/index.phtml:427
+#: module/Photo/view/photo/album/index.phtml:436
 msgid "Zoom (z)"
 msgstr "Zoom (z)"
 
-#: module/Photo/view/photo/album/index.phtml:430
+#: module/Photo/view/photo/album/index.phtml:439
 msgid "The image could not be loaded."
 msgstr "The image could not be loaded."
 
-#: module/Photo/view/photo/album/index.phtml:443
+#: module/Photo/view/photo/album/index.phtml:452
 msgid "Download"
 msgstr "Download"
 
-#: module/Photo/view/photo/album/index.phtml:467
+#: module/Photo/view/photo/album/index.phtml:476
 msgid "Share"
 msgstr "Share"
 
-#: module/Photo/view/photo/album/index.phtml:478
+#: module/Photo/view/photo/album/index.phtml:487
 msgid "Copied URL!"
 msgstr "Copied URL!"
 
-#: module/Photo/view/photo/album/index.phtml:489
+#: module/Photo/view/photo/album/index.phtml:498
 msgid "Go to album"
 msgstr "Go to album"
 
-#: module/Photo/view/photo/album/index.phtml:532
+#: module/Photo/view/photo/album/index.phtml:541
 msgid "Set as profile picture"
 msgstr "Set as profile picture"
 
-#: module/Photo/view/photo/album/index.phtml:549
+#: module/Photo/view/photo/album/index.phtml:558
 msgid "Set as profile picture!"
 msgstr "Set as profile picture!"
 
-#: module/Photo/view/photo/album/index.phtml:552
+#: module/Photo/view/photo/album/index.phtml:561
 msgid "Could not set as profile photo, try again"
 msgstr "Could not set as profile photo, try again"
 
-#: module/Photo/view/photo/album/index.phtml:585
+#: module/Photo/view/photo/album/index.phtml:594
 msgid "Cannot load vote"
 msgstr "Cannot load vote"
 
-#: module/Photo/view/photo/album/index.phtml:605
+#: module/Photo/view/photo/album/index.phtml:614
 msgid "Voted!"
 msgstr "Voted!"
 
-#: module/Photo/view/photo/album/index.phtml:617
+#: module/Photo/view/photo/album/index.phtml:626
 msgid "Could not vote, try again"
 msgstr "Could not vote, try again"
 
-#: module/Photo/view/photo/album/index.phtml:632
+#: module/Photo/view/photo/album/index.phtml:641
 msgid "Loading tags..."
 msgstr "Loading tags..."
 
-#: module/Photo/view/photo/album/index.phtml:653
+#: module/Photo/view/photo/album/index.phtml:662
 msgid "Cannot load tags"
 msgstr "Cannot load tags"
 
-#: module/Photo/view/photo/album/index.phtml:748
+#: module/Photo/view/photo/album/index.phtml:757
 msgid "Cannot load metadata"
 msgstr "Cannot load metadata"
 
-#: module/Photo/view/photo/album/index.phtml:774
+#: module/Photo/view/photo/album/index.phtml:783
 msgid "Photo of the Week:<br> Week"
 msgstr "Photo of the Week:<br> Week"
 
-#: module/Photo/view/photo/album/index.phtml:774
+#: module/Photo/view/photo/album/index.phtml:783
 msgid "of"
 msgstr "of"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:33
+#: module/Photo/view/photo/photo-admin/index.phtml:51
 #, php-format
 msgid "Photo #%d"
 msgstr "Photo #%d"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:71
+#: module/Photo/view/photo/photo-admin/index.phtml:89
 msgid "Move photo"
 msgstr "Move photo"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:73
-#: module/Photo/view/photo/photo-admin/index.phtml:139
+#: module/Photo/view/photo/photo-admin/index.phtml:91
+#: module/Photo/view/photo/photo-admin/index.phtml:157
 msgid "Delete photo"
 msgstr "Delete photo"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:94
+#: module/Photo/view/photo/photo-admin/index.phtml:112
 msgid "Move the photo to another album"
 msgstr "Move the photo to another album"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:103
+#: module/Photo/view/photo/photo-admin/index.phtml:121
 msgid "The photo has been moved"
 msgstr "The photo has been moved"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:125
+#: module/Photo/view/photo/photo-admin/index.phtml:143
 msgid ""
 "Are you sure you want to delete this photo? <strong>This action can not be "
 "reverted.</strong>"
@@ -5553,27 +5589,27 @@ msgstr ""
 "Are you sure you want to delete this photo? <strong>This action can not be "
 "reverted.</strong>"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:128
+#: module/Photo/view/photo/photo-admin/index.phtml:146
 msgid "Please wait while your photo is being deleted."
 msgstr "Please wait while your photo is being deleted."
 
-#: module/Photo/view/photo/photo-admin/index.phtml:134
+#: module/Photo/view/photo/photo-admin/index.phtml:152
 msgid "The photo has been deleted"
 msgstr "The photo has been deleted"
 
-#: module/Photo/view/photo/photo/index.phtml:69
+#: module/Photo/view/photo/photo/index.phtml:82
 msgid "There are no photos in this year."
 msgstr "There are no photos in this year."
 
-#: module/Photo/view/photo/photo/weekly.phtml:6
+#: module/Photo/view/photo/photo/weekly.phtml:18
 msgid "Currently, no pictures of the week are available."
 msgstr "Currently, no pictures of the week are available."
 
-#: module/Photo/view/photo/photo/weekly.phtml:9
+#: module/Photo/view/photo/photo/weekly.phtml:21
 msgid "Current photo of the week"
 msgstr "Current photo of the week"
 
-#: module/Photo/view/photo/photo/weekly.phtml:40
+#: module/Photo/view/photo/photo/weekly.phtml:52
 msgid "Old photos of the week"
 msgstr "Old photos of the week"
 
@@ -5589,8 +5625,8 @@ msgstr "The login and password combination is incorrect."
 msgid "Too many login attempts, try again later."
 msgstr "Too many login attempts, try again later."
 
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:77
-#: module/User/src/Authentication/Adapter/UserAdapter.php:91
+#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:78
+#: module/User/src/Authentication/Adapter/UserAdapter.php:92
 msgid ""
 "Your password was found in a public data breach and is therefore considered "
 "insecure. Please request a password reset before continuing. We recommend "
@@ -5606,8 +5642,8 @@ msgstr ""
 msgid "You cannot sign in to this account at this moment."
 msgstr "You cannot sign in to this account at this moment."
 
-#: module/User/src/Authorization/GenericAclService.php:98
-#: module/User/src/Authorization/GenericAclService.php:122
+#: module/User/src/Authorization/GenericAclService.php:108
+#: module/User/src/Authorization/GenericAclService.php:135
 msgid ""
 "You are not allowed to perform this action. If you are not logged in please "
 "do so before continuing. If you are already logged in this action may "
@@ -5617,21 +5653,21 @@ msgstr ""
 "do so before continuing. If you are already logged in this action may "
 "require you to login in with a different account."
 
-#: module/User/src/Controller/UserController.php:184
+#: module/User/src/Controller/UserController.php:178
 msgid "You are not allowed to change passwords"
 msgstr "You are not allowed to change passwords"
 
-#: module/User/src/Form/Activate.php:31 module/User/src/Form/UserLogin.php:45
+#: module/User/src/Form/Activate.php:29 module/User/src/Form/UserLogin.php:43
 msgid "Your password"
 msgstr "Your password"
 
-#: module/User/src/Form/Activate.php:41
+#: module/User/src/Form/Activate.php:39
 msgid "Verify your password"
 msgstr "Verify your password"
 
-#: module/User/src/Form/Activate.php:51
-#: module/User/view/user/user/activate.phtml:2
-#: module/User/view/user/user/activate.phtml:23
+#: module/User/src/Form/Activate.php:49
+#: module/User/view/user/user/activate.phtml:20
+#: module/User/view/user/user/activate.phtml:40
 msgid "Activate"
 msgstr "Activate"
 
@@ -5640,47 +5676,47 @@ msgid "Authorise"
 msgstr "Authorise"
 
 #: module/User/src/Form/ApiToken.php:35
-#: module/User/view/user/api-admin/add.phtml:33
+#: module/User/view/user/api-admin/add.phtml:45
 msgid "Create API token"
 msgstr "Create API token"
 
-#: module/User/src/Form/CompanyUserLogin.php:36
-#: module/User/src/Form/CompanyUserReset.php:34
+#: module/User/src/Form/CompanyUserLogin.php:34
+#: module/User/src/Form/CompanyUserReset.php:27
 msgid "Email address"
 msgstr "Email address"
 
-#: module/User/src/Form/CompanyUserLogin.php:46
-#: module/User/view/user/user/activate.phtml:41
+#: module/User/src/Form/CompanyUserLogin.php:44
+#: module/User/view/user/user/activate.phtml:58
 msgid "Password"
 msgstr "Password"
 
-#: module/User/src/Form/CompanyUserLogin.php:56
+#: module/User/src/Form/CompanyUserLogin.php:54
 msgid "Log in as company"
 msgstr "Log in as company"
 
-#: module/User/src/Form/CompanyUserReset.php:44
+#: module/User/src/Form/CompanyUserReset.php:37
 msgid "Request password reset"
 msgstr "Request password reset"
 
-#: module/User/src/Form/Password.php:31
+#: module/User/src/Form/Password.php:29
 msgid "Old password"
 msgstr "Old password"
 
-#: module/User/src/Form/Password.php:41
+#: module/User/src/Form/Password.php:39
 msgid "New password"
 msgstr "New password"
 
-#: module/User/src/Form/Password.php:51
+#: module/User/src/Form/Password.php:49
 msgid "Verify new password"
 msgstr "Verify new password"
 
-#: module/User/src/Form/Register.php:44
-#: module/User/view/user/user/register.phtml:2
-#: module/User/view/user/user/register.phtml:23
+#: module/User/src/Form/Register.php:42
+#: module/User/view/user/user/register.phtml:14
+#: module/User/view/user/user/register.phtml:34
 msgid "Register"
 msgstr "Register"
 
-#: module/User/src/Form/Register.php:69
+#: module/User/src/Form/Register.php:65
 msgid ""
 "This member cannot create an account, please contact the secretary for more "
 "information."
@@ -5688,11 +5724,11 @@ msgstr ""
 "This member cannot create an account, please contact the secretary for more "
 "information."
 
-#: module/User/src/Form/Register.php:77
+#: module/User/src/Form/Register.php:73
 msgid "There is no member with this membership number."
 msgstr "There is no member with this membership number."
 
-#: module/User/src/Form/Register.php:85
+#: module/User/src/Form/Register.php:81
 msgid ""
 "You already attempted to register, please check your email or try again "
 "after 20 minutes."
@@ -5700,60 +5736,60 @@ msgstr ""
 "You already attempted to register, please check your email or try again "
 "after 20 minutes."
 
-#: module/User/src/Form/Register.php:93
+#: module/User/src/Form/Register.php:89
 msgid "This member already has an account."
 msgstr "This member already has an account."
 
-#: module/User/src/Form/UserLogin.php:35
+#: module/User/src/Form/UserLogin.php:33
 msgid "Membership number or email address"
 msgstr "Membership number or email address"
 
-#: module/User/src/Form/UserLogin.php:55
+#: module/User/src/Form/UserLogin.php:53
 msgid "Log in as member"
 msgstr "Log in as member"
 
-#: module/User/src/Form/UserLogin.php:65
+#: module/User/src/Form/UserLogin.php:63
 msgid "Remember me"
 msgstr "Remember me"
 
-#: module/User/src/Form/UserReset.php:52
-#: module/User/view/partial/reset/company.phtml:33
-#: module/User/view/partial/reset/member.phtml:47
-#: module/User/view/user/user/reset-password.phtml:2
-#: module/User/view/user/user/reset-password.phtml:13
+#: module/User/src/Form/UserReset.php:50
+#: module/User/view/partial/reset/company.phtml:46
+#: module/User/view/partial/reset/member.phtml:59
+#: module/User/view/user/user/reset-password.phtml:18
+#: module/User/view/user/user/reset-password.phtml:29
 msgid "Reset password"
 msgstr "Reset password"
 
-#: module/User/src/Model/Enums/JWTClaims.php:38
+#: module/User/src/Model/Enums/JWTClaims.php:40
 msgid "Family name"
 msgstr "Family name"
 
-#: module/User/src/Model/Enums/JWTClaims.php:39
+#: module/User/src/Model/Enums/JWTClaims.php:41
 msgid "Given name"
 msgstr "Given name"
 
-#: module/User/src/Model/Enums/JWTClaims.php:40
+#: module/User/src/Model/Enums/JWTClaims.php:42
 msgid "Is 18+?"
 msgstr "Is 18+?"
 
-#: module/User/src/Model/Enums/JWTClaims.php:41
+#: module/User/src/Model/Enums/JWTClaims.php:43
 msgid "Member number"
 msgstr "Member number"
 
-#: module/User/src/Service/ApiUser.php:43
-#: module/User/src/Service/ApiUser.php:75
+#: module/User/src/Service/ApiUser.php:46
+#: module/User/src/Service/ApiUser.php:74
 msgid "You are not allowed to view API tokens"
 msgstr "You are not allowed to view API tokens"
 
-#: module/User/src/Service/ApiUser.php:59
+#: module/User/src/Service/ApiUser.php:60
 msgid "You are not allowed to remove API tokens"
 msgstr "You are not allowed to remove API tokens"
 
-#: module/User/src/Service/ApiUser.php:119
+#: module/User/src/Service/ApiUser.php:115
 msgid "You are not allowed to add API tokens"
 msgstr "You are not allowed to add API tokens"
 
-#: module/User/src/Service/User.php:104 module/User/src/Service/User.php:327
+#: module/User/src/Service/User.php:105 module/User/src/Service/User.php:339
 msgid ""
 "You cannot use this password, it was found in a public data breach and is "
 "therefore considered insecure. We recommend using a password generated by a "
@@ -5763,26 +5799,26 @@ msgstr ""
 "therefore considered insecure. We recommend using a password generated by a "
 "good password manager, such as Bitwarden or 1Password."
 
-#: module/User/src/Service/User.php:316
+#: module/User/src/Service/User.php:326
 msgid "Password incorrect"
 msgstr "Password incorrect"
 
-#: module/User/src/Service/User.php:476
+#: module/User/src/Service/User.php:481
 msgid "You are not allowed to change your password"
 msgstr "You are not allowed to change your password"
 
-#: module/User/view/partial/login/company.phtml:64
-#: module/User/view/partial/login/member.phtml:74
+#: module/User/view/partial/login/company.phtml:77
+#: module/User/view/partial/login/member.phtml:87
 #, php-format
 msgid "If you forgot your password, go to the %sPassword reset page%s"
 msgstr "If you forgot your password, go to the %sPassword reset page%s"
 
-#: module/User/view/partial/login/member.phtml:70
+#: module/User/view/partial/login/member.phtml:83
 #, php-format
 msgid "If you don't have an account yet, go to the %sRegistration page%s"
 msgstr "If you don't have an account yet, go to the %sRegistration page%s"
 
-#: module/User/view/partial/reset/member.phtml:39
+#: module/User/view/partial/reset/member.phtml:51
 msgid ""
 "Have you forgotten your e-mail address and do you want to change it? Ask the "
 "secretary by going to GEWIS (preferred) or by sending an e-mail."
@@ -5790,44 +5826,44 @@ msgstr ""
 "Have you forgotten your e-mail address and do you want to change it? Ask the "
 "secretary by going to GEWIS (preferred) or by sending an e-mail."
 
-#: module/User/view/user/api-admin/add.phtml:3
-#: module/User/view/user/api-admin/index.phtml:3
-#: module/User/view/user/api-admin/index.phtml:5
-#: module/User/view/user/api-admin/remove.phtml:3
+#: module/User/view/user/api-admin/add.phtml:15
+#: module/User/view/user/api-admin/index.phtml:15
+#: module/User/view/user/api-admin/index.phtml:17
+#: module/User/view/user/api-admin/remove.phtml:15
 msgid "API Tokens"
 msgstr "API Tokens"
 
-#: module/User/view/user/api-admin/add.phtml:4
+#: module/User/view/user/api-admin/add.phtml:16
 msgid "Add Token"
 msgstr "Add Token"
 
-#: module/User/view/user/api-admin/add.phtml:6
+#: module/User/view/user/api-admin/add.phtml:18
 msgid "Add a token"
 msgstr "Add a token"
 
-#: module/User/view/user/api-admin/add.phtml:41
+#: module/User/view/user/api-admin/add.phtml:53
 msgid "Token was successfully generated"
 msgstr "Token was successfully generated"
 
-#: module/User/view/user/api-admin/add.phtml:49
-#: module/User/view/user/api-admin/index.phtml:11
+#: module/User/view/user/api-admin/add.phtml:61
+#: module/User/view/user/api-admin/index.phtml:23
 msgid "Token"
 msgstr "Token"
 
-#: module/User/view/user/api-admin/index.phtml:30
+#: module/User/view/user/api-admin/index.phtml:42
 msgid "Add new Token"
 msgstr "Add new Token"
 
-#: module/User/view/user/api-admin/remove.phtml:4
+#: module/User/view/user/api-admin/remove.phtml:16
 msgid "Remove Token"
 msgstr "Remove Token"
 
-#: module/User/view/user/api-authentication/redirect.phtml:13
+#: module/User/view/user/api-authentication/redirect.phtml:21
 #, php-format
 msgid "You are being redirected to %s"
 msgstr "You are being redirected to %s"
 
-#: module/User/view/user/api-authentication/redirect.phtml:22
+#: module/User/view/user/api-authentication/redirect.phtml:30
 #, php-format
 msgid ""
 "If your browser does not redirect you back, please <a href=\"%s\">click "
@@ -5836,12 +5872,12 @@ msgstr ""
 "If your browser does not redirect you back, please <a href=\"%s\">click "
 "here</a> to continue."
 
-#: module/User/view/user/api-authentication/token.phtml:16
+#: module/User/view/user/api-authentication/token.phtml:28
 #, php-format
 msgid "Authorize %s to use your account?"
 msgstr "Authorize %s to use your account?"
 
-#: module/User/view/user/api-authentication/token.phtml:25
+#: module/User/view/user/api-authentication/token.phtml:37
 #, php-format
 msgid ""
 "It has been more than 90 days since you last used <strong>%s</strong>. As a "
@@ -5850,38 +5886,38 @@ msgstr ""
 "It has been more than 90 days since you last used <strong>%s</strong>. As a "
 "reminder, the application has access to:"
 
-#: module/User/view/user/api-authentication/token.phtml:30
+#: module/User/view/user/api-authentication/token.phtml:42
 msgid "The application will get the following information:"
 msgstr "The application will get the following information:"
 
-#: module/User/view/user/user/activate.phtml:7
+#: module/User/view/user/user/activate.phtml:25
 msgid "Your account has been activated. You are now able to login."
 msgstr "Your account has been activated. You are now able to login."
 
-#: module/User/view/user/user/activate.phtml:36
+#: module/User/view/user/user/activate.phtml:53
 #, php-format
 msgid ""
 "Welcome %s. Create your password for the website and activate your account."
 msgstr ""
 "Welcome %s. Create your password for the website and activate your account."
 
-#: module/User/view/user/user/activate.phtml:54
+#: module/User/view/user/user/activate.phtml:72
 msgid "Verify password"
 msgstr "Verify password"
 
-#: module/User/view/user/user/change-password.phtml:7
+#: module/User/view/user/user/change-password.phtml:20
 msgid "Password changed successfully"
 msgstr "Password changed successfully"
 
-#: module/User/view/user/user/login.phtml:2
+#: module/User/view/user/user/login.phtml:16
 msgid "Log in"
 msgstr "Log in"
 
-#: module/User/view/user/user/logout.phtml:1
+#: module/User/view/user/user/logout.phtml:10
 msgid "You are logged out."
 msgstr "You are logged out."
 
-#: module/User/view/user/user/register.phtml:7
+#: module/User/view/user/user/register.phtml:19
 msgid ""
 "Your account for the GEWIS website has been registered, check your inbox for "
 "an activation e-mail."
@@ -5889,7 +5925,7 @@ msgstr ""
 "Your account for the GEWIS website has been registered, check your inbox for "
 "an activation e-mail."
 
-#: module/User/view/user/user/register.phtml:60
+#: module/User/view/user/user/register.phtml:71
 #, php-format
 msgid ""
 "To read more about the benefits of becoming a member and how to become a "
@@ -5898,7 +5934,7 @@ msgstr ""
 "To read more about the benefits of becoming a member and how to become a "
 "member, go to this %sinformation page%s."
 
-#: module/User/view/user/user/reset-password.phtml:7
+#: module/User/view/user/user/reset-password.phtml:23
 msgid ""
 "An e-mail has been sent with instructions for resetting your password. If "
 "you have not received an e-mail, try again in 20 minutes."

--- a/module/Application/language/gewisweb.pot
+++ b/module/Application/language/gewisweb.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GEWISweb 0.1.0-dev\n"
+"Project-Id-Version: GEWISweb v2.8.6-419-g641a385c1-dirty\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-25 00:26+0200\n"
+"POT-Creation-Date: 2023-06-25 00:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,193 +18,2540 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: module/Activity/view/activity/activity/archive.phtml:34
-#: module/Photo/view/photo/photo/index.phtml:36
-msgid "Older"
+msgid " <strong>has a limited capacity</strong> and "
 msgstr ""
 
-#: module/Activity/view/activity/activity/archive.phtml:54
-msgid "There are no activities in the archive."
+msgid "# Decisions"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:14
-msgid "Create activity proposal"
+#, php-format
+msgid "%d votes"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:30
-#: module/Activity/view/activity/activity-calendar/index.phtml:38
-#: module/Application/view/partial/main-nav.phtml:417
-#: module/Decision/view/decision/member/index.phtml:207
-msgid "Option calendar"
+#, php-format
+msgid "%s %s"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:31
-msgid "Propose options for an activity"
+#, php-format
+msgid "%s %s on %s"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:39
-msgid "Organisation"
+#, php-format
+msgid "%s for company %s will expire on %s"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:40
-#: module/Activity/view/activity/activity-calendar/create.phtml:78
+#, php-format
+msgid "%s for company %s will start on %s"
+msgstr ""
+
+#, php-format
+msgid "%s has never been part of a committee or fraternity."
+msgstr ""
+
+#, php-format
+msgid "%s is currently a member of:"
+msgstr ""
+
+#, php-format
+msgid "%s is currently the <strong>%s</strong>."
+msgstr ""
+
+#, php-format
+msgid "%s is the upcoming <strong>%s</strong>."
+msgstr ""
+
+#, php-format
+msgid "%s was a member of:"
+msgstr ""
+
+#, php-format
+msgid "%s was the <strong>%s</strong> during the association year %d/%d."
+msgstr ""
+
+#, php-format
+msgid "%s wil be %s years old today!"
+msgstr ""
+
+#, php-format
+msgid "%s's activities"
+msgstr ""
+
+#, php-format
+msgid "%sRequest a poll%s"
+msgstr ""
+
+msgid "(Update Pending)"
+msgstr ""
+
+msgid ".. Move up a folder"
+msgstr ""
+
+msgid "1 vote"
+msgstr ""
+
+msgid "403 Forbidden"
+msgstr ""
+
+msgid "A 404 error occurred"
+msgstr ""
+
+msgid "A list of helpful resources for active members."
+msgstr ""
+
+msgid "API Tokens"
+msgstr ""
+
+msgid "API Users"
+msgstr ""
+
+msgid "Abbreviation"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Activate"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "Active Option Planning Periods"
+msgstr ""
+
+msgid "Active jobs"
+msgstr ""
+
+msgid "Active members"
+msgstr ""
+
+msgid "Activities"
+msgstr ""
+
 msgid ""
-"Select the organ for which the options are and in which option period the "
-"options should be planned."
+"Activities that have sign-up lists which are open or approved cannot be "
+"updated."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:49
-msgid "Period"
+msgid "Activity Archive"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:64
-#: module/Activity/view/activity/activity/create.phtml:62
-msgid "Committee / fraternity"
+msgid "Activity Categories"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:77
-#: module/Activity/view/activity/admin/list.phtml:67
-#: module/Company/view/company/admin-approval/job-approval.phtml:100
-#: module/Company/view/company/admin-approval/job-proposal.phtml:140
-#: module/Company/view/company/admin/edit-package.phtml:111
-#: module/Company/view/company/company-account/jobs.phtml:234
-msgid "Details"
+msgid "Activity Policy"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:90
-#: module/Activity/view/activity/activity-calendar/index.phtml:64
-#: module/Activity/view/activity/activity/view.phtml:268
-#: module/Activity/view/activity/admin-approval/view.phtml:80
-#: module/Activity/view/activity/admin-approval/view.phtml:85
-#: module/Activity/view/activity/admin-approval/view.phtml:92
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:133
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:138
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:150
-#: module/Activity/view/activity/admin-category/add.phtml:69
-#: module/Activity/view/activity/admin-category/add.phtml:106
-#: module/Activity/view/activity/admin/participantsTable.phtml:20
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:18
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:23
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:30
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:102
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:107
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:114
-#: module/Activity/view/partial/create.phtml:44
-#: module/Activity/view/partial/create.phtml:118
-#: module/Activity/view/partial/signuplist.phtml:54
-#: module/Activity/view/partial/signuplist.phtml:70
-#: module/Company/view/company/admin-approval/index.phtml:30
-#: module/Company/view/company/admin-approval/job-approval.phtml:66
-#: module/Company/view/company/admin-approval/job-approval.phtml:70
-#: module/Company/view/company/admin-approval/job-approval.phtml:119
-#: module/Company/view/company/admin-approval/job-approval.phtml:124
-#: module/Company/view/company/admin-approval/job-approval.phtml:131
-#: module/Company/view/company/admin-approval/job-proposal.phtml:97
-#: module/Company/view/company/admin-approval/job-proposal.phtml:101
-#: module/Company/view/company/admin-approval/job-proposal.phtml:159
-#: module/Company/view/company/admin-approval/job-proposal.phtml:164
-#: module/Company/view/company/admin-approval/job-proposal.phtml:174
-#: module/Company/view/company/admin/edit-package.phtml:83
-#: module/Company/view/company/admin/index.phtml:126
-#: module/Company/view/company/admin/index.phtml:212
-#: module/Company/view/company/company-account/jobs.phtml:196
-#: module/Decision/view/decision/admin/document.phtml:71
-#: module/Decision/view/decision/member/birthdays.phtml:23
-#: module/Decision/view/decision/organ-admin/index.phtml:24
-#: module/Decision/view/decision/organ/index.phtml:23
-#: module/Education/view/education/admin/course.phtml:44
-#: module/Photo/view/photo/album-admin/edit.phtml:35
-#: module/User/view/user/api-admin/add.phtml:57
-#: module/User/view/user/api-admin/index.phtml:22
-#: module/Activity/src/Form/ActivityCategory.php:24
-#: module/Activity/src/Form/ActivityCategory.php:34
-#: module/Activity/src/Form/SignupListField.php:34
-#: module/Activity/src/Form/SignupListField.php:44
-#: module/Activity/src/Form/SignupList.php:35
-#: module/Activity/src/Form/SignupList.php:45
-#: module/Company/src/Form/Company.php:51
-#: module/Company/src/Form/Company.php:93
-#: module/Company/src/Form/Company.php:113
-#: module/Company/src/Form/JobCategory.php:45
-#: module/Company/src/Form/JobCategory.php:55
-#: module/Company/src/Form/JobLabel.php:31
-#: module/Company/src/Form/JobLabel.php:41 module/Company/src/Form/Job.php:106
-#: module/Company/src/Form/Job.php:137 module/Company/src/Form/Job.php:147
-#: module/Education/src/Form/Course.php:43 module/User/src/Form/ApiToken.php:25
-msgid "Name"
+msgid "Add"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:106
-#: module/Activity/view/activity/admin-approval/view.phtml:137
-#: module/Activity/view/activity/admin-approval/view.phtml:142
-#: module/Activity/view/activity/admin-approval/view.phtml:149
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:220
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:225
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:237
-#: module/Activity/view/partial/create.phtml:87
-#: module/Activity/view/partial/create.phtml:161
-#: module/Company/view/company/admin-approval/job-approval.phtml:176
-#: module/Company/view/company/admin-approval/job-approval.phtml:181
-#: module/Company/view/company/admin-approval/job-approval.phtml:188
-#: module/Company/view/company/admin-approval/job-proposal.phtml:234
-#: module/Company/view/company/admin-approval/job-proposal.phtml:239
-#: module/Company/view/company/admin-approval/job-proposal.phtml:249
-#: module/Company/view/company/company/jobs.phtml:140
-#: module/Company/view/partial/company/company/list/company.phtml:99
-#: module/Company/src/Form/Company.php:198
-#: module/Company/src/Form/Company.php:208 module/Company/src/Form/Job.php:201
-#: module/Company/src/Form/Job.php:211
-msgid "Description"
+msgid "Add Banner Package"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:119
-#: module/Activity/view/activity/activity-calendar/index.phtml:193
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:169
-#: module/Activity/view/partial/create.phtml:170
-#: module/Activity/src/Form/SignupListField.php:93
-#: module/Activity/src/Form/SignupListField.php:106
-msgid "Options"
+msgid "Add Category"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:120
-msgid "Add options for your activity proposal."
+msgid "Add Company"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:142
+msgid "Add Course"
+msgstr ""
+
+msgid "Add Job"
+msgstr ""
+
+msgid "Add Job Package"
+msgstr ""
+
+msgid "Add Label"
+msgstr ""
+
+msgid "Add Option Period"
+msgstr ""
+
+msgid "Add Package"
+msgstr ""
+
+msgid "Add Spotlight Package"
+msgstr ""
+
+msgid "Add Token"
+msgstr ""
+
+msgid "Add a sign-up list"
+msgstr ""
+
+msgid "Add a sign-up list field"
+msgstr ""
+
+msgid "Add a token"
+msgstr ""
+
+msgid ""
+"Add activity categories to your activity to give potential subscribers a "
+"better understanding of the activity."
+msgstr ""
+
 msgid "Add an option"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:146
-msgid "Remove the last option"
+msgid "Add course"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:154
-#: module/Decision/src/Form/Minutes.php:55
-#: module/Frontpage/src/Form/Poll.php:63
-msgid "Submit"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:39
 msgid ""
-"Welcome on the page of the digital Option Calendar. In the calendar below "
-"you can place options for GEWIS activities, just like you were used to do in "
-"the paper version of the option calendar before. The red dots indicate "
-"activities that are already fixed in the GEWIS agenda, the blue dots are "
-"options for activities. If you insert an option, please give it a clear "
-"name, so it is clear what the option is for."
+"Add job labels to your job to give viewers a better understanding of the job."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:41
-msgid "There are a few rules:"
+msgid "Add new Token"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:43
+msgid "Add option"
+msgstr ""
+
+msgid "Add options for your activity proposal."
+msgstr ""
+
+msgid "Add photos"
+msgstr ""
+
+msgid ""
+"Add sign-up lists to allow people to sign up for this activity. Each list "
+"can have optional fields to collect specific information from the "
+"participants."
+msgstr ""
+
+msgid "Additional actions"
+msgstr ""
+
+msgid "Additional information"
+msgstr ""
+
+msgid "Address"
+msgstr ""
+
+msgid "Addresses"
+msgstr ""
+
+msgid "Admin"
+msgstr ""
+
+msgid "Administrator"
+msgstr ""
+
+msgid "Advisory Board"
+msgstr ""
+
+msgid "Advisory Boards"
+msgstr ""
+
+msgid "Afternoon"
+msgstr ""
+
+msgid "Age"
+msgstr ""
+
+msgid "Agenda"
+msgstr ""
+
+msgid "Album title"
+msgstr ""
+
+msgid "Alcohol Policy"
+msgstr ""
+
+msgid "All Activities"
+msgstr ""
+
+msgid "All rights reserved."
+msgstr ""
+
+msgid "Already subscribed"
+msgstr ""
+
+msgid "Already voted!"
+msgstr ""
+
+msgid "Also for data removal requests, you can contact"
+msgstr ""
+
+msgid ""
+"An e-mail has been sent with instructions for resetting your password. If "
+"you have not received an e-mail, try again in 20 minutes."
+msgstr ""
+
+msgid "An error occurred"
+msgstr ""
+
+msgid "An error occurred while saving the course!"
+msgstr ""
+
+msgid "An error occurred while trying to generate an album photo."
+msgstr ""
+
+msgid "An unknown error occurred during uploading ("
+msgstr ""
+
+msgid "An unknown error occurred during uploading (%i)"
+msgstr ""
+
+msgid ""
+"An unknown error occurred while try to change the status of a job update "
+"proposal. Please try again."
+msgstr ""
+
+msgid ""
+"An unknown error occurred while trying to transfer jobs, please try again."
+msgstr ""
+
+msgid "Answers"
+msgstr ""
+
+#, php-format
+msgid "Answers from %s (%s)"
+msgstr ""
+
+msgid "Aperture"
+msgstr ""
+
+msgid "App"
+msgstr ""
+
+msgid "Applied Physics"
+msgstr ""
+
+msgid "Apply Update"
+msgstr ""
+
+msgid "Approval"
+msgstr ""
+
+msgid "Approval status"
+msgstr ""
+
+msgid "Approvals"
+msgstr ""
+
+msgid "Approve"
+msgstr ""
+
+msgid "Approve Job"
+msgstr ""
+
+msgid "Approve option"
+msgstr ""
+
+msgid "Approve poll"
+msgstr ""
+
+msgid "Approved"
+msgstr ""
+
+msgid "Approved (Has Updates)"
+msgstr ""
+
+msgid "Approved Activities"
+msgstr ""
+
+msgid "Approved polls"
+msgstr ""
+
+msgid "Approver"
+msgstr ""
+
+msgid "Are you sure that you want to approve this poll?"
+msgstr ""
+
+msgid "Are you sure you want to approve this option?"
+msgstr ""
+
+#, php-format
+msgid "Are you sure you want to delete %s?"
+msgstr ""
+
+#, php-format
+msgid ""
+"Are you sure you want to delete %s? This will also delete all associated "
+"exams and summaries will be deleted."
+msgstr ""
+
+msgid ""
+"Are you sure you want to delete the selected items? <strong>This action can "
+"not be reverted.</strong>"
+msgstr ""
+
+msgid "Are you sure you want to delete this activity category?"
+msgstr ""
+
+msgid ""
+"Are you sure you want to delete this album including all photos inside of "
+"it? <strong>This action can not be reverted.</strong>"
+msgstr ""
+
+msgid "Are you sure you want to delete this document?"
+msgstr ""
+
+msgid "Are you sure you want to delete this job?"
+msgstr ""
+
+msgid ""
+"Are you sure you want to delete this option planning period? This will "
+"<strong>not</strong> delete proposed options."
+msgstr ""
+
+msgid "Are you sure you want to delete this option?"
+msgstr ""
+
+msgid "Are you sure you want to delete this package?"
+msgstr ""
+
+msgid ""
+"Are you sure you want to delete this photo? <strong>This action can not be "
+"reverted.</strong>"
+msgstr ""
+
+msgid "Are you sure you want to delete this poll?"
+msgstr ""
+
+msgid "Are you sure you would like to authorize"
+msgstr ""
+
+#, php-format
+msgid "Are you sure you would like to authorize %s"
+msgstr ""
+
+msgid "Article"
+msgstr ""
+
+msgid "Artist"
+msgstr ""
+
+#, php-format
+msgid ""
+"As per HR article 5 paragraph 4, you have the right to revoke your "
+"authorization for the %s GMM. You can communicate this to the board in "
+"writing (not by email) or by using the form below. Please note that you can "
+"only revoke an authorization that was granted via this website by using the "
+"form below."
+msgstr ""
+
+msgid "Association"
+msgstr ""
+
+msgid "Attachment"
+msgstr ""
+
+msgid "Author"
+msgstr ""
+
+msgid "Authorise"
+msgstr ""
+
+msgid "Authorizations"
+msgstr ""
+
+msgid "Authorize"
+msgstr ""
+
+#, php-format
+msgid "Authorize %s to use your account?"
+msgstr ""
+
+#, php-format
+msgid "Authorize someone for the %s GMM (%s)"
+msgstr ""
+
+msgid "Authorizer"
+msgstr ""
+
+msgid "Available documents"
+msgstr ""
+
+msgid "BM"
+msgstr ""
+
+msgid "Banner"
+msgstr ""
+
+msgid "Banner Package"
+msgstr ""
+
+msgid "Banner active"
+msgstr ""
+
+msgid "Biomedical Engineering"
+msgstr ""
+
+msgid "Birth date"
+msgstr ""
+
+msgid "Birthdays"
+msgstr ""
+
+msgid "Board"
+msgstr ""
+
+msgid "Board Meeting"
+msgstr ""
+
+msgid "Board Policies"
+msgstr ""
+
+msgid "Books"
+msgstr ""
+
+msgid "Borrel Policy"
+msgstr ""
+
+msgid "Brand Manager"
+msgstr ""
+
+msgid "Browsing directory: "
+msgstr ""
+
+msgid ""
+"By subscribing an external participant to this activity, they must agree to "
+"the terms outlined in the"
+msgstr ""
+
+msgid "By subscribing to this activity, you agree to the terms outlined in the"
+msgstr ""
+
+msgid "Bylaws"
+msgstr ""
+
+msgid "CM"
+msgstr ""
+
+msgid "Camera"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Cannot load metadata"
+msgstr ""
+
+msgid "Cannot load tags"
+msgstr ""
+
+msgid "Cannot load vote"
+msgstr ""
+
+msgid "Career"
+msgstr ""
+
+msgid "Career Activities"
+msgstr ""
+
+msgid "Career related"
+msgstr ""
+
+msgid "Categories"
+msgstr ""
+
+msgid "Category"
+msgstr ""
+
+msgid "Chair's Meeting"
+msgstr ""
+
+msgid "Change password"
+msgstr ""
+
+#, php-format
+msgid ""
+"Changes in activity attributes are shown like this: %s. If there are no "
+"changes to a certain attribute, you will see the existing data. Sign-up list "
+"differences are <strong>not</strong> shown with colours, both the old sign-"
+"up list(s) and the new sign-up list(s) are shown. There might not be "
+"difference between the two!"
+msgstr ""
+
+msgid "Check the spelling of your search term"
+msgstr ""
+
+msgid ""
+"Check this if the document is scanned, as this will enable higher quality "
+"downloads. Please note that enabling setting this for non-scanned documents "
+"will significantly impact the ability to download the document."
+msgstr ""
+
+msgid "Chemical Engineering"
+msgstr ""
+
+msgid "Choice"
+msgstr ""
+
+msgid "Choose a meeting"
+msgstr ""
+
+msgid "Choose to which job package you want to transfer the selected jobs."
+msgstr ""
+
+msgid "Choose which options are applicable to this activity."
+msgstr ""
+
+msgid "City and postal code"
+msgstr ""
+
+msgid "Close"
+msgstr ""
+
+msgid "Close date and time"
+msgstr ""
+
+msgid "Code"
+msgstr ""
+
+msgid "Comment"
+msgstr ""
+
+msgid "Comment on this poll"
+msgstr ""
+
+msgid "Comments"
+msgstr ""
+
+msgid "Commissaris Carrièreontwikkeling en Externe Betrekkingen"
+msgstr ""
+
+msgid "Commissaris Externe Betrekkingen"
+msgstr ""
+
+msgid "Commissaris Innovatie"
+msgstr ""
+
+msgid "Commissaris Interne Betrekkingen"
+msgstr ""
+
+msgid "Commissaris Kennisbeheer"
+msgstr ""
+
+msgid "Commissaris Onderwijs"
+msgstr ""
+
+msgid "Committee"
+msgstr ""
+
+msgid "Committee / fraternity"
+msgstr ""
+
+msgid "Committees"
+msgstr ""
+
+msgid "Companies"
+msgstr ""
+
+msgid "Company"
+msgstr ""
+
+msgid "Company Account"
+msgstr ""
+
+msgid "Complaint or suggestion about TU/e education?"
+msgstr ""
+
+msgid "Complete agenda"
+msgstr ""
+
+msgid "Confidential Contact Person (CCP)"
+msgstr ""
+
+msgid "Confirm authorization"
+msgstr ""
+
+msgid "Confirm subscription"
+msgstr ""
+
+msgid "Contact"
+msgstr ""
+
+msgid "Contact Information"
+msgstr ""
+
+msgid "Content"
+msgstr ""
+
+msgid "Continue"
+msgstr ""
+
+msgid "Continue reading"
+msgstr ""
+
+msgid "Contract Number"
+msgstr ""
+
+msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
+msgstr ""
+
+msgid "Controller"
+msgstr ""
+
+msgid "Copied URL!"
+msgstr ""
+
+msgid "Corporate Identity"
+msgstr ""
+
+msgid "Costs"
+msgstr ""
+
+msgid "Could not set as profile photo, try again"
+msgstr ""
+
+msgid "Could not vote, try again"
+msgstr ""
+
+msgid "Country"
+msgstr ""
+
+msgid "Course Admin"
+msgstr ""
+
+#, php-format
+msgid "Course Documents of %s"
+msgstr ""
+
+msgid "Course code"
+msgstr ""
+
+msgid "Course code or course description"
+msgstr ""
+
+msgid "Course does not exist"
+msgstr ""
+
+msgid "Course name"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Cover photo to upload"
+msgstr ""
+
+msgid "Create"
+msgstr ""
+
+msgid "Create API token"
+msgstr ""
+
+msgid "Create Activity"
+msgstr ""
+
+msgid "Create Activity Category"
+msgstr ""
+
+msgid "Create Album"
+msgstr ""
+
+msgid "Create Company"
+msgstr ""
+
+msgid "Create Job Category"
+msgstr ""
+
+msgid "Create Job Label"
+msgstr ""
+
+msgid "Create Option Period"
+msgstr ""
+
+msgid "Create a new page"
+msgstr ""
+
+msgid "Create activity proposal"
+msgstr ""
+
+msgid "Create album"
+msgstr ""
+
+msgid "Create an activity"
+msgstr ""
+
+msgid "Create new album"
+msgstr ""
+
+msgid "Create news item"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Creator"
+msgstr ""
+
+msgid "Current photo of the week"
+msgstr ""
+
+msgid "Current subscriptions"
+msgstr ""
+
+msgid "Currently, no pictures of the week are available."
+msgstr ""
+
+msgid "Date"
+msgstr ""
+
+msgid "Date and time"
+msgstr ""
+
+msgid "Date/time"
+msgstr ""
+
+msgid "Day"
+msgstr ""
+
+msgid "Decisions"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Delete %i photos"
+msgstr ""
+
+msgid "Delete Activity Category"
+msgstr ""
+
+msgid "Delete Course"
+msgstr ""
+
+msgid "Delete Document"
+msgstr ""
+
+msgid "Delete album"
+msgstr ""
+
+msgid "Delete company"
+msgstr ""
+
+msgid "Delete confirmation"
+msgstr ""
+
+msgid "Delete job"
+msgstr ""
+
+msgid "Delete option"
+msgstr ""
+
+msgid "Delete package"
+msgstr ""
+
+msgid "Delete period"
+msgstr ""
+
+msgid "Delete photo"
+msgstr ""
+
+msgid "Delete photos"
+msgstr ""
+
+msgid "Delete poll"
+msgstr ""
+
+msgid "Delete this news item"
+msgstr ""
+
+msgid "Delete this page"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Deselect this to allow people without a GEWIS account to subscribe."
+msgstr ""
+
+msgid "Details"
+msgstr ""
+
+msgid "Digital Infrastructure Officer"
+msgstr ""
+
+msgid "Disapprove"
+msgstr ""
+
+msgid "Disapprove Job"
+msgstr ""
+
+msgid "Disapproved Activities"
+msgstr ""
+
+msgid "Disclaimer on educational content"
+msgstr ""
+
+msgid "Display GEWIS member count"
+msgstr ""
+
+msgid "Display number of subscribed members"
+msgstr ""
+
+#, php-format
+msgid ""
+"Do you have a complaint or suggestion concerning the education at the TU/e? "
+"Contact the %seducation officer%s to share your ideas."
+msgstr ""
+
+#, php-format
+msgid ""
+"Do you want to contribute to the collection of old exams and summaries? Send "
+"them to the %seducation officer%s so that your (future) peers can benefit."
+msgstr ""
+
+msgid "Document name"
+msgstr ""
+
+msgid "Document to upload"
+msgstr ""
+
+msgid "Documents"
+msgstr ""
+
+msgid "Documents for this meeting"
+msgstr ""
+
+#, php-format
+msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
+msgstr ""
+
+msgid "Download"
+msgstr ""
+
+msgid "Dutch"
+msgstr ""
+
+msgid "Dutch Name"
+msgstr ""
+
+msgid "Dutch content"
+msgstr ""
+
+msgid "Dutch name"
+msgstr ""
+
+msgid "Dutch option"
+msgstr ""
+
+msgid "Dutch question"
+msgstr ""
+
+msgid "Dutch title"
+msgstr ""
+
+msgid "E-mail Address"
+msgstr ""
+
+msgid "E-mail address"
+msgstr ""
+
+msgid "E-mail address format is not valid"
+msgstr ""
+
+msgid "E-mail address format is not valid."
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+#, php-format
+msgid "Edit %s"
+msgstr ""
+
+msgid "Edit Album"
+msgstr ""
+
+msgid "Edit Company"
+msgstr ""
+
+msgid "Edit Course"
+msgstr ""
+
+msgid "Edit Exam"
+msgstr ""
+
+msgid "Edit Job"
+msgstr ""
+
+msgid "Edit Job Category"
+msgstr ""
+
+msgid "Edit Job Label"
+msgstr ""
+
+msgid "Edit Option Period"
+msgstr ""
+
+msgid "Edit Package"
+msgstr ""
+
+msgid "Edit Summary"
+msgstr ""
+
+msgid "Edit album"
+msgstr ""
+
+msgid "Edit organ information"
+msgstr ""
+
+msgid "Education"
+msgstr ""
+
+msgid "Education admin"
+msgstr ""
+
+msgid "Electrical Engineering"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "Email address"
+msgstr ""
+
+msgid "Email address:"
+msgstr ""
+
+msgid "Email the board of GEWIS"
+msgstr ""
+
+msgid "Email the secretary of GEWIS"
+msgstr ""
+
+msgid "Empty folder"
+msgstr ""
+
+msgid "Enable Dutch Translations"
+msgstr ""
+
+msgid "Enable English Translations"
+msgstr ""
+
+msgid "End"
+msgstr ""
+
+msgid "End date"
+msgstr ""
+
+msgid "End date and time"
+msgstr ""
+
+msgid "End date and time of option period"
+msgstr ""
+
+msgid "End date and time of planning period"
+msgstr ""
+
+msgid "End date of membership"
+msgstr ""
+
+msgid "English"
+msgstr ""
+
+msgid "English Name"
+msgstr ""
+
+msgid "English content"
+msgstr ""
+
+msgid "English name"
+msgstr ""
+
+msgid "English option"
+msgstr ""
+
+msgid "English question"
+msgstr ""
+
+msgid "English title"
+msgstr ""
+
+msgid "Enter a new name for this document:"
+msgstr ""
+
+msgid "Enter how someone can contact the person responsible for this job."
+msgstr ""
+
+msgid ""
+"Enter how someone can contact this company and who is responsible for this "
+"company."
+msgstr ""
+
+msgid "Enter information about the representative of this company."
+msgstr ""
+
+msgid ""
+"Enter the maximum number of activities for which options can be created. You "
+"can either set the number globally or individually for each organ."
+msgstr ""
+
+msgid "Enter the start and end date and time of the option period."
+msgstr ""
+
+msgid "Enter the start and end date and time of the planning period."
+msgstr ""
+
+msgid "Enter the start and end date and time of this activity."
+msgstr ""
+
+msgid ""
+"Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
+"resultaten te zien."
+msgstr ""
+
+msgid "Evening"
+msgstr ""
+
+msgid "Exam date"
+msgstr ""
+
+msgid "Exam to upload"
+msgstr ""
+
+msgid "Exams"
+msgstr ""
+
+msgid "Exams and summaries"
+msgstr ""
+
+msgid "Exceptional Members"
+msgstr ""
+
+msgid "Expiration Date"
+msgstr ""
+
+msgid "Expiration date"
+msgstr ""
+
+msgid "Expiration date for the poll (YYYY-MM-DD)"
+msgstr ""
+
+msgid "Expired packages"
+msgstr ""
+
+msgid "Exposure time"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "External applications"
+msgstr ""
+
+msgid "FAQ"
+msgstr ""
+
+msgid "Family name"
+msgstr ""
+
+msgid "Featured"
+msgstr ""
+
+msgid "Featured Package"
+msgstr ""
+
+msgid "Featured company"
+msgstr ""
+
+msgid "Featured in language"
+msgstr ""
+
+msgid "File"
+msgstr ""
+
+msgid "Filename"
+msgstr ""
+
+msgid "Filter..."
+msgstr ""
+
+msgid "Final"
+msgstr ""
+
+#, php-format
+msgid "Final test from %s (%s)"
+msgstr ""
+
+msgid "Finalize exam uploads"
+msgstr ""
+
+msgid "Finalize summary uploads"
+msgstr ""
+
+msgid "Finalize uploads"
+msgstr ""
+
+msgid "Financial Audit Committee"
+msgstr ""
+
+msgid "Financial Audit Committees"
+msgstr ""
+
+msgid "Find a member"
+msgstr ""
+
+msgid "First authentication"
+msgstr ""
+
+msgid "First name"
+msgstr ""
+
+msgid "Flash"
+msgstr ""
+
+msgid "Focal length"
+msgstr ""
+
+msgid "For old exams of minor courses, you can also look at:"
+msgstr ""
+
+#, php-format
+msgid "Found %d %s matching your description"
+msgstr ""
+
+msgid "Fraternities"
+msgstr ""
+
+msgid "Fraternity"
+msgstr ""
+
+msgid "From"
+msgstr ""
+
+msgid "Full name:"
+msgstr ""
+
+msgid "GEWIKI"
+msgstr ""
+
+msgid "GEWIS has many different committees, learn more about them below!"
+msgstr ""
+
+msgid "GEWIS members only"
+msgstr ""
+
+msgid "GEWIS song"
+msgstr ""
+
+msgid "GMM"
+msgstr ""
+
+#, php-format
+msgid "GMM %d (%s)"
+msgstr ""
+
+msgid "GMM Committee"
+msgstr ""
+
+msgid "GMM Committees"
+msgstr ""
+
+msgid "GMM Taskforce"
+msgstr ""
+
+msgid "GMM Taskforces"
+msgstr ""
+
+msgid "General"
+msgstr ""
+
+msgid "General Members Meeting"
+msgstr ""
+
+msgid "Generate a new cover photo"
+msgstr ""
+
+msgid "Generatie"
+msgstr ""
+
+msgid "Generation"
+msgstr ""
+
+msgid "Given name"
+msgstr ""
+
+msgid "Global Value"
+msgstr ""
+
+msgid "Go to album"
+msgstr ""
+
+msgid "Google Calendar"
+msgstr ""
+
+msgid "Graduate"
+msgstr ""
+
+msgid "Has key code?"
+msgstr ""
+
+msgid "Has limited capacity"
+msgstr ""
+
+msgid ""
+"Have you forgotten your e-mail address and do you want to change it? Ask the "
+"secretary by going to GEWIS (preferred) or by sending an e-mail."
+msgstr ""
+
+msgid ""
+"Here you can add, edit, or remove activity categories. Click on 'Add "
+"Category' to add a new category or click on a category to edit/remove it."
+msgstr ""
+
+msgid ""
+"Here you can find everyone who signed up for this activity (may contain "
+"duplicates). Using the tabs above you can navigate to the different sign-up "
+"lists of this activity. From there you can remove external participants and "
+"(when supplied) view additional signup information from each participant."
+msgstr ""
+
+msgid ""
+"Here you can find everyone who signed up to this sign-up list. Here you can "
+"add or remove external participants and view detailed information regarding "
+"the signup of all participants."
+msgstr ""
+
+msgid "Hidden"
+msgstr ""
+
+msgid "Highlighted"
+msgstr ""
+
+msgid "Highlights"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "Home address (parents)"
+msgstr ""
+
+msgid "Honorary"
+msgstr ""
+
+msgid "House Rules"
+msgstr ""
+
+msgid "Housing"
+msgstr ""
+
+#, php-format
+msgid ""
+"I, %s I am fully aware that by filling in this form I authorize the person "
+"in this form to represent me at the %s General Members Meeting (%s) of s.v. "
+"GEWIS."
+msgstr ""
+
+#, php-format
+msgid ""
+"I, %s am fully aware that by revoking my authorization, %s cannot represent "
+"me at the %s General Members Meeting (%s) of s.v. GEWIS."
+msgstr ""
+
+msgid "ICT Policy"
+msgstr ""
+
+msgid "ISO"
+msgstr ""
+
+msgid ""
+"If an exam has been put online without the intention of the author, please "
+"let the board of GEWIS know by sending an"
+msgstr ""
+
+msgid "If approved, this job will be <strong>hidden</strong>."
+msgstr ""
+
+msgid ""
+"If approved, this job will be <strong>published</strong>, however, its "
+"actual visiblity depends on the company and associated job package."
+msgstr ""
+
+msgid ""
+"If this is checked the My Future logo will be displayed on the activity page "
+"and the activity will be included on the career activities page."
+msgstr ""
+
+msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
+msgstr ""
+
+#, php-format
+msgid ""
+"If you aren't able to attend a GMM in person but you want your voice to be "
+"heard, consider %sauthorizing another member%s to act on your behalf."
+msgstr ""
+
+#, php-format
+msgid "If you don't have an account yet, go to the %sRegistration page%s"
+msgstr ""
+
+#, php-format
+msgid "If you forgot your password, go to the %sPassword reset page%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"If your browser does not redirect you back, please <a href=\"%s\">click "
+"here</a> to continue."
+msgstr ""
+
+msgid ""
+"If your information is no longer up to date and you would like to change it, "
+"you can contact the secretary of GEWIS."
+msgstr ""
+
+msgid "In this photo:"
+msgstr ""
+
+msgid "Inactief Lid"
+msgstr ""
+
+msgid "Inactive members"
+msgstr ""
+
+msgid "Infimum"
+msgstr ""
+
+msgid "Information"
+msgstr ""
+
+msgid "Information for committees"
+msgstr ""
+
+msgid "Initials"
+msgstr ""
+
+msgid "Inkoper"
+msgstr ""
+
+msgid "Innovation Sciences"
+msgstr ""
+
+msgid "Interim"
+msgstr ""
+
+#, php-format
+msgid "Interim test from %s (%s)"
+msgstr ""
+
+msgid "Internal Regulations"
+msgstr ""
+
+msgid "Invalid form"
+msgstr ""
+
+msgid "Is 18+?"
+msgstr ""
+
+#, php-format
+msgid ""
+"It has been more than 90 days since you last used <strong>%s</strong>. As a "
+"reminder, the application has access to:"
+msgstr ""
+
 msgid ""
 "It is not allowed to put more than 3 options for the same activity in the "
 "calendar."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:44
+msgid "It will become visible after it has been approved by the board."
+msgstr ""
+
+msgid "Job Labels"
+msgstr ""
+
+#, php-format
+msgid "Job Package (%s active)"
+msgstr ""
+
+msgid "Job Packages"
+msgstr ""
+
+msgid "Job approval status reset!"
+msgstr ""
+
+msgid "Job approved!"
+msgstr ""
+
+msgid "Job category successfully created!"
+msgstr ""
+
+msgid "Job disapproved!"
+msgstr ""
+
+msgid "Job has been updated!"
+msgstr ""
+
+msgid "Job label successfully created!"
+msgstr ""
+
+msgid ""
+"Job proposal successfully created! It will become active after it has been "
+"approved."
+msgstr ""
+
+msgid "Job successfully created!"
+msgstr ""
+
+msgid "Job successfully deleted."
+msgstr ""
+
+msgid "Job successfully edited!"
+msgstr ""
+
+msgid "Job update has been rejected!"
+msgstr ""
+
+msgid "Jobs"
+msgstr ""
+
+msgid "Jobs (Active)"
+msgstr ""
+
+msgid "Jobs (Active) / Type"
+msgstr ""
+
+msgid "Jobs successfully transferred"
+msgstr ""
+
+msgid "Key Policy"
+msgstr ""
+
+msgid "Labels"
+msgstr ""
+
+msgid "Language"
+msgstr ""
+
+msgid "Language settings"
+msgstr ""
+
+msgid "Last authentication"
+msgstr ""
+
+msgid "Last membership change"
+msgstr ""
+
+msgid "Last name"
+msgstr ""
+
+msgid "Lid"
+msgstr ""
+
+msgid "Links"
+msgstr ""
+
+msgid "Loading an infimum..."
+msgstr ""
+
+msgid "Loading tags..."
+msgstr ""
+
+msgid "Location"
+msgstr ""
+
+msgid "Log in"
+msgstr ""
+
+msgid "Log in as company"
+msgstr ""
+
+msgid "Log in as member"
+msgstr ""
+
+msgid "Login"
+msgstr ""
+
+msgid "Login to subscribe"
+msgstr ""
+
+msgid "Login to view more information"
+msgstr ""
+
+msgid "Login to view the subscribed members."
+msgstr ""
+
+msgid "Logo"
+msgstr ""
+
+msgid "Logo of"
+msgstr ""
+
+msgid "Logout"
+msgstr ""
+
+msgid "Long dutch description"
+msgstr ""
+
+msgid "Long english description"
+msgstr ""
+
+msgid ""
+"Looking for a specific decision but forgot the numbers? Try dropping the "
+"decision point and/or number"
+msgstr ""
+
+msgid "Lunch break"
+msgstr ""
+
+msgid "MMM d"
+msgstr ""
+
+msgid ""
+"Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
+"2022)."
+msgstr ""
+
+msgid "Mail address"
+msgstr ""
+
+msgid "Mail everybody"
+msgstr ""
+
+msgid "Mail the education officer"
+msgstr ""
+
+msgid ""
+"Make this page available at the following URL. Providing a category is "
+"required."
+msgstr ""
+
+msgid "Max Activities"
+msgstr ""
+
+msgid "Max. value"
+msgstr ""
+
+msgid "Meeting"
+msgstr ""
+
+msgid "Meeting document uploaded"
+msgstr ""
+
+msgid "Meeting minutes uploaded"
+msgstr ""
+
+msgid "Meeting number"
+msgstr ""
+
+msgid "Meetings"
+msgstr ""
+
+msgid "Member"
+msgstr ""
+
+msgid "Member number"
+msgstr ""
+
+msgid "Members"
+msgstr ""
+
+msgid "Membership number"
+msgstr ""
+
+msgid "Membership number or email address"
+msgstr ""
+
+msgid "Membership type"
+msgstr ""
+
+msgid "Memberships of committees and fraternities"
+msgstr ""
+
+msgid "Message"
+msgstr ""
+
+msgid "Middle name"
+msgstr ""
+
+msgid "Min. value"
+msgstr ""
+
+msgid "Minutes"
+msgstr ""
+
+msgid "Minutes to upload"
+msgstr ""
+
+msgid "Modified by"
+msgstr ""
+
+msgid "More information about this activity is available below."
+msgstr ""
+
+msgid "More of my photo's"
+msgstr ""
+
+msgid "Morning"
+msgstr ""
+
+msgid "Most recent"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move %i photos"
+msgstr ""
+
+msgid "Move Jobs"
+msgstr ""
+
+msgid "Move album"
+msgstr ""
+
+msgid "Move down"
+msgstr ""
+
+msgid "Move photo"
+msgstr ""
+
+msgid "Move the album"
+msgstr ""
+
+msgid "Move the photo to another album"
+msgstr ""
+
+msgid "Move the photos to another album"
+msgstr ""
+
+msgid "Move up"
+msgstr ""
+
+msgid "Multiple days"
+msgstr ""
+
+msgid "My Activities"
+msgstr ""
+
+msgid "My Company"
+msgstr ""
+
+msgid "My Information"
+msgstr ""
+
+msgid "My activities"
+msgstr ""
+
+msgid "My information"
+msgstr ""
+
+msgid "My options"
+msgstr ""
+
+msgid "My photo's"
+msgstr ""
+
+msgid "N/A"
+msgstr ""
+
+msgid "NEW"
+msgstr ""
+
+msgid "Naam"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Name (Plural)"
+msgstr ""
+
+msgid "New password"
+msgstr ""
+
+msgid "News"
+msgstr ""
+
+msgid "News items"
+msgstr ""
+
+msgid "Next"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "No Company"
+msgstr ""
+
+msgid "No Exception available"
+msgstr ""
+
+msgid "No GMM available."
+msgstr ""
+
+msgid "No date"
+msgstr ""
+
+msgid "No decisions were found."
+msgstr ""
+
+msgid "No documents have been added."
+msgstr ""
+
+msgid "No meeting available."
+msgstr ""
+
+msgid "No notifications"
+msgstr ""
+
+msgid ""
+"No one has been tagged in this photo yet. Tag someone you recognise now!"
+msgstr ""
+
+msgid "No organ"
+msgstr ""
+
+msgid "None"
+msgstr ""
+
+msgid "Not allowed to add photos."
+msgstr ""
+
+msgid "Not allowed to add tags."
+msgstr ""
+
+msgid "Not allowed to create albums"
+msgstr ""
+
+msgid "Not allowed to create albums."
+msgstr ""
+
+msgid "Not allowed to delete albums."
+msgstr ""
+
+msgid "Not allowed to delete photos."
+msgstr ""
+
+msgid "Not allowed to download photos"
+msgstr ""
+
+msgid "Not allowed to edit albums"
+msgstr ""
+
+msgid "Not allowed to edit albums."
+msgstr ""
+
+msgid "Not allowed to generate album covers."
+msgstr ""
+
+msgid "Not allowed to move albums"
+msgstr ""
+
+msgid "Not allowed to move photos"
+msgstr ""
+
+msgid "Not allowed to remove tags."
+msgstr ""
+
+msgid "Not allowed to search for members."
+msgstr ""
+
+msgid "Not allowed to upload photos."
+msgstr ""
+
+msgid "Not allowed to view albums"
+msgstr ""
+
+msgid "Not allowed to view albums without dates"
+msgstr ""
+
+msgid "Not allowed to view organ information"
+msgstr ""
+
+msgid "Not allowed to view photo details"
+msgstr ""
+
+msgid "Not allowed to view photos"
+msgstr ""
+
+msgid "Not allowed to view previous photos of the week"
+msgstr ""
+
+msgid "Not allowed to view tags."
+msgstr ""
+
+msgid "Not allowed to view the list of organs"
+msgstr ""
+
+msgid "Not allowed to vote for a photo of the week"
+msgstr ""
+
+msgid "Notifications"
+msgstr ""
+
+msgid "Number"
+msgstr ""
+
+msgid "Old activities"
+msgstr ""
+
+msgid "Old members"
+msgstr ""
+
+msgid "Old password"
+msgstr ""
+
+msgid "Old photos of the week"
+msgstr ""
+
+msgid "Old polls"
+msgstr ""
+
+msgid "Older"
+msgstr ""
+
+msgid "Onderwijscommissaris"
+msgstr ""
+
+msgid "Only allow GEWIS members"
+msgstr ""
+
+msgid "Open date and time"
+msgstr ""
+
+msgid "Option 1, Option 2, ..."
+msgstr ""
+
+msgid "Option Calendar"
+msgstr ""
+
+msgid "Option Period"
+msgstr ""
+
+msgid "Option calendar"
+msgstr ""
+
+msgid "Option does not fall within option period (also check the end date)."
+msgstr ""
+
+msgid "Option planning period created successfully."
+msgstr ""
+
+msgid "Option planning period deleted."
+msgstr ""
+
+msgid "Option planning period has been updated."
+msgstr ""
+
+msgid "Option should end after it starts."
+msgstr ""
+
+msgid "Optional message..."
+msgstr ""
+
+msgid "Options"
+msgstr ""
+
+msgid "Or select a page to edit below."
+msgstr ""
+
+msgid "Or subscribe without a GEWIS membership: "
+msgstr ""
+
+msgid ""
+"Order your course books via GEWIS to receive a discount. Specific ordering "
+"deadlines and pickup dates will be timely communicated to you via an email."
+msgstr ""
+
+msgid "Ordinary"
+msgstr ""
+
+msgid "Organ"
+msgstr ""
+
+msgid "Organ Regulations"
+msgstr ""
+
+msgid "Organ list"
+msgstr ""
+
+msgid "Organ mutations"
+msgstr ""
+
+msgid "Organisation"
+msgstr ""
+
+msgid "Organizer"
+msgstr ""
+
+msgid "Organs"
+msgstr ""
+
+msgid ""
+"Original job and proposed update do not have any job labels applied to them."
+msgstr ""
+
+msgid "Other"
+msgstr ""
+
+msgid "Other albums"
+msgstr ""
+
+#, php-format
+msgid "Other exam material from %s (%s)"
+msgstr ""
+
+msgid "Overview"
+msgstr ""
+
+msgid "PR-Functionaris"
+msgstr ""
+
+msgid "Packages"
+msgstr ""
+
+msgid "Pages"
+msgstr ""
+
+msgid "Participants"
+msgstr ""
+
+msgid "Password"
+msgstr ""
+
+msgid "Password changed successfully"
+msgstr ""
+
+msgid "Password incorrect"
+msgstr ""
+
+msgid "Past option planning periods cannot be deleted."
+msgstr ""
+
+msgid "Penningmeester"
+msgstr ""
+
+msgid "Period"
+msgstr ""
+
+msgid "Permissions"
+msgstr ""
+
+msgid "Personal"
+msgstr ""
+
+msgid "Phone Number"
+msgstr ""
+
+msgid "Phone number"
+msgstr ""
+
+#, php-format
+msgid "Photo #%d"
+msgstr ""
+
+msgid "Photo admin"
+msgstr ""
+
+msgid "Photo of the Week:<br> Week"
+msgstr ""
+
+msgid "Photo of the week"
+msgstr ""
+
+#, php-format
+msgid "Photo's of %s"
+msgstr ""
+
+msgid "Photos"
+msgstr ""
+
+msgid "Photos of the Week"
+msgstr ""
+
+#, php-format
+msgid "Photos of the Week in %d/%d"
+msgstr ""
+
+msgid "Pin news item"
+msgstr ""
+
+msgid "Plan activity"
+msgstr ""
+
+msgid "Planned Activities"
+msgstr ""
+
+msgid "Planned Option Planning Periods"
+msgstr ""
+
+msgid "Planning Period"
+msgstr ""
+
+#, php-format
+msgid ""
+"Please contact %s or the board (%s) with any questions or concerns. Have fun!"
+msgstr ""
+
+#, php-format
+msgid ""
+"Please contact %s or the board (%s) with any questions, concerns or if you "
+"are unable to attend after the deadline for unsubscribing has passed. Have "
+"fun!"
+msgstr ""
+
+msgid "Please fill in this CAPTCHA:"
+msgstr ""
+
+msgid "Please note that numbers are not dependant on the selected language(s)."
+msgstr ""
+
+msgid "Please select a GMM to view authorizations."
+msgstr ""
+
+msgid "Please wait while the album is being deleted."
+msgstr ""
+
+msgid "Please wait while the photos are being deleted."
+msgstr ""
+
+msgid "Please wait while your photo is being deleted."
+msgstr ""
+
+msgid "Poll"
+msgstr ""
+
+msgid "Poll history"
+msgstr ""
+
+msgid "Polls"
+msgstr ""
+
+msgid "Polls awaiting approval"
+msgstr ""
+
+msgid "Poster Policy"
+msgstr ""
+
+msgid "Previous"
+msgstr ""
+
+msgid "Previous exceptions"
+msgstr ""
+
+msgid "Privacy Policy"
+msgstr ""
+
+msgid "Profile"
+msgstr ""
+
+msgid "Proposals"
+msgstr ""
+
+msgid "Propose options for an activity"
+msgstr ""
+
+msgid "Public Archive"
+msgstr ""
+
+msgid "Public archive"
+msgstr ""
+
+msgid "Published"
+msgstr ""
+
+msgid "Random"
+msgstr ""
+
+msgid "Recent changes"
+msgstr ""
+
+msgid "Recently Approved Jobs"
+msgstr ""
+
+msgid "Recently Rejected Jobs"
+msgstr ""
+
+msgid "Recently Unapproved Jobs"
+msgstr ""
+
+msgid "Recipient"
+msgstr ""
+
+msgid "Regenerate"
+msgstr ""
+
+msgid "Regenerate album cover"
+msgstr ""
+
+msgid "Register"
+msgstr ""
+
+msgid "Regulations"
+msgstr ""
+
+msgid "Reject Update"
+msgstr ""
+
+msgid "Remember me"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
+
+msgid "Remove Token"
+msgstr ""
+
+msgid "Remove option"
+msgstr ""
+
+msgid "Remove the last option"
+msgstr ""
+
+msgid "Remove the last sign-up list"
+msgstr ""
+
+msgid "Remove the last sign-up list field"
+msgstr ""
+
+msgid "Remove this picture as your profile picture"
+msgstr ""
+
+msgid "Rename"
+msgstr ""
+
+msgid "Rename Meeting Document"
+msgstr ""
+
+msgid "Representative Information"
+msgstr ""
+
+msgid "Request a poll"
+msgstr ""
+
+msgid "Request password reset"
+msgstr ""
+
+msgid "Request poll"
+msgstr ""
+
+msgid "Required role"
+msgstr ""
+
+msgid "Reset Approval Status"
+msgstr ""
+
+msgid "Reset password"
+msgstr ""
+
+msgid "Retired fraternities"
+msgstr ""
+
+msgid "Revoke authorization"
+msgstr ""
+
+msgid "Revoked"
+msgstr ""
+
+#, php-format
+msgid "Revoked authorizations for GMM %d"
+msgstr ""
+
+msgid "Root"
+msgstr ""
+
+msgid ""
+"S.v. GEWIS uses cookies on this website, these are required for the website "
+"to function. Additionally, we may collection information about how you use "
+"our website in order to improve your experience. If you do not want your "
+"behaviour to be tracked please opt out below."
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Scanned?"
+msgstr ""
+
+msgid "Search"
+msgstr ""
+
+msgid "Search by keyword or meeting number"
+msgstr ""
+
+msgid "Search for decision"
+msgstr ""
+
+msgid "Search query"
+msgstr ""
+
+msgid "Search through the list of decisions accumulated from past meetings:"
+msgstr ""
+
+msgid "Secretaris"
+msgstr ""
+
+msgid "Select a job category"
+msgstr ""
+
+msgid "Select a new parent album"
+msgstr ""
+
+msgid "Select a new parent for the album"
+msgstr ""
+
+msgid "Select a period"
+msgstr ""
+
+msgid "Select a target job package"
+msgstr ""
+
+msgid "Select a type"
+msgstr ""
+
+msgid "Select an option"
+msgstr ""
+
+msgid ""
+"Select an organ to edit its information. Changes will not be displayed until "
+"they have been approved."
+msgstr ""
+
+msgid "Select the jobs that you want to transfer to another job package."
+msgstr ""
+
+msgid ""
+"Select the organ for which the options are and in which option period the "
+"options should be planned."
+msgstr ""
+
+msgid ""
+"Select this if this sign-up list has limited capacity or is expected to have "
+"limited capacity. Please ensure that you also write this in the description "
+"of the activity."
+msgstr ""
+
+msgid "Select this if you want this news item to stay at the top of the page."
+msgstr ""
+
+msgid ""
+"Select this to display the number of subscribed GEWIS members to external "
+"visitors."
+msgstr ""
+
+msgid ""
+"Select whether an organ (committee, fraternity, etc.) or a company is "
+"responsible for this activity, or both."
+msgstr ""
+
+msgid "Set as profile picture"
+msgstr ""
+
+msgid "Set as profile picture!"
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Share"
+msgstr ""
+
+msgid "Short dutch description"
+msgstr ""
+
+msgid "Short english description"
+msgstr ""
+
+msgid "Shutter speed"
+msgstr ""
+
+msgid "Sign-up List"
+msgstr ""
+
+msgid "Sign-up Lists"
+msgstr ""
+
+msgid "Slogan"
+msgstr ""
+
+msgid "Slug"
+msgstr ""
+
+msgid "Some of the required fields for this type are empty"
+msgstr ""
+
+msgid "Sort on"
+msgstr ""
+
+msgid ""
+"Specify the permanent link for this company, it should be unique across all "
+"companies."
+msgstr ""
+
+msgid ""
+"Specify the permanent link for this job, it should be unique for this "
+"company."
+msgstr ""
+
+msgid "Stack trace"
+msgstr ""
+
+msgid "Start"
+msgstr ""
+
+msgid "Start Date"
+msgstr ""
+
+msgid "Start date"
+msgstr ""
+
+msgid "Start date and time"
+msgstr ""
+
+msgid "Start date and time of option period"
+msgstr ""
+
+msgid "Start date and time of planning period"
+msgstr ""
+
+#, php-format
+msgid "Still haven't found what you're looking for? Take a look at %s."
+msgstr ""
+
+msgid "Street and number"
+msgstr ""
+
+msgid "Student address"
+msgstr ""
+
+msgid "Studievereniging GEWIS"
+msgstr ""
+
+msgid "Study Association GEWIS"
+msgstr ""
+
+msgid ""
+"Study association GEWIS obviously has several fraternities which contribute "
+"to the atmosphere at GEWIS and organize fun activities. Some fraternities "
+"have retired, but luckily new fraternities continue to be founded."
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Submitter"
+msgstr ""
+
+msgid "Subscribe"
+msgstr ""
+
+msgid "Subscribe an external participant"
+msgstr ""
+
+msgid "Subscribe as external participant"
+msgstr ""
+
+msgid "Subscribe now"
+msgstr ""
+
+msgid "Subscribe yourself"
+msgstr ""
+
+msgid "Subscription closed"
+msgstr ""
+
+msgid "Successfully added course!"
+msgstr ""
+
+msgid "Successfully removed external participant"
+msgstr ""
+
+msgid "Successfully subscribed"
+msgstr ""
+
+msgid "Successfully subscribed as external participant"
+msgstr ""
+
+msgid "Successfully subscribed external participant"
+msgstr ""
+
+msgid "Successfully unsubscribed"
+msgstr ""
+
+msgid "Successfully updated course information!"
+msgstr ""
+
+msgid "SudoSOS"
+msgstr ""
+
+msgid "Summaries"
+msgstr ""
+
+#, php-format
+msgid "Summary by %s on %s (%s)"
+msgstr ""
+
+msgid "Summary date"
+msgstr ""
+
+#, php-format
+msgid "Summary on %s (%s)"
+msgstr ""
+
+msgid "Tafelvoetbalcoordinator"
+msgstr ""
+
+msgid "Tag someone"
+msgstr ""
+
+msgid "Terms"
+msgstr ""
+
+msgid "Text"
+msgstr ""
+
+#, php-format
+msgid "The %s%s %s%s will be held on %s."
+msgstr ""
+
+msgid "The activity category was created successfully!"
+msgstr ""
+
+msgid "The activity category was successfully updated!"
+msgstr ""
+
+msgid "The activity does now have an acceptable amount of options"
+msgstr ""
+
+msgid "The activity has been successfully created."
+msgstr ""
+
+msgid "The activity must start after today"
+msgstr ""
+
+msgid "The activity must start before it ends"
+msgstr ""
+
+msgid "The activity must start before it ends."
+msgstr ""
+
+msgid "The album has been deleted"
+msgstr ""
+
+msgid "The album has been moved"
+msgstr ""
+
+msgid "The application will get the following information:"
+msgstr ""
+
+msgid ""
+"The board can always decide to make an exception to the rules written above, "
+"for example in case of dependence on a third party, or when it concerns very "
+"big activities or weekends."
+msgstr ""
+
+msgid "The currently active fraternities of GEWIS (in arbitrary order)"
+msgstr ""
+
+msgid "The e-mail address must be unique across companies."
+msgstr ""
+
+msgid ""
+"The exams on the website of GEWIS are provided by Education & Student "
+"Affairs of the department of Mathematics and Computer Science of the TU/e."
+msgstr ""
+
 msgid ""
 "The first to put an option for an activity on a particular date, has the "
 "first dibs to let the activity take place on this date. Five weeks before "
@@ -215,1748 +2562,191 @@ msgid ""
 "line gets the chance to use this date for an activity."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:45
-msgid ""
-"The board can always decide to make an exception to the rules written above, "
-"for example in case of dependence on a third party, or when it concerns very "
-"big activities or weekends."
+msgid "The following fraternities have retired:"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:51
-msgid "Your option has been added successfully"
+msgid "The image could not be loaded."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:59
-msgid "My options"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:63
-msgid "Creator"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:65
-#: module/Activity/view/activity/admin/participantsTable.phtml:22
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
-#: module/Activity/view/partial/option.phtml:19
-#: module/Decision/view/decision/decision/index.phtml:23
-#: module/Decision/view/decision/organ/index.phtml:24
-#: module/Education/view/education/admin/course-documents.phtml:68
-#: module/Activity/src/Form/SignupListField.php:60
-#: module/Education/src/Form/Fieldset/Exam.php:68
-msgid "Type"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:66
-#: module/Activity/view/activity/activity/list.phtml:50
-#: module/Activity/view/activity/activity/view.phtml:90
-msgid "Start"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:67
-#: module/Activity/view/activity/activity/list.phtml:52
-#: module/Activity/view/activity/activity/view.phtml:93
-msgid "End"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:88
-#: module/Activity/view/activity/activity-calendar/index.phtml:121
-#: module/Activity/view/activity/admin-option/index.phtml:48
-#: module/Activity/view/activity/admin-option/index.phtml:98
-#: module/Activity/view/activity/admin-option/index.phtml:138
-#: module/Company/view/company/admin/edit-company.phtml:162
-#: module/Company/view/company/admin/edit-package.phtml:126
-#: module/Company/view/company/admin/index.phtml:204
-#: module/Company/view/company/company-account/jobs.phtml:254
-#: module/Decision/view/decision/admin/document.phtml:150
-#: module/Decision/view/decision/admin/document.phtml:181
-#: module/Education/view/education/admin/course-documents.phtml:92
-#: module/Education/view/education/admin/course-documents.phtml:141
-#: module/Education/view/education/admin/course-documents.phtml:176
-#: module/Education/view/education/admin/course.phtml:70
-#: module/Education/view/education/admin/course.phtml:105
-#: module/Education/view/education/admin/edit-exam.phtml:62
-#: module/Education/view/education/admin/edit-summary.phtml:62
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:88
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:158
-msgid "Delete"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:92
-#: module/Activity/view/activity/activity-calendar/index.phtml:145
-#: module/Activity/view/activity/admin-approval/view.phtml:208
-#: module/Decision/view/decision/organ-admin/edit.phtml:181
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:84
-msgid "Approve"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:96
-msgid "Modified by"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:110
-msgid "Delete option"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:113
-msgid "Are you sure you want to delete this option?"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:119
-#: module/Activity/view/activity/activity-calendar/index.phtml:143
-#: module/Activity/view/activity/admin-category/index.phtml:64
-#: module/Activity/view/activity/admin-option/index.phtml:135
-#: module/Company/view/company/admin/edit-company.phtml:214
-#: module/Company/view/company/admin/edit-package.phtml:160
-#: module/Company/view/company/admin/index.phtml:244
-#: module/Company/view/company/company-account/jobs.phtml:304
-#: module/Decision/view/decision/admin/document.phtml:178
-#: module/Decision/view/decision/admin/document.phtml:205
-#: module/Decision/view/decision/decision/authorizations.phtml:185
-#: module/Education/view/education/admin/course-documents.phtml:173
-#: module/Education/view/education/admin/course.phtml:102
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:231
-#: module/Photo/view/photo/album-admin/index.phtml:232
-#: module/Photo/view/photo/album-admin/index.phtml:264
-#: module/Photo/view/photo/photo-admin/index.phtml:158
-#: module/User/src/Form/ApiAppAuthorisation.php:26
-msgid "Cancel"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:134
-msgid "Approve option"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:137
-msgid "Are you sure you want to approve this option?"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:160
-#: module/Activity/src/Form/ActivityCalendarOption.php:30
-msgid "Day"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:180
-msgid "Planned Activities"
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:181
-#: module/Activity/view/activity/activity/list.phtml:68
-msgid "There are no activities."
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:194
-msgid "There are no options."
-msgstr ""
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:236
-msgid "Plan activity"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:51
-msgid "Organizer"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:52
-msgid ""
-"Select whether an organ (committee, fraternity, etc.) or a company is "
-"responsible for this activity, or both."
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:76
-#: module/Activity/view/activity/admin/list.phtml:25
-#: module/Activity/view/activity/admin/view.phtml:74
-#: module/Company/view/company/admin-approval/index.phtml:58
-#: module/Company/view/company/company/job-list.phtml:85
-#: module/User/view/user/user/login.phtml:34
-msgid "Company"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:87
-#: module/Activity/view/activity/admin/participantsTable.phtml:25
-msgid "Date and time"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:88
-msgid "Enter the start and end date and time of this activity."
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:101
-msgid "Start date and time"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:116
-msgid "End date and time"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:130
-#: module/Activity/view/activity/admin-approval/view.phtml:165
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:263
-#: module/Activity/view/activity/admin-category/add.phtml:17
-#: module/Activity/view/activity/admin-category/index.phtml:10
-#: module/Activity/view/activity/admin-category/index.phtml:14
-#: module/Activity/view/activity/admin-category/index.phtml:19
-msgid "Activity Categories"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:131
-msgid ""
-"Add activity categories to your activity to give potential subscribers a "
-"better understanding of the activity."
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:151
-#: module/Activity/view/activity/admin-category/index.phtml:24
-msgid "There are currently no activity categories..."
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:177
-#: module/Activity/view/activity/activity/view.phtml:134
-#: module/Activity/view/activity/admin-approval/view.phtml:179
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:290
-msgid "Sign-up Lists"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:178
-msgid ""
-"Add sign-up lists to allow people to sign up for this activity. Each list "
-"can have optional fields to collect specific information from the "
-"participants."
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:184
-#: module/Activity/view/activity/admin-approval/view.phtml:67
-#: module/Activity/view/activity/admin-approval/view.phtml:185
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:120
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:300
-#: module/Activity/view/activity/admin-category/add.phtml:53
-#: module/Activity/view/partial/create.phtml:30
-#: module/Company/view/company/admin-approval/job-approval.phtml:106
-#: module/Company/view/company/admin-approval/job-proposal.phtml:146
-#: module/Company/view/partial/company/admin/editors/category.phtml:20
-#: module/Company/view/partial/company/admin/editors/company.phtml:218
-#: module/Company/view/partial/company/admin/editors/job.phtml:146
-#: module/Company/view/partial/company/admin/editors/label.phtml:29
-#: module/Company/view/partial/company/admin/editors/package.phtml:96
-#: module/Application/src/Model/Enums/Languages.php:24
-msgid "Dutch"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:189
-#: module/Activity/view/activity/admin-approval/view.phtml:72
-#: module/Activity/view/activity/admin-approval/view.phtml:190
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:125
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:305
-#: module/Activity/view/activity/admin-category/add.phtml:90
-#: module/Activity/view/partial/create.phtml:104
-#: module/Company/view/company/admin-approval/job-approval.phtml:111
-#: module/Company/view/company/admin-approval/job-proposal.phtml:151
-#: module/Company/view/partial/company/admin/editors/category.phtml:65
-#: module/Company/view/partial/company/admin/editors/company.phtml:279
-#: module/Company/view/partial/company/admin/editors/job.phtml:240
-#: module/Company/view/partial/company/admin/editors/label.phtml:74
-#: module/Company/view/partial/company/admin/editors/package.phtml:128
-#: module/Application/src/Model/Enums/Languages.php:23
-msgid "English"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:217
-msgid "Remove the last sign-up list"
-msgstr ""
-
-#: module/Activity/view/activity/activity/create.phtml:221
-msgid "Add a sign-up list"
-msgstr ""
-
-#: module/Activity/view/activity/activity/createSuccess.phtml:15
-msgid "The activity has been successfully created."
-msgstr ""
-
-#: module/Activity/view/activity/activity/createSuccess.phtml:16
-msgid "It will become visible after it has been approved by the board."
-msgstr ""
-
-#: module/Activity/view/activity/activity/index.phtml:15
-#: module/Activity/view/activity/activity/index.phtml:21
-#: module/Activity/view/activity/activity/view.phtml:30
-#: module/Activity/view/activity/activity/view.phtml:38
-#: module/Activity/view/activity/admin-approval/view.phtml:22
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:24
-#: module/Activity/view/activity/admin/participants.phtml:22
-#: module/Activity/view/activity/admin/view.phtml:19
-#: module/Application/view/partial/admin.phtml:38
-#: module/Application/view/partial/main-nav.phtml:374
-#: module/Application/view/partial/main-nav.phtml:378
-#: module/Application/view/partial/main-nav.phtml:383
-#: module/Decision/view/decision/member/index.phtml:203
-msgid "Activities"
-msgstr ""
-
-#: module/Activity/view/activity/activity/index.phtml:27
-msgid "All Activities"
-msgstr ""
-
-#: module/Activity/view/activity/activity/index.phtml:30
-msgid "Career Activities"
-msgstr ""
-
-#: module/Activity/view/activity/activity/index.phtml:34
-msgid "My Activities"
-msgstr ""
-
-#: module/Activity/view/activity/activity/index.phtml:45
-#: module/Activity/src/Controller/ActivityController.php:228
-msgid "Create Activity"
-msgstr ""
-
-#: module/Activity/view/activity/activity/list.phtml:22
-msgid "MMM d"
-msgstr ""
-
-#: module/Activity/view/activity/activity/list.phtml:46
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:79
-msgid "Continue reading"
-msgstr ""
-
-#: module/Activity/view/activity/activity/list.phtml:55
-#: module/Activity/view/activity/activity/view.phtml:96
-#: module/Activity/view/activity/admin-approval/view.phtml:99
-#: module/Activity/view/activity/admin-approval/view.phtml:104
-#: module/Activity/view/activity/admin-approval/view.phtml:111
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:162
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:167
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:179
-#: module/Activity/view/partial/create.phtml:58
-#: module/Activity/view/partial/create.phtml:132
-#: module/Company/view/company/admin-approval/job-approval.phtml:157
-#: module/Company/view/company/admin-approval/job-approval.phtml:162
-#: module/Company/view/company/admin-approval/job-approval.phtml:169
-#: module/Company/view/company/admin-approval/job-proposal.phtml:209
-#: module/Company/view/company/admin-approval/job-proposal.phtml:214
-#: module/Company/view/company/admin-approval/job-proposal.phtml:224
-#: module/Photo/view/partial/metadata.phtml:82
-#: module/Company/src/Form/Job.php:181 module/Company/src/Form/Job.php:191
-msgid "Location"
-msgstr ""
-
-#: module/Activity/view/activity/activity/list.phtml:58
-#: module/Activity/view/activity/activity/view.phtml:99
-#: module/Activity/view/activity/admin-approval/view.phtml:118
-#: module/Activity/view/activity/admin-approval/view.phtml:123
-#: module/Activity/view/activity/admin-approval/view.phtml:130
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:191
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:196
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:208
-#: module/Activity/view/partial/create.phtml:72
-#: module/Activity/view/partial/create.phtml:146
-msgid "Costs"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:150
-msgid "the organizing party"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:162
 #, php-format
-msgid ""
-"Please contact %s or the board (%s) with any questions, concerns or if you "
-"are unable to attend after the deadline for unsubscribing has passed. Have "
-"fun!"
+msgid "The latest %s that took place:"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:165
-#, php-format
-msgid ""
-"Please contact %s or the board (%s) with any questions or concerns. Have fun!"
+msgid "The login and password combination is incorrect."
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:180
-#, php-format
-msgid ""
-"This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
+msgid "The number of English options must equal the number of Dutch options"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:181
-msgid " <strong>has a limited capacity</strong> and "
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:193
-msgid "Already subscribed"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:200
-msgid "Subscription closed"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:206
-msgid "Subscribe now"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:213
-msgid "Unsubscribe yourself"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:216
-msgid "You are not allowed to unsubscribe after the deadline!"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:235
-#: module/Activity/view/activity/activity/view.phtml:252
-msgid "Subscribe yourself"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:238
-msgid "Login to subscribe"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:242
-msgid "Or subscribe without a GEWIS membership: "
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:263
-msgid "Current subscriptions"
-msgstr ""
-
-#: module/Activity/view/activity/activity/view.phtml:281
 #, php-format
 msgid "The number of subscribed members is currently %d."
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:285
-msgid "Login to view the subscribed members."
+msgid "The option period must end after it starts."
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:19
-#: module/Activity/view/activity/admin-approval/view.phtml:29
-#: module/Activity/view/activity/admin-approval/view.phtml:198
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:314
-#: module/Company/view/company/admin-approval/job-approval.phtml:21
-#: module/Company/view/company/admin-approval/job-approval.phtml:238
-#: module/Company/view/company/admin-approval/job-proposal.phtml:23
-#: module/Company/view/company/admin-approval/job-proposal.phtml:333
-msgid "Approval"
+msgid "The option period must start after the planning period ends."
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:33
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:56
-#: module/Activity/view/partial/create.phtml:16
-#: module/Company/view/company/admin-approval/job-approval.phtml:30
-#: module/Company/view/company/admin-approval/job-proposal.phtml:54
-#: module/Company/view/partial/company/admin/editors/category.phtml:16
-#: module/Company/view/partial/company/admin/editors/company.phtml:204
-#: module/Company/view/partial/company/admin/editors/job.phtml:132
-#: module/Company/view/partial/company/admin/editors/label.phtml:16
-#: module/Company/view/partial/company/admin/editors/package.phtml:18
-#: module/Photo/view/photo/album/index.phtml:519
-msgid "Information"
+msgid "The photo has been deleted"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:42
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:73
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:89
-#: module/Activity/view/partial/signupForm.phtml:86
-#: module/Photo/view/partial/tags.phtml:52
-#: module/Photo/view/photo/album/index.phtml:342
-#: module/Photo/view/photo/album/index.phtml:687
-msgid "and"
+msgid "The photo has been moved"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:53
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:100
+msgid "The photos have been been deleted"
+msgstr ""
+
+msgid "The photos have been moved"
+msgstr ""
+
+msgid "The planning period must end after it starts."
+msgstr ""
+
+msgid "The requested URL could not be matched by routing."
+msgstr ""
+
+msgid ""
+"The requested controller could not be mapped to an existing controller class."
+msgstr ""
+
+msgid "The requested controller was not dispatchable."
+msgstr ""
+
+msgid "The requested controller was unable to dispatch the request."
+msgstr ""
+
+msgid ""
+"The sign-up list closing date and time must be before the activity starts."
+msgstr ""
+
+msgid ""
+"The sign-up list opening date and time must be before the sign-up list "
+"closes."
+msgstr ""
+
+msgid "The uploaded file does not have a valid extension"
+msgstr ""
+
+msgid "The uploaded file is not a valid image"
+msgstr ""
+
+#, php-format
+msgid ""
+"The uploaded file is not a valid image \n"
+"Error: %s"
+msgstr ""
+
+msgid "There already are minutes for this meeting"
+msgstr ""
+
+msgid "There already exists a course with this code"
+msgstr ""
+
+msgid "There are a few rules:"
+msgstr ""
+
+msgid "There are currently no activity categories..."
+msgstr ""
+
+msgid "There are currently no job labels..."
+msgstr ""
+
+msgid "There are no activities in the archive."
+msgstr ""
+
+msgid "There are no activities."
+msgstr ""
+
+msgid "There are no exams to be edited. Upload exams to edit them."
+msgstr ""
+
+msgid "There are no jobs that you can transfer..."
+msgstr ""
+
+msgid "There are no meetings for which you can upload documents."
+msgstr ""
+
+msgid "There are no options."
+msgstr ""
+
+msgid "There are no photos in this year."
+msgstr ""
+
+msgid "There are no planned option creation periods in the future."
+msgstr ""
+
+msgid "There are no revoked authorizations for this GMM."
+msgstr ""
+
+msgid "There are no summaries to be edited. Upload exams to edit them."
+msgstr ""
+
+msgid ""
+"There are no upcoming meetings for which you can authorize someone.\n"
+"You may still be able to authorize someone or revoke an authorization by "
+"contacting the board."
+msgstr ""
+
+msgid "There are no valid authorizations for this GMM."
+msgstr ""
+
+msgid "There currently is no poll."
+msgstr ""
+
+msgid "There is currently no option creation period planned."
+msgstr ""
+
+msgid "There is no company or update proposal that requires your approval."
+msgstr ""
+
+msgid "There is no job or update proposal that requires your approval."
+msgstr ""
+
+msgid "There is no member with this membership number."
+msgstr ""
+
+msgid "This activity has already started/ended and can no longer be updated."
+msgstr ""
+
+msgid "This activity needs a GEFLITST member to take photos"
+msgstr ""
+
+#, php-format
+msgid "This activity was approved by <strong>%s</strong>."
+msgstr ""
+
+#, php-format
+msgid "This activity was disapproved by <strong>%s</strong>."
+msgstr ""
+
+msgid "This album does not contain any photos."
+msgstr ""
+
+msgid "This course does not have any exams."
+msgstr ""
+
+msgid ""
+"This functionality is currently unavailable. Our apologies for the "
+"inconvenience."
+msgstr ""
+
+msgid "This is a career related activity"
+msgstr ""
+
 #, php-format
 msgid ""
 "This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
 "it will start on <strong>%s</strong> and end on <strong>%s</strong>."
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:60
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:113
-msgid "More information about this activity is available below."
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view.phtml:157
-msgid "View details / subscriptions"
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view.phtml:220
-msgid "Disapprove"
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view.phtml:230
-#, php-format
-msgid "This activity was approved by <strong>%s</strong>."
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view.phtml:252
-#, php-format
-msgid "This activity was disapproved by <strong>%s</strong>."
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:21
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:31
-msgid "Update Proposal"
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:60
-#, php-format
-msgid ""
-"Changes in activity attributes are shown like this: %s. If there are no "
-"changes to a certain attribute, you will see the existing data. Sign-up list "
-"differences are <strong>not</strong> shown with colours, both the old sign-"
-"up list(s) and the new sign-up list(s) are shown. There might not be "
-"difference between the two!"
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
-#: module/Company/view/company/admin-approval/job-proposal.phtml:62
-msgid "old"
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
-#: module/Company/view/company/admin-approval/job-proposal.phtml:62
-msgid "new"
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:250
-msgid "View details of the old activity"
-msgstr ""
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:255
-msgid "View details of the new activity"
-msgstr ""
-
-#: module/Activity/view/activity/admin-category/add.phtml:50
-#: module/Activity/view/partial/create.phtml:27
-#: module/Application/src/Form/Localisable.php:32
-msgid "Enable Dutch Translations"
-msgstr ""
-
-#: module/Activity/view/activity/admin-category/add.phtml:87
-#: module/Activity/view/partial/create.phtml:101
-#: module/Application/src/Form/Localisable.php:44
-msgid "Enable English Translations"
-msgstr ""
-
-#: module/Activity/view/activity/admin-category/index.phtml:20
-msgid ""
-"Here you can add, edit, or remove activity categories. Click on 'Add "
-"Category' to add a new category or click on a category to edit/remove it."
-msgstr ""
-
-#: module/Activity/view/activity/admin-category/index.phtml:42
-#: module/Company/view/company/admin/categories.phtml:17
-msgid "Add Category"
-msgstr ""
-
-#: module/Activity/view/activity/admin-category/index.phtml:53
-#: module/Company/view/company/admin/edit-company.phtml:203
-#: module/Company/view/company/admin/edit-package.phtml:151
-#: module/Company/view/company/admin/index.phtml:231
-#: module/Company/view/company/company-account/jobs.phtml:294
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:175
-#: module/Photo/view/photo/album-admin/index.phtml:213
-#: module/Photo/view/photo/album-admin/index.phtml:245
-#: module/Photo/view/photo/photo-admin/index.phtml:139
-msgid "Delete confirmation"
-msgstr ""
-
-#: module/Activity/view/activity/admin-category/index.phtml:56
-msgid "Are you sure you want to delete this activity category?"
-msgstr ""
-
-#: module/Activity/view/activity/admin-category/index.phtml:62
-msgid "Delete Activity Category"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:21
-#: module/Activity/view/activity/admin/view.phtml:70
-msgid "Dutch name"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:22
-#: module/Activity/view/activity/admin/view.phtml:71
-msgid "English name"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:23
-#: module/Activity/view/activity/admin/view.phtml:72
-#: module/Company/view/company/admin/edit-company.phtml:107
-#: module/Company/view/company/company-account/jobs.phtml:57
-#: module/Photo/src/Form/EditAlbum.php:37
-msgid "Start date"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:24
-#: module/Activity/view/activity/admin/view.phtml:73
-msgid "Organ"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:26
-#: module/Activity/view/activity/admin/view.phtml:75
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:42
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:115
-msgid "Submitter"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:27
-msgid "Update status"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:29
-#: module/Company/view/company/admin/edit-package.phtml:85
-msgid "Approved"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:45
-#: module/Activity/view/activity/admin/list.phtml:46
-#: module/Activity/view/activity/admin/view.phtml:91
-#: module/Activity/view/activity/admin/view.phtml:92
-#: module/Education/view/education/education/index.phtml:112
-msgid "None"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:50
-#: module/Activity/view/activity/admin/list.phtml:52
-msgid "Update pending"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:63
-#: module/Activity/view/activity/admin-option/index.phtml:94
-#: module/Company/view/company/admin/edit-company.phtml:157
-#: module/Company/view/company/admin/edit-package.phtml:122
-#: module/Company/view/company/company-account/jobs.phtml:245
-#: module/Decision/view/decision/organ-admin/edit.phtml:49
-#: module/Education/view/education/admin/course-documents.phtml:34
-#: module/Education/view/education/admin/course.phtml:65
-#: module/Education/view/education/admin/edit-course.phtml:24
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:40
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:38
-msgid "Edit"
-msgstr ""
-
-#: module/Activity/view/activity/admin/list.phtml:71
-#: module/Activity/view/activity/admin/participants.phtml:19
-#: module/Activity/view/activity/admin/participants.phtml:29
-#: module/Activity/view/activity/admin/participants.phtml:61
-#: module/Activity/view/activity/admin/view.phtml:97
-msgid "Participants"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/add.phtml:16
-#: module/Activity/view/activity/admin-option/index.phtml:13
-#: module/Application/view/partial/admin.phtml:62
-msgid "Option Calendar"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/add.phtml:25
-#: module/Activity/view/activity/admin-option/index.phtml:23
-#: module/Activity/view/activity/admin-option/index.phtml:65
-msgid "Planning Period"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/add.phtml:26
-msgid "Enter the start and end date and time of the planning period."
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/add.phtml:65
-#: module/Activity/view/activity/admin-option/index.phtml:24
-#: module/Activity/view/activity/admin-option/index.phtml:66
-msgid "Option Period"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/add.phtml:66
-msgid "Enter the start and end date and time of the option period."
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/add.phtml:105
-msgid "Max Activities"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/add.phtml:106
-msgid ""
-"Enter the maximum number of activities for which options can be created. You "
-"can either set the number globally or individually for each organ."
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/add.phtml:113
-msgid "Global Value"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:14
-#: module/Activity/view/activity/admin/view.phtml:20
-#: module/Application/view/partial/admin.phtml:43
-msgid "Overview"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:18
-msgid "Active Option Planning Periods"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:25
-#: module/Activity/view/activity/admin-option/index.phtml:67
-#: module/Company/view/company/admin-approval/index.phtml:31
-#: module/Company/view/company/admin-approval/index.phtml:59
-#: module/Company/view/company/admin/edit-company.phtml:116
-#: module/Company/view/company/admin/edit-package.phtml:86
-#: module/Company/view/company/admin/index.phtml:177
-#: module/Company/view/company/admin/index.phtml:218
-#: module/Company/view/company/company-account/jobs.phtml:66
-#: module/Company/view/company/company-account/jobs.phtml:199
-#: module/Education/view/education/admin/course-documents.phtml:74
-#: module/Education/view/education/admin/course-documents.phtml:125
-#: module/Education/view/education/admin/course.phtml:47
-msgid "Actions"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:56
-msgid "There is currently no option creation period planned."
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:60
-msgid "Planned Option Planning Periods"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:106
-msgid "There are no planned option creation periods in the future."
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:113
-#: module/Activity/src/Controller/AdminOptionController.php:101
-msgid "Add Option Period"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:125
-msgid "Delete period"
-msgstr ""
-
-#: module/Activity/view/activity/admin-option/index.phtml:129
-msgid ""
-"Are you sure you want to delete this option planning period? This will "
-"<strong>not</strong> delete proposed options."
-msgstr ""
-
-#: module/Activity/view/activity/admin/participants.phtml:41
-msgid "General"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participants.phtml:55
-msgid ""
-"Here you can find everyone who signed up for this activity (may contain "
-"duplicates). Using the tabs above you can navigate to the different sign-up "
-"lists of this activity. From there you can remove external participants and "
-"(when supplied) view additional signup information from each participant."
-msgstr ""
-
-#: module/Activity/view/activity/admin/participants.phtml:57
-msgid ""
-"Here you can find everyone who signed up to this sign-up list. Here you can "
-"add or remove external participants and view detailed information regarding "
-"the signup of all participants."
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:21
-#: module/Decision/view/decision/member/self.phtml:49
-#: module/Decision/view/decision/member/view.phtml:33
-#: module/Frontpage/view/frontpage/organ/organ.phtml:99
-#: module/Decision/src/Form/OrganInformation.php:32
-msgid "Email"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:23
-#: module/Decision/view/decision/member/self.phtml:64
-#: module/Decision/view/decision/member/view.phtml:49
-msgid "Generation"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:28
-msgid "Sign-up List"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:70
-#: module/Decision/view/decision/member/self.phtml:55
-#: module/Decision/view/decision/member/view.phtml:39
-#: module/Photo/view/partial/metadata.phtml:21
-#: module/Photo/view/partial/metadata.phtml:28
-#: module/Photo/view/partial/metadata.phtml:49
-#: module/Photo/view/partial/metadata.phtml:56
-#: module/Photo/view/partial/metadata.phtml:63
-#: module/Photo/view/partial/metadata.phtml:70
-#: module/Photo/view/partial/metadata.phtml:77
-#: module/Photo/view/partial/metadata.phtml:86
-msgid "Unknown"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:76
-#, php-format
-msgid "User (%s)"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:83
-#: module/Decision/src/Model/Enums/MembershipTypes.php:23
-msgid "External"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:96
-#: module/Education/view/education/admin/course-documents.phtml:133
-msgid "N/A"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:116
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
-#: module/Company/view/company/admin/edit-company.phtml:126
-#: module/Company/view/company/admin/edit-package.phtml:92
-#: module/Company/view/company/admin/index.phtml:197
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:214
-#: module/Company/view/company/company-account/jobs.phtml:222
-#: module/Decision/view/decision/member/view.phtml:59
-#: module/Photo/view/partial/metadata.phtml:42
-#: module/Application/language/additional-strings:20
-msgid "Yes"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:118
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
-#: module/Company/view/company/admin/edit-company.phtml:126
-#: module/Company/view/company/admin/edit-package.phtml:92
-#: module/Company/view/company/admin/index.phtml:197
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:214
-#: module/Decision/view/decision/member/view.phtml:59
-#: module/Photo/view/partial/metadata.phtml:42
-#: module/Application/language/additional-strings:21
-msgid "No"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:141
-msgid "Additional actions"
-msgstr ""
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:145
-msgid "Mail everybody"
-msgstr ""
-
-#: module/Activity/view/activity/admin/view.phtml:24
-msgid "Unapproved Activities"
-msgstr ""
-
-#: module/Activity/view/activity/admin/view.phtml:31
-msgid "Approved Activities"
-msgstr ""
-
-#: module/Activity/view/activity/admin/view.phtml:38
-msgid "Disapproved Activities"
-msgstr ""
-
-#: module/Activity/view/activity/admin/view.phtml:46
-msgid "Upcoming Activities"
-msgstr ""
-
-#: module/Activity/view/activity/admin/view.phtml:53
-msgid "Old activities"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:37
-#: module/Activity/view/partial/signuplist.phtml:25
-msgid "Open date and time"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:48
-#: module/Activity/view/partial/signuplist.phtml:39
-msgid "Close date and time"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:59
-msgid "GEWIS members only"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:70
-msgid "Display GEWIS member count"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:81
-#: module/Activity/view/partial/signuplist.phtml:120
-msgid "Has limited capacity"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:93
-msgid ""
-"This sign-up list contains additional fields which require input from "
-"subscribers, they are shown below."
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:128
-#: module/Activity/src/Form/SignupListField.php:55
-msgid "Text"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:131
-#: module/Activity/src/Form/SignupListField.php:56
-msgid "Yes/No"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
-#: module/Activity/src/Form/SignupListField.php:57
-msgid "Number"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:137
-#: module/Activity/src/Form/SignupListField.php:58
-msgid "Choice"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:147
-#: module/Activity/src/Form/SignupListField.php:70
-msgid "Min. value"
-msgstr ""
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:157
-#: module/Activity/src/Form/SignupListField.php:80
-msgid "Max. value"
-msgstr ""
-
-#: module/Activity/view/partial/create.phtml:17
-msgid ""
-"What is this activity about? Fill in the blanks below, please note that at "
-"least one language must be used."
-msgstr ""
-
-#: module/Activity/view/partial/create.phtml:171
-msgid "Choose which options are applicable to this activity."
-msgstr ""
-
-#: module/Activity/view/partial/create.phtml:181
-msgid "This is a career related activity"
-msgstr ""
-
-#: module/Activity/view/partial/create.phtml:183
-msgid ""
-"If this is checked the My Future logo will be displayed on the activity page "
-"and the activity will be included on the career activities page."
-msgstr ""
-
-#: module/Activity/view/partial/create.phtml:195
-msgid "This activity needs a GEFLITST member to take photos"
-msgstr ""
-
-#: module/Activity/view/partial/create.phtml:197
-msgid ""
-"When this is checked, GEFLITST will be notified that this activity needs a "
-"photographer."
-msgstr ""
-
-#: module/Activity/view/partial/option.phtml:33
-msgid "From"
-msgstr ""
-
-#: module/Activity/view/partial/option.phtml:47
-msgid "Until"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:21
-#: module/Activity/view/partial/signupForm.phtml:26
-msgid "By subscribing to this activity, you agree to the terms outlined in the"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:23
-msgid "Confirm subscription"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:28
-msgid "Subscribe as external participant"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:33
-msgid ""
-"By subscribing an external participant to this activity, they must agree to "
-"the terms outlined in the"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:35
-msgid "Subscribe an external participant"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:67
-msgid "Full name:"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:68
-msgid "Email address:"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:72
-msgid "Please fill in this CAPTCHA:"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:86
-#: module/Decision/view/decision/member/index.phtml:254
-msgid "Activity Policy"
-msgstr ""
-
-#: module/Activity/view/partial/signupForm.phtml:88
-#: module/Decision/view/decision/member/index.phtml:259
-msgid "Alcohol Policy"
-msgstr ""
-
-#: module/Activity/view/partial/signuplist-fields.phtml:95
-msgid "Please note that numbers are not dependant on the selected language(s)."
-msgstr ""
-
-#: module/Activity/view/partial/signuplist.phtml:88
-msgid "Only allow GEWIS members"
-msgstr ""
-
-#: module/Activity/view/partial/signuplist.phtml:90
-msgid "Deselect this to allow people without a GEWIS account to subscribe."
-msgstr ""
-
-#: module/Activity/view/partial/signuplist.phtml:103
-msgid "Display number of subscribed members"
-msgstr ""
-
-#: module/Activity/view/partial/signuplist.phtml:105
-msgid ""
-"Select this to display the number of subscribed GEWIS members to external "
-"visitors."
-msgstr ""
-
-#: module/Activity/view/partial/signuplist.phtml:122
-msgid ""
-"Select this if this sign-up list has limited capacity or is expected to have "
-"limited capacity. Please ensure that you also write this in the description "
-"of the activity."
-msgstr ""
-
-#: module/Activity/view/partial/signuplist.phtml:153
-msgid "Remove the last sign-up list field"
-msgstr ""
-
-#: module/Activity/view/partial/signuplist.phtml:158
-msgid "Add a sign-up list field"
-msgstr ""
-
-#: module/Application/view/error/403.phtml:17
-msgid "You do not have the required privileges to view this page"
-msgstr ""
-
-#: module/Application/view/error/403.phtml:22
-msgid "You might be able to view this page by logging in"
-msgstr ""
-
-#: module/Application/view/error/403.phtml:28
-#: module/Application/view/partial/admin.phtml:28
-#: module/Application/view/partial/main-nav.phtml:87
-#: module/User/view/user/user/login.phtml:39
-msgid "Login"
-msgstr ""
-
-#: module/Application/view/error/404.phtml:12
-#: module/Application/view/error/debug/404.phtml:12
-msgid "A 404 error occurred"
-msgstr ""
-
-#: module/Application/view/error/500.phtml:12
-#: module/Application/view/error/debug/500.phtml:13
-msgid "An error occurred"
-msgstr ""
-
-#: module/Application/view/error/500.phtml:13
-msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
-msgstr ""
-
-#: module/Application/view/error/debug/403.phtml:12
-msgid "403 Forbidden"
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:22
-msgid "The requested controller was unable to dispatch the request."
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:26
-msgid ""
-"The requested controller could not be mapped to an existing controller class."
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:30
-msgid "The requested controller was not dispatchable."
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:33
-msgid "The requested URL could not be matched by routing."
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:36
-msgid "We cannot determine at this time why a 404 was generated."
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:50
-msgid "Controller"
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:58
-#, php-format
-msgid "resolves to %s"
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:75
-#: module/Application/view/error/debug/500.phtml:24
-msgid "Additional information"
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:78
-#: module/Application/view/error/debug/404.phtml:104
-#: module/Application/view/error/debug/500.phtml:29
-#: module/Application/view/error/debug/500.phtml:69
-msgid "File"
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:83
-#: module/Application/view/error/debug/404.phtml:109
-#: module/Application/view/error/debug/500.phtml:38
-#: module/Application/view/error/debug/500.phtml:78
-msgid "Message"
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:87
-#: module/Application/view/error/debug/404.phtml:113
-#: module/Application/view/error/debug/500.phtml:46
-#: module/Application/view/error/debug/500.phtml:86
-msgid "Stack trace"
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:97
-#: module/Application/view/error/debug/500.phtml:60
-msgid "Previous exceptions"
-msgstr ""
-
-#: module/Application/view/error/debug/404.phtml:130
-#: module/Application/view/error/debug/500.phtml:107
-msgid "No Exception available"
-msgstr ""
-
-#: module/Application/view/layout/layout.phtml:15
-msgid "Study Association GEWIS"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:50
-#: module/Application/view/partial/admin.phtml:105
-#: module/Company/view/company/admin/categories.phtml:23
-#: module/Company/view/company/admin/categories.phtml:43
-msgid "Categories"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:76
-#: module/Application/view/partial/main-nav.phtml:326
-#: module/Application/view/partial/main-nav.phtml:330
-#: module/Application/view/partial/main-nav.phtml:335
-#: module/Company/view/company/admin-approval/index.phtml:19
-#: module/Company/view/company/admin-approval/job-approval.phtml:24
-#: module/Company/view/company/admin-approval/job-proposal.phtml:26
-#: module/Company/view/company/admin/edit-company.phtml:19
-#: module/Company/view/company/admin/index.phtml:20
-msgid "Career"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:83
-#: module/Company/view/company/admin/index.phtml:21
-#: module/Company/view/company/company/job-list.phtml:36
-#: module/Company/view/company/company/jobs.phtml:34
-#: module/Company/view/company/company/list.phtml:21
-#: module/Company/view/company/company/show.phtml:17
-#: module/Company/view/company/company/show.phtml:24
-#: module/Company/view/company/company/spotlight.phtml:33
-msgid "Companies"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:96
-#: module/Company/view/company/admin-approval/index.phtml:20
-#: module/Company/view/company/admin-approval/job-approval.phtml:25
-msgid "Approvals"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:114
-#: module/Company/view/company/admin-approval/job-approval.phtml:224
-#: module/Company/view/company/admin/labels.phtml:23
-#: module/Company/view/company/admin/labels.phtml:42
-#: module/Company/src/Form/Job.php:241
-msgid "Labels"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:128
-#: module/Application/view/partial/main-nav.phtml:368
-#: module/Education/view/education/admin/add-course.phtml:15
-#: module/Education/view/education/admin/bulk-exam.phtml:19
-#: module/Education/view/education/admin/bulk-summary.phtml:19
-#: module/Education/view/education/admin/course-documents.phtml:27
-#: module/Education/view/education/admin/course.phtml:17
-#: module/Education/view/education/admin/edit-course.phtml:17
-#: module/Education/view/education/admin/edit-exam.phtml:31
-#: module/Education/view/education/admin/edit-summary.phtml:31
-#: module/Education/view/education/admin/index.phtml:11
-#: module/Education/view/education/education/course.phtml:21
-#: module/Education/view/education/education/index.phtml:16
-#: module/Education/view/education/education/index.phtml:31
-msgid "Education"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:133
-#: module/Education/view/education/admin/add-course.phtml:16
-#: module/Education/view/education/admin/course-documents.phtml:28
-#: module/Education/view/education/admin/course.phtml:18
-#: module/Education/view/education/admin/edit-course.phtml:18
-msgid "Courses"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:138
-#: module/Education/view/education/admin/bulk-exam.phtml:24
-msgid "Upload exams"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:143
-#: module/Education/view/education/admin/bulk-summary.phtml:24
-msgid "Upload summaries"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:155
-#: module/Decision/view/decision/admin/authorizations.phtml:14
-#: module/Decision/view/decision/admin/document.phtml:29
-#: module/Decision/view/decision/admin/minutes.phtml:15
-#: module/Decision/view/decision/decision/index.phtml:17
-#: module/Decision/view/decision/member/index.phtml:100
-msgid "Meetings"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:160
-#: module/Decision/view/decision/admin/minutes.phtml:16
-#: module/Decision/view/decision/decision/view.phtml:53
-msgid "Minutes"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:165
-#: module/Decision/view/decision/admin/document.phtml:30
-#: module/Decision/view/decision/decision/view.phtml:31
-#: module/Education/view/education/admin/course.phtml:60
-msgid "Documents"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:170
-#: module/Decision/view/decision/admin/authorizations.phtml:15
-#: module/Decision/view/decision/decision/authorizations.phtml:27
-#: module/Decision/view/decision/decision/authorizations.phtml:34
-#: module/Decision/view/decision/member/index.phtml:61
-msgid "Authorizations"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:181
-#: module/Decision/view/decision/member/index.phtml:73
-#: module/Decision/view/decision/organ-admin/edit.phtml:48
-#: module/Decision/view/decision/organ-admin/index.phtml:15
-msgid "Organs"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:189
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:54
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:39
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:14
-msgid "News"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:196
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:23
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:25
-msgid "Pages"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:203
-#: module/Application/view/partial/main-nav.phtml:434
-#: module/Application/view/partial/main-nav.phtml:438
-#: module/Application/view/partial/main-nav.phtml:443
-#: module/Application/view/partial/main-nav.phtml:452
-#: module/Photo/view/photo/album-admin/add.phtml:33
-#: module/Photo/view/photo/album-admin/create.phtml:15
-#: module/Photo/view/photo/album-admin/edit.phtml:15
-#: module/Photo/view/photo/album-admin/index.phtml:33
-#: module/Photo/view/photo/album/index.phtml:29
-#: module/Photo/view/photo/album/index.phtml:69
-#: module/Photo/view/photo/photo-admin/index.phtml:38
-#: module/Photo/view/photo/photo/index.phtml:15
-msgid "Photos"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:210
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:32
-#: module/Frontpage/view/frontpage/poll/index.phtml:22
-#: module/Frontpage/view/frontpage/poll/index.phtml:30
-msgid "Polls"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:219
-msgid "Users"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:224
-msgid "API Users"
-msgstr ""
-
-#: module/Application/view/partial/admin.phtml:245
-#: module/Application/view/partial/main-nav.phtml:161
-msgid "Admin"
-msgstr ""
-
-#: module/Application/view/partial/company.phtml:26
-#: module/Frontpage/view/frontpage/page/page.phtml:20
-msgid "Home"
-msgstr ""
-
-#: module/Application/view/partial/company.phtml:31
-#: module/Company/view/company/admin/edit-package.phtml:79
-#: module/Company/view/company/admin/index.phtml:135
-#: module/Company/view/company/admin/index.phtml:213
-#: module/Company/view/company/company-account/jobs.phtml:26
-#: module/Company/view/company/company-account/jobs.phtml:30
-#: module/Company/view/company/company-account/jobs.phtml:33
-#: module/Company/view/company/company-account/jobs.phtml:188
-#: module/Company/view/company/company-account/transfer-jobs.phtml:17
-#: module/Company/src/Form/JobsTransfer.php:27
-msgid "Jobs"
-msgstr ""
-
-#: module/Application/view/partial/company.phtml:36
-#: module/Company/view/company/company-account/highlights.phtml:10
-#: module/Company/view/company/company-account/highlights.phtml:13
-msgid "Highlights"
-msgstr ""
-
-#: module/Application/view/partial/company.phtml:41
-#: module/Company/view/company/admin/edit-package.phtml:70
-#: module/Company/view/company/company-account/banner.phtml:10
-#: module/Company/view/company/company-account/banner.phtml:13
-#: module/Company/src/Form/Package.php:112
-msgid "Banner"
-msgstr ""
-
-#: module/Application/view/partial/company.phtml:46
-msgid "Settings"
-msgstr ""
-
-#: module/Application/view/partial/company.phtml:58
-#: module/Application/view/partial/main-nav.phtml:116
-msgid "My Company"
-msgstr ""
-
-#: module/Application/view/partial/footer.phtml:21
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:273
-msgid "Infimum"
-msgstr ""
-
-#: module/Application/view/partial/footer.phtml:22
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:276
-msgid "Loading an infimum..."
-msgstr ""
-
-#: module/Application/view/partial/footer.phtml:36
-#: module/Application/view/partial/footer.phtml:41
-#: module/Application/src/Service/Infimum.php:66
-msgid "Unable to retrieve infimum."
-msgstr ""
-
-#: module/Application/view/partial/footer.phtml:50
-msgid "All rights reserved."
-msgstr ""
-
-#: module/Application/view/partial/footer.phtml:52
-msgid ""
-"Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
-"2022)."
-msgstr ""
-
-#: module/Application/view/partial/footer.phtml:58
-#: module/Application/view/partial/main-nav.phtml:318
-#: module/Company/view/company/company/companyStory.phtml:37
-#: module/Company/view/company/company/jobs.phtml:105
-#: module/Company/view/partial/company/company/list/company.phtml:41
-msgid "Contact"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:53
-msgid "Language settings"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:81
-#: module/Application/view/partial/main-nav.phtml:485
-#: module/Decision/view/decision/member/birthdays.phtml:15
-#: module/Decision/view/decision/member/index.phtml:22
-#: module/Decision/view/decision/member/index.phtml:28
-#: module/Decision/view/decision/member/search.phtml:11
-#: module/Decision/view/decision/member/view.phtml:23
-msgid "Members"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:98
-msgid "Subscribe"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:121
-#: module/Application/view/partial/main-nav.phtml:154
-#: module/Decision/view/decision/member/index.phtml:42
-#: module/User/view/user/user/change-password.phtml:15
-#: module/User/view/user/user/change-password.phtml:36
-#: module/User/src/Form/Password.php:59
-msgid "Change password"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:126
-#: module/Application/view/partial/main-nav.phtml:168
-msgid "Logout"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:144
-msgid "My information"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:149
-#: module/Decision/view/decision/member/index.phtml:56
-msgid "SudoSOS"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:177
-msgid "Toggle navigation"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:191
-#: module/Application/view/partial/main-nav.phtml:196
-#: module/Application/view/partial/main-nav.phtml:201
-#: module/Decision/view/decision/member/index.phtml:69
-msgid "Association"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:212
-#: module/Decision/view/decision/member/view.phtml:72
-msgid "Board"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:217
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:14
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:20
-#: module/Frontpage/view/frontpage/organ/organ.phtml:64
-msgid "Committees"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:222
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:15
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:19
-#: module/Frontpage/view/frontpage/organ/organ.phtml:60
-msgid "Fraternities"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:233
-msgid "Exceptional Members"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:244
-msgid "GEWIS song"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:255
-#: module/Decision/view/decision/member/index.phtml:226
-msgid "Regulations"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:262
-#: module/Application/view/partial/main-nav.phtml:267
-msgid "Useful Information"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:273
-#: module/Decision/view/decision/member/index.phtml:93
-msgid "Links"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:278
-msgid "Well-being"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:289
-msgid "Confidential Contact Person (CCP)"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:294
-msgid "FAQ"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:305
-msgid "Housing"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:343
-#: module/Company/view/company/admin/index.phtml:161
-msgid "Featured"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:390
-msgid "My activities"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:399
-msgid "Activity Archive"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:408
-msgid "Create an activity"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:424
-msgid "Career related"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:457
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:218
-msgid "Photo of the week"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:470
-#: module/Decision/view/decision/member/index.phtml:52
-msgid "My photo's"
-msgstr ""
-
-#: module/Application/view/partial/main-nav.phtml:499
-msgid "You are currently using administrator privileges to use the website!"
-msgstr ""
-
-#: module/Application/view/partial/paginator.phtml:19
-#: module/Photo/view/photo/album/index.phtml:437
-msgid "Previous"
-msgstr ""
-
-#: module/Application/view/partial/paginator.phtml:37
-#: module/Photo/view/photo/album/index.phtml:438
-msgid "Next"
-msgstr ""
-
-#: module/Application/view/partial/privacy-widget.phtml:13
-msgid ""
-"S.v. GEWIS uses cookies on this website, these are required for the website "
-"to function. Additionally, we may collection information about how you use "
-"our website in order to improve your experience. If you do not want your "
-"behaviour to be tracked please opt out below."
-msgstr ""
-
-#: module/Application/view/partial/privacy-widget.phtml:19
-msgid "Tracking is currently"
-msgstr ""
-
-#: module/Application/view/partial/privacy-widget.phtml:20
-msgid "enabled"
-msgstr ""
-
-#: module/Application/view/partial/privacy-widget.phtml:21
-msgid "disabled"
-msgstr ""
-
-#: module/Application/view/partial/privacy-widget.phtml:23
-msgid "disabled (Do Not Track)"
-msgstr ""
-
-#: module/Application/view/partial/privacy-widget.phtml:25
-msgid "unavailable"
-msgstr ""
-
-#: module/Application/view/partial/privacy-widget.phtml:31
-#: module/Decision/view/decision/member/index.phtml:294
-msgid "Privacy Policy"
-msgstr ""
-
-#: module/Application/view/partial/privacy-widget.phtml:33
-#: module/User/src/Form/ApiAppAuthorisation.php:48
-msgid "Continue"
-msgstr ""
-
-#: module/Company/view/company/admin/add-category.phtml:14
-#: module/Company/view/company/admin/add-category.phtml:22
-#: module/Company/view/company/admin/add-category.phtml:37
-msgid "Create Job Category"
-msgstr ""
-
-#: module/Company/view/company/admin/add-company.phtml:14
-#: module/Company/view/company/admin/add-company.phtml:28
-#: module/Company/view/company/admin/add-company.phtml:43
-msgid "Create Company"
-msgstr ""
-
-#: module/Company/view/company/admin/add-job.phtml:14
-#: module/Company/view/company/admin/add-job.phtml:33
-#: module/Company/view/company/admin/add-job.phtml:48
-#: module/Company/view/company/admin/edit-package.phtml:140
-#: module/Company/view/company/company-account/jobs.phtml:97
-#: module/Company/view/company/company-account/jobs.phtml:282
-msgid "Add Job"
-msgstr ""
-
-#: module/Company/view/company/admin/add-label.phtml:14
-#: module/Company/view/company/admin/add-label.phtml:28
-#: module/Company/view/company/admin/add-label.phtml:43
-msgid "Create Job Label"
-msgstr ""
-
-#: module/Company/view/company/admin/add-package.phtml:15
-#: module/Company/view/company/admin/add-package.phtml:29
-#: module/Company/view/company/admin/add-package.phtml:45
-msgid "Add Package"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/index.phtml:24
-msgid "Unapproved Companies"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/index.phtml:38
-msgid "There is no company or update proposal that requires your approval."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/index.phtml:50
-msgid "Unapproved Jobs"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/index.phtml:56
-msgid "Dutch Name"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/index.phtml:57
-msgid "English Name"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/index.phtml:66
-msgid "There is no job or update proposal that requires your approval."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/index.phtml:82
-msgid "View Update"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/index.phtml:90
-msgid "View Proposal"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:35
 #, php-format
 msgid "This job is proposed by <strong>%s</strong> as part of job package %s."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:44
-#: module/Company/view/company/admin-approval/job-approval.phtml:48
-#: module/Company/view/company/admin-approval/job-proposal.phtml:69
-#: module/Company/view/company/admin-approval/job-proposal.phtml:73
-#: module/Company/view/partial/company/admin/editors/company.phtml:18
-#: module/Company/view/partial/company/admin/editors/job.phtml:18
-#: module/Company/src/Form/Company.php:61
-#: module/Company/src/Form/JobCategory.php:85
-#: module/Company/src/Form/JobCategory.php:95
-#: module/Company/src/Form/Job.php:69
-msgid "Slug"
+msgid "This job package does not contain any jobs."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:55
-#: module/Company/view/company/admin-approval/job-approval.phtml:59
-#: module/Company/view/company/admin-approval/job-proposal.phtml:83
-#: module/Company/view/company/admin-approval/job-proposal.phtml:87
-#: module/Company/src/Form/Job.php:79
-msgid "Category"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:77
-#: module/Company/view/company/admin-approval/job-approval.phtml:81
-#: module/Company/view/company/admin-approval/job-proposal.phtml:111
-#: module/Company/view/company/admin-approval/job-proposal.phtml:115
-#: module/Decision/view/decision/member/self.phtml:174
-msgid "Phone number"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:88
-#: module/Company/view/company/admin-approval/job-approval.phtml:92
-#: module/Company/view/company/admin-approval/job-proposal.phtml:125
-#: module/Company/view/company/admin-approval/job-proposal.phtml:129
-#: module/User/src/Form/UserReset.php:40
-#: module/User/src/Model/Enums/JWTClaims.php:39
-msgid "E-mail address"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:138
-#: module/Company/view/company/admin-approval/job-approval.phtml:143
-#: module/Company/view/company/admin-approval/job-approval.phtml:150
-#: module/Company/view/company/admin-approval/job-proposal.phtml:184
-#: module/Company/view/company/admin-approval/job-proposal.phtml:189
-#: module/Company/view/company/admin-approval/job-proposal.phtml:199
-#: module/Frontpage/view/frontpage/organ/organ.phtml:110
-#: module/Company/src/Form/Company.php:178
-#: module/Company/src/Form/Company.php:188 module/Company/src/Form/Job.php:161
-#: module/Company/src/Form/Job.php:171
-#: module/Decision/src/Form/OrganInformation.php:42
-msgid "Website"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:195
-#: module/Company/view/company/admin-approval/job-approval.phtml:200
-#: module/Company/view/company/admin-approval/job-approval.phtml:211
-#: module/Company/view/company/admin-approval/job-proposal.phtml:259
-#: module/Company/view/company/admin-approval/job-proposal.phtml:264
-#: module/Company/view/company/admin-approval/job-proposal.phtml:280
-#: module/Company/src/Form/Job.php:221 module/Company/src/Form/Job.php:231
-msgid "Attachment"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:204
-#: module/Company/view/company/admin-approval/job-approval.phtml:215
-#: module/Company/view/company/admin-approval/job-proposal.phtml:284
-#: module/Company/view/company/company/jobs.phtml:133
-msgid "View Attachment"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:244
-msgid ""
-"If approved, this job will be <strong>published</strong>, however, its "
-"actual visiblity depends on the company and associated job package."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:246
-msgid "If approved, this job will be <strong>hidden</strong>."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:291
-#: module/Company/view/company/admin-approval/job-proposal.phtml:397
-msgid "Optional message..."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:312
-#, php-format
-msgid "This job was approved by <strong>%s</strong>."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:341
-#, php-format
-msgid ""
-"This job was disapproved by <strong>%s</strong> with the message \"%s\"."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:347
-#, php-format
-msgid "This job was disapproved by <strong>%s</strong>."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:27
-msgid "Proposals"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:59
 #, php-format
 msgid ""
 "This job update is proposed by <strong>%s</strong> as part of job package "
@@ -1964,615 +2754,30 @@ msgid ""
 "changes to a certain attribute, you will see the existing data."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:268
-msgid "View Original Attachment"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:273
-#: module/Company/view/company/admin-approval/job-proposal.phtml:289
-msgid "View New Attachment"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:297
-#: module/Company/view/partial/company/admin/editors/job.phtml:328
-msgid "Job Labels"
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:328
-msgid ""
-"Original job and proposed update do not have any job labels applied to them."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:340
-msgid ""
-"Warning! This is an update to an unapproved job. Applying this update will "
-"approve the job."
-msgstr ""
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:350
-msgid ""
-"Warning! This is an update to rejected job. Applying this update will "
-"approve the job."
-msgstr ""
-
-#: module/Company/view/company/admin/categories.phtml:36
-#: module/Company/view/company/admin/labels.phtml:35
-msgid "edit"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-category.phtml:14
-#: module/Company/view/company/admin/edit-category.phtml:21
-msgid "Edit Job Category"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-category.phtml:36
-msgid "Update Job Category"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:17
-msgid "Edit Company"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:53
 #, php-format
-msgid "Edit %s"
+msgid "This job was approved by <strong>%s</strong>."
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:59
-#: module/Company/src/Form/JobsTransfer.php:39
-msgid "Packages"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:70
-msgid "Add Job Package"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:80
-msgid "Add Spotlight Package"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:90
-msgid "Add Banner Package"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:101
-#: module/Company/view/company/company-account/jobs.phtml:54
-#: module/Company/src/Form/Package.php:79
-msgid "Contract Number"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:104
-#: module/Company/view/company/admin/edit-package.phtml:84
-#: module/Company/view/company/company-account/jobs.phtml:197
-msgid "Active"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:110
-#: module/Company/view/company/company-account/jobs.phtml:60
-msgid "Expiration date"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:113
-msgid "Jobs (Active) / Type"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:136
-#: module/Company/view/company/admin/index.phtml:50
-#: module/Company/view/company/admin/index.phtml:82
-msgid "Banner Package"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:139
-#: module/Company/view/company/admin/index.phtml:53
-#: module/Company/view/company/admin/index.phtml:85
-msgid "Featured Package"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:187
-msgid "Update Company"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:206
-msgid "Are you sure you want to delete this package?"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-company.phtml:212
-msgid "Delete package"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-job.phtml:19
-#: module/Company/view/company/admin/edit-job.phtml:38
-msgid "Edit Job"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-job.phtml:47
 #, php-format
 msgid ""
-"You are currently updating an update proposal that was previously rejected "
-"for the following reason: %s"
+"This job was disapproved by <strong>%s</strong> with the message \"%s\"."
 msgstr ""
 
-#: module/Company/view/company/admin/edit-job.phtml:53
-msgid ""
-"You are currently updating an update proposal that was previously rejected, "
-"however, no reason was provided."
-msgstr ""
-
-#: module/Company/view/company/admin/edit-job.phtml:58
 #, php-format
-msgid ""
-"You are currently updating a job that was previously rejected for the "
-"following reason: %s"
+msgid "This job was disapproved by <strong>%s</strong>."
 msgstr ""
 
-#: module/Company/view/company/admin/edit-job.phtml:64
-msgid ""
-"You are currently updating a job that was previously rejected, however, no "
-"reason was provided."
-msgstr ""
-
-#: module/Company/view/company/admin/edit-job.phtml:85
-msgid "Update Job"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-label.phtml:14
-#: module/Company/view/company/admin/edit-label.phtml:28
-msgid "Edit Job Label"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-label.phtml:43
-msgid "Update Job Label"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-package.phtml:19
-#: module/Company/view/company/admin/edit-package.phtml:40
-msgid "Edit Package"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-package.phtml:56
-msgid "Update Package"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-package.phtml:101
-msgid "(Update Pending)"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-package.phtml:154
-#: module/Company/view/company/company-account/jobs.phtml:297
-msgid "Are you sure you want to delete this job?"
-msgstr ""
-
-#: module/Company/view/company/admin/edit-package.phtml:159
-#: module/Company/view/company/company-account/jobs.phtml:302
-msgid "Delete job"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:36
-#: module/Company/view/company/company-account/jobs.phtml:39
-msgid "Notifications"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:38
-msgid "No notifications"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:56
-#: module/Company/view/company/admin/index.phtml:88
-#, php-format
-msgid "Job Package (%s active)"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:63
-#, php-format
-msgid "%s for company %s will start on %s"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:95
-#, php-format
-msgid "%s for company %s will expire on %s"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:110
-#: module/Education/view/education/admin/course.phtml:27
-msgid "Filter..."
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:115
-msgid "Add Company"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:144
-#: module/Company/view/company/admin/index.phtml:214
-msgid "Active jobs"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:152
-#: module/Company/view/company/admin/index.phtml:215
-msgid "Banner active"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:169
-#: module/Company/view/company/admin/index.phtml:217
-msgid "Expired packages"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:216
-msgid "Featured in language"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:234
-#: module/Decision/view/decision/admin/document.phtml:169
-#, php-format
-msgid "Are you sure you want to delete %s?"
-msgstr ""
-
-#: module/Company/view/company/admin/index.phtml:241
-msgid "Delete company"
-msgstr ""
-
-#: module/Company/view/company/admin/labels.phtml:17
-msgid "Add Label"
-msgstr ""
-
-#: module/Company/view/company/company-account/banner.phtml:20
-#: module/Company/view/company/company-account/highlights.phtml:20
-msgid ""
-"This functionality is currently unavailable. Our apologies for the "
-"inconvenience."
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:45
-msgid "Job Packages"
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:63
-msgid "Jobs (Active)"
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:106
-#: module/Company/view/company/company/job-list.phtml:152
-msgid "View"
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:118
-msgid "Recently Approved Jobs"
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:120
-msgid "You do not have recently approved jobs."
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:140
-msgid "Recently Rejected Jobs"
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:142
-msgid "You do not have recently rejected jobs."
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:162
-msgid "Recently Unapproved Jobs"
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:164
-msgid "You do not have any recent jobs pending approval."
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:198
-msgid "Approved (Has Updates)"
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:206
-msgid "This job package does not contain any jobs."
-msgstr ""
-
-#: module/Company/view/company/company-account/jobs.phtml:272
-#: module/Company/view/company/company-account/transfer-jobs.phtml:14
-#: module/Company/view/company/company-account/transfer-jobs.phtml:24
-#: module/Company/src/Form/JobsTransfer.php:50
-msgid "Transfer Jobs"
-msgstr ""
-
-#: module/Company/view/company/company-account/self.phtml:10
-msgid "Company Account"
-msgstr ""
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:30
-msgid "Select the jobs that you want to transfer to another job package."
-msgstr ""
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:48
-msgid "There are no jobs that you can transfer..."
-msgstr ""
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:64
-msgid "Choose to which job package you want to transfer the selected jobs."
-msgstr ""
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:81
-msgid "Move Jobs"
-msgstr ""
-
-#: module/Company/view/company/company/companyStory.phtml:34
-#: module/Company/view/company/company/jobs.phtml:95
-#: module/Company/view/partial/company/company/grid/company.phtml:32
-#: module/Company/view/partial/company/company/list/company.phtml:36
-msgid "Logo of"
-msgstr ""
-
-#: module/Company/view/company/company/companyStory.phtml:63
-#: module/Company/view/partial/company/company/list/company.phtml:62
-msgid "Visit Website"
-msgstr ""
-
-#: module/Company/view/company/company/companyStory.phtml:68
-msgid "Highlighted"
-msgstr ""
-
-#: module/Company/view/company/company/job-list.phtml:74
-msgid "What are you looking for?"
-msgstr ""
-
-#: module/Company/view/company/company/job-list.phtml:77
-msgid "Sort on"
-msgstr ""
-
-#: module/Company/view/company/company/job-list.phtml:79
-msgid "Random"
-msgstr ""
-
-#: module/Company/view/company/company/job-list.phtml:80
-msgid "Most recent"
-msgstr ""
-
-#: module/Company/view/company/company/job-list.phtml:108
-#, php-format
-msgid "Unfortunately, there aren't any %s at the moment."
-msgstr ""
-
-#: module/Company/view/company/company/job-list.phtml:183
-#, php-format
-msgid "Still haven't found what you're looking for? Take a look at %s."
-msgstr ""
-
-#: module/Company/view/company/company/jobs.phtml:76
-msgid "at"
-msgstr ""
-
-#: module/Company/view/company/company/jobs.phtml:126
-msgid "View Website"
-msgstr ""
-
-#: module/Company/view/company/company/list.phtml:40
-#: module/Company/view/company/company/spotlight.phtml:49
-msgid "in the spotlight"
-msgstr ""
-
-#: module/Company/view/company/company/spotlight.phtml:37
-msgid "Featured company"
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:21
-msgid ""
-"Specify the permanent link for this company, it should be unique across all "
-"companies."
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:70
-msgid "View current logo"
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:94
-msgid "Representative Information"
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:95
-msgid "Enter information about the representative of this company."
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:136
-#: module/Company/view/partial/company/admin/editors/job.phtml:78
-msgid "Contact Information"
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:137
-msgid ""
-"Enter how someone can contact this company and who is responsible for this "
-"company."
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:205
-#: module/Company/view/partial/company/admin/editors/job.phtml:133
-msgid ""
-"What is this company about? Fill in the blanks below, please note that at "
-"least one language must be used."
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:21
-msgid ""
-"Specify the permanent link for this job, it should be unique for this "
-"company."
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:79
-msgid "Enter how someone can contact the person responsible for this job."
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:224
-#: module/Company/view/partial/company/admin/editors/job.phtml:320
-msgid "View current attachment"
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:329
-msgid ""
-"Add job labels to your job to give viewers a better understanding of the job."
-msgstr ""
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:349
-msgid "There are currently no job labels..."
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:31
-#, php-format
-msgid "GMM %d (%s)"
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:38
-msgid "No GMM available."
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:43
-#, php-format
-msgid "Valid authorizations for GMM %d"
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:48
-#: module/Decision/view/decision/admin/authorizations.phtml:72
-msgid "Authorizer"
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:49
-#: module/Decision/view/decision/admin/authorizations.phtml:73
-msgid "Recipient"
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:50
-#: module/Decision/view/decision/admin/authorizations.phtml:74
-msgid "Created"
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:64
-msgid "There are no valid authorizations for this GMM."
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:67
-#, php-format
-msgid "Revoked authorizations for GMM %d"
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:75
-msgid "Revoked"
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:90
-msgid "There are no revoked authorizations for this GMM."
-msgstr ""
-
-#: module/Decision/view/decision/admin/authorizations.phtml:93
-msgid "Please select a GMM to view authorizations."
-msgstr ""
-
-#: module/Decision/view/decision/admin/document.phtml:33
-msgid "There are no meetings for which you can upload documents."
-msgstr ""
-
-#: module/Decision/view/decision/admin/document.phtml:37
-msgid "Meeting document uploaded"
-msgstr ""
-
-#: module/Decision/view/decision/admin/document.phtml:62
-msgid "No meeting available."
-msgstr ""
-
-#: module/Decision/view/decision/admin/document.phtml:103
-msgid "Documents for this meeting"
-msgstr ""
-
-#: module/Decision/view/decision/admin/document.phtml:106
 msgid "This meeting does not have any associated documents."
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:145
-#: module/Decision/view/decision/admin/document.phtml:208
-msgid "Rename"
+msgid "This member already has an account."
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:163
-#: module/Education/view/education/admin/course-documents.phtml:163
-msgid "Delete Document"
-msgstr ""
-
-#: module/Decision/view/decision/admin/document.phtml:195
-msgid "Rename Meeting Document"
-msgstr ""
-
-#: module/Decision/view/decision/admin/document.phtml:198
-msgid "Enter a new name for this document:"
-msgstr ""
-
-#: module/Decision/view/decision/admin/minutes.phtml:31
-#: module/Decision/src/Form/Document.php:29
-#: module/Decision/src/Form/Minutes.php:33
-msgid "Meeting"
-msgstr ""
-
-#: module/Decision/view/decision/admin/minutes.phtml:55
-msgid "Upload"
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:36
 msgid ""
-"There are no upcoming meetings for which you can authorize someone.\n"
-"You may still be able to authorize someone or revoke an authorization by "
-"contacting the board."
+"This member cannot create an account, please contact the secretary for more "
+"information."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:40
-#, php-format
-msgid "You have authorized %s for the %s GMM (%s)."
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:47
-#, php-format
-msgid ""
-"As per HR article 5 paragraph 4, you have the right to revoke your "
-"authorization for the %s GMM. You can communicate this to the board in "
-"writing (not by email) or by using the form below. Please note that you can "
-"only revoke an authorization that was granted via this website by using the "
-"form below."
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:63
-#: module/Decision/view/decision/decision/authorizations.phtml:118
-msgid "Terms"
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:68
-#, php-format
-msgid ""
-"I, %s am fully aware that by revoking my authorization, %s cannot represent "
-"me at the %s General Members Meeting (%s) of s.v. GEWIS."
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:89
-#, php-format
-msgid "Authorize someone for the %s GMM (%s)"
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:105
-#: module/User/view/user/user/login.phtml:29
-msgid "Member"
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:123
-#, php-format
-msgid ""
-"I, %s I am fully aware that by filling in this form I authorize the person "
-"in this form to represent me at the %s General Members Meeting (%s) of s.v. "
-"GEWIS."
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:133
-#: module/Decision/view/decision/decision/authorizations.phtml:139
-#: module/Decision/src/Form/Authorization.php:50
-msgid "Authorize"
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:175
-msgid "Are you sure you would like to authorize"
-msgstr ""
-
-#: module/Decision/view/decision/decision/authorizations.phtml:181
 msgid ""
 "This member has already received 2 or more authorizations through the "
 "website. Since you can only use two authorizations at the same time, this "
@@ -2582,1707 +2787,832 @@ msgid ""
 "click on \"confirm authorization\"."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:187
-msgid "Confirm authorization"
+msgid "This option planning period cannot be edited."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:211
-#, php-format
-msgid "Are you sure you would like to authorize %s"
+msgid "This poll has no comments"
 msgstr ""
 
-#: module/Decision/view/decision/decision/files.phtml:26
-#: module/Decision/view/decision/decision/files.phtml:28
-#: module/Decision/view/decision/decision/files.phtml:47
-#: module/Decision/view/decision/decision/files.phtml:51
-msgid "Root"
-msgstr ""
-
-#: module/Decision/view/decision/decision/files.phtml:47
-msgid "Public Archive"
-msgstr ""
-
-#: module/Decision/view/decision/decision/files.phtml:51
-msgid "Browsing directory: "
-msgstr ""
-
-#: module/Decision/view/decision/decision/files.phtml:78
-msgid "Filename"
-msgstr ""
-
-#: module/Decision/view/decision/decision/files.phtml:92
-msgid ".. Move up a folder"
-msgstr ""
-
-#: module/Decision/view/decision/decision/files.phtml:101
-msgid "Empty folder"
-msgstr ""
-
-#: module/Decision/view/decision/decision/index.phtml:24
-msgid "Meeting number"
-msgstr ""
-
-#: module/Decision/view/decision/decision/index.phtml:25
-#: module/Decision/view/decision/member/birthdays.phtml:22
-#: module/Education/view/education/admin/course-documents.phtml:65
-#: module/Education/view/education/admin/course-documents.phtml:116
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:41
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:114
-msgid "Date"
-msgstr ""
-
-#: module/Decision/view/decision/decision/index.phtml:26
-msgid "# Decisions"
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:14
-msgid "Search for decision"
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:32
-#: module/Decision/src/Form/SearchDecision.php:25
-#: module/Education/src/Form/SearchCourse.php:23
-msgid "Search query"
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:41
-#: module/Decision/view/decision/member/index.phtml:157
-#: module/Education/view/education/education/index.phtml:59
-#: module/Decision/src/Form/SearchDecision.php:35
-#: module/Decision/src/Form/SearchDecision.php:36
-msgid "Search"
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:50
-msgid "No decisions were found."
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:52
-msgid "Check the spelling of your search term"
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:53
-msgid "Try alternate words or selections"
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:54
-msgid "Try using a more generic search term"
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:55
-msgid "Try entering fewer keywords"
-msgstr ""
-
-#: module/Decision/view/decision/decision/search.phtml:56
 msgid ""
-"Looking for a specific decision but forgot the numbers? Try dropping the "
-"decision point and/or number"
+"This sign-up list contains additional fields which require input from "
+"subscribers, they are shown below."
 msgstr ""
 
-#: module/Decision/view/decision/decision/view.phtml:47
-msgid "No documents have been added."
-msgstr ""
-
-#: module/Decision/view/decision/decision/view.phtml:62
-#, php-format
-msgid "View the minutes of the %s"
-msgstr ""
-
-#: module/Decision/view/decision/decision/view.phtml:71
-msgid "Decisions"
-msgstr ""
-
-#: module/Decision/view/decision/member/birthdays.phtml:14
-msgid "Birthdays"
-msgstr ""
-
-#: module/Decision/view/decision/member/birthdays.phtml:24
-msgid "Age"
-msgstr ""
-
-#: module/Decision/view/decision/member/birthdays.phtml:44
-msgid "years"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:33
-msgid "Personal"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:37
-msgid "Profile"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:78
-msgid "Public archive"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:83
-msgid "Find a member"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:106
-msgid "Upcoming meeting"
-msgid_plural "Upcoming meetings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: module/Decision/view/decision/member/index.phtml:118
-#, php-format
-msgid "The %s%s %s%s will be held on %s."
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:144
 #, php-format
 msgid ""
-"If you aren't able to attend a GMM in person but you want your voice to be "
-"heard, consider %sauthorizing another member%s to act on your behalf."
+"This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:152
-msgid "Search through the list of decisions accumulated from past meetings:"
+msgid "This slug contains invalid characters"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:155
-msgid "Search by keyword or meeting number"
+msgid "This slug is already taken"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:162
-#, php-format
-msgid "The latest %s that took place:"
+msgid "Thumbnail photo to upload"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:174
-#, php-format
-msgid "%s %s on %s"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:189
-msgid "View all meetings"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:194
-#: module/Decision/view/decision/organ/show.phtml:25
-#: module/Frontpage/view/frontpage/organ/organ.phtml:145
-msgid "Active members"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:195
-msgid "A list of helpful resources for active members."
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:199
-msgid "Webmail"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:211
-msgid "GEWIKI"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:215
-msgid "Corporate Identity"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:219
-msgid "Administrator"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:237
-msgid "Bylaws"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:249
-msgid "Internal Regulations"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:264
-msgid "Board Policies"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:269
-msgid "Borrel Policy"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:274
-msgid "House Rules"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:279
-msgid "ICT Policy"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:284
-msgid "Key Policy"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:289
-msgid "Poster Policy"
-msgstr ""
-
-#: module/Decision/view/decision/member/index.phtml:300
-msgid "Organ Regulations"
-msgstr ""
-
-#: module/Decision/view/decision/member/search.phtml:10
-#: module/Decision/view/decision/member/search.phtml:16
-msgid "Zoeken op lid"
-msgstr ""
-
-#: module/Decision/view/decision/member/search.phtml:20
-msgid "Zoek"
-msgstr ""
-
-#: module/Decision/view/decision/member/search.phtml:30
-msgid "Naam"
-msgstr ""
-
-#: module/Decision/view/decision/member/search.phtml:31
-msgid "Generatie"
-msgstr ""
-
-#: module/Decision/view/decision/member/search.phtml:38
-msgid ""
-"Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
-"resultaten te zien."
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:20
-msgid "My Information"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:29
-#: module/User/src/Form/Register.php:32 module/User/src/Form/UserReset.php:30
-msgid "Membership number"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:33
-msgid "Initials"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:37
-msgid "First name"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:41
-#: module/User/src/Model/Enums/JWTClaims.php:45
-msgid "Middle name"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:45
-msgid "Last name"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:60
-#: module/Decision/view/decision/member/view.phtml:45
-msgid "Birth date"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:68
-#: module/Decision/view/decision/member/view.phtml:54
-#: module/User/src/Model/Enums/JWTClaims.php:44
-msgid "Membership type"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:72
-msgid "Last membership change"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:76
-msgid "End date of membership"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:83
-msgid ""
-"If your information is no longer up to date and you would like to change it, "
-"you can contact the secretary of GEWIS."
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:84
-msgid "Also for data removal requests, you can contact"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:85
-msgid "Email the secretary of GEWIS"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:85
-msgid "the secretary of GEWIS"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:89
-#: module/Decision/view/decision/member/view.phtml:117
-msgid "Memberships of committees and fraternities"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:94
-msgid "You have not been a member of a committee or fraternity."
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:97
-msgid "You are currently a member of:"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:121
-msgid "You were a member of:"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:145
-#: module/Decision/view/decision/member/view.phtml:188
-msgid "Addresses"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:150
-#: module/Decision/view/decision/member/view.phtml:193
-msgid "Country"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:154
-#: module/Decision/view/decision/member/view.phtml:197
-msgid "Street and number"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:157
-#: module/Decision/view/decision/member/self.phtml:167
-#: module/Decision/view/decision/member/view.phtml:200
-#: module/Decision/view/decision/member/view.phtml:210
-#, php-format
-msgid "%s %s"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:164
-#: module/Decision/view/decision/member/view.phtml:207
-msgid "City and postal code"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:180
-msgid "External applications"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:183
-msgid "App"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:184
-msgid "First authentication"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:185
-msgid "Last authentication"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:230
-msgid "Remove this picture as your profile picture"
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:232
-msgid "Your profile picture will be chosen automatically instead."
-msgstr ""
-
-#: module/Decision/view/decision/member/self.phtml:247
-msgid "More of my photo's"
-msgstr ""
-
-#: module/Decision/view/decision/member/view.phtml:58
-msgid "Has key code?"
-msgstr ""
-
-#: module/Decision/view/decision/member/view.phtml:79
-#, php-format
-msgid "%s is the upcoming <strong>%s</strong>."
-msgstr ""
-
-#: module/Decision/view/decision/member/view.phtml:95
-#, php-format
-msgid "%s is currently the <strong>%s</strong>."
-msgstr ""
-
-#: module/Decision/view/decision/member/view.phtml:105
-#, php-format
-msgid "%s was the <strong>%s</strong> during the association year %d/%d."
-msgstr ""
-
-#: module/Decision/view/decision/member/view.phtml:124
-#, php-format
-msgid "%s has never been part of a committee or fraternity."
-msgstr ""
-
-#: module/Decision/view/decision/member/view.phtml:132
-#, php-format
-msgid "%s is currently a member of:"
-msgstr ""
-
-#: module/Decision/view/decision/member/view.phtml:161
-#, php-format
-msgid "%s was a member of:"
-msgstr ""
-
-#: module/Decision/view/decision/member/view.phtml:262
-#, php-format
-msgid "Photo's of %s"
-msgstr ""
-
-#: module/Decision/view/decision/organ-admin/edit.phtml:75
-msgid "Edit organ information"
-msgstr ""
-
-#: module/Decision/view/decision/organ-admin/edit.phtml:150
 msgid ""
 "To optimally display your image on the overview page, please crop it below"
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:166
 msgid "To optimally display your image your page, please crop it below"
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:182
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:110
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:143
-#: module/Decision/src/Form/OrganInformation.php:123
-#: module/Frontpage/src/Form/NewsItem.php:78
-#: module/Frontpage/src/Form/Page.php:100
-#: module/Photo/src/Form/EditAlbum.php:59
-msgid "Save"
-msgstr ""
-
-#: module/Decision/view/decision/organ-admin/index.phtml:18
-msgid ""
-"Select an organ to edit its information. Changes will not be displayed until "
-"they have been approved."
-msgstr ""
-
-#: module/Decision/view/decision/organ-admin/index.phtml:23
-#: module/Decision/view/decision/organ/index.phtml:22
-#: module/Company/src/Form/JobLabel.php:51
-#: module/Company/src/Form/JobLabel.php:61
-msgid "Abbreviation"
-msgstr ""
-
-#: module/Decision/view/decision/organ-admin/index.phtml:25
-msgid "Approval status"
-msgstr ""
-
-#: module/Decision/view/decision/organ/index.phtml:15
-msgid "Organ list"
-msgstr ""
-
-#: module/Decision/view/decision/organ/show.phtml:50
-msgid "Inactive members"
-msgstr ""
-
-#: module/Decision/view/decision/organ/show.phtml:61
-msgid "Old members"
-msgstr ""
-
-#: module/Decision/view/decision/organ/show.phtml:70
-msgid "Organ mutations"
-msgstr ""
-
-#: module/Education/view/education/admin/add-course.phtml:17
-msgid "Add"
-msgstr ""
-
-#: module/Education/view/education/admin/add-course.phtml:28
-#: module/Education/view/education/admin/course.phtml:31
-msgid "Add Course"
-msgstr ""
-
-#: module/Education/view/education/admin/bulk-exam.phtml:20
-msgid "Upload Exams"
-msgstr ""
-
-#: module/Education/view/education/admin/bulk-exam.phtml:35
-msgid "Finalize exam uploads"
-msgstr ""
-
-#: module/Education/view/education/admin/bulk-summary.phtml:20
-msgid "Upload Summaries"
-msgstr ""
-
-#: module/Education/view/education/admin/bulk-summary.phtml:35
-msgid "Finalize summary uploads"
-msgstr ""
-
-#: module/Education/view/education/admin/course-documents.phtml:47
-#, php-format
-msgid "Course Documents of %s"
-msgstr ""
-
-#: module/Education/view/education/admin/course-documents.phtml:57
-#: module/Education/view/education/education/index.phtml:36
-msgid "Exams"
-msgstr ""
-
-#: module/Education/view/education/admin/course-documents.phtml:71
-#: module/Education/view/education/admin/course-documents.phtml:122
-#: module/Education/src/Form/Fieldset/Exam.php:84
-#: module/Education/src/Form/Fieldset/Summary.php:78
-msgid "Language"
-msgstr ""
-
-#: module/Education/view/education/admin/course-documents.phtml:100
-#: module/Education/view/education/admin/course-documents.phtml:149
-msgid "This course does not have any exams."
-msgstr ""
-
-#: module/Education/view/education/admin/course-documents.phtml:108
-msgid "Summaries"
-msgstr ""
-
-#: module/Education/view/education/admin/course-documents.phtml:119
-#: module/Education/src/Form/Fieldset/Summary.php:68
-#: module/Frontpage/src/Form/PollComment.php:27
-msgid "Author"
-msgstr ""
-
-#: module/Education/view/education/admin/course-documents.phtml:167
-msgid "Are you sure you want to delete this document?"
-msgstr ""
-
-#: module/Education/view/education/admin/course.phtml:22
-msgid "Course Admin"
-msgstr ""
-
-#: module/Education/view/education/admin/course.phtml:41
-msgid "Code"
-msgstr ""
-
-#: module/Education/view/education/admin/course.phtml:87
-msgid "Delete Course"
-msgstr ""
-
-#: module/Education/view/education/admin/course.phtml:93
-#, php-format
-msgid ""
-"Are you sure you want to delete %s? This will also delete all associated "
-"exams and summaries will be deleted."
-msgstr ""
-
-#: module/Education/view/education/admin/edit-course.phtml:37
-msgid "Edit Course"
-msgstr ""
-
-#: module/Education/view/education/admin/edit-exam.phtml:32
-msgid "Edit Exam"
-msgstr ""
-
-#: module/Education/view/education/admin/edit-exam.phtml:35
-msgid "Upload of all exams was finished."
-msgstr ""
-
-#: module/Education/view/education/admin/edit-exam.phtml:37
-msgid "There are no exams to be edited. Upload exams to edit them."
-msgstr ""
-
-#: module/Education/view/education/admin/edit-exam.phtml:128
-#: module/Education/view/education/admin/edit-summary.phtml:130
-msgid ""
-"Check this if the document is scanned, as this will enable higher quality "
-"downloads. Please note that enabling setting this for non-scanned documents "
-"will significantly impact the ability to download the document."
-msgstr ""
-
-#: module/Education/view/education/admin/edit-summary.phtml:32
-msgid "Edit Summary"
-msgstr ""
-
-#: module/Education/view/education/admin/edit-summary.phtml:35
-msgid "Upload of all summaries was finished."
-msgstr ""
-
-#: module/Education/view/education/admin/edit-summary.phtml:37
-msgid "There are no summaries to be edited. Upload exams to edit them."
-msgstr ""
-
-#: module/Education/view/education/admin/index.phtml:13
-msgid "Education admin"
-msgstr ""
-
-#: module/Education/view/education/education/course.phtml:33
-msgid "Exams and summaries"
-msgstr ""
-
-#: module/Education/view/education/education/course.phtml:44
-#, php-format
-msgid "Summary by %s on %s (%s)"
-msgstr ""
-
-#: module/Education/view/education/education/course.phtml:53
-#, php-format
-msgid "Summary on %s (%s)"
-msgstr ""
-
-#: module/Education/view/education/education/course.phtml:64
-#, php-format
-msgid "Final test from %s (%s)"
-msgstr ""
-
-#: module/Education/view/education/education/course.phtml:67
-#, php-format
-msgid "Interim test from %s (%s)"
-msgstr ""
-
-#: module/Education/view/education/education/course.phtml:70
-#, php-format
-msgid "Answers from %s (%s)"
-msgstr ""
-
-#: module/Education/view/education/education/course.phtml:73
-#, php-format
-msgid "Other exam material from %s (%s)"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:54
-msgid "Course code or course description"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:76
-#, php-format
-msgid "Found %d %s matching your description"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:79
-msgid "course"
-msgid_plural "courses"
-msgstr[0] ""
-msgstr[1] ""
-
-#: module/Education/view/education/education/index.phtml:91
-#: module/Education/src/Form/Course.php:33
-#: module/Education/src/Form/Fieldset/Exam.php:47
-#: module/Education/src/Form/Fieldset/Summary.php:47
-msgid "Course code"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:92
-msgid "Course name"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:93
-msgid "Available documents"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:104
-msgid "View available documents"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:123
-#, php-format
-msgid ""
-"Do you want to contribute to the collection of old exams and summaries? Send "
-"them to the %seducation officer%s so that your (future) peers can benefit."
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:124
-#: module/Education/view/education/education/index.phtml:182
-msgid "Mail the education officer"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:132
-msgid "For old exams of minor courses, you can also look at:"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:135
-msgid "Applied Physics"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:138
-msgid "Biomedical Engineering"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:141
-msgid "Electrical Engineering"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:144
-msgid "Chemical Engineering"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:147
-msgid "Innovation Sciences"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:154
-msgid "Useful links"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:159
-msgid "Books"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:162
-msgid ""
-"Order your course books via GEWIS to receive a discount. Specific ordering "
-"deadlines and pickup dates will be timely communicated to you via an email."
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:165
-msgid "Visit the webshop"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:167
-msgid "Visit webshop"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:175
-msgid "Complaint or suggestion about TU/e education?"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:181
-#, php-format
-msgid ""
-"Do you have a complaint or suggestion concerning the education at the TU/e? "
-"Contact the %seducation officer%s to share your ideas."
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:192
-msgid "Disclaimer on educational content"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:197
-msgid ""
-"The exams on the website of GEWIS are provided by Education & Student "
-"Affairs of the department of Mathematics and Computer Science of the TU/e."
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:198
-msgid ""
-"If an exam has been put online without the intention of the author, please "
-"let the board of GEWIS know by sending an"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:199
-msgid "Email the board of GEWIS"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:199
-msgid "email to the board of GEWIS"
-msgstr ""
-
-#: module/Education/view/education/education/index.phtml:200
-msgid ""
-"then this exam will be removed from the website. Using the summaries or "
-"exams on this website for commercial goals without the permission of the "
-"author is illegal."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/admin/index.phtml:10
-msgid ""
-"Welcome to the admin interface of the GEWIS website. If you are experiencing "
-"any issues or have a question, please contact the ApplicatieBeheerCommissie."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/admin/index.phtml:12
-msgid "Recent changes"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:47
-msgid "Studievereniging GEWIS"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:49
-msgid ""
-"Welcome to the website of Study association GEWIS, the study association of "
-"the department of Mathematics & Computer Science of the Eindhoven University "
-"of Technology."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:148
-msgid "Verjaardagen"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:153
-#, php-format
-msgid "%s wil be %s years old today!"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:168
-msgid "Agenda"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:185
-#, php-format
-msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:194
-#: module/Frontpage/view/frontpage/organ/organ.phtml:136
-msgid "Complete agenda"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:198
-msgid "Google Calendar"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
-msgid "Poll"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:296
-msgid "View details"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:301
-msgid "There currently is no poll."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:305
-#: module/Frontpage/view/frontpage/poll/request.phtml:174
-msgid "Request poll"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:308
-#: module/Frontpage/view/frontpage/poll/index.phtml:39
-msgid "Old polls"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:49
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:80
-#: module/Frontpage/src/Form/NewsItem.php:57
-#: module/Frontpage/src/Form/Page.php:79
-msgid "English content"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:73
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:104
-#: module/Frontpage/src/Form/NewsItem.php:47
-#: module/Frontpage/src/Form/Page.php:69
-msgid "Dutch content"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:101
-msgid "Pin news item"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:103
-msgid "Select this if you want this news item to stay at the top of the page."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:118
-msgid "Delete this news item"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:16
-msgid "News items"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:17
-msgid "Create news item"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:21
-msgid "GEWIS has many different committees, learn more about them below!"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:27
-msgid "Information for committees"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:20
-msgid ""
-"Study association GEWIS obviously has several fraternities which contribute "
-"to the atmosphere at GEWIS and organize fun activities. Some fraternities "
-"have retired, but luckily new fraternities continue to be founded."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:21
-msgid "The currently active fraternities of GEWIS (in arbitrary order)"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:36
-msgid "Retired fraternities"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:37
-msgid "The following fraternities have retired:"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:67
-msgid "GMM Committees"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:69
-msgid "GMM Taskforces"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:71
-msgid "Financial Audit Committees"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:73
-msgid "Advisory Boards"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:122
-#, php-format
-msgid "%s's activities"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:168
-msgid "Login to view more information"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:48
-msgid "URL options"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:49
-msgid ""
-"Make this page available at the following URL. Providing a category is "
-"required."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:128
-msgid "Permissions"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:151
-msgid "Delete this page"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:29
-msgid "Create a new page"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:31
-msgid "Or select a page to edit below."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:34
-msgid "Polls awaiting approval"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:51
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:124
-#: module/Frontpage/src/Form/Poll.php:28
-msgid "Dutch question"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:40
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:54
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:113
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:127
-#: module/Frontpage/src/Form/Poll.php:38
-msgid "English question"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:43
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:116
-msgid "Approver"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:60
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:133
-msgid "Dutch option"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:61
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:134
-msgid "English option"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:95
-msgid "Approved polls"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:178
-msgid "Are you sure you want to delete this poll?"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:184
-msgid "Delete poll"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:201
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:227
-#: module/Frontpage/src/Form/PollApproval.php:36
-msgid "Approve poll"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:204
-msgid "Are you sure that you want to approve this poll?"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/history.phtml:14
-msgid "Poll history"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:41
-#, php-format
-msgid "%sRequest a poll%s"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:56
-msgid "Unfortunately there currently is no poll :("
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:61
-msgid "Comments"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:63
-msgid "This poll has no comments"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:84
-msgid "Comment on this poll"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:14
-#: module/Frontpage/view/frontpage/poll/request.phtml:19
-msgid "Request a poll"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:21
-msgid "Your poll request has been received and will be reviewed shortly."
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:158
-msgid "Remove option"
-msgstr ""
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:163
-msgid "Add option"
-msgstr ""
-
-#: module/Frontpage/view/partial/poll.phtml:61
-#: module/Frontpage/view/partial/poll.phtml:72
-msgid "1 vote"
-msgstr ""
-
-#: module/Frontpage/view/partial/poll.phtml:61
-#: module/Frontpage/view/partial/poll.phtml:72
-#, php-format
-msgid "%d votes"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:19
-msgid "Artist"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:26
-msgid "Camera"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:33
-msgid "Date/time"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:40
-msgid "Flash"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:47
-msgid "Focal length"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:54
-msgid "Exposure time"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:61
-msgid "Shutter speed"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:68
-msgid "Aperture"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:75
-msgid "ISO"
-msgstr ""
-
-#: module/Photo/view/partial/metadata.phtml:95
-msgid "View on map"
-msgstr ""
-
-#: module/Photo/view/partial/tags.phtml:22
-#: module/Photo/view/photo/album/index.phtml:674
-msgid "In this photo:"
-msgstr ""
-
-#: module/Photo/view/partial/tags.phtml:23
-#: module/Photo/view/photo/album/index.phtml:675
-msgid ""
-"No one has been tagged in this photo yet. Tag someone you recognise now!"
-msgstr ""
-
-#: module/Photo/view/partial/tags.phtml:61
-#: module/Photo/view/photo/album/index.phtml:703
-msgid "Tag someone"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/add.phtml:41
-msgid "Upload Photos"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/add.phtml:43
-#, php-format
-msgid "Uploading photos to %s"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/create.phtml:16
-msgid "Create Album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/create.phtml:28
-#: module/Photo/src/Form/CreateAlbum.php:25
-#: module/Photo/src/Form/EditAlbum.php:27
-msgid "Album title"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/create.phtml:37
-msgid "Create album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/edit.phtml:16
-msgid "Edit Album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/edit.phtml:22
-msgid "Update Album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:55
-#: module/Photo/view/photo/photo-admin/index.phtml:62
-msgid "Photo admin"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:104
-msgid "Other albums"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:117
-msgid "Create new album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:122
-msgid "Edit album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:125
-msgid "Add photos"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:127
-msgid "Move album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:130
-msgid "Move %i photos"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:133
-msgid "Regenerate album cover"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:137
-#: module/Photo/view/photo/album-admin/index.phtml:231
-msgid "Delete album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:140
-msgid "Delete %i photos"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:158
-msgid "Generate a new cover photo"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:164
-msgid "An error occurred while trying to generate an album photo."
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:171
-msgid "Regenerate"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:173
-#: module/Photo/view/photo/album/index.phtml:435
-msgid "Close"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:186
-msgid "Move the album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:191
-msgid "Select a new parent for the album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:195
-msgid "The album has been moved"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:200
-#: module/Photo/view/photo/album-admin/index.phtml:291
-#: module/Photo/view/photo/photo-admin/index.phtml:126
-msgid "Move"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:217
-msgid ""
-"Are you sure you want to delete this album including all photos inside of "
-"it? <strong>This action can not be reverted.</strong>"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:220
-msgid "Please wait while the album is being deleted."
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:226
-msgid "The album has been deleted"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:249
-msgid ""
-"Are you sure you want to delete the selected items? <strong>This action can "
-"not be reverted.</strong>"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:252
-msgid "Please wait while the photos are being deleted."
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:258
-msgid "The photos have been been deleted"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:263
-msgid "Delete photos"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:277
-msgid "Move the photos to another album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:282
-#: module/Photo/view/photo/photo-admin/index.phtml:117
-msgid "Select a new parent album"
-msgstr ""
-
-#: module/Photo/view/photo/album-admin/index.phtml:286
-msgid "The photos have been moved"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:86
-#: module/Photo/view/photo/photo/weekly.phtml:13
-#: module/Photo/view/photo/photo/weekly.phtml:20
-msgid "Photos of the Week"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:140
-msgid "View user profile"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:152
-msgid "No date"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:201
-#: module/Photo/view/photo/photo/index.phtml:71
-msgid "NEW"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:225
-msgid "This album does not contain any photos."
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:398
-msgid "Already voted!"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:401
-#: module/Photo/view/photo/album/index.phtml:572
-msgid "Vote for photo of the week"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:436
-msgid "Zoom (z)"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:439
-msgid "The image could not be loaded."
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:452
-msgid "Download"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:476
-msgid "Share"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:487
-msgid "Copied URL!"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:498
-msgid "Go to album"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:541
-msgid "Set as profile picture"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:558
-msgid "Set as profile picture!"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:561
-msgid "Could not set as profile photo, try again"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:594
-msgid "Cannot load vote"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:614
-msgid "Voted!"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:626
-msgid "Could not vote, try again"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:641
-msgid "Loading tags..."
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:662
-msgid "Cannot load tags"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:757
-msgid "Cannot load metadata"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:783
-msgid "Photo of the Week:<br> Week"
-msgstr ""
-
-#: module/Photo/view/photo/album/index.phtml:783
-msgid "of"
-msgstr ""
-
-#: module/Photo/view/photo/photo-admin/index.phtml:51
-#, php-format
-msgid "Photo #%d"
-msgstr ""
-
-#: module/Photo/view/photo/photo-admin/index.phtml:89
-msgid "Move photo"
-msgstr ""
-
-#: module/Photo/view/photo/photo-admin/index.phtml:91
-#: module/Photo/view/photo/photo-admin/index.phtml:157
-msgid "Delete photo"
-msgstr ""
-
-#: module/Photo/view/photo/photo-admin/index.phtml:112
-msgid "Move the photo to another album"
-msgstr ""
-
-#: module/Photo/view/photo/photo-admin/index.phtml:121
-msgid "The photo has been moved"
-msgstr ""
-
-#: module/Photo/view/photo/photo-admin/index.phtml:143
-msgid ""
-"Are you sure you want to delete this photo? <strong>This action can not be "
-"reverted.</strong>"
-msgstr ""
-
-#: module/Photo/view/photo/photo-admin/index.phtml:146
-msgid "Please wait while your photo is being deleted."
-msgstr ""
-
-#: module/Photo/view/photo/photo-admin/index.phtml:152
-msgid "The photo has been deleted"
-msgstr ""
-
-#: module/Photo/view/photo/photo/index.phtml:82
-msgid "There are no photos in this year."
-msgstr ""
-
-#: module/Photo/view/photo/photo/weekly.phtml:18
-msgid "Currently, no pictures of the week are available."
-msgstr ""
-
-#: module/Photo/view/photo/photo/weekly.phtml:21
-msgid "Current photo of the week"
-msgstr ""
-
-#: module/Photo/view/photo/photo/weekly.phtml:52
-msgid "Old photos of the week"
-msgstr ""
-
-#: module/User/view/partial/login/company.phtml:77
-#: module/User/view/partial/login/member.phtml:87
-#, php-format
-msgid "If you forgot your password, go to the %sPassword reset page%s"
-msgstr ""
-
-#: module/User/view/partial/login/member.phtml:83
-#, php-format
-msgid "If you don't have an account yet, go to the %sRegistration page%s"
-msgstr ""
-
-#: module/User/view/partial/reset/company.phtml:46
-#: module/User/view/partial/reset/member.phtml:59
-#: module/User/view/user/user/reset-password.phtml:18
-#: module/User/view/user/user/reset-password.phtml:29
-#: module/User/src/Form/UserReset.php:50
-msgid "Reset password"
-msgstr ""
-
-#: module/User/view/partial/reset/member.phtml:51
-msgid ""
-"Have you forgotten your e-mail address and do you want to change it? Ask the "
-"secretary by going to GEWIS (preferred) or by sending an e-mail."
-msgstr ""
-
-#: module/User/view/user/api-admin/add.phtml:15
-#: module/User/view/user/api-admin/index.phtml:15
-#: module/User/view/user/api-admin/index.phtml:17
-#: module/User/view/user/api-admin/remove.phtml:15
-msgid "API Tokens"
-msgstr ""
-
-#: module/User/view/user/api-admin/add.phtml:16
-msgid "Add Token"
-msgstr ""
-
-#: module/User/view/user/api-admin/add.phtml:18
-msgid "Add a token"
-msgstr ""
-
-#: module/User/view/user/api-admin/add.phtml:45
-#: module/User/src/Form/ApiToken.php:35
-msgid "Create API token"
-msgstr ""
-
-#: module/User/view/user/api-admin/add.phtml:53
-msgid "Token was successfully generated"
-msgstr ""
-
-#: module/User/view/user/api-admin/add.phtml:61
-#: module/User/view/user/api-admin/index.phtml:23
-msgid "Token"
-msgstr ""
-
-#: module/User/view/user/api-admin/index.phtml:35
-#: module/Activity/src/Controller/AdminController.php:234
-#: module/Activity/src/Controller/AdminController.php:372
-msgid "Remove"
-msgstr ""
-
-#: module/User/view/user/api-admin/index.phtml:42
-msgid "Add new Token"
-msgstr ""
-
-#: module/User/view/user/api-admin/remove.phtml:16
-msgid "Remove Token"
-msgstr ""
-
-#: module/User/view/user/api-authentication/redirect.phtml:21
-#, php-format
-msgid "You are being redirected to %s"
-msgstr ""
-
-#: module/User/view/user/api-authentication/redirect.phtml:30
-#, php-format
-msgid ""
-"If your browser does not redirect you back, please <a href=\"%s\">click "
-"here</a> to continue."
-msgstr ""
-
-#: module/User/view/user/api-authentication/token.phtml:28
-#, php-format
-msgid "Authorize %s to use your account?"
-msgstr ""
-
-#: module/User/view/user/api-authentication/token.phtml:37
-#, php-format
-msgid ""
-"It has been more than 90 days since you last used <strong>%s</strong>. As a "
-"reminder, the application has access to:"
-msgstr ""
-
-#: module/User/view/user/api-authentication/token.phtml:42
-msgid "The application will get the following information:"
-msgstr ""
-
-#: module/User/view/user/user/activate.phtml:20
-#: module/User/view/user/user/activate.phtml:40
-#: module/User/src/Form/Activate.php:49
-msgid "Activate"
-msgstr ""
-
-#: module/User/view/user/user/activate.phtml:25
-msgid "Your account has been activated. You are now able to login."
-msgstr ""
-
-#: module/User/view/user/user/activate.phtml:53
-#, php-format
-msgid ""
-"Welcome %s. Create your password for the website and activate your account."
-msgstr ""
-
-#: module/User/view/user/user/activate.phtml:58
-#: module/User/src/Form/CompanyUserLogin.php:44
-msgid "Password"
-msgstr ""
-
-#: module/User/view/user/user/activate.phtml:72
-msgid "Verify password"
-msgstr ""
-
-#: module/User/view/user/user/change-password.phtml:20
-msgid "Password changed successfully"
-msgstr ""
-
-#: module/User/view/user/user/login.phtml:16
-msgid "Log in"
-msgstr ""
-
-#: module/User/view/user/user/logout.phtml:10
-msgid "You are logged out."
-msgstr ""
-
-#: module/User/view/user/user/register.phtml:14
-#: module/User/view/user/user/register.phtml:34
-#: module/User/src/Form/Register.php:42
-msgid "Register"
-msgstr ""
-
-#: module/User/view/user/user/register.phtml:19
-msgid ""
-"Your account for the GEWIS website has been registered, check your inbox for "
-"an activation e-mail."
-msgstr ""
-
-#: module/User/view/user/user/register.phtml:71
 #, php-format
 msgid ""
 "To read more about the benefits of becoming a member and how to become a "
 "member, go to this %sinformation page%s."
 msgstr ""
 
-#: module/User/view/user/user/reset-password.phtml:23
-msgid ""
-"An e-mail has been sent with instructions for resetting your password. If "
-"you have not received an e-mail, try again in 20 minutes."
+msgid "Toggle navigation"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityCalendarController.php:82
-msgid "You are not allowed to create activity proposals"
+msgid "Token"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:258
-#: module/Activity/src/Controller/ActivityController.php:351
-#: module/Activity/src/Controller/AdminController.php:294
-#: module/Activity/src/Controller/AdminController.php:381
-msgid "Invalid form"
+msgid "Token was successfully generated"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:267
-#: module/Activity/src/Controller/ActivityController.php:360
-msgid "You need to log in to subscribe"
+msgid "Too many login attempts, try again later."
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:277
-#: module/Activity/src/Controller/ActivityController.php:370
-msgid "You cannot subscribe to this activity at this moment in time"
+msgid "Tracking is currently"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:286
-msgid "You have already been subscribed for this activity"
+msgid "Transfer Jobs"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:292
-msgid "Successfully subscribed"
+msgid "Try alternate words or selections"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:297
-#: module/Activity/src/Controller/ActivityController.php:386
-#: module/Activity/src/Controller/AdminController.php:318
-msgid "Use the form to subscribe"
+msgid "Try entering fewer keywords"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:381
-msgid "Successfully subscribed as external participant"
+msgid "Try using a more generic search term"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:413
-msgid "Wrong form"
+msgid "Type"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:420
-msgid "You have to be logged in to subscribe for this activity"
+msgid "URL options"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:431
-msgid "You cannot unsubscribe from this activity at this moment in time"
+msgid "Unable to retrieve infimum."
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:441
-msgid "You are not subscribed to this activity!"
+msgid "Unapproved Activities"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:447
-msgid "Successfully unsubscribed"
+msgid "Unapproved Companies"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:452
-msgid "Use the form to unsubscribe"
+msgid "Unapproved Jobs"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminApprovalController.php:41
-msgid "You are not allowed to view the approval of this activity"
+msgid "Unfortunately there currently is no poll :("
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:50
-#: module/Activity/src/Service/ActivityCategory.php:76
-msgid "You are not allowed to create an activity category"
+#, php-format
+msgid "Unfortunately, there aren't any %s at the moment."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:63
-msgid "The activity category was created successfully!"
+msgid "Unknown"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:73
-#: module/Activity/src/Form/ActivityCategory.php:44
-msgid "Create Activity Category"
+msgid "Unsubscribe yourself"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:122
-msgid "You are not allowed to edit an activity category"
+msgid "Until"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:142
-msgid "The activity category was successfully updated!"
+msgid "Upcoming Activities"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:159
+msgid "Upcoming meeting"
+msgid_plural "Upcoming meetings"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Update Activity"
+msgstr ""
+
 msgid "Update Activity Category"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:62
+msgid "Update Album"
+msgstr ""
+
+msgid "Update Company"
+msgstr ""
+
+msgid "Update Job"
+msgstr ""
+
+msgid "Update Job Category"
+msgstr ""
+
+msgid "Update Job Label"
+msgstr ""
+
+msgid "Update Package"
+msgstr ""
+
+msgid "Update Proposal"
+msgstr ""
+
+msgid "Update pending"
+msgstr ""
+
+msgid ""
+"Update proposal for job successfully created! It will become active after it "
+"has been approved."
+msgstr ""
+
+msgid "Update status"
+msgstr ""
+
+msgid "Upload"
+msgstr ""
+
+msgid "Upload Exams"
+msgstr ""
+
+msgid "Upload Photos"
+msgstr ""
+
+msgid "Upload Summaries"
+msgstr ""
+
+msgid "Upload document"
+msgstr ""
+
+msgid "Upload exams"
+msgstr ""
+
+msgid "Upload of all exams was finished."
+msgstr ""
+
+msgid "Upload of all summaries was finished."
+msgstr ""
+
+msgid "Upload summaries"
+msgstr ""
+
+#, php-format
+msgid "Uploading photos to %s"
+msgstr ""
+
+msgid "Use the form to subscribe"
+msgstr ""
+
+msgid "Use the form to unsubscribe"
+msgstr ""
+
+msgid "Use the form to unsubscribe an external participant"
+msgstr ""
+
+msgid "Useful Information"
+msgstr ""
+
+msgid "Useful links"
+msgstr ""
+
+#, php-format
+msgid "User (%s)"
+msgstr ""
+
+msgid "Users"
+msgstr ""
+
+msgid "VIRT"
+msgstr ""
+
+#, php-format
+msgid "Valid authorizations for GMM %d"
+msgstr ""
+
+msgid "Value is required and can't be empty"
+msgstr ""
+
+msgid "Verify new password"
+msgstr ""
+
+msgid "Verify password"
+msgstr ""
+
+msgid "Verify your password"
+msgstr ""
+
+msgid "Verjaardagen"
+msgstr ""
+
+msgid "Vice-Voorzitter"
+msgstr ""
+
+msgid "Vicevoorzitter"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "View Attachment"
+msgstr ""
+
+msgid "View New Attachment"
+msgstr ""
+
+msgid "View Original Attachment"
+msgstr ""
+
+msgid "View Proposal"
+msgstr ""
+
+msgid "View Update"
+msgstr ""
+
+msgid "View Website"
+msgstr ""
+
+msgid "View all meetings"
+msgstr ""
+
+msgid "View available documents"
+msgstr ""
+
+msgid "View current attachment"
+msgstr ""
+
+msgid "View current logo"
+msgstr ""
+
+msgid "View details"
+msgstr ""
+
+msgid "View details / subscriptions"
+msgstr ""
+
+msgid "View details of the new activity"
+msgstr ""
+
+msgid "View details of the old activity"
+msgstr ""
+
+msgid "View on map"
+msgstr ""
+
+#, php-format
+msgid "View the minutes of the %s"
+msgstr ""
+
+msgid "View user profile"
+msgstr ""
+
+msgid "Virtual Meeting"
+msgstr ""
+
+msgid "Visit Website"
+msgstr ""
+
+msgid "Visit the webshop"
+msgstr ""
+
+msgid "Visit webshop"
+msgstr ""
+
+msgid "Voorzitter"
+msgstr ""
+
+msgid "Vote for photo of the week"
+msgstr ""
+
+msgid "Voted!"
+msgstr ""
+
+msgid ""
+"Warning! This is an update to an unapproved job. Applying this update will "
+"approve the job."
+msgstr ""
+
+msgid ""
+"Warning! This is an update to rejected job. Applying this update will "
+"approve the job."
+msgstr ""
+
+msgid "We cannot determine at this time why a 404 was generated."
+msgstr ""
+
+msgid "Webmail"
+msgstr ""
+
+msgid "Website"
+msgstr ""
+
+#, php-format
+msgid ""
+"Welcome %s. Create your password for the website and activate your account."
+msgstr ""
+
+msgid ""
+"Welcome on the page of the digital Option Calendar. In the calendar below "
+"you can place options for GEWIS activities, just like you were used to do in "
+"the paper version of the option calendar before. The red dots indicate "
+"activities that are already fixed in the GEWIS agenda, the blue dots are "
+"options for activities. If you insert an option, please give it a clear "
+"name, so it is clear what the option is for."
+msgstr ""
+
+msgid ""
+"Welcome to the admin interface of the GEWIS website. If you are experiencing "
+"any issues or have a question, please contact the ApplicatieBeheerCommissie."
+msgstr ""
+
+msgid ""
+"Welcome to the website of Study association GEWIS, the study association of "
+"the department of Mathematics & Computer Science of the Eindhoven University "
+"of Technology."
+msgstr ""
+
+msgid "Well-being"
+msgstr ""
+
+msgid "What are you looking for?"
+msgstr ""
+
+msgid ""
+"What is this activity about? Fill in the blanks below, please note that at "
+"least one language must be used."
+msgstr ""
+
+msgid ""
+"What is this company about? Fill in the blanks below, please note that at "
+"least one language must be used."
+msgstr ""
+
+msgid ""
+"When this is checked, GEFLITST will be notified that this activity needs a "
+"photographer."
+msgstr ""
+
+msgid "Wrong form"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "Yes/No"
+msgstr ""
+
+msgid ""
+"You already attempted to register, please check your email or try again "
+"after 20 minutes."
+msgstr ""
+
+#, php-format
+msgid "You are being redirected to %s"
+msgstr ""
+
+msgid "You are currently a member of:"
+msgstr ""
+
+#, php-format
+msgid ""
+"You are currently updating a job that was previously rejected for the "
+"following reason: %s"
+msgstr ""
+
+msgid ""
+"You are currently updating a job that was previously rejected, however, no "
+"reason was provided."
+msgstr ""
+
+#, php-format
+msgid ""
+"You are currently updating an update proposal that was previously rejected "
+"for the following reason: %s"
+msgstr ""
+
+msgid ""
+"You are currently updating an update proposal that was previously rejected, "
+"however, no reason was provided."
+msgstr ""
+
+msgid "You are currently using administrator privileges to use the website!"
+msgstr ""
+
+msgid "You are logged out."
+msgstr ""
+
+msgid "You are not allowed authorize people."
+msgstr ""
+
+msgid "You are not allowed to access the activities through the API"
+msgstr ""
+
+msgid "You are not allowed to access the admin interface"
+msgstr ""
+
+msgid "You are not allowed to add API tokens"
+msgstr ""
+
+msgid "You are not allowed to add courses"
+msgstr ""
+
+msgid "You are not allowed to administer activities"
+msgstr ""
+
+msgid "You are not allowed to administer career settings"
+msgstr ""
+
+msgid "You are not allowed to administer courses"
+msgstr ""
+
+msgid "You are not allowed to administer education settings"
+msgstr ""
+
+msgid "You are not allowed to administer option calendar periods"
+msgstr ""
+
+msgid "You are not allowed to administer polls"
+msgstr ""
+
+msgid "You are not allowed to approve polls"
+msgstr ""
+
+msgid "You are not allowed to approve this option"
+msgstr ""
+
+msgid "You are not allowed to approve update proposals of jobs"
+msgstr ""
+
+msgid "You are not allowed to authorize someone"
+msgstr ""
+
+msgid "You are not allowed to browse files."
+msgstr ""
+
+msgid "You are not allowed to change passwords"
+msgstr ""
+
+msgid "You are not allowed to change the approval status of jobs"
+msgstr ""
+
+msgid "You are not allowed to change the status of the activity"
+msgstr ""
+
+msgid "You are not allowed to change your password"
+msgstr ""
+
+msgid "You are not allowed to create a company"
+msgstr ""
+
+msgid "You are not allowed to create activity option proposals"
+msgstr ""
+
+msgid "You are not allowed to create activity proposals"
+msgstr ""
+
+msgid "You are not allowed to create an activity"
+msgstr ""
+
+msgid "You are not allowed to create an activity category"
+msgstr ""
+
+msgid "You are not allowed to create an activity for this organ"
+msgstr ""
+
+msgid "You are not allowed to create comments on this poll"
+msgstr ""
+
+msgid "You are not allowed to create companies"
+msgstr ""
+
+msgid "You are not allowed to create job categories"
+msgstr ""
+
+msgid "You are not allowed to create job labels"
+msgstr ""
+
+msgid "You are not allowed to create jobs"
+msgstr ""
+
+msgid "You are not allowed to create new pages."
+msgstr ""
+
+msgid "You are not allowed to create news items"
+msgstr ""
+
+msgid "You are not allowed to create option calendar periods"
+msgstr ""
+
+msgid "You are not allowed to create packages"
+msgstr ""
+
+msgid "You are not allowed to delete an activity category"
+msgstr ""
+
+msgid "You are not allowed to delete companies"
+msgstr ""
+
+msgid "You are not allowed to delete course documents"
+msgstr ""
+
+msgid "You are not allowed to delete courses"
+msgstr ""
+
+msgid "You are not allowed to delete exams"
+msgstr ""
+
+msgid "You are not allowed to delete jobs"
+msgstr ""
+
+msgid "You are not allowed to delete meeting documents."
+msgstr ""
+
+msgid "You are not allowed to delete news items"
+msgstr ""
+
+msgid "You are not allowed to delete option calendar periods"
+msgstr ""
+
+msgid "You are not allowed to delete packages"
+msgstr ""
+
+msgid "You are not allowed to delete pages."
+msgstr ""
+
+msgid "You are not allowed to delete polls"
+msgstr ""
+
+msgid "You are not allowed to delete this option"
+msgstr ""
+
+msgid "You are not allowed to download course documents"
+msgstr ""
+
+msgid "You are not allowed to edit an activity category"
+msgstr ""
+
+msgid "You are not allowed to edit categories"
+msgstr ""
+
+msgid "You are not allowed to edit companies"
+msgstr ""
+
+msgid "You are not allowed to edit courses"
+msgstr ""
+
+msgid "You are not allowed to edit job categories"
+msgstr ""
+
+msgid "You are not allowed to edit job labels"
+msgstr ""
+
+msgid "You are not allowed to edit jobs"
+msgstr ""
+
+msgid "You are not allowed to edit labels"
+msgstr ""
+
+msgid "You are not allowed to edit news items"
+msgstr ""
+
+msgid "You are not allowed to edit option calendar periods"
+msgstr ""
+
+msgid "You are not allowed to edit organ information"
+msgstr ""
+
+msgid "You are not allowed to edit packages"
+msgstr ""
+
+msgid "You are not allowed to edit pages."
+msgstr ""
+
+msgid "You are not allowed to edit this organ's information"
+msgstr ""
+
+msgid "You are not allowed to list all job categories"
+msgstr ""
+
+msgid "You are not allowed to list all job labels"
+msgstr ""
+
+msgid "You are not allowed to list all news items."
+msgstr ""
+
+msgid "You are not allowed to list job categories"
+msgstr ""
+
+msgid "You are not allowed to list job labels"
+msgstr ""
+
+msgid "You are not allowed to list meetings."
+msgstr ""
+
+msgid "You are not allowed to list the companies"
+msgstr ""
+
+msgid ""
+"You are not allowed to perform this action. If you are not logged in please "
+"do so before continuing. If you are already logged in this action may "
+"require you to login in with a different account."
+msgstr ""
+
+msgid "You are not allowed to remove API tokens"
+msgstr ""
+
+msgid "You are not allowed to remove external signups for this activity"
+msgstr ""
+
+msgid "You are not allowed to rename meeting documents"
+msgstr ""
+
+msgid "You are not allowed to request polls"
+msgstr ""
+
+msgid "You are not allowed to revoke authorizations."
+msgstr ""
+
+msgid "You are not allowed to search decisions."
+msgstr ""
+
+msgid "You are not allowed to subscribe an external user to this sign-up list"
+msgstr ""
+
+msgid "You are not allowed to subscribe to this sign-up list"
+msgstr ""
+
+msgid "You are not allowed to transfer jobs"
+msgstr ""
+
+msgid "You are not allowed to unsubscribe after the deadline!"
+msgstr ""
+
 msgid "You are not allowed to update this activity"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:76
+msgid "You are not allowed to upload exams"
+msgstr ""
+
+msgid "You are not allowed to upload images."
+msgstr ""
+
+msgid "You are not allowed to upload meeting documents."
+msgstr ""
+
+msgid "You are not allowed to upload meeting minutes."
+msgstr ""
+
+msgid "You are not allowed to use the external admin signup"
+msgstr ""
+
+msgid "You are not allowed to use the external signup"
+msgstr ""
+
+msgid "You are not allowed to use this form"
+msgstr ""
+
+msgid "You are not allowed to view API tokens"
+msgstr ""
+
+msgid "You are not allowed to view activities"
+msgstr ""
+
+msgid "You are not allowed to view activity categories"
+msgstr ""
+
+msgid "You are not allowed to view all authorizations."
+msgstr ""
+
+msgid "You are not allowed to view authorizations."
+msgstr ""
+
+msgid "You are not allowed to view infima"
+msgstr ""
+
+msgid "You are not allowed to view meeting documents."
+msgstr ""
+
+msgid "You are not allowed to view meeting minutes."
+msgstr ""
+
+msgid "You are not allowed to view meetings."
+msgstr ""
+
+msgid "You are not allowed to view members."
+msgstr ""
+
+msgid "You are not allowed to view membership info."
+msgstr ""
+
+msgid "You are not allowed to view sign-up lists"
+msgstr ""
+
+msgid "You are not allowed to view the activities"
+msgstr ""
+
+msgid "You are not allowed to view the approval of this activity"
+msgstr ""
+
+msgid "You are not allowed to view the approval status of jobs"
+msgstr ""
+
+msgid "You are not allowed to view the banner"
+msgstr ""
+
+msgid "You are not allowed to view the company accounts"
+msgstr ""
+
+msgid "You are not allowed to view the disapproved activities"
+msgstr ""
+
+msgid "You are not allowed to view the featured company"
+msgstr ""
+
+msgid "You are not allowed to view the list of birthdays."
+msgstr ""
+
+msgid "You are not allowed to view the list of pages."
+msgstr ""
+
+msgid "You are not allowed to view the participants of this activity"
+msgstr ""
+
+msgid "You are not allowed to view the sign up data"
+msgstr ""
+
+msgid "You are not allowed to view the status of a job"
+msgstr ""
+
+msgid "You are not allowed to view this activity"
+msgstr ""
+
+msgid "You are not allowed to view this page."
+msgstr ""
+
+msgid "You are not allowed to view unapproved activities"
+msgstr ""
+
+msgid "You are not allowed to view unapproved polls"
+msgstr ""
+
 msgid ""
-"Activities that have sign-up lists which are open or approved cannot be "
-"updated."
+"You are not allowed to view upcoming activities coupled to a member account"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:87
-msgid "This activity has already started/ended and can no longer be updated."
+msgid "You are not allowed to view upcoming the activities"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:106
+msgid "You are not allowed to vote on this poll."
+msgstr ""
+
+msgid "You are not subscribed to this activity!"
+msgstr ""
+
+msgid "You cannot create new jobs in expired job packages."
+msgstr ""
+
+msgid "You cannot sign in to this account at this moment."
+msgstr ""
+
+msgid "You cannot subscribe to this activity at this moment in time"
+msgstr ""
+
+msgid "You cannot unsubscribe from this activity at this moment in time"
+msgstr ""
+
+msgid "You cannot update jobs in expired job packages."
+msgstr ""
+
+msgid ""
+"You cannot use this password, it was found in a public data breach and is "
+"therefore considered insecure. We recommend using a password generated by a "
+"good password manager, such as Bitwarden or 1Password."
+msgstr ""
+
+msgid "You do not have any recent jobs pending approval."
+msgstr ""
+
+msgid "You do not have recently approved jobs."
+msgstr ""
+
+msgid "You do not have recently rejected jobs."
+msgstr ""
+
+msgid "You do not have the required privileges to view this page"
+msgstr ""
+
+msgid "You have already been subscribed for this activity"
+msgstr ""
+
+#, php-format
+msgid "You have authorized %s for the %s GMM (%s)."
+msgstr ""
+
+msgid "You have not been a member of a committee or fraternity."
+msgstr ""
+
 msgid ""
 "You have successfully created an update proposal for the activity! If the "
 "activity was already approved, the proposal will be applied after it has "
@@ -4290,1229 +3620,38 @@ msgid ""
 "to the activity."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:143
-msgid "Update Activity"
+msgid "You have to be logged in to subscribe for this activity"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:188
-#: module/Activity/src/Controller/AdminController.php:200
-#: module/Activity/src/Controller/AdminController.php:212
-msgid "You are not allowed to view the participants of this activity"
+msgid "You might be able to view this page by logging in"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:273
-#: module/Activity/src/Controller/AdminController.php:364
-msgid "You are not allowed to use this form"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminController.php:310
-msgid "Successfully subscribed external participant"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminController.php:391
-msgid "Successfully removed external participant"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminController.php:399
-msgid "Use the form to unsubscribe an external participant"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminController.php:409
-msgid "You are not allowed to administer activities"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:41
-msgid "You are not allowed to administer option calendar periods"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:57
-msgid "You are not allowed to create option calendar periods"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:77
-msgid "Option planning period created successfully."
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:109
-msgid "You are not allowed to delete option calendar periods"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:124
-msgid "Past option planning periods cannot be deleted."
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:132
-msgid "Option planning period deleted."
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:145
-msgid "You are not allowed to edit option calendar periods"
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:161
-msgid "This option planning period cannot be edited."
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:185
-msgid "Option planning period has been updated."
-msgstr ""
-
-#: module/Activity/src/Controller/AdminOptionController.php:207
-msgid "Edit Option Period"
-msgstr ""
-
-#: module/Activity/src/Controller/ApiController.php:30
-msgid "You are not allowed to access the activities through the API"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:26
-msgid "Morning"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:27
-msgid "Lunch break"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:28
-msgid "Afternoon"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:29
-msgid "Evening"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:31
-msgid "Multiple days"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:60
-msgid "Select a type"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:84
-msgid "The activity must start before it ends"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:97
-msgid "The activity must start after today"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:30
-msgid "Start date and time of planning period"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:41
-msgid "End date and time of planning period"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:52
-msgid "Start date and time of option period"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:63
-msgid "End date and time of option period"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:89
-msgid "Create Option Period"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:126
-msgid "The planning period must end after it starts."
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:149
-msgid "The option period must start after the planning period ends."
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:172
-msgid "The option period must end after it starts."
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:63
-msgid "Select a period"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:78
-msgid "Select an option"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:128
-#: module/Activity/src/Form/ActivityCalendarProposal.php:142
-#: module/Activity/src/Form/ActivityCalendarProposal.php:150
-#: module/Activity/src/Form/Activity.php:282
-#: module/Activity/src/Form/Activity.php:294
-#: module/Activity/src/Form/Activity.php:308
-#: module/Activity/src/Form/Activity.php:320
-#: module/Activity/src/Form/Activity.php:335
-#: module/Activity/src/Form/Activity.php:350
-#: module/Education/src/Form/Bulk.php:57
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:165
-msgid "Option should end after it starts."
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:176
-msgid "Option does not fall within option period (also check the end date)."
-msgstr ""
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:220
-msgid "The activity does now have an acceptable amount of options"
-msgstr ""
-
-#: module/Activity/src/Form/Activity.php:35
-msgid "No organ"
-msgstr ""
-
-#: module/Activity/src/Form/Activity.php:36
-msgid "No Company"
-msgstr ""
-
-#: module/Activity/src/Form/Activity.php:373
-msgid ""
-"The sign-up list closing date and time must be before the activity starts."
-msgstr ""
-
-#: module/Activity/src/Form/Activity.php:409
-msgid "The activity must start before it ends."
-msgstr ""
-
-#: module/Activity/src/Form/SignupListField.php:90
-#: module/Activity/src/Form/SignupListField.php:103
-msgid "Option 1, Option 2, ..."
-msgstr ""
-
-#: module/Activity/src/Form/SignupListField.php:160
-msgid "Some of the required fields for this type are empty"
-msgstr ""
-
-#: module/Activity/src/Form/SignupListField.php:191
-msgid "The number of English options must equal the number of Dutch options"
-msgstr ""
-
-#: module/Activity/src/Form/SignupList.php:180
-msgid ""
-"The sign-up list opening date and time must be before the sign-up list "
-"closes."
-msgstr ""
-
-#: module/Activity/src/Service/ActivityCalendar.php:169
-msgid "You are not allowed to approve this option"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityCalendar.php:209
-msgid "You are not allowed to delete this option"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityCategory.php:31
-#: module/Activity/src/Service/ActivityCategory.php:47
-msgid "You are not allowed to view activity categories"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityCategory.php:105
-msgid "You are not allowed to delete an activity category"
-msgstr ""
-
-#: module/Activity/src/Service/Activity.php:66
-#: module/Activity/src/Service/Activity.php:105
-msgid "You are not allowed to create an activity"
-msgstr ""
-
-#: module/Activity/src/Service/Activity.php:145
-msgid "You are not allowed to create an activity for this organ"
-msgstr ""
-
-#: module/Activity/src/Service/Activity.php:406
-msgid "You are not allowed to create activity option proposals"
-msgstr ""
-
-#: module/Activity/src/Service/Activity.php:754
-#: module/Activity/src/Service/Activity.php:772
-#: module/Activity/src/Service/Activity.php:790
-msgid "You are not allowed to change the status of the activity"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityQuery.php:86
-msgid "You are not allowed to view this activity"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityQuery.php:102
-#: module/Activity/src/Service/ActivityQuery.php:262
-#: module/Activity/src/Service/Signup.php:128
-msgid "You are not allowed to view the activities"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityQuery.php:117
-msgid "You are not allowed to view unapproved activities"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityQuery.php:132
-msgid "You are not allowed to view activities"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityQuery.php:159
-msgid "You are not allowed to view the disapproved activities"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityQuery.php:177
-msgid "You are not allowed to view upcoming the activities"
-msgstr ""
-
-#: module/Activity/src/Service/ActivityQuery.php:185
-msgid ""
-"You are not allowed to view upcoming activities coupled to a member account"
-msgstr ""
-
-#: module/Activity/src/Service/SignupListQuery.php:26
-msgid "You are not allowed to view sign-up lists"
-msgstr ""
-
-#: module/Activity/src/Service/Signup.php:47
-#: module/Activity/src/Service/Signup.php:147
-msgid "You need to be logged in to sign up for this activity"
-msgstr ""
-
-#: module/Activity/src/Service/Signup.php:61
-msgid "You are not allowed to use the external admin signup"
-msgstr ""
-
-#: module/Activity/src/Service/Signup.php:75
-msgid "You are not allowed to use the external signup"
-msgstr ""
-
-#: module/Activity/src/Service/Signup.php:96
-msgid "You are not allowed to view the sign up data"
-msgstr ""
-
-#: module/Activity/src/Service/Signup.php:229
-msgid "You are not allowed to subscribe an external user to this sign-up list"
-msgstr ""
-
-#: module/Activity/src/Service/Signup.php:276
-msgid "You are not allowed to subscribe to this sign-up list"
-msgstr ""
-
-#: module/Activity/src/Service/Signup.php:292
 msgid "You need to be logged in to sign off for this activity"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:333
-msgid "You are not allowed to remove external signups for this activity"
+msgid "You need to be logged in to sign up for this activity"
 msgstr ""
 
-#: module/Application/src/Service/FileStorage.php:91
-msgid "An unknown error occurred during uploading (%i)"
+msgid "You need to log in to subscribe"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:45
-#: module/Company/src/Controller/AdminApprovalController.php:71
-msgid "You are not allowed to view the approval status of jobs"
+msgid "You were a member of:"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:89
-msgid "Approve Job"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:93
-msgid "Disapprove Job"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:97
-msgid "Reset Approval Status"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:107
-msgid "You are not allowed to change the approval status of jobs"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:141
-msgid "Job approved!"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:149
-msgid "Job disapproved!"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:153
-msgid "Job approval status reset!"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:164
-#: module/Company/src/Controller/AdminApprovalController.php:194
-msgid "You are not allowed to approve update proposals of jobs"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:180
-msgid "Apply Update"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:184
-msgid "Reject Update"
-msgstr ""
-
-#: module/Company/src/Controller/AdminApprovalController.php:218
 msgid ""
-"An unknown error occurred while try to change the status of a job update "
-"proposal. Please try again."
+"Your account for the GEWIS website has been registered, check your inbox for "
+"an activation e-mail."
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:230
-msgid "Job has been updated!"
+msgid "Your account has been activated. You are now able to login."
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:238
-msgid "Job update has been rejected!"
+msgid "Your option has been added successfully"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:47
-msgid "You are not allowed to administer career settings"
+msgid "Your password"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:80
-msgid "You are not allowed to create companies"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:123
-msgid "You are not allowed to edit companies"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:190
-#: module/Company/src/Service/Company.php:856
-msgid "You are not allowed to delete companies"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:215
-msgid "You are not allowed to create packages"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:284
-#: module/Company/src/Service/Company.php:905
-msgid "You are not allowed to edit packages"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:372
-#: module/Company/src/Service/Company.php:741
-msgid "You are not allowed to delete packages"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:414
-#: module/Company/src/Controller/CompanyAccountController.php:120
-msgid "You are not allowed to create jobs"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:453
-msgid "Job successfully created!"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:493
-#: module/Company/src/Controller/CompanyAccountController.php:203
-#: module/Company/src/Service/Company.php:931
-#: module/Company/src/Service/Company.php:1002
-msgid "You are not allowed to edit jobs"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:532
-msgid "Job successfully edited!"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:568
-#: module/Company/src/Controller/CompanyAccountController.php:310
-msgid "You are not allowed to delete jobs"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:610
-msgid "You are not allowed to create job categories"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:629
-msgid "Job category successfully created!"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:665
-#: module/Company/src/Service/Company.php:881
-msgid "You are not allowed to edit job categories"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:705
-msgid "You are not allowed to create job labels"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:724
-msgid "Job label successfully created!"
-msgstr ""
-
-#: module/Company/src/Controller/AdminController.php:758
-#: module/Company/src/Service/Company.php:893
-msgid "You are not allowed to edit job labels"
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:47
-#: module/Company/src/Controller/CompanyAccountController.php:58
-#: module/Company/src/Controller/CompanyAccountController.php:69
-msgid "You are not allowed to view the company accounts"
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:143
-msgid "You cannot create new jobs in expired job packages."
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:166
-msgid ""
-"Job proposal successfully created! It will become active after it has been "
-"approved."
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:223
-msgid "You cannot update jobs in expired job packages."
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:249
-msgid ""
-"Update proposal for job successfully created! It will become active after it "
-"has been approved."
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:335
-msgid "Job successfully deleted."
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:344
-msgid "You are not allowed to view the status of a job"
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:369
-msgid "You are not allowed to transfer jobs"
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:406
-msgid "Jobs successfully transferred"
-msgstr ""
-
-#: module/Company/src/Controller/CompanyAccountController.php:417
-msgid ""
-"An unknown error occurred while trying to transfer jobs, please try again."
-msgstr ""
-
-#: module/Company/src/Form/Company.php:71
-msgid "Logo"
-msgstr ""
-
-#: module/Company/src/Form/Company.php:81 module/Company/src/Form/Job.php:91
-#: module/Company/src/Form/Package.php:66
-msgid "Published"
-msgstr ""
-
-#: module/Company/src/Form/Company.php:103
-#: module/Company/src/Form/Company.php:133 module/Company/src/Form/Job.php:116
-msgid "E-mail Address"
-msgstr ""
-
-#: module/Company/src/Form/Company.php:123
-msgid "Address"
-msgstr ""
-
-#: module/Company/src/Form/Company.php:143 module/Company/src/Form/Job.php:126
-msgid "Phone Number"
-msgstr ""
-
-#: module/Company/src/Form/Company.php:154
-#: module/Company/src/Form/Company.php:164
-msgid "Slogan"
-msgstr ""
-
-#: module/Company/src/Form/Company.php:261
-#: module/Company/src/Form/JobCategory.php:194
-#: module/Company/src/Form/Job.php:282
-msgid "This slug is already taken"
-msgstr ""
-
-#: module/Company/src/Form/Company.php:272
-#: module/Company/src/Form/JobCategory.php:204
-#: module/Company/src/Form/Job.php:293
-msgid "This slug contains invalid characters"
-msgstr ""
-
-#: module/Company/src/Form/Company.php:346
-msgid "E-mail address format is not valid."
-msgstr ""
-
-#: module/Company/src/Form/Company.php:356
-msgid "The e-mail address must be unique across companies."
-msgstr ""
-
-#: module/Company/src/Form/Company.php:400 module/Company/src/Form/Job.php:341
-#: module/User/src/Form/CompanyUserLogin.php:125
-#: module/User/src/Form/CompanyUserReset.php:64
-#: module/User/src/Form/UserReset.php:93
-msgid "E-mail address format is not valid"
-msgstr ""
-
-#: module/Company/src/Form/JobCategory.php:65
-#: module/Company/src/Form/JobCategory.php:75
-msgid "Name (Plural)"
-msgstr ""
-
-#: module/Company/src/Form/JobCategory.php:105
-msgid "Hidden"
-msgstr ""
-
-#: module/Company/src/Form/Job.php:80
-msgid "Select a job category"
-msgstr ""
-
-#: module/Company/src/Form/JobsTransfer.php:38
-msgid "Select a target job package"
-msgstr ""
-
-#: module/Company/src/Form/Package.php:38
-msgid "Start Date"
-msgstr ""
-
-#: module/Company/src/Form/Package.php:52
-msgid "Expiration Date"
-msgstr ""
-
-#: module/Company/src/Form/Package.php:90
-#: module/Company/src/Form/Package.php:100
-msgid "Article"
-msgstr ""
-
-#: module/Company/src/Form/Package.php:179
-msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
-msgstr ""
-
-#: module/Company/src/Service/Company.php:92
-msgid "You are not allowed to view the banner"
-msgstr ""
-
-#: module/Company/src/Service/Company.php:102
-msgid "You are not allowed to view the featured company"
-msgstr ""
-
-#: module/Company/src/Service/Company.php:170
-#: module/Company/src/Service/Company.php:190
-#: module/Company/src/Service/Company.php:218
-msgid "You are not allowed to list the companies"
-msgstr ""
-
-#: module/Company/src/Service/Company.php:205
-msgid "You are not allowed to access the admin interface"
-msgstr ""
-
-#: module/Company/src/Service/Company.php:948
-msgid "You are not allowed to edit categories"
-msgstr ""
-
-#: module/Company/src/Service/Company.php:965
-msgid "You are not allowed to edit labels"
-msgstr ""
-
-#: module/Company/src/Service/Company.php:1015
-msgid "You are not allowed to create a company"
-msgstr ""
-
-#: module/Company/src/Service/CompanyQuery.php:98
-msgid "You are not allowed to list all job categories"
-msgstr ""
-
-#: module/Company/src/Service/CompanyQuery.php:106
-msgid "You are not allowed to list job categories"
-msgstr ""
-
-#: module/Company/src/Service/CompanyQuery.php:146
-msgid "You are not allowed to list all job labels"
-msgstr ""
-
-#: module/Company/src/Service/CompanyQuery.php:154
-msgid "You are not allowed to list job labels"
-msgstr ""
-
-#: module/Decision/src/Controller/AdminController.php:55
-msgid "Meeting minutes uploaded"
-msgstr ""
-
-#: module/Decision/src/Controller/AdminController.php:137
-msgid "You are not allowed to rename meeting documents"
-msgstr ""
-
-#: module/Decision/src/Controller/AdminController.php:177
-#: module/Decision/src/Service/Decision.php:279
-msgid "You are not allowed to delete meeting documents."
-msgstr ""
-
-#: module/Decision/src/Controller/DecisionController.php:109
-msgid "You are not allowed to search decisions."
-msgstr ""
-
-#: module/Decision/src/Controller/DecisionController.php:142
-msgid "You are not allowed to authorize someone"
-msgstr ""
-
-#: module/Decision/src/Controller/DecisionController.php:190
-#: module/Decision/src/Service/Decision.php:571
-msgid "You are not allowed to revoke authorizations."
-msgstr ""
-
-#: module/Decision/src/Controller/DecisionController.php:219
-msgid "You are not allowed to browse files."
-msgstr ""
-
-#: module/Decision/src/Controller/MemberController.php:40
-#: module/Decision/src/Service/Decision.php:137
-msgid "You are not allowed to view meetings."
-msgstr ""
-
-#: module/Decision/src/Controller/MemberController.php:98
-msgid "Not allowed to search for members."
-msgstr ""
-
-#: module/Decision/src/Controller/MemberController.php:151
-msgid "You are not allowed to view the list of birthdays."
-msgstr ""
-
-#: module/Decision/src/Form/AuthorizationRevocation.php:42
-msgid "Revoke authorization"
-msgstr ""
-
-#: module/Decision/src/Form/Document.php:39
-msgid "Document name"
-msgstr ""
-
-#: module/Decision/src/Form/Document.php:49
-msgid "Document to upload"
-msgstr ""
-
-#: module/Decision/src/Form/Document.php:59
-msgid "Upload document"
-msgstr ""
-
-#: module/Decision/src/Form/Minutes.php:34
-msgid "Choose a meeting"
-msgstr ""
-
-#: module/Decision/src/Form/Minutes.php:45
-msgid "Minutes to upload"
-msgstr ""
-
-#: module/Decision/src/Form/Minutes.php:94
-msgid "There already are minutes for this meeting"
-msgstr ""
-
-#: module/Decision/src/Form/OrganInformation.php:52
-msgid "Short dutch description"
-msgstr ""
-
-#: module/Decision/src/Form/OrganInformation.php:62
-msgid "Short english description"
-msgstr ""
-
-#: module/Decision/src/Form/OrganInformation.php:72
-msgid "Long dutch description"
-msgstr ""
-
-#: module/Decision/src/Form/OrganInformation.php:82
-msgid "Long english description"
-msgstr ""
-
-#: module/Decision/src/Form/OrganInformation.php:92
-msgid "Thumbnail photo to upload"
-msgstr ""
-
-#: module/Decision/src/Form/OrganInformation.php:102
-msgid "Cover photo to upload"
-msgstr ""
-
-#: module/Decision/src/Form/ReorderDocument.php:46
-msgid "Move up"
-msgstr ""
-
-#: module/Decision/src/Form/ReorderDocument.php:50
-msgid "Move down"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:21
-msgid "Home address (parents)"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:22
-msgid "Student address"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:23
-msgid "Mail address"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:22
-msgid "Board Meeting"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:23
-msgid "General Members Meeting"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:24
-msgid "Chair's Meeting"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:25
-msgid "Virtual Meeting"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:32
-msgid "BM"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:33
-msgid "GMM"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:34
-msgid "CM"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:35
-msgid "VIRT"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:22
-msgid "Ordinary"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:24
-msgid "Graduate"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:25
-msgid "Honorary"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:24
-msgid "Committee"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:25
-msgid "GMM Committee"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:26
-msgid "Fraternity"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:27
-msgid "Financial Audit Committee"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:28
-msgid "GMM Taskforce"
-msgstr ""
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:29
-msgid "Advisory Board"
-msgstr ""
-
-#: module/Decision/src/Service/Decision.php:90
-#: module/Decision/src/Service/Decision.php:109
-#: module/Decision/src/Service/Decision.php:121
-msgid "You are not allowed to list meetings."
-msgstr ""
-
-#: module/Decision/src/Service/Decision.php:178
-msgid "You are not allowed to view meeting documents."
-msgstr ""
-
-#: module/Decision/src/Service/Decision.php:195
-msgid "You are not allowed to view meeting minutes."
-msgstr ""
-
-#: module/Decision/src/Service/Decision.php:388
-msgid "You are not allowed to view all authorizations."
-msgstr ""
-
-#: module/Decision/src/Service/Decision.php:404
-msgid "You are not allowed to view authorizations."
-msgstr ""
-
-#: module/Decision/src/Service/Decision.php:514
-msgid "You are not allowed to upload meeting minutes."
-msgstr ""
-
-#: module/Decision/src/Service/Decision.php:528
-msgid "You are not allowed to upload meeting documents."
-msgstr ""
-
-#: module/Decision/src/Service/Decision.php:558
-msgid "You are not allowed authorize people."
-msgstr ""
-
-#: module/Decision/src/Service/MemberInfo.php:65
-msgid "You are not allowed to view membership info."
-msgstr ""
-
-#: module/Decision/src/Service/MemberInfo.php:69
-#: module/Decision/src/Service/Member.php:50
-msgid "You are not allowed to view members."
-msgstr ""
-
-#: module/Decision/src/Service/Organ.php:66
-msgid "Not allowed to view the list of organs"
-msgstr ""
-
-#: module/Decision/src/Service/Organ.php:78
-msgid "Not allowed to view organ information"
-msgstr ""
-
-#: module/Decision/src/Service/Organ.php:93
-msgid "You are not allowed to edit organ information"
-msgstr ""
-
-#: module/Decision/src/Service/Organ.php:305
-msgid "You are not allowed to edit this organ's information"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:41
-msgid "You are not allowed to administer education settings"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:51
-msgid "You are not allowed to administer courses"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:60
-#: module/Education/src/Service/Exam.php:473
-msgid "You are not allowed to add courses"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:76
-msgid "Successfully added course!"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:83
-#: module/Education/src/Controller/AdminController.php:125
-msgid "An error occurred while saving the course!"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:98
-#: module/Education/src/Controller/AdminController.php:162
-msgid "You are not allowed to edit courses"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:121
-msgid "Successfully updated course information!"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:140
-msgid "You are not allowed to delete courses"
-msgstr ""
-
-#: module/Education/src/Controller/AdminController.php:183
-msgid "You are not allowed to delete course documents"
-msgstr ""
-
-#: module/Education/src/Form/Bulk.php:43
-msgid "Finalize uploads"
-msgstr ""
-
-#: module/Education/src/Form/Bulk.php:64
-msgid "Course does not exist"
-msgstr ""
-
-#: module/Education/src/Form/Course.php:53
-msgid "Add course"
-msgstr ""
-
-#: module/Education/src/Form/Course.php:84
-msgid "There already exists a course with this code"
-msgstr ""
-
-#: module/Education/src/Form/Fieldset/Exam.php:57
-msgid "Exam date"
-msgstr ""
-
-#: module/Education/src/Form/Fieldset/Exam.php:98
-#: module/Education/src/Form/Fieldset/Summary.php:92
-msgid "Scanned?"
-msgstr ""
-
-#: module/Education/src/Form/Fieldset/Summary.php:57
-msgid "Summary date"
-msgstr ""
-
-#: module/Education/src/Form/TempUpload.php:25
-msgid "Exam to upload"
-msgstr ""
-
-#: module/Education/src/Model/Enums/ExamTypes.php:25
-msgid "Final"
-msgstr ""
-
-#: module/Education/src/Model/Enums/ExamTypes.php:26
-msgid "Interim"
-msgstr ""
-
-#: module/Education/src/Model/Enums/ExamTypes.php:27
-msgid "Answers"
-msgstr ""
-
-#: module/Education/src/Model/Enums/ExamTypes.php:28
-msgid "Other"
-msgstr ""
-
-#: module/Education/src/Service/Exam.php:98
-msgid "You are not allowed to download course documents"
-msgstr ""
-
-#: module/Education/src/Service/Exam.php:318
-msgid "You are not allowed to delete exams"
-msgstr ""
-
-#: module/Education/src/Service/Exam.php:334
-#: module/Education/src/Service/Exam.php:456
-msgid "You are not allowed to upload exams"
-msgstr ""
-
-#: module/Frontpage/src/Controller/InfimumController.php:26
-msgid "You are not allowed to view infima"
-msgstr ""
-
-#: module/Frontpage/src/Controller/NewsAdminController.php:51
-msgid "You are not allowed to create news items"
-msgstr ""
-
-#: module/Frontpage/src/Controller/NewsAdminController.php:88
-msgid "You are not allowed to edit news items"
-msgstr ""
-
-#: module/Frontpage/src/Controller/NewsAdminController.php:133
-msgid "You are not allowed to delete news items"
-msgstr ""
-
-#: module/Frontpage/src/Controller/PageAdminController.php:31
-#: module/Frontpage/src/Service/Page.php:107
-msgid "You are not allowed to view the list of pages."
-msgstr ""
-
-#: module/Frontpage/src/Controller/PageAdminController.php:46
-#: module/Frontpage/src/Service/Page.php:260
-msgid "You are not allowed to create new pages."
-msgstr ""
-
-#: module/Frontpage/src/Controller/PageAdminController.php:77
-#: module/Frontpage/src/Service/Page.php:193
-msgid "You are not allowed to edit pages."
-msgstr ""
-
-#: module/Frontpage/src/Controller/PageAdminController.php:104
-msgid "You are not allowed to delete pages."
-msgstr ""
-
-#: module/Frontpage/src/Controller/PageAdminController.php:121
-msgid "You are not allowed to upload images."
-msgstr ""
-
-#: module/Frontpage/src/Controller/PollAdminController.php:32
-msgid "You are not allowed to administer polls"
-msgstr ""
-
-#: module/Frontpage/src/Controller/PollAdminController.php:64
-msgid "You are not allowed to approve polls"
-msgstr ""
-
-#: module/Frontpage/src/Controller/PollAdminController.php:96
-msgid "You are not allowed to delete polls"
-msgstr ""
-
-#: module/Frontpage/src/Controller/PollController.php:96
-msgid "You are not allowed to create comments on this poll"
-msgstr ""
-
-#: module/Frontpage/src/Form/NewsItem.php:27
-#: module/Frontpage/src/Form/Page.php:49
-msgid "Dutch title"
-msgstr ""
-
-#: module/Frontpage/src/Form/NewsItem.php:37
-#: module/Frontpage/src/Form/Page.php:59
-msgid "English title"
-msgstr ""
-
-#: module/Frontpage/src/Form/Page.php:89
-msgid "Required role"
-msgstr ""
-
-#: module/Frontpage/src/Form/PollApproval.php:25
-msgid "Expiration date for the poll (YYYY-MM-DD)"
-msgstr ""
-
-#: module/Frontpage/src/Form/PollComment.php:37
-msgid "Content"
-msgstr ""
-
-#: module/Frontpage/src/Form/PollComment.php:47
-msgid "Comment"
-msgstr ""
-
-#: module/Frontpage/src/Service/News.php:45
-msgid "You are not allowed to list all news items."
-msgstr ""
-
-#: module/Frontpage/src/Service/Page.php:56
-msgid "You are not allowed to view this page."
-msgstr ""
-
-#: module/Frontpage/src/Service/Page.php:244
-#: module/Photo/src/Service/Admin.php:212
-msgid "The uploaded file does not have a valid extension"
-msgstr ""
-
-#: module/Frontpage/src/Service/Page.php:249
-msgid "The uploaded file is not a valid image"
-msgstr ""
-
-#: module/Frontpage/src/Service/Poll.php:71
-msgid "You are not allowed to view unapproved polls"
-msgstr ""
-
-#: module/Frontpage/src/Service/Poll.php:183
-msgid "You are not allowed to vote on this poll."
-msgstr ""
-
-#: module/Frontpage/src/Service/Poll.php:329
-msgid "You are not allowed to request polls"
-msgstr ""
-
-#: module/Photo/src/Controller/AlbumController.php:50
-#: module/Photo/src/Service/Album.php:122
-msgid "Not allowed to view albums without dates"
-msgstr ""
-
-#: module/Photo/src/Controller/ApiController.php:50
-msgid "Not allowed to view photo details"
-msgstr ""
-
-#: module/Photo/src/Controller/PhotoController.php:44
-#: module/Photo/src/Service/Album.php:67 module/Photo/src/Service/Album.php:99
-#: module/Photo/src/Service/Album.php:234
-#: module/Photo/src/Service/Album.php:248
-msgid "Not allowed to view albums"
-msgstr ""
-
-#: module/Photo/src/Controller/PhotoController.php:91
-#: module/Photo/src/Service/Photo.php:95
-msgid "Not allowed to download photos"
-msgstr ""
-
-#: module/Photo/src/Controller/PhotoController.php:106
-msgid "Not allowed to view previous photos of the week"
-msgstr ""
-
-#: module/Photo/src/Controller/PhotoController.php:163
-msgid "Not allowed to vote for a photo of the week"
-msgstr ""
-
-#: module/Photo/src/Controller/TagController.php:27
-msgid "Not allowed to add tags."
-msgstr ""
-
-#: module/Photo/src/Controller/TagController.php:53
-msgid "Not allowed to remove tags."
-msgstr ""
-
-#: module/Photo/src/Form/CreateAlbum.php:35
-msgid "Create"
-msgstr ""
-
-#: module/Photo/src/Form/EditAlbum.php:48
-msgid "End date"
-msgstr ""
-
-#: module/Photo/src/Service/Admin.php:66
-msgid "Not allowed to add photos."
-msgstr ""
-
-#: module/Photo/src/Service/Admin.php:185
-msgid "An unknown error occurred during uploading ("
-msgstr ""
-
-#: module/Photo/src/Service/Admin.php:201
-#, php-format
-msgid ""
-"The uploaded file is not a valid image \n"
-"Error: %s"
-msgstr ""
-
-#: module/Photo/src/Service/Admin.php:225
-msgid "Not allowed to upload photos."
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:191
-msgid "Not allowed to create albums"
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:213
-msgid "Not allowed to create albums."
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:327
-#, php-format
-msgid "Photos of the Week in %d/%d"
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:358
-msgid "Not allowed to edit albums"
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:376
-msgid "Not allowed to edit albums."
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:401
-msgid "Not allowed to move albums"
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:435
-msgid "Not allowed to delete albums."
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:456
-msgid "Not allowed to generate album covers."
-msgstr ""
-
-#: module/Photo/src/Service/Album.php:504
-msgid "Not allowed to move photos"
-msgstr ""
-
-#: module/Photo/src/Service/Photo.php:73 module/Photo/src/Service/Photo.php:114
-#: module/Photo/src/Service/Photo.php:159
-#: module/Photo/src/Service/Photo.php:210
-#: module/Photo/src/Service/Photo.php:226
-msgid "Not allowed to view photos"
-msgstr ""
-
-#: module/Photo/src/Service/Photo.php:245
-msgid "Not allowed to delete photos."
-msgstr ""
-
-#: module/Photo/src/Service/Photo.php:623
-#: module/Photo/src/Service/Photo.php:672
-msgid "Not allowed to view tags."
-msgstr ""
-
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:43
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:65
-#: module/User/src/Authentication/Adapter/UserAdapter.php:43
-#: module/User/src/Authentication/Adapter/UserAdapter.php:79
-msgid "The login and password combination is incorrect."
-msgstr ""
-
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:53
-#: module/User/src/Authentication/Adapter/UserAdapter.php:67
-msgid "Too many login attempts, try again later."
-msgstr ""
-
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:78
-#: module/User/src/Authentication/Adapter/UserAdapter.php:92
 msgid ""
 "Your password was found in a public data breach and is therefore considered "
 "insecure. Please request a password reset before continuing. We recommend "
@@ -5520,207 +3659,77 @@ msgid ""
 "1Password."
 msgstr ""
 
-#: module/User/src/Authentication/Adapter/UserAdapter.php:57
-msgid "You cannot sign in to this account at this moment."
+msgid "Your poll request has been received and will be reviewed shortly."
 msgstr ""
 
-#: module/User/src/Authorization/GenericAclService.php:108
-#: module/User/src/Authorization/GenericAclService.php:135
+msgid "Your profile picture will be chosen automatically instead."
+msgstr ""
+
+msgid "Zoek"
+msgstr ""
+
+msgid "Zoeken op lid"
+msgstr ""
+
+msgid "Zoom (z)"
+msgstr ""
+
+msgid "and"
+msgstr ""
+
+msgid "at"
+msgstr ""
+
+msgid "course"
+msgid_plural "courses"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "disabled"
+msgstr ""
+
+msgid "disabled (Do Not Track)"
+msgstr ""
+
+msgid "edit"
+msgstr ""
+
+msgid "email to the board of GEWIS"
+msgstr ""
+
+msgid "enabled"
+msgstr ""
+
+msgid "in the spotlight"
+msgstr ""
+
+msgid "new"
+msgstr ""
+
+msgid "of"
+msgstr ""
+
+msgid "old"
+msgstr ""
+
+#, php-format
+msgid "resolves to %s"
+msgstr ""
+
+msgid "the organizing party"
+msgstr ""
+
+msgid "the secretary of GEWIS"
+msgstr ""
+
 msgid ""
-"You are not allowed to perform this action. If you are not logged in please "
-"do so before continuing. If you are already logged in this action may "
-"require you to login in with a different account."
+"then this exam will be removed from the website. Using the summaries or "
+"exams on this website for commercial goals without the permission of the "
+"author is illegal."
 msgstr ""
 
-#: module/User/src/Controller/UserController.php:178
-msgid "You are not allowed to change passwords"
+msgid "unavailable"
 msgstr ""
 
-#: module/User/src/Form/Activate.php:29 module/User/src/Form/UserLogin.php:43
-msgid "Your password"
-msgstr ""
-
-#: module/User/src/Form/Activate.php:39
-msgid "Verify your password"
-msgstr ""
-
-#: module/User/src/Form/ApiAppAuthorisation.php:37
-msgid "Authorise"
-msgstr ""
-
-#: module/User/src/Form/CompanyUserLogin.php:34
-#: module/User/src/Form/CompanyUserReset.php:27
-msgid "Email address"
-msgstr ""
-
-#: module/User/src/Form/CompanyUserLogin.php:54
-msgid "Log in as company"
-msgstr ""
-
-#: module/User/src/Form/CompanyUserReset.php:37
-msgid "Request password reset"
-msgstr ""
-
-#: module/User/src/Form/Password.php:29
-msgid "Old password"
-msgstr ""
-
-#: module/User/src/Form/Password.php:39
-msgid "New password"
-msgstr ""
-
-#: module/User/src/Form/Password.php:49
-msgid "Verify new password"
-msgstr ""
-
-#: module/User/src/Form/Register.php:65
-msgid ""
-"This member cannot create an account, please contact the secretary for more "
-"information."
-msgstr ""
-
-#: module/User/src/Form/Register.php:73
-msgid "There is no member with this membership number."
-msgstr ""
-
-#: module/User/src/Form/Register.php:81
-msgid ""
-"You already attempted to register, please check your email or try again "
-"after 20 minutes."
-msgstr ""
-
-#: module/User/src/Form/Register.php:89
-msgid "This member already has an account."
-msgstr ""
-
-#: module/User/src/Form/UserLogin.php:33
-msgid "Membership number or email address"
-msgstr ""
-
-#: module/User/src/Form/UserLogin.php:53
-msgid "Log in as member"
-msgstr ""
-
-#: module/User/src/Form/UserLogin.php:63
-msgid "Remember me"
-msgstr ""
-
-#: module/User/src/Model/Enums/JWTClaims.php:40
-msgid "Family name"
-msgstr ""
-
-#: module/User/src/Model/Enums/JWTClaims.php:41
-msgid "Given name"
-msgstr ""
-
-#: module/User/src/Model/Enums/JWTClaims.php:42
-msgid "Is 18+?"
-msgstr ""
-
-#: module/User/src/Model/Enums/JWTClaims.php:43
-msgid "Member number"
-msgstr ""
-
-#: module/User/src/Service/ApiUser.php:46
-#: module/User/src/Service/ApiUser.php:74
-msgid "You are not allowed to view API tokens"
-msgstr ""
-
-#: module/User/src/Service/ApiUser.php:60
-msgid "You are not allowed to remove API tokens"
-msgstr ""
-
-#: module/User/src/Service/ApiUser.php:115
-msgid "You are not allowed to add API tokens"
-msgstr ""
-
-#: module/User/src/Service/User.php:105 module/User/src/Service/User.php:339
-msgid ""
-"You cannot use this password, it was found in a public data breach and is "
-"therefore considered insecure. We recommend using a password generated by a "
-"good password manager, such as Bitwarden or 1Password."
-msgstr ""
-
-#: module/User/src/Service/User.php:326
-msgid "Password incorrect"
-msgstr ""
-
-#: module/User/src/Service/User.php:481
-msgid "You are not allowed to change your password"
-msgstr ""
-
-#: module/Application/language/additional-strings:1
-msgid "Lid"
-msgstr ""
-
-#: module/Application/language/additional-strings:2
-msgid "Brand Manager"
-msgstr ""
-
-#: module/Application/language/additional-strings:3
-msgid "Commissaris Carrièreontwikkeling en Externe Betrekkingen"
-msgstr ""
-
-#: module/Application/language/additional-strings:4
-msgid "Commissaris Externe Betrekkingen"
-msgstr ""
-
-#: module/Application/language/additional-strings:5
-msgid "Commissaris Innovatie"
-msgstr ""
-
-#: module/Application/language/additional-strings:6
-msgid "Commissaris Interne Betrekkingen"
-msgstr ""
-
-#: module/Application/language/additional-strings:7
-msgid "Commissaris Kennisbeheer"
-msgstr ""
-
-#: module/Application/language/additional-strings:8
-msgid "Commissaris Onderwijs"
-msgstr ""
-
-#: module/Application/language/additional-strings:9
-msgid "Digital Infrastructure Officer"
-msgstr ""
-
-#: module/Application/language/additional-strings:10
-msgid "Onderwijscommissaris"
-msgstr ""
-
-#: module/Application/language/additional-strings:11
-msgid "Penningmeester"
-msgstr ""
-
-#: module/Application/language/additional-strings:12
-msgid "PR-Functionaris"
-msgstr ""
-
-#: module/Application/language/additional-strings:13
-msgid "Secretaris"
-msgstr ""
-
-#: module/Application/language/additional-strings:14
-msgid "Vicevoorzitter"
-msgstr ""
-
-#: module/Application/language/additional-strings:15
-msgid "Vice-Voorzitter"
-msgstr ""
-
-#: module/Application/language/additional-strings:16
-msgid "Voorzitter"
-msgstr ""
-
-#: module/Application/language/additional-strings:17
-msgid "Tafelvoetbalcoordinator"
-msgstr ""
-
-#: module/Application/language/additional-strings:18
-msgid "Inkoper"
-msgstr ""
-
-#: module/Application/language/additional-strings:19
-msgid "Inactief Lid"
+msgid "years"
 msgstr ""

--- a/module/Application/language/gewisweb.pot
+++ b/module/Application/language/gewisweb.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-22 13:08+0200\n"
+"POT-Creation-Date: 2023-06-25 00:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,174 +16,175 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: module/Activity/view/activity/activity/archive.phtml:20
-#: module/Photo/view/photo/photo/index.phtml:23
+#: module/Activity/view/activity/activity/archive.phtml:34
+#: module/Photo/view/photo/photo/index.phtml:36
 msgid "Older"
 msgstr ""
 
-#: module/Activity/view/activity/activity/archive.phtml:40
+#: module/Activity/view/activity/activity/archive.phtml:54
 msgid "There are no activities in the archive."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:5
+#: module/Activity/view/activity/activity-calendar/create.phtml:14
 msgid "Create activity proposal"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:21
-#: module/Activity/view/activity/activity-calendar/index.phtml:20
-#: module/Application/view/partial/main-nav.phtml:386
-#: module/Decision/view/decision/member/index.phtml:196
+#: module/Activity/view/activity/activity-calendar/create.phtml:30
+#: module/Activity/view/activity/activity-calendar/index.phtml:38
+#: module/Application/view/partial/main-nav.phtml:417
+#: module/Decision/view/decision/member/index.phtml:207
 msgid "Option calendar"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:22
+#: module/Activity/view/activity/activity-calendar/create.phtml:31
 msgid "Propose options for an activity"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:30
+#: module/Activity/view/activity/activity-calendar/create.phtml:39
 msgid "Organisation"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:31
-#: module/Activity/view/activity/activity-calendar/create.phtml:69
+#: module/Activity/view/activity/activity-calendar/create.phtml:40
+#: module/Activity/view/activity/activity-calendar/create.phtml:78
 msgid ""
 "Select the organ for which the options are and in which option period the "
 "options should be planned."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:40
+#: module/Activity/view/activity/activity-calendar/create.phtml:49
 msgid "Period"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:55
-#: module/Activity/view/activity/activity/create.phtml:49
+#: module/Activity/view/activity/activity-calendar/create.phtml:64
+#: module/Activity/view/activity/activity/create.phtml:62
 msgid "Committee / fraternity"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:68
-#: module/Activity/view/activity/admin/list.phtml:59
-#: module/Company/view/company/admin-approval/job-approval.phtml:86
-#: module/Company/view/company/admin-approval/job-proposal.phtml:130
-#: module/Company/view/company/admin/edit-package.phtml:97
-#: module/Company/view/company/company-account/jobs.phtml:215
+#: module/Activity/view/activity/activity-calendar/create.phtml:77
+#: module/Activity/view/activity/admin/list.phtml:67
+#: module/Company/view/company/admin-approval/job-approval.phtml:100
+#: module/Company/view/company/admin-approval/job-proposal.phtml:140
+#: module/Company/view/company/admin/edit-package.phtml:111
+#: module/Company/view/company/company-account/jobs.phtml:234
 msgid "Details"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:81
-#: module/Activity/view/activity/activity-calendar/index.phtml:46
-#: module/Activity/view/activity/activity/view.phtml:248
-#: module/Activity/view/activity/admin-approval/view.phtml:64
-#: module/Activity/view/activity/admin-approval/view.phtml:69
-#: module/Activity/view/activity/admin-approval/view.phtml:76
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:112
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:117
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:129
-#: module/Activity/view/activity/admin-category/add.phtml:56
-#: module/Activity/view/activity/admin-category/add.phtml:93
-#: module/Activity/view/activity/admin/participantsTable.phtml:11
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:5
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:10
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:17
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:89
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:94
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:101
-#: module/Activity/view/partial/create.phtml:31
-#: module/Activity/view/partial/create.phtml:105
-#: module/Activity/view/partial/signuplist.phtml:41
-#: module/Activity/view/partial/signuplist.phtml:57
-#: module/Company/view/company/admin-approval/index.phtml:14
-#: module/Company/view/company/admin-approval/job-approval.phtml:52
-#: module/Company/view/company/admin-approval/job-approval.phtml:56
-#: module/Company/view/company/admin-approval/job-approval.phtml:105
-#: module/Company/view/company/admin-approval/job-approval.phtml:110
-#: module/Company/view/company/admin-approval/job-approval.phtml:117
-#: module/Company/view/company/admin-approval/job-proposal.phtml:87
-#: module/Company/view/company/admin-approval/job-proposal.phtml:91
-#: module/Company/view/company/admin-approval/job-proposal.phtml:149
-#: module/Company/view/company/admin-approval/job-proposal.phtml:154
+#: module/Activity/view/activity/activity-calendar/create.phtml:90
+#: module/Activity/view/activity/activity-calendar/index.phtml:64
+#: module/Activity/view/activity/activity/view.phtml:268
+#: module/Activity/view/activity/admin-approval/view.phtml:80
+#: module/Activity/view/activity/admin-approval/view.phtml:85
+#: module/Activity/view/activity/admin-approval/view.phtml:92
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:133
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:138
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:150
+#: module/Activity/view/activity/admin-category/add.phtml:69
+#: module/Activity/view/activity/admin-category/add.phtml:106
+#: module/Activity/view/activity/admin/participantsTable.phtml:20
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:18
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:23
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:30
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:102
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:107
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:114
+#: module/Activity/view/partial/create.phtml:44
+#: module/Activity/view/partial/create.phtml:118
+#: module/Activity/view/partial/signuplist.phtml:54
+#: module/Activity/view/partial/signuplist.phtml:70
+#: module/Company/view/company/admin-approval/index.phtml:30
+#: module/Company/view/company/admin-approval/job-approval.phtml:66
+#: module/Company/view/company/admin-approval/job-approval.phtml:70
+#: module/Company/view/company/admin-approval/job-approval.phtml:119
+#: module/Company/view/company/admin-approval/job-approval.phtml:124
+#: module/Company/view/company/admin-approval/job-approval.phtml:131
+#: module/Company/view/company/admin-approval/job-proposal.phtml:97
+#: module/Company/view/company/admin-approval/job-proposal.phtml:101
+#: module/Company/view/company/admin-approval/job-proposal.phtml:159
 #: module/Company/view/company/admin-approval/job-proposal.phtml:164
-#: module/Company/view/company/admin/edit-package.phtml:69
-#: module/Company/view/company/admin/index.phtml:112
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:177
-#: module/Decision/view/decision/admin/document.phtml:57
-#: module/Decision/view/decision/member/birthdays.phtml:12
-#: module/Decision/view/decision/organ-admin/index.phtml:12
-#: module/Decision/view/decision/organ/index.phtml:14
-#: module/Education/view/education/admin/course.phtml:32
-#: module/Photo/view/photo/album-admin/edit.phtml:23
-#: module/User/view/user/api-admin/add.phtml:45
-#: module/User/view/user/api-admin/index.phtml:10
+#: module/Company/view/company/admin-approval/job-proposal.phtml:174
+#: module/Company/view/company/admin/edit-package.phtml:83
+#: module/Company/view/company/admin/index.phtml:126
+#: module/Company/view/company/admin/index.phtml:212
+#: module/Company/view/company/company-account/jobs.phtml:196
+#: module/Decision/view/decision/admin/document.phtml:71
+#: module/Decision/view/decision/member/birthdays.phtml:23
+#: module/Decision/view/decision/organ-admin/index.phtml:24
+#: module/Decision/view/decision/organ/index.phtml:23
+#: module/Education/view/education/admin/course.phtml:44
+#: module/Photo/view/photo/album-admin/edit.phtml:35
+#: module/User/view/user/api-admin/add.phtml:57
+#: module/User/view/user/api-admin/index.phtml:22
 #: module/Activity/src/Form/ActivityCategory.php:24
 #: module/Activity/src/Form/ActivityCategory.php:34
-#: module/Activity/src/Form/SignupListField.php:33
-#: module/Activity/src/Form/SignupListField.php:43
-#: module/Activity/src/Form/SignupList.php:36
-#: module/Activity/src/Form/SignupList.php:46
-#: module/Company/src/Form/Company.php:52
-#: module/Company/src/Form/Company.php:94
-#: module/Company/src/Form/Company.php:114
+#: module/Activity/src/Form/SignupListField.php:34
+#: module/Activity/src/Form/SignupListField.php:44
+#: module/Activity/src/Form/SignupList.php:35
+#: module/Activity/src/Form/SignupList.php:45
+#: module/Company/src/Form/Company.php:51
+#: module/Company/src/Form/Company.php:93
+#: module/Company/src/Form/Company.php:113
 #: module/Company/src/Form/JobCategory.php:45
 #: module/Company/src/Form/JobCategory.php:55
-#: module/Company/src/Form/JobLabel.php:32
-#: module/Company/src/Form/JobLabel.php:42 module/Company/src/Form/Job.php:102
-#: module/Company/src/Form/Job.php:133 module/Company/src/Form/Job.php:143
-#: module/Education/src/Form/Course.php:42 module/User/src/Form/ApiToken.php:25
+#: module/Company/src/Form/JobLabel.php:31
+#: module/Company/src/Form/JobLabel.php:41 module/Company/src/Form/Job.php:106
+#: module/Company/src/Form/Job.php:137 module/Company/src/Form/Job.php:147
+#: module/Education/src/Form/Course.php:43 module/User/src/Form/ApiToken.php:25
 msgid "Name"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:97
-#: module/Activity/view/activity/admin-approval/view.phtml:121
-#: module/Activity/view/activity/admin-approval/view.phtml:126
-#: module/Activity/view/activity/admin-approval/view.phtml:133
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:199
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:204
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:216
-#: module/Activity/view/partial/create.phtml:74
-#: module/Activity/view/partial/create.phtml:148
-#: module/Company/view/company/admin-approval/job-approval.phtml:162
-#: module/Company/view/company/admin-approval/job-approval.phtml:167
-#: module/Company/view/company/admin-approval/job-approval.phtml:174
-#: module/Company/view/company/admin-approval/job-proposal.phtml:224
-#: module/Company/view/company/admin-approval/job-proposal.phtml:229
+#: module/Activity/view/activity/activity-calendar/create.phtml:106
+#: module/Activity/view/activity/admin-approval/view.phtml:137
+#: module/Activity/view/activity/admin-approval/view.phtml:142
+#: module/Activity/view/activity/admin-approval/view.phtml:149
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:220
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:225
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:237
+#: module/Activity/view/partial/create.phtml:87
+#: module/Activity/view/partial/create.phtml:161
+#: module/Company/view/company/admin-approval/job-approval.phtml:176
+#: module/Company/view/company/admin-approval/job-approval.phtml:181
+#: module/Company/view/company/admin-approval/job-approval.phtml:188
+#: module/Company/view/company/admin-approval/job-proposal.phtml:234
 #: module/Company/view/company/admin-approval/job-proposal.phtml:239
-#: module/Company/view/company/company/jobs.phtml:128
-#: module/Company/view/partial/company/company/list/company.phtml:89
-#: module/Company/src/Form/Company.php:199
-#: module/Company/src/Form/Company.php:209 module/Company/src/Form/Job.php:197
-#: module/Company/src/Form/Job.php:207
+#: module/Company/view/company/admin-approval/job-proposal.phtml:249
+#: module/Company/view/company/company/jobs.phtml:140
+#: module/Company/view/partial/company/company/list/company.phtml:99
+#: module/Company/src/Form/Company.php:198
+#: module/Company/src/Form/Company.php:208 module/Company/src/Form/Job.php:201
+#: module/Company/src/Form/Job.php:211
 msgid "Description"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:110
-#: module/Activity/view/activity/activity-calendar/index.phtml:175
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:156
-#: module/Activity/view/partial/create.phtml:157
-#: module/Activity/src/Form/SignupListField.php:92
-#: module/Activity/src/Form/SignupListField.php:105
+#: module/Activity/view/activity/activity-calendar/create.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:193
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:169
+#: module/Activity/view/partial/create.phtml:170
+#: module/Activity/src/Form/SignupListField.php:93
+#: module/Activity/src/Form/SignupListField.php:106
 msgid "Options"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:111
+#: module/Activity/view/activity/activity-calendar/create.phtml:120
 msgid "Add options for your activity proposal."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:133
+#: module/Activity/view/activity/activity-calendar/create.phtml:142
 msgid "Add an option"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:137
+#: module/Activity/view/activity/activity-calendar/create.phtml:146
 msgid "Remove the last option"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:145
-#: module/Decision/src/Form/Minutes.php:53
+#: module/Activity/view/activity/activity-calendar/create.phtml:154
+#: module/Decision/src/Form/Minutes.php:55
 #: module/Frontpage/src/Form/Poll.php:63
 msgid "Submit"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:21
+#: module/Activity/view/activity/activity-calendar/index.phtml:39
 msgid ""
 "Welcome on the page of the digital Option Calendar. In the calendar below "
 "you can place options for GEWIS activities, just like you were used to do in "
@@ -193,17 +194,17 @@ msgid ""
 "name, so it is clear what the option is for."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:23
+#: module/Activity/view/activity/activity-calendar/index.phtml:41
 msgid "There are a few rules:"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:25
+#: module/Activity/view/activity/activity-calendar/index.phtml:43
 msgid ""
 "It is not allowed to put more than 3 options for the same activity in the "
 "calendar."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:26
+#: module/Activity/view/activity/activity-calendar/index.phtml:44
 msgid ""
 "The first to put an option for an activity on a particular date, has the "
 "first dibs to let the activity take place on this date. Five weeks before "
@@ -214,348 +215,348 @@ msgid ""
 "line gets the chance to use this date for an activity."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:27
+#: module/Activity/view/activity/activity-calendar/index.phtml:45
 msgid ""
 "The board can always decide to make an exception to the rules written above, "
 "for example in case of dependence on a third party, or when it concerns very "
 "big activities or weekends."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:33
+#: module/Activity/view/activity/activity-calendar/index.phtml:51
 msgid "Your option has been added successfully"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:41
+#: module/Activity/view/activity/activity-calendar/index.phtml:59
 msgid "My options"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:45
+#: module/Activity/view/activity/activity-calendar/index.phtml:63
 msgid "Creator"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:47
-#: module/Activity/view/activity/admin/participantsTable.phtml:13
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:108
-#: module/Activity/view/partial/option.phtml:10
-#: module/Decision/view/decision/decision/index.phtml:9
-#: module/Decision/view/decision/organ/index.phtml:15
-#: module/Education/view/education/admin/course-documents.phtml:58
-#: module/Activity/src/Form/SignupListField.php:59
-#: module/Education/src/Form/Fieldset/Exam.php:69
+#: module/Activity/view/activity/activity-calendar/index.phtml:65
+#: module/Activity/view/activity/admin/participantsTable.phtml:22
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
+#: module/Activity/view/partial/option.phtml:19
+#: module/Decision/view/decision/decision/index.phtml:23
+#: module/Decision/view/decision/organ/index.phtml:24
+#: module/Education/view/education/admin/course-documents.phtml:68
+#: module/Activity/src/Form/SignupListField.php:60
+#: module/Education/src/Form/Fieldset/Exam.php:68
 msgid "Type"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:48
-#: module/Activity/view/activity/activity/list.phtml:37
-#: module/Activity/view/activity/activity/view.phtml:70
+#: module/Activity/view/activity/activity-calendar/index.phtml:66
+#: module/Activity/view/activity/activity/list.phtml:50
+#: module/Activity/view/activity/activity/view.phtml:90
 msgid "Start"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:49
-#: module/Activity/view/activity/activity/list.phtml:39
-#: module/Activity/view/activity/activity/view.phtml:73
+#: module/Activity/view/activity/activity-calendar/index.phtml:67
+#: module/Activity/view/activity/activity/list.phtml:52
+#: module/Activity/view/activity/activity/view.phtml:93
 msgid "End"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:70
-#: module/Activity/view/activity/activity-calendar/index.phtml:103
-#: module/Activity/view/activity/admin-option/index.phtml:40
-#: module/Activity/view/activity/admin-option/index.phtml:90
-#: module/Activity/view/activity/admin-option/index.phtml:130
-#: module/Company/view/company/admin/edit-company.phtml:150
-#: module/Company/view/company/admin/edit-package.phtml:112
-#: module/Company/view/company/admin/index.phtml:190
-#: module/Company/view/company/company-account/jobs.phtml:235
-#: module/Decision/view/decision/admin/document.phtml:136
-#: module/Decision/view/decision/admin/document.phtml:167
-#: module/Education/view/education/admin/course-documents.phtml:82
-#: module/Education/view/education/admin/course-documents.phtml:131
-#: module/Education/view/education/admin/course-documents.phtml:166
-#: module/Education/view/education/admin/course.phtml:58
-#: module/Education/view/education/admin/course.phtml:93
-#: module/Education/view/education/admin/edit-exam.phtml:49
-#: module/Education/view/education/admin/edit-summary.phtml:49
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:73
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:143
+#: module/Activity/view/activity/activity-calendar/index.phtml:88
+#: module/Activity/view/activity/activity-calendar/index.phtml:121
+#: module/Activity/view/activity/admin-option/index.phtml:48
+#: module/Activity/view/activity/admin-option/index.phtml:98
+#: module/Activity/view/activity/admin-option/index.phtml:138
+#: module/Company/view/company/admin/edit-company.phtml:162
+#: module/Company/view/company/admin/edit-package.phtml:126
+#: module/Company/view/company/admin/index.phtml:204
+#: module/Company/view/company/company-account/jobs.phtml:254
+#: module/Decision/view/decision/admin/document.phtml:150
+#: module/Decision/view/decision/admin/document.phtml:181
+#: module/Education/view/education/admin/course-documents.phtml:92
+#: module/Education/view/education/admin/course-documents.phtml:141
+#: module/Education/view/education/admin/course-documents.phtml:176
+#: module/Education/view/education/admin/course.phtml:70
+#: module/Education/view/education/admin/course.phtml:105
+#: module/Education/view/education/admin/edit-exam.phtml:62
+#: module/Education/view/education/admin/edit-summary.phtml:62
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:88
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:158
 msgid "Delete"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:74
-#: module/Activity/view/activity/activity-calendar/index.phtml:127
-#: module/Activity/view/activity/admin-approval/view.phtml:192
-#: module/Decision/view/decision/organ-admin/edit.phtml:170
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:69
+#: module/Activity/view/activity/activity-calendar/index.phtml:92
+#: module/Activity/view/activity/activity-calendar/index.phtml:145
+#: module/Activity/view/activity/admin-approval/view.phtml:208
+#: module/Decision/view/decision/organ-admin/edit.phtml:181
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:84
 msgid "Approve"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:78
+#: module/Activity/view/activity/activity-calendar/index.phtml:96
 msgid "Modified by"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:92
+#: module/Activity/view/activity/activity-calendar/index.phtml:110
 msgid "Delete option"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:95
+#: module/Activity/view/activity/activity-calendar/index.phtml:113
 msgid "Are you sure you want to delete this option?"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:101
-#: module/Activity/view/activity/activity-calendar/index.phtml:125
-#: module/Activity/view/activity/admin-category/index.phtml:56
-#: module/Activity/view/activity/admin-option/index.phtml:127
-#: module/Company/view/company/admin/edit-company.phtml:202
-#: module/Company/view/company/admin/edit-package.phtml:146
-#: module/Company/view/company/admin/index.phtml:230
-#: module/Company/view/company/company-account/jobs.phtml:285
-#: module/Decision/view/decision/admin/document.phtml:164
-#: module/Decision/view/decision/admin/document.phtml:191
-#: module/Decision/view/decision/decision/authorizations.phtml:167
-#: module/Education/view/education/admin/course-documents.phtml:163
-#: module/Education/view/education/admin/course.phtml:90
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:171
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:217
-#: module/Photo/view/photo/album-admin/index.phtml:221
-#: module/Photo/view/photo/album-admin/index.phtml:253
-#: module/Photo/view/photo/photo-admin/index.phtml:140
+#: module/Activity/view/activity/activity-calendar/index.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:143
+#: module/Activity/view/activity/admin-category/index.phtml:64
+#: module/Activity/view/activity/admin-option/index.phtml:135
+#: module/Company/view/company/admin/edit-company.phtml:214
+#: module/Company/view/company/admin/edit-package.phtml:160
+#: module/Company/view/company/admin/index.phtml:244
+#: module/Company/view/company/company-account/jobs.phtml:304
+#: module/Decision/view/decision/admin/document.phtml:178
+#: module/Decision/view/decision/admin/document.phtml:205
+#: module/Decision/view/decision/decision/authorizations.phtml:185
+#: module/Education/view/education/admin/course-documents.phtml:173
+#: module/Education/view/education/admin/course.phtml:102
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:231
+#: module/Photo/view/photo/album-admin/index.phtml:232
+#: module/Photo/view/photo/album-admin/index.phtml:264
+#: module/Photo/view/photo/photo-admin/index.phtml:158
 #: module/User/src/Form/ApiAppAuthorisation.php:26
 msgid "Cancel"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:116
+#: module/Activity/view/activity/activity-calendar/index.phtml:134
 msgid "Approve option"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:137
 msgid "Are you sure you want to approve this option?"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:142
+#: module/Activity/view/activity/activity-calendar/index.phtml:160
 #: module/Activity/src/Form/ActivityCalendarOption.php:30
 msgid "Day"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:162
+#: module/Activity/view/activity/activity-calendar/index.phtml:180
 msgid "Planned Activities"
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:163
-#: module/Activity/view/activity/activity/list.phtml:55
+#: module/Activity/view/activity/activity-calendar/index.phtml:181
+#: module/Activity/view/activity/activity/list.phtml:68
 msgid "There are no activities."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:176
+#: module/Activity/view/activity/activity-calendar/index.phtml:194
 msgid "There are no options."
 msgstr ""
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:218
+#: module/Activity/view/activity/activity-calendar/index.phtml:236
 msgid "Plan activity"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:38
+#: module/Activity/view/activity/activity/create.phtml:51
 msgid "Organizer"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:39
+#: module/Activity/view/activity/activity/create.phtml:52
 msgid ""
 "Select whether an organ (committee, fraternity, etc.) or a company is "
 "responsible for this activity, or both."
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:63
-#: module/Activity/view/activity/admin/list.phtml:17
-#: module/Activity/view/activity/admin/view.phtml:57
-#: module/Company/view/company/admin-approval/index.phtml:42
-#: module/Company/view/company/company/job-list.phtml:71
-#: module/User/view/user/user/login.phtml:20
+#: module/Activity/view/activity/activity/create.phtml:76
+#: module/Activity/view/activity/admin/list.phtml:25
+#: module/Activity/view/activity/admin/view.phtml:74
+#: module/Company/view/company/admin-approval/index.phtml:58
+#: module/Company/view/company/company/job-list.phtml:85
+#: module/User/view/user/user/login.phtml:34
 msgid "Company"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:74
-#: module/Activity/view/activity/admin/participantsTable.phtml:16
+#: module/Activity/view/activity/activity/create.phtml:87
+#: module/Activity/view/activity/admin/participantsTable.phtml:25
 msgid "Date and time"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:75
+#: module/Activity/view/activity/activity/create.phtml:88
 msgid "Enter the start and end date and time of this activity."
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:88
+#: module/Activity/view/activity/activity/create.phtml:101
 msgid "Start date and time"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:103
+#: module/Activity/view/activity/activity/create.phtml:116
 msgid "End date and time"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:117
-#: module/Activity/view/activity/admin-approval/view.phtml:149
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:242
-#: module/Activity/view/activity/admin-category/add.phtml:4
-#: module/Activity/view/activity/admin-category/index.phtml:2
-#: module/Activity/view/activity/admin-category/index.phtml:6
-#: module/Activity/view/activity/admin-category/index.phtml:11
+#: module/Activity/view/activity/activity/create.phtml:130
+#: module/Activity/view/activity/admin-approval/view.phtml:165
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:263
+#: module/Activity/view/activity/admin-category/add.phtml:17
+#: module/Activity/view/activity/admin-category/index.phtml:10
+#: module/Activity/view/activity/admin-category/index.phtml:14
+#: module/Activity/view/activity/admin-category/index.phtml:19
 msgid "Activity Categories"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:118
+#: module/Activity/view/activity/activity/create.phtml:131
 msgid ""
 "Add activity categories to your activity to give potential subscribers a "
 "better understanding of the activity."
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:138
-#: module/Activity/view/activity/admin-category/index.phtml:16
+#: module/Activity/view/activity/activity/create.phtml:151
+#: module/Activity/view/activity/admin-category/index.phtml:24
 msgid "There are currently no activity categories..."
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:164
-#: module/Activity/view/activity/activity/view.phtml:114
-#: module/Activity/view/activity/admin-approval/view.phtml:163
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:269
+#: module/Activity/view/activity/activity/create.phtml:177
+#: module/Activity/view/activity/activity/view.phtml:134
+#: module/Activity/view/activity/admin-approval/view.phtml:179
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:290
 msgid "Sign-up Lists"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:165
+#: module/Activity/view/activity/activity/create.phtml:178
 msgid ""
 "Add sign-up lists to allow people to sign up for this activity. Each list "
 "can have optional fields to collect specific information from the "
 "participants."
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:171
-#: module/Activity/view/activity/admin-approval/view.phtml:51
-#: module/Activity/view/activity/admin-approval/view.phtml:169
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:99
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:279
-#: module/Activity/view/activity/admin-category/add.phtml:40
-#: module/Activity/view/partial/create.phtml:17
-#: module/Company/view/company/admin-approval/job-approval.phtml:92
-#: module/Company/view/company/admin-approval/job-proposal.phtml:136
-#: module/Company/view/partial/company/admin/editors/category.phtml:7
-#: module/Company/view/partial/company/admin/editors/company.phtml:205
-#: module/Company/view/partial/company/admin/editors/job.phtml:133
-#: module/Company/view/partial/company/admin/editors/label.phtml:16
-#: module/Company/view/partial/company/admin/editors/package.phtml:87
-#: module/Application/src/Model/Enums/Languages.php:19
+#: module/Activity/view/activity/activity/create.phtml:184
+#: module/Activity/view/activity/admin-approval/view.phtml:67
+#: module/Activity/view/activity/admin-approval/view.phtml:185
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:120
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:300
+#: module/Activity/view/activity/admin-category/add.phtml:53
+#: module/Activity/view/partial/create.phtml:30
+#: module/Company/view/company/admin-approval/job-approval.phtml:106
+#: module/Company/view/company/admin-approval/job-proposal.phtml:146
+#: module/Company/view/partial/company/admin/editors/category.phtml:20
+#: module/Company/view/partial/company/admin/editors/company.phtml:218
+#: module/Company/view/partial/company/admin/editors/job.phtml:146
+#: module/Company/view/partial/company/admin/editors/label.phtml:29
+#: module/Company/view/partial/company/admin/editors/package.phtml:96
+#: module/Application/src/Model/Enums/Languages.php:24
 msgid "Dutch"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:176
-#: module/Activity/view/activity/admin-approval/view.phtml:56
-#: module/Activity/view/activity/admin-approval/view.phtml:174
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:104
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:284
-#: module/Activity/view/activity/admin-category/add.phtml:77
-#: module/Activity/view/partial/create.phtml:91
-#: module/Company/view/company/admin-approval/job-approval.phtml:97
-#: module/Company/view/company/admin-approval/job-proposal.phtml:141
-#: module/Company/view/partial/company/admin/editors/category.phtml:52
-#: module/Company/view/partial/company/admin/editors/company.phtml:266
-#: module/Company/view/partial/company/admin/editors/job.phtml:227
-#: module/Company/view/partial/company/admin/editors/label.phtml:61
-#: module/Company/view/partial/company/admin/editors/package.phtml:119
-#: module/Application/src/Model/Enums/Languages.php:18
+#: module/Activity/view/activity/activity/create.phtml:189
+#: module/Activity/view/activity/admin-approval/view.phtml:72
+#: module/Activity/view/activity/admin-approval/view.phtml:190
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:125
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:305
+#: module/Activity/view/activity/admin-category/add.phtml:90
+#: module/Activity/view/partial/create.phtml:104
+#: module/Company/view/company/admin-approval/job-approval.phtml:111
+#: module/Company/view/company/admin-approval/job-proposal.phtml:151
+#: module/Company/view/partial/company/admin/editors/category.phtml:65
+#: module/Company/view/partial/company/admin/editors/company.phtml:279
+#: module/Company/view/partial/company/admin/editors/job.phtml:240
+#: module/Company/view/partial/company/admin/editors/label.phtml:74
+#: module/Company/view/partial/company/admin/editors/package.phtml:128
+#: module/Application/src/Model/Enums/Languages.php:23
 msgid "English"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:204
+#: module/Activity/view/activity/activity/create.phtml:217
 msgid "Remove the last sign-up list"
 msgstr ""
 
-#: module/Activity/view/activity/activity/create.phtml:208
+#: module/Activity/view/activity/activity/create.phtml:221
 msgid "Add a sign-up list"
 msgstr ""
 
-#: module/Activity/view/activity/activity/createSuccess.phtml:6
+#: module/Activity/view/activity/activity/createSuccess.phtml:15
 msgid "The activity has been successfully created."
 msgstr ""
 
-#: module/Activity/view/activity/activity/createSuccess.phtml:7
+#: module/Activity/view/activity/activity/createSuccess.phtml:16
 msgid "It will become visible after it has been approved by the board."
 msgstr ""
 
-#: module/Activity/view/activity/activity/index.phtml:2
-#: module/Activity/view/activity/activity/index.phtml:8
-#: module/Activity/view/activity/activity/view.phtml:10
-#: module/Activity/view/activity/activity/view.phtml:18
-#: module/Activity/view/activity/admin-approval/view.phtml:9
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:9
-#: module/Activity/view/activity/admin/participants.phtml:7
-#: module/Activity/view/activity/admin/view.phtml:3
-#: module/Application/view/partial/admin.phtml:32
-#: module/Application/view/partial/main-nav.phtml:350
-#: module/Application/view/partial/main-nav.phtml:354
-#: module/Application/view/partial/main-nav.phtml:359
-#: module/Decision/view/decision/member/index.phtml:192
+#: module/Activity/view/activity/activity/index.phtml:15
+#: module/Activity/view/activity/activity/index.phtml:21
+#: module/Activity/view/activity/activity/view.phtml:30
+#: module/Activity/view/activity/activity/view.phtml:38
+#: module/Activity/view/activity/admin-approval/view.phtml:22
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:24
+#: module/Activity/view/activity/admin/participants.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:19
+#: module/Application/view/partial/admin.phtml:38
+#: module/Application/view/partial/main-nav.phtml:374
+#: module/Application/view/partial/main-nav.phtml:378
+#: module/Application/view/partial/main-nav.phtml:383
+#: module/Decision/view/decision/member/index.phtml:203
 msgid "Activities"
 msgstr ""
 
-#: module/Activity/view/activity/activity/index.phtml:14
+#: module/Activity/view/activity/activity/index.phtml:27
 msgid "All Activities"
 msgstr ""
 
-#: module/Activity/view/activity/activity/index.phtml:17
+#: module/Activity/view/activity/activity/index.phtml:30
 msgid "Career Activities"
 msgstr ""
 
-#: module/Activity/view/activity/activity/index.phtml:21
+#: module/Activity/view/activity/activity/index.phtml:34
 msgid "My Activities"
 msgstr ""
 
-#: module/Activity/view/activity/activity/index.phtml:32
-#: module/Activity/src/Controller/ActivityController.php:236
+#: module/Activity/view/activity/activity/index.phtml:45
+#: module/Activity/src/Controller/ActivityController.php:228
 msgid "Create Activity"
 msgstr ""
 
-#: module/Activity/view/activity/activity/list.phtml:9
+#: module/Activity/view/activity/activity/list.phtml:22
 msgid "MMM d"
 msgstr ""
 
-#: module/Activity/view/activity/activity/list.phtml:33
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:61
+#: module/Activity/view/activity/activity/list.phtml:46
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:79
 msgid "Continue reading"
 msgstr ""
 
-#: module/Activity/view/activity/activity/list.phtml:42
-#: module/Activity/view/activity/activity/view.phtml:76
-#: module/Activity/view/activity/admin-approval/view.phtml:83
-#: module/Activity/view/activity/admin-approval/view.phtml:88
-#: module/Activity/view/activity/admin-approval/view.phtml:95
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:141
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:146
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:158
-#: module/Activity/view/partial/create.phtml:45
-#: module/Activity/view/partial/create.phtml:119
-#: module/Company/view/company/admin-approval/job-approval.phtml:143
-#: module/Company/view/company/admin-approval/job-approval.phtml:148
-#: module/Company/view/company/admin-approval/job-approval.phtml:155
-#: module/Company/view/company/admin-approval/job-proposal.phtml:199
-#: module/Company/view/company/admin-approval/job-proposal.phtml:204
+#: module/Activity/view/activity/activity/list.phtml:55
+#: module/Activity/view/activity/activity/view.phtml:96
+#: module/Activity/view/activity/admin-approval/view.phtml:99
+#: module/Activity/view/activity/admin-approval/view.phtml:104
+#: module/Activity/view/activity/admin-approval/view.phtml:111
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:162
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:167
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:179
+#: module/Activity/view/partial/create.phtml:58
+#: module/Activity/view/partial/create.phtml:132
+#: module/Company/view/company/admin-approval/job-approval.phtml:157
+#: module/Company/view/company/admin-approval/job-approval.phtml:162
+#: module/Company/view/company/admin-approval/job-approval.phtml:169
+#: module/Company/view/company/admin-approval/job-proposal.phtml:209
 #: module/Company/view/company/admin-approval/job-proposal.phtml:214
-#: module/Photo/view/partial/metadata.phtml:69
-#: module/Company/src/Form/Job.php:177 module/Company/src/Form/Job.php:187
+#: module/Company/view/company/admin-approval/job-proposal.phtml:224
+#: module/Photo/view/partial/metadata.phtml:82
+#: module/Company/src/Form/Job.php:181 module/Company/src/Form/Job.php:191
 msgid "Location"
 msgstr ""
 
-#: module/Activity/view/activity/activity/list.phtml:45
-#: module/Activity/view/activity/activity/view.phtml:79
-#: module/Activity/view/activity/admin-approval/view.phtml:102
-#: module/Activity/view/activity/admin-approval/view.phtml:107
-#: module/Activity/view/activity/admin-approval/view.phtml:114
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:170
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:175
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:187
-#: module/Activity/view/partial/create.phtml:59
-#: module/Activity/view/partial/create.phtml:133
+#: module/Activity/view/activity/activity/list.phtml:58
+#: module/Activity/view/activity/activity/view.phtml:99
+#: module/Activity/view/activity/admin-approval/view.phtml:118
+#: module/Activity/view/activity/admin-approval/view.phtml:123
+#: module/Activity/view/activity/admin-approval/view.phtml:130
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:191
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:196
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:208
+#: module/Activity/view/partial/create.phtml:72
+#: module/Activity/view/partial/create.phtml:146
 msgid "Costs"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:130
+#: module/Activity/view/activity/activity/view.phtml:150
 msgid "the organizing party"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:142
+#: module/Activity/view/activity/activity/view.phtml:162
 #, php-format
 msgid ""
 "Please contact %s or the board (%s) with any questions, concerns or if you "
@@ -563,140 +564,140 @@ msgid ""
 "fun!"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:145
+#: module/Activity/view/activity/activity/view.phtml:165
 #, php-format
 msgid ""
 "Please contact %s or the board (%s) with any questions or concerns. Have fun!"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:160
+#: module/Activity/view/activity/activity/view.phtml:180
 #, php-format
 msgid ""
 "This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:161
+#: module/Activity/view/activity/activity/view.phtml:181
 msgid " <strong>has a limited capacity</strong> and "
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:173
+#: module/Activity/view/activity/activity/view.phtml:193
 msgid "Already subscribed"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:180
+#: module/Activity/view/activity/activity/view.phtml:200
 msgid "Subscription closed"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:186
+#: module/Activity/view/activity/activity/view.phtml:206
 msgid "Subscribe now"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:193
+#: module/Activity/view/activity/activity/view.phtml:213
 msgid "Unsubscribe yourself"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:196
+#: module/Activity/view/activity/activity/view.phtml:216
 msgid "You are not allowed to unsubscribe after the deadline!"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:215
-#: module/Activity/view/activity/activity/view.phtml:232
+#: module/Activity/view/activity/activity/view.phtml:235
+#: module/Activity/view/activity/activity/view.phtml:252
 msgid "Subscribe yourself"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:218
+#: module/Activity/view/activity/activity/view.phtml:238
 msgid "Login to subscribe"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:222
+#: module/Activity/view/activity/activity/view.phtml:242
 msgid "Or subscribe without a GEWIS membership: "
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:243
+#: module/Activity/view/activity/activity/view.phtml:263
 msgid "Current subscriptions"
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:261
+#: module/Activity/view/activity/activity/view.phtml:281
 #, php-format
 msgid "The number of subscribed members is currently %d."
 msgstr ""
 
-#: module/Activity/view/activity/activity/view.phtml:265
+#: module/Activity/view/activity/activity/view.phtml:285
 msgid "Login to view the subscribed members."
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:6
-#: module/Activity/view/activity/admin-approval/view.phtml:16
-#: module/Activity/view/activity/admin-approval/view.phtml:182
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:293
-#: module/Company/view/company/admin-approval/job-approval.phtml:7
-#: module/Company/view/company/admin-approval/job-approval.phtml:224
-#: module/Company/view/company/admin-approval/job-proposal.phtml:13
-#: module/Company/view/company/admin-approval/job-proposal.phtml:323
+#: module/Activity/view/activity/admin-approval/view.phtml:19
+#: module/Activity/view/activity/admin-approval/view.phtml:29
+#: module/Activity/view/activity/admin-approval/view.phtml:198
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:314
+#: module/Company/view/company/admin-approval/job-approval.phtml:21
+#: module/Company/view/company/admin-approval/job-approval.phtml:238
+#: module/Company/view/company/admin-approval/job-proposal.phtml:23
+#: module/Company/view/company/admin-approval/job-proposal.phtml:333
 msgid "Approval"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:20
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:41
-#: module/Activity/view/partial/create.phtml:3
-#: module/Company/view/company/admin-approval/job-approval.phtml:16
-#: module/Company/view/company/admin-approval/job-proposal.phtml:44
-#: module/Company/view/partial/company/admin/editors/category.phtml:3
-#: module/Company/view/partial/company/admin/editors/company.phtml:191
-#: module/Company/view/partial/company/admin/editors/job.phtml:119
-#: module/Company/view/partial/company/admin/editors/label.phtml:3
-#: module/Company/view/partial/company/admin/editors/package.phtml:9
-#: module/Photo/view/photo/album/index.phtml:510
+#: module/Activity/view/activity/admin-approval/view.phtml:33
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:56
+#: module/Activity/view/partial/create.phtml:16
+#: module/Company/view/company/admin-approval/job-approval.phtml:30
+#: module/Company/view/company/admin-approval/job-proposal.phtml:54
+#: module/Company/view/partial/company/admin/editors/category.phtml:16
+#: module/Company/view/partial/company/admin/editors/company.phtml:204
+#: module/Company/view/partial/company/admin/editors/job.phtml:132
+#: module/Company/view/partial/company/admin/editors/label.phtml:16
+#: module/Company/view/partial/company/admin/editors/package.phtml:18
+#: module/Photo/view/photo/album/index.phtml:519
 msgid "Information"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:26
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:55
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:68
-#: module/Activity/view/partial/signupForm.phtml:72
-#: module/Photo/view/partial/tags.phtml:40
-#: module/Photo/view/photo/album/index.phtml:333
-#: module/Photo/view/photo/album/index.phtml:678
+#: module/Activity/view/activity/admin-approval/view.phtml:42
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:73
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:89
+#: module/Activity/view/partial/signupForm.phtml:86
+#: module/Photo/view/partial/tags.phtml:52
+#: module/Photo/view/photo/album/index.phtml:342
+#: module/Photo/view/photo/album/index.phtml:687
 msgid "and"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:37
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:79
+#: module/Activity/view/activity/admin-approval/view.phtml:53
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:100
 #, php-format
 msgid ""
 "This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
 "it will start on <strong>%s</strong> and end on <strong>%s</strong>."
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:44
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:92
+#: module/Activity/view/activity/admin-approval/view.phtml:60
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:113
 msgid "More information about this activity is available below."
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:141
+#: module/Activity/view/activity/admin-approval/view.phtml:157
 msgid "View details / subscriptions"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:204
+#: module/Activity/view/activity/admin-approval/view.phtml:220
 msgid "Disapprove"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:214
+#: module/Activity/view/activity/admin-approval/view.phtml:230
 #, php-format
 msgid "This activity was approved by <strong>%s</strong>."
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view.phtml:236
+#: module/Activity/view/activity/admin-approval/view.phtml:252
 #, php-format
 msgid "This activity was disapproved by <strong>%s</strong>."
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:6
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:16
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:21
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:31
 msgid "Update Proposal"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:45
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:60
 #, php-format
 msgid ""
 "Changes in activity attributes are shown like this: %s. If there are no "
@@ -706,239 +707,239 @@ msgid ""
 "difference between the two!"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:46
-#: module/Company/view/company/admin-approval/job-proposal.phtml:52
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
+#: module/Company/view/company/admin-approval/job-proposal.phtml:62
 msgid "old"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:46
-#: module/Company/view/company/admin-approval/job-proposal.phtml:52
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
+#: module/Company/view/company/admin-approval/job-proposal.phtml:62
 msgid "new"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:229
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:250
 msgid "View details of the old activity"
 msgstr ""
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:234
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:255
 msgid "View details of the new activity"
 msgstr ""
 
-#: module/Activity/view/activity/admin-category/add.phtml:37
-#: module/Activity/view/partial/create.phtml:14
-#: module/Application/src/Form/Localisable.php:27
+#: module/Activity/view/activity/admin-category/add.phtml:50
+#: module/Activity/view/partial/create.phtml:27
+#: module/Application/src/Form/Localisable.php:32
 msgid "Enable Dutch Translations"
 msgstr ""
 
-#: module/Activity/view/activity/admin-category/add.phtml:74
-#: module/Activity/view/partial/create.phtml:88
-#: module/Application/src/Form/Localisable.php:39
+#: module/Activity/view/activity/admin-category/add.phtml:87
+#: module/Activity/view/partial/create.phtml:101
+#: module/Application/src/Form/Localisable.php:44
 msgid "Enable English Translations"
 msgstr ""
 
-#: module/Activity/view/activity/admin-category/index.phtml:12
+#: module/Activity/view/activity/admin-category/index.phtml:20
 msgid ""
 "Here you can add, edit, or remove activity categories. Click on 'Add "
 "Category' to add a new category or click on a category to edit/remove it."
 msgstr ""
 
-#: module/Activity/view/activity/admin-category/index.phtml:34
-#: module/Company/view/company/admin/categories.phtml:4
+#: module/Activity/view/activity/admin-category/index.phtml:42
+#: module/Company/view/company/admin/categories.phtml:17
 msgid "Add Category"
 msgstr ""
 
-#: module/Activity/view/activity/admin-category/index.phtml:45
-#: module/Company/view/company/admin/edit-company.phtml:191
-#: module/Company/view/company/admin/edit-package.phtml:137
-#: module/Company/view/company/admin/index.phtml:217
-#: module/Company/view/company/company-account/jobs.phtml:275
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:160
-#: module/Photo/view/photo/album-admin/index.phtml:202
-#: module/Photo/view/photo/album-admin/index.phtml:234
-#: module/Photo/view/photo/photo-admin/index.phtml:121
+#: module/Activity/view/activity/admin-category/index.phtml:53
+#: module/Company/view/company/admin/edit-company.phtml:203
+#: module/Company/view/company/admin/edit-package.phtml:151
+#: module/Company/view/company/admin/index.phtml:231
+#: module/Company/view/company/company-account/jobs.phtml:294
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:175
+#: module/Photo/view/photo/album-admin/index.phtml:213
+#: module/Photo/view/photo/album-admin/index.phtml:245
+#: module/Photo/view/photo/photo-admin/index.phtml:139
 msgid "Delete confirmation"
 msgstr ""
 
-#: module/Activity/view/activity/admin-category/index.phtml:48
+#: module/Activity/view/activity/admin-category/index.phtml:56
 msgid "Are you sure you want to delete this activity category?"
 msgstr ""
 
-#: module/Activity/view/activity/admin-category/index.phtml:54
+#: module/Activity/view/activity/admin-category/index.phtml:62
 msgid "Delete Activity Category"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:13
-#: module/Activity/view/activity/admin/view.phtml:53
+#: module/Activity/view/activity/admin/list.phtml:21
+#: module/Activity/view/activity/admin/view.phtml:70
 msgid "Dutch name"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:14
-#: module/Activity/view/activity/admin/view.phtml:54
+#: module/Activity/view/activity/admin/list.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:71
 msgid "English name"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:15
-#: module/Activity/view/activity/admin/view.phtml:55
-#: module/Company/view/company/admin/edit-company.phtml:95
-#: module/Company/view/company/company-account/jobs.phtml:38
+#: module/Activity/view/activity/admin/list.phtml:23
+#: module/Activity/view/activity/admin/view.phtml:72
+#: module/Company/view/company/admin/edit-company.phtml:107
+#: module/Company/view/company/company-account/jobs.phtml:57
 #: module/Photo/src/Form/EditAlbum.php:37
 msgid "Start date"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:16
-#: module/Activity/view/activity/admin/view.phtml:56
+#: module/Activity/view/activity/admin/list.phtml:24
+#: module/Activity/view/activity/admin/view.phtml:73
 msgid "Organ"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:18
-#: module/Activity/view/activity/admin/view.phtml:58
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:27
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:100
+#: module/Activity/view/activity/admin/list.phtml:26
+#: module/Activity/view/activity/admin/view.phtml:75
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:42
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:115
 msgid "Submitter"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:19
+#: module/Activity/view/activity/admin/list.phtml:27
 msgid "Update status"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:21
-#: module/Company/view/company/admin/edit-package.phtml:71
+#: module/Activity/view/activity/admin/list.phtml:29
+#: module/Company/view/company/admin/edit-package.phtml:85
 msgid "Approved"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:37
-#: module/Activity/view/activity/admin/list.phtml:38
-#: module/Activity/view/activity/admin/view.phtml:76
-#: module/Activity/view/activity/admin/view.phtml:77
-#: module/Education/view/education/education/index.phtml:86
+#: module/Activity/view/activity/admin/list.phtml:45
+#: module/Activity/view/activity/admin/list.phtml:46
+#: module/Activity/view/activity/admin/view.phtml:91
+#: module/Activity/view/activity/admin/view.phtml:92
+#: module/Education/view/education/education/index.phtml:112
 msgid "None"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:42
-#: module/Activity/view/activity/admin/list.phtml:44
+#: module/Activity/view/activity/admin/list.phtml:50
+#: module/Activity/view/activity/admin/list.phtml:52
 msgid "Update pending"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:55
-#: module/Activity/view/activity/admin-option/index.phtml:86
-#: module/Company/view/company/admin/edit-company.phtml:145
-#: module/Company/view/company/admin/edit-package.phtml:108
-#: module/Company/view/company/company-account/jobs.phtml:226
-#: module/Decision/view/decision/organ-admin/edit.phtml:37
-#: module/Education/view/education/admin/course-documents.phtml:24
-#: module/Education/view/education/admin/course.phtml:53
-#: module/Education/view/education/admin/edit-course.phtml:10
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:26
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:26
+#: module/Activity/view/activity/admin/list.phtml:63
+#: module/Activity/view/activity/admin-option/index.phtml:94
+#: module/Company/view/company/admin/edit-company.phtml:157
+#: module/Company/view/company/admin/edit-package.phtml:122
+#: module/Company/view/company/company-account/jobs.phtml:245
+#: module/Decision/view/decision/organ-admin/edit.phtml:49
+#: module/Education/view/education/admin/course-documents.phtml:34
+#: module/Education/view/education/admin/course.phtml:65
+#: module/Education/view/education/admin/edit-course.phtml:24
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:40
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:38
 msgid "Edit"
 msgstr ""
 
-#: module/Activity/view/activity/admin/list.phtml:63
-#: module/Activity/view/activity/admin/participants.phtml:4
-#: module/Activity/view/activity/admin/participants.phtml:14
-#: module/Activity/view/activity/admin/participants.phtml:46
-#: module/Activity/view/activity/admin/view.phtml:82
+#: module/Activity/view/activity/admin/list.phtml:71
+#: module/Activity/view/activity/admin/participants.phtml:19
+#: module/Activity/view/activity/admin/participants.phtml:29
+#: module/Activity/view/activity/admin/participants.phtml:61
+#: module/Activity/view/activity/admin/view.phtml:97
 msgid "Participants"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/add.phtml:3
-#: module/Activity/view/activity/admin-option/index.phtml:5
-#: module/Application/view/partial/admin.phtml:45
+#: module/Activity/view/activity/admin-option/add.phtml:16
+#: module/Activity/view/activity/admin-option/index.phtml:13
+#: module/Application/view/partial/admin.phtml:62
 msgid "Option Calendar"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/add.phtml:12
-#: module/Activity/view/activity/admin-option/index.phtml:15
-#: module/Activity/view/activity/admin-option/index.phtml:57
+#: module/Activity/view/activity/admin-option/add.phtml:25
+#: module/Activity/view/activity/admin-option/index.phtml:23
+#: module/Activity/view/activity/admin-option/index.phtml:65
 msgid "Planning Period"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/add.phtml:13
+#: module/Activity/view/activity/admin-option/add.phtml:26
 msgid "Enter the start and end date and time of the planning period."
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/add.phtml:52
-#: module/Activity/view/activity/admin-option/index.phtml:16
-#: module/Activity/view/activity/admin-option/index.phtml:58
+#: module/Activity/view/activity/admin-option/add.phtml:65
+#: module/Activity/view/activity/admin-option/index.phtml:24
+#: module/Activity/view/activity/admin-option/index.phtml:66
 msgid "Option Period"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/add.phtml:53
+#: module/Activity/view/activity/admin-option/add.phtml:66
 msgid "Enter the start and end date and time of the option period."
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/add.phtml:92
+#: module/Activity/view/activity/admin-option/add.phtml:105
 msgid "Max Activities"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/add.phtml:93
+#: module/Activity/view/activity/admin-option/add.phtml:106
 msgid ""
 "Enter the maximum number of activities for which options can be created. You "
 "can either set the number globally or individually for each organ."
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/add.phtml:100
+#: module/Activity/view/activity/admin-option/add.phtml:113
 msgid "Global Value"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:6
-#: module/Activity/view/activity/admin/view.phtml:4
-#: module/Application/view/partial/admin.phtml:36
+#: module/Activity/view/activity/admin-option/index.phtml:14
+#: module/Activity/view/activity/admin/view.phtml:20
+#: module/Application/view/partial/admin.phtml:43
 msgid "Overview"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:10
+#: module/Activity/view/activity/admin-option/index.phtml:18
 msgid "Active Option Planning Periods"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:17
-#: module/Activity/view/activity/admin-option/index.phtml:59
-#: module/Company/view/company/admin-approval/index.phtml:15
-#: module/Company/view/company/admin-approval/index.phtml:43
-#: module/Company/view/company/admin/edit-company.phtml:104
-#: module/Company/view/company/admin/edit-package.phtml:72
-#: module/Company/view/company/admin/index.phtml:163
-#: module/Company/view/company/admin/index.phtml:204
-#: module/Company/view/company/company-account/jobs.phtml:47
-#: module/Company/view/company/company-account/jobs.phtml:180
-#: module/Education/view/education/admin/course-documents.phtml:64
-#: module/Education/view/education/admin/course-documents.phtml:115
-#: module/Education/view/education/admin/course.phtml:35
+#: module/Activity/view/activity/admin-option/index.phtml:25
+#: module/Activity/view/activity/admin-option/index.phtml:67
+#: module/Company/view/company/admin-approval/index.phtml:31
+#: module/Company/view/company/admin-approval/index.phtml:59
+#: module/Company/view/company/admin/edit-company.phtml:116
+#: module/Company/view/company/admin/edit-package.phtml:86
+#: module/Company/view/company/admin/index.phtml:177
+#: module/Company/view/company/admin/index.phtml:218
+#: module/Company/view/company/company-account/jobs.phtml:66
+#: module/Company/view/company/company-account/jobs.phtml:199
+#: module/Education/view/education/admin/course-documents.phtml:74
+#: module/Education/view/education/admin/course-documents.phtml:125
+#: module/Education/view/education/admin/course.phtml:47
 msgid "Actions"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:48
+#: module/Activity/view/activity/admin-option/index.phtml:56
 msgid "There is currently no option creation period planned."
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:52
+#: module/Activity/view/activity/admin-option/index.phtml:60
 msgid "Planned Option Planning Periods"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:98
+#: module/Activity/view/activity/admin-option/index.phtml:106
 msgid "There are no planned option creation periods in the future."
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:105
-#: module/Activity/src/Controller/AdminOptionController.php:97
+#: module/Activity/view/activity/admin-option/index.phtml:113
+#: module/Activity/src/Controller/AdminOptionController.php:101
 msgid "Add Option Period"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:117
+#: module/Activity/view/activity/admin-option/index.phtml:125
 msgid "Delete period"
 msgstr ""
 
-#: module/Activity/view/activity/admin-option/index.phtml:121
+#: module/Activity/view/activity/admin-option/index.phtml:129
 msgid ""
 "Are you sure you want to delete this option planning period? This will "
 "<strong>not</strong> delete proposed options."
 msgstr ""
 
-#: module/Activity/view/activity/admin/participants.phtml:26
+#: module/Activity/view/activity/admin/participants.phtml:41
 msgid "General"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participants.phtml:40
+#: module/Activity/view/activity/admin/participants.phtml:55
 msgid ""
 "Here you can find everyone who signed up for this activity (may contain "
 "duplicates). Using the tabs above you can navigate to the different sign-up "
@@ -946,804 +947,804 @@ msgid ""
 "(when supplied) view additional signup information from each participant."
 msgstr ""
 
-#: module/Activity/view/activity/admin/participants.phtml:42
+#: module/Activity/view/activity/admin/participants.phtml:57
 msgid ""
 "Here you can find everyone who signed up to this sign-up list. Here you can "
 "add or remove external participants and view detailed information regarding "
 "the signup of all participants."
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:12
-#: module/Decision/view/decision/member/self.phtml:39
-#: module/Decision/view/decision/member/view.phtml:34
-#: module/Frontpage/view/frontpage/organ/organ.phtml:83
-#: module/Decision/src/Form/OrganInformation.php:34
+#: module/Activity/view/activity/admin/participantsTable.phtml:21
+#: module/Decision/view/decision/member/self.phtml:49
+#: module/Decision/view/decision/member/view.phtml:33
+#: module/Frontpage/view/frontpage/organ/organ.phtml:99
+#: module/Decision/src/Form/OrganInformation.php:32
 msgid "Email"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:14
-#: module/Decision/view/decision/member/self.phtml:54
-#: module/Decision/view/decision/member/view.phtml:50
+#: module/Activity/view/activity/admin/participantsTable.phtml:23
+#: module/Decision/view/decision/member/self.phtml:64
+#: module/Decision/view/decision/member/view.phtml:49
 msgid "Generation"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:19
+#: module/Activity/view/activity/admin/participantsTable.phtml:28
 msgid "Sign-up List"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:61
-#: module/Decision/view/decision/member/self.phtml:45
-#: module/Decision/view/decision/member/view.phtml:40
-#: module/Photo/view/partial/metadata.phtml:8
-#: module/Photo/view/partial/metadata.phtml:15
-#: module/Photo/view/partial/metadata.phtml:36
-#: module/Photo/view/partial/metadata.phtml:43
-#: module/Photo/view/partial/metadata.phtml:50
-#: module/Photo/view/partial/metadata.phtml:57
-#: module/Photo/view/partial/metadata.phtml:64
-#: module/Photo/view/partial/metadata.phtml:73
+#: module/Activity/view/activity/admin/participantsTable.phtml:70
+#: module/Decision/view/decision/member/self.phtml:55
+#: module/Decision/view/decision/member/view.phtml:39
+#: module/Photo/view/partial/metadata.phtml:21
+#: module/Photo/view/partial/metadata.phtml:28
+#: module/Photo/view/partial/metadata.phtml:49
+#: module/Photo/view/partial/metadata.phtml:56
+#: module/Photo/view/partial/metadata.phtml:63
+#: module/Photo/view/partial/metadata.phtml:70
+#: module/Photo/view/partial/metadata.phtml:77
+#: module/Photo/view/partial/metadata.phtml:86
 msgid "Unknown"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:67
+#: module/Activity/view/activity/admin/participantsTable.phtml:76
 #, php-format
 msgid "User (%s)"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:74
-#: module/Decision/src/Model/Enums/MembershipTypes.php:21
+#: module/Activity/view/activity/admin/participantsTable.phtml:83
+#: module/Decision/src/Model/Enums/MembershipTypes.php:23
 msgid "External"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:87
-#: module/Education/view/education/admin/course-documents.phtml:123
+#: module/Activity/view/activity/admin/participantsTable.phtml:96
+#: module/Education/view/education/admin/course-documents.phtml:133
 msgid "N/A"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:107
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:49
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:52
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:60
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:63
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:71
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:74
-#: module/Company/view/company/admin/edit-company.phtml:114
-#: module/Company/view/company/admin/edit-package.phtml:78
-#: module/Company/view/company/admin/index.phtml:183
-#: module/Company/view/company/admin/index.phtml:184
-#: module/Company/view/company/company-account/jobs.phtml:195
-#: module/Company/view/company/company-account/jobs.phtml:203
-#: module/Decision/view/decision/member/view.phtml:60
-#: module/Photo/view/partial/metadata.phtml:29
+#: module/Activity/view/activity/admin/participantsTable.phtml:116
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
+#: module/Company/view/company/admin/edit-company.phtml:126
+#: module/Company/view/company/admin/edit-package.phtml:92
+#: module/Company/view/company/admin/index.phtml:197
+#: module/Company/view/company/admin/index.phtml:198
+#: module/Company/view/company/company-account/jobs.phtml:214
+#: module/Company/view/company/company-account/jobs.phtml:222
+#: module/Decision/view/decision/member/view.phtml:59
+#: module/Photo/view/partial/metadata.phtml:42
 #: module/Application/language/additional-strings:20
 msgid "Yes"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:109
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:49
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:52
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:60
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:63
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:71
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:74
-#: module/Company/view/company/admin/edit-company.phtml:114
-#: module/Company/view/company/admin/edit-package.phtml:78
-#: module/Company/view/company/admin/index.phtml:183
-#: module/Company/view/company/admin/index.phtml:184
-#: module/Company/view/company/company-account/jobs.phtml:195
-#: module/Decision/view/decision/member/view.phtml:60
-#: module/Photo/view/partial/metadata.phtml:29
+#: module/Activity/view/activity/admin/participantsTable.phtml:118
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
+#: module/Company/view/company/admin/edit-company.phtml:126
+#: module/Company/view/company/admin/edit-package.phtml:92
+#: module/Company/view/company/admin/index.phtml:197
+#: module/Company/view/company/admin/index.phtml:198
+#: module/Company/view/company/company-account/jobs.phtml:214
+#: module/Decision/view/decision/member/view.phtml:59
+#: module/Photo/view/partial/metadata.phtml:42
 #: module/Application/language/additional-strings:21
 msgid "No"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:132
+#: module/Activity/view/activity/admin/participantsTable.phtml:141
 msgid "Additional actions"
 msgstr ""
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:136
+#: module/Activity/view/activity/admin/participantsTable.phtml:145
 msgid "Mail everybody"
 msgstr ""
 
-#: module/Activity/view/activity/admin/view.phtml:8
+#: module/Activity/view/activity/admin/view.phtml:24
 msgid "Unapproved Activities"
 msgstr ""
 
-#: module/Activity/view/activity/admin/view.phtml:15
+#: module/Activity/view/activity/admin/view.phtml:31
 msgid "Approved Activities"
 msgstr ""
 
-#: module/Activity/view/activity/admin/view.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:38
 msgid "Disapproved Activities"
 msgstr ""
 
-#: module/Activity/view/activity/admin/view.phtml:30
+#: module/Activity/view/activity/admin/view.phtml:46
 msgid "Upcoming Activities"
 msgstr ""
 
-#: module/Activity/view/activity/admin/view.phtml:37
+#: module/Activity/view/activity/admin/view.phtml:53
 msgid "Old activities"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:24
-#: module/Activity/view/partial/signuplist.phtml:12
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:37
+#: module/Activity/view/partial/signuplist.phtml:25
 msgid "Open date and time"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:35
-#: module/Activity/view/partial/signuplist.phtml:26
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:48
+#: module/Activity/view/partial/signuplist.phtml:39
 msgid "Close date and time"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:46
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:59
 msgid "GEWIS members only"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:57
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:70
 msgid "Display GEWIS member count"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:68
-#: module/Activity/view/partial/signuplist.phtml:107
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:81
+#: module/Activity/view/partial/signuplist.phtml:120
 msgid "Has limited capacity"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:80
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:93
 msgid ""
 "This sign-up list contains additional fields which require input from "
 "subscribers, they are shown below."
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:115
-#: module/Activity/src/Form/SignupListField.php:54
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:128
+#: module/Activity/src/Form/SignupListField.php:55
 msgid "Text"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:118
-#: module/Activity/src/Form/SignupListField.php:55
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:131
+#: module/Activity/src/Form/SignupListField.php:56
 msgid "Yes/No"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
-#: module/Activity/src/Form/SignupListField.php:56
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
+#: module/Activity/src/Form/SignupListField.php:57
 msgid "Number"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:124
-#: module/Activity/src/Form/SignupListField.php:57
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:137
+#: module/Activity/src/Form/SignupListField.php:58
 msgid "Choice"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
-#: module/Activity/src/Form/SignupListField.php:69
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:147
+#: module/Activity/src/Form/SignupListField.php:70
 msgid "Min. value"
 msgstr ""
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:144
-#: module/Activity/src/Form/SignupListField.php:79
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:157
+#: module/Activity/src/Form/SignupListField.php:80
 msgid "Max. value"
 msgstr ""
 
-#: module/Activity/view/partial/create.phtml:4
+#: module/Activity/view/partial/create.phtml:17
 msgid ""
 "What is this activity about? Fill in the blanks below, please note that at "
 "least one language must be used."
 msgstr ""
 
-#: module/Activity/view/partial/create.phtml:158
+#: module/Activity/view/partial/create.phtml:171
 msgid "Choose which options are applicable to this activity."
 msgstr ""
 
-#: module/Activity/view/partial/create.phtml:168
+#: module/Activity/view/partial/create.phtml:181
 msgid "This is a career related activity"
 msgstr ""
 
-#: module/Activity/view/partial/create.phtml:170
+#: module/Activity/view/partial/create.phtml:183
 msgid ""
 "If this is checked the My Future logo will be displayed on the activity page "
 "and the activity will be included on the career activities page."
 msgstr ""
 
-#: module/Activity/view/partial/create.phtml:182
+#: module/Activity/view/partial/create.phtml:195
 msgid "This activity needs a GEFLITST member to take photos"
 msgstr ""
 
-#: module/Activity/view/partial/create.phtml:184
+#: module/Activity/view/partial/create.phtml:197
 msgid ""
 "When this is checked, GEFLITST will be notified that this activity needs a "
 "photographer."
 msgstr ""
 
-#: module/Activity/view/partial/option.phtml:24
+#: module/Activity/view/partial/option.phtml:33
 msgid "From"
 msgstr ""
 
-#: module/Activity/view/partial/option.phtml:38
+#: module/Activity/view/partial/option.phtml:47
 msgid "Until"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:7
-#: module/Activity/view/partial/signupForm.phtml:12
+#: module/Activity/view/partial/signupForm.phtml:21
+#: module/Activity/view/partial/signupForm.phtml:26
 msgid "By subscribing to this activity, you agree to the terms outlined in the"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:9
+#: module/Activity/view/partial/signupForm.phtml:23
 msgid "Confirm subscription"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:14
+#: module/Activity/view/partial/signupForm.phtml:28
 msgid "Subscribe as external participant"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:19
+#: module/Activity/view/partial/signupForm.phtml:33
 msgid ""
 "By subscribing an external participant to this activity, they must agree to "
 "the terms outlined in the"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:21
+#: module/Activity/view/partial/signupForm.phtml:35
 msgid "Subscribe an external participant"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:53
+#: module/Activity/view/partial/signupForm.phtml:67
 msgid "Full name:"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:54
+#: module/Activity/view/partial/signupForm.phtml:68
 msgid "Email address:"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:58
+#: module/Activity/view/partial/signupForm.phtml:72
 msgid "Please fill in this CAPTCHA:"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:72
-#: module/Decision/view/decision/member/index.phtml:243
+#: module/Activity/view/partial/signupForm.phtml:86
+#: module/Decision/view/decision/member/index.phtml:254
 msgid "Activity Policy"
 msgstr ""
 
-#: module/Activity/view/partial/signupForm.phtml:74
-#: module/Decision/view/decision/member/index.phtml:248
+#: module/Activity/view/partial/signupForm.phtml:88
+#: module/Decision/view/decision/member/index.phtml:259
 msgid "Alcohol Policy"
 msgstr ""
 
-#: module/Activity/view/partial/signuplist-fields.phtml:86
+#: module/Activity/view/partial/signuplist-fields.phtml:95
 msgid "Please note that numbers are not dependant on the selected language(s)."
 msgstr ""
 
-#: module/Activity/view/partial/signuplist.phtml:75
+#: module/Activity/view/partial/signuplist.phtml:88
 msgid "Only allow GEWIS members"
 msgstr ""
 
-#: module/Activity/view/partial/signuplist.phtml:77
+#: module/Activity/view/partial/signuplist.phtml:90
 msgid "Deselect this to allow people without a GEWIS account to subscribe."
 msgstr ""
 
-#: module/Activity/view/partial/signuplist.phtml:90
+#: module/Activity/view/partial/signuplist.phtml:103
 msgid "Display number of subscribed members"
 msgstr ""
 
-#: module/Activity/view/partial/signuplist.phtml:92
+#: module/Activity/view/partial/signuplist.phtml:105
 msgid ""
 "Select this to display the number of subscribed GEWIS members to external "
 "visitors."
 msgstr ""
 
-#: module/Activity/view/partial/signuplist.phtml:109
+#: module/Activity/view/partial/signuplist.phtml:122
 msgid ""
 "Select this if this sign-up list has limited capacity or is expected to have "
 "limited capacity. Please ensure that you also write this in the description "
 "of the activity."
 msgstr ""
 
-#: module/Activity/view/partial/signuplist.phtml:140
+#: module/Activity/view/partial/signuplist.phtml:153
 msgid "Remove the last sign-up list field"
 msgstr ""
 
-#: module/Activity/view/partial/signuplist.phtml:145
+#: module/Activity/view/partial/signuplist.phtml:158
 msgid "Add a sign-up list field"
 msgstr ""
 
-#: module/Application/view/error/403.phtml:6
+#: module/Application/view/error/403.phtml:17
 msgid "You do not have the required privileges to view this page"
 msgstr ""
 
-#: module/Application/view/error/403.phtml:9
+#: module/Application/view/error/403.phtml:22
 msgid "You might be able to view this page by logging in"
 msgstr ""
 
-#: module/Application/view/error/403.phtml:15
-#: module/Application/view/partial/admin.phtml:24
-#: module/Application/view/partial/main-nav.phtml:74
-#: module/User/view/user/user/login.phtml:25
+#: module/Application/view/error/403.phtml:28
+#: module/Application/view/partial/admin.phtml:28
+#: module/Application/view/partial/main-nav.phtml:87
+#: module/User/view/user/user/login.phtml:39
 msgid "Login"
 msgstr ""
 
-#: module/Application/view/error/404.phtml:3
-#: module/Application/view/error/debug/404.phtml:3
+#: module/Application/view/error/404.phtml:12
+#: module/Application/view/error/debug/404.phtml:12
 msgid "A 404 error occurred"
 msgstr ""
 
-#: module/Application/view/error/500.phtml:3
-#: module/Application/view/error/debug/500.phtml:3
+#: module/Application/view/error/500.phtml:12
+#: module/Application/view/error/debug/500.phtml:13
 msgid "An error occurred"
 msgstr ""
 
-#: module/Application/view/error/500.phtml:4
+#: module/Application/view/error/500.phtml:13
 msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
 msgstr ""
 
-#: module/Application/view/error/debug/403.phtml:3
+#: module/Application/view/error/debug/403.phtml:12
 msgid "403 Forbidden"
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:12
+#: module/Application/view/error/debug/404.phtml:22
 msgid "The requested controller was unable to dispatch the request."
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:15
+#: module/Application/view/error/debug/404.phtml:26
 msgid ""
 "The requested controller could not be mapped to an existing controller class."
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:18
+#: module/Application/view/error/debug/404.phtml:30
 msgid "The requested controller was not dispatchable."
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:21
+#: module/Application/view/error/debug/404.phtml:33
 msgid "The requested URL could not be matched by routing."
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:24
+#: module/Application/view/error/debug/404.phtml:36
 msgid "We cannot determine at this time why a 404 was generated."
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:36
+#: module/Application/view/error/debug/404.phtml:50
 msgid "Controller"
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:43
+#: module/Application/view/error/debug/404.phtml:58
 #, php-format
 msgid "resolves to %s"
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:55
-#: module/Application/view/error/debug/500.phtml:10
+#: module/Application/view/error/debug/404.phtml:75
+#: module/Application/view/error/debug/500.phtml:24
 msgid "Additional information"
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:58
-#: module/Application/view/error/debug/404.phtml:83
-#: module/Application/view/error/debug/500.phtml:13
-#: module/Application/view/error/debug/500.phtml:40
+#: module/Application/view/error/debug/404.phtml:78
+#: module/Application/view/error/debug/404.phtml:104
+#: module/Application/view/error/debug/500.phtml:29
+#: module/Application/view/error/debug/500.phtml:69
 msgid "File"
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:63
-#: module/Application/view/error/debug/404.phtml:88
-#: module/Application/view/error/debug/500.phtml:18
-#: module/Application/view/error/debug/500.phtml:45
+#: module/Application/view/error/debug/404.phtml:83
+#: module/Application/view/error/debug/404.phtml:109
+#: module/Application/view/error/debug/500.phtml:38
+#: module/Application/view/error/debug/500.phtml:78
 msgid "Message"
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:67
-#: module/Application/view/error/debug/404.phtml:92
-#: module/Application/view/error/debug/500.phtml:23
-#: module/Application/view/error/debug/500.phtml:50
+#: module/Application/view/error/debug/404.phtml:87
+#: module/Application/view/error/debug/404.phtml:113
+#: module/Application/view/error/debug/500.phtml:46
+#: module/Application/view/error/debug/500.phtml:86
 msgid "Stack trace"
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:77
-#: module/Application/view/error/debug/500.phtml:34
+#: module/Application/view/error/debug/404.phtml:97
+#: module/Application/view/error/debug/500.phtml:60
 msgid "Previous exceptions"
 msgstr ""
 
-#: module/Application/view/error/debug/404.phtml:107
-#: module/Application/view/error/debug/500.phtml:66
+#: module/Application/view/error/debug/404.phtml:130
+#: module/Application/view/error/debug/500.phtml:107
 msgid "No Exception available"
 msgstr ""
 
-#: module/Application/view/layout/layout.phtml:6
+#: module/Application/view/layout/layout.phtml:15
 msgid "Study Association GEWIS"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:40
-#: module/Application/view/partial/admin.phtml:80
-#: module/Company/view/company/admin/categories.phtml:10
-#: module/Company/view/company/admin/categories.phtml:30
+#: module/Application/view/partial/admin.phtml:50
+#: module/Application/view/partial/admin.phtml:105
+#: module/Company/view/company/admin/categories.phtml:23
+#: module/Company/view/company/admin/categories.phtml:43
 msgid "Categories"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:55
-#: module/Application/view/partial/main-nav.phtml:305
-#: module/Application/view/partial/main-nav.phtml:309
-#: module/Application/view/partial/main-nav.phtml:314
-#: module/Company/view/company/admin-approval/index.phtml:3
-#: module/Company/view/company/admin-approval/job-approval.phtml:10
-#: module/Company/view/company/admin-approval/job-proposal.phtml:16
-#: module/Company/view/company/admin/edit-company.phtml:7
-#: module/Company/view/company/admin/index.phtml:6
+#: module/Application/view/partial/admin.phtml:76
+#: module/Application/view/partial/main-nav.phtml:326
+#: module/Application/view/partial/main-nav.phtml:330
+#: module/Application/view/partial/main-nav.phtml:335
+#: module/Company/view/company/admin-approval/index.phtml:19
+#: module/Company/view/company/admin-approval/job-approval.phtml:24
+#: module/Company/view/company/admin-approval/job-proposal.phtml:26
+#: module/Company/view/company/admin/edit-company.phtml:19
+#: module/Company/view/company/admin/index.phtml:20
 msgid "Career"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:61
-#: module/Company/view/company/admin/index.phtml:7
-#: module/Company/view/company/company/job-list.phtml:22
-#: module/Company/view/company/company/jobs.phtml:22
-#: module/Company/view/company/company/list.phtml:4
-#: module/Company/view/company/company/show.phtml:5
-#: module/Company/view/company/company/show.phtml:12
-#: module/Company/view/company/company/spotlight.phtml:17
+#: module/Application/view/partial/admin.phtml:83
+#: module/Company/view/company/admin/index.phtml:21
+#: module/Company/view/company/company/job-list.phtml:36
+#: module/Company/view/company/company/jobs.phtml:34
+#: module/Company/view/company/company/list.phtml:21
+#: module/Company/view/company/company/show.phtml:17
+#: module/Company/view/company/company/show.phtml:24
+#: module/Company/view/company/company/spotlight.phtml:33
 msgid "Companies"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:73
-#: module/Company/view/company/admin-approval/index.phtml:4
-#: module/Company/view/company/admin-approval/job-approval.phtml:11
+#: module/Application/view/partial/admin.phtml:96
+#: module/Company/view/company/admin-approval/index.phtml:20
+#: module/Company/view/company/admin-approval/job-approval.phtml:25
 msgid "Approvals"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:87
-#: module/Company/view/company/admin-approval/job-approval.phtml:210
-#: module/Company/view/company/admin/labels.phtml:10
-#: module/Company/view/company/admin/labels.phtml:29
-#: module/Company/src/Form/Job.php:237
+#: module/Application/view/partial/admin.phtml:114
+#: module/Company/view/company/admin-approval/job-approval.phtml:224
+#: module/Company/view/company/admin/labels.phtml:23
+#: module/Company/view/company/admin/labels.phtml:42
+#: module/Company/src/Form/Job.php:241
 msgid "Labels"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:98
-#: module/Application/view/partial/main-nav.phtml:344
-#: module/Education/view/education/admin/add-course.phtml:3
-#: module/Education/view/education/admin/bulk-exam.phtml:11
-#: module/Education/view/education/admin/bulk-summary.phtml:11
-#: module/Education/view/education/admin/course-documents.phtml:17
-#: module/Education/view/education/admin/course.phtml:5
-#: module/Education/view/education/admin/edit-course.phtml:3
-#: module/Education/view/education/admin/edit-exam.phtml:18
-#: module/Education/view/education/admin/edit-summary.phtml:18
-#: module/Education/view/education/admin/index.phtml:3
-#: module/Education/view/education/education/course.phtml:11
-#: module/Education/view/education/education/index.phtml:2
-#: module/Education/view/education/education/index.phtml:17
+#: module/Application/view/partial/admin.phtml:128
+#: module/Application/view/partial/main-nav.phtml:368
+#: module/Education/view/education/admin/add-course.phtml:15
+#: module/Education/view/education/admin/bulk-exam.phtml:19
+#: module/Education/view/education/admin/bulk-summary.phtml:19
+#: module/Education/view/education/admin/course-documents.phtml:27
+#: module/Education/view/education/admin/course.phtml:17
+#: module/Education/view/education/admin/edit-course.phtml:17
+#: module/Education/view/education/admin/edit-exam.phtml:31
+#: module/Education/view/education/admin/edit-summary.phtml:31
+#: module/Education/view/education/admin/index.phtml:11
+#: module/Education/view/education/education/course.phtml:21
+#: module/Education/view/education/education/index.phtml:16
+#: module/Education/view/education/education/index.phtml:31
 msgid "Education"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:103
-#: module/Education/view/education/admin/add-course.phtml:4
-#: module/Education/view/education/admin/course-documents.phtml:18
-#: module/Education/view/education/admin/course.phtml:6
-#: module/Education/view/education/admin/edit-course.phtml:4
+#: module/Application/view/partial/admin.phtml:133
+#: module/Education/view/education/admin/add-course.phtml:16
+#: module/Education/view/education/admin/course-documents.phtml:28
+#: module/Education/view/education/admin/course.phtml:18
+#: module/Education/view/education/admin/edit-course.phtml:18
 msgid "Courses"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:108
-#: module/Education/view/education/admin/bulk-exam.phtml:16
+#: module/Application/view/partial/admin.phtml:138
+#: module/Education/view/education/admin/bulk-exam.phtml:24
 msgid "Upload exams"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:113
-#: module/Education/view/education/admin/bulk-summary.phtml:16
+#: module/Application/view/partial/admin.phtml:143
+#: module/Education/view/education/admin/bulk-summary.phtml:24
 msgid "Upload summaries"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:123
-#: module/Decision/view/decision/admin/authorizations.phtml:3
-#: module/Decision/view/decision/admin/document.phtml:14
-#: module/Decision/view/decision/admin/minutes.phtml:3
-#: module/Decision/view/decision/decision/index.phtml:3
-#: module/Decision/view/decision/member/index.phtml:89
+#: module/Application/view/partial/admin.phtml:155
+#: module/Decision/view/decision/admin/authorizations.phtml:14
+#: module/Decision/view/decision/admin/document.phtml:29
+#: module/Decision/view/decision/admin/minutes.phtml:15
+#: module/Decision/view/decision/decision/index.phtml:17
+#: module/Decision/view/decision/member/index.phtml:100
 msgid "Meetings"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:127
-#: module/Decision/view/decision/admin/minutes.phtml:4
-#: module/Decision/view/decision/decision/view.phtml:41
+#: module/Application/view/partial/admin.phtml:160
+#: module/Decision/view/decision/admin/minutes.phtml:16
+#: module/Decision/view/decision/decision/view.phtml:53
 msgid "Minutes"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:130
-#: module/Decision/view/decision/admin/document.phtml:15
-#: module/Decision/view/decision/decision/view.phtml:19
-#: module/Education/view/education/admin/course.phtml:48
+#: module/Application/view/partial/admin.phtml:165
+#: module/Decision/view/decision/admin/document.phtml:30
+#: module/Decision/view/decision/decision/view.phtml:31
+#: module/Education/view/education/admin/course.phtml:60
 msgid "Documents"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:133
-#: module/Decision/view/decision/admin/authorizations.phtml:4
-#: module/Decision/view/decision/decision/authorizations.phtml:3
-#: module/Decision/view/decision/decision/authorizations.phtml:16
-#: module/Decision/view/decision/member/index.phtml:50
+#: module/Application/view/partial/admin.phtml:170
+#: module/Decision/view/decision/admin/authorizations.phtml:15
+#: module/Decision/view/decision/decision/authorizations.phtml:27
+#: module/Decision/view/decision/decision/authorizations.phtml:34
+#: module/Decision/view/decision/member/index.phtml:61
 msgid "Authorizations"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:141
-#: module/Decision/view/decision/member/index.phtml:62
-#: module/Decision/view/decision/organ-admin/edit.phtml:36
-#: module/Decision/view/decision/organ-admin/index.phtml:3
+#: module/Application/view/partial/admin.phtml:181
+#: module/Decision/view/decision/member/index.phtml:73
+#: module/Decision/view/decision/organ-admin/edit.phtml:48
+#: module/Decision/view/decision/organ-admin/index.phtml:15
 msgid "Organs"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:147
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:36
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:25
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:3
+#: module/Application/view/partial/admin.phtml:189
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:54
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:39
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:14
 msgid "News"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:152
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:25
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:11
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:13
+#: module/Application/view/partial/admin.phtml:196
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:23
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:25
 msgid "Pages"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:157
-#: module/Application/view/partial/main-nav.phtml:401
-#: module/Application/view/partial/main-nav.phtml:405
-#: module/Application/view/partial/main-nav.phtml:409
-#: module/Application/view/partial/main-nav.phtml:416
-#: module/Photo/view/photo/album-admin/add.phtml:21
-#: module/Photo/view/photo/album-admin/create.phtml:3
-#: module/Photo/view/photo/album-admin/edit.phtml:3
-#: module/Photo/view/photo/album-admin/index.phtml:22
-#: module/Photo/view/photo/album/index.phtml:20
-#: module/Photo/view/photo/album/index.phtml:60
-#: module/Photo/view/photo/photo-admin/index.phtml:20
-#: module/Photo/view/photo/photo/index.phtml:3
+#: module/Application/view/partial/admin.phtml:203
+#: module/Application/view/partial/main-nav.phtml:434
+#: module/Application/view/partial/main-nav.phtml:438
+#: module/Application/view/partial/main-nav.phtml:443
+#: module/Application/view/partial/main-nav.phtml:452
+#: module/Photo/view/photo/album-admin/add.phtml:33
+#: module/Photo/view/photo/album-admin/create.phtml:15
+#: module/Photo/view/photo/album-admin/edit.phtml:15
+#: module/Photo/view/photo/album-admin/index.phtml:33
+#: module/Photo/view/photo/album/index.phtml:29
+#: module/Photo/view/photo/album/index.phtml:69
+#: module/Photo/view/photo/photo-admin/index.phtml:38
+#: module/Photo/view/photo/photo/index.phtml:15
 msgid "Photos"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:162
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:17
-#: module/Frontpage/view/frontpage/poll/index.phtml:3
-#: module/Frontpage/view/frontpage/poll/index.phtml:11
+#: module/Application/view/partial/admin.phtml:210
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:32
+#: module/Frontpage/view/frontpage/poll/index.phtml:22
+#: module/Frontpage/view/frontpage/poll/index.phtml:30
 msgid "Polls"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:169
+#: module/Application/view/partial/admin.phtml:219
 msgid "Users"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:173
+#: module/Application/view/partial/admin.phtml:224
 msgid "API Users"
 msgstr ""
 
-#: module/Application/view/partial/admin.phtml:192
-#: module/Application/view/partial/main-nav.phtml:143
+#: module/Application/view/partial/admin.phtml:245
+#: module/Application/view/partial/main-nav.phtml:161
 msgid "Admin"
 msgstr ""
 
-#: module/Application/view/partial/company.phtml:23
-#: module/Frontpage/view/frontpage/page/page.phtml:5
+#: module/Application/view/partial/company.phtml:26
+#: module/Frontpage/view/frontpage/page/page.phtml:20
 msgid "Home"
 msgstr ""
 
-#: module/Application/view/partial/company.phtml:28
-#: module/Company/view/company/admin/edit-package.phtml:65
-#: module/Company/view/company/admin/index.phtml:121
-#: module/Company/view/company/admin/index.phtml:199
-#: module/Company/view/company/company-account/jobs.phtml:7
-#: module/Company/view/company/company-account/jobs.phtml:11
-#: module/Company/view/company/company-account/jobs.phtml:14
-#: module/Company/view/company/company-account/jobs.phtml:169
-#: module/Company/view/company/company-account/transfer-jobs.phtml:5
-#: module/Company/src/Form/JobsTransfer.php:29
+#: module/Application/view/partial/company.phtml:31
+#: module/Company/view/company/admin/edit-package.phtml:79
+#: module/Company/view/company/admin/index.phtml:135
+#: module/Company/view/company/admin/index.phtml:213
+#: module/Company/view/company/company-account/jobs.phtml:26
+#: module/Company/view/company/company-account/jobs.phtml:30
+#: module/Company/view/company/company-account/jobs.phtml:33
+#: module/Company/view/company/company-account/jobs.phtml:188
+#: module/Company/view/company/company-account/transfer-jobs.phtml:17
+#: module/Company/src/Form/JobsTransfer.php:27
 msgid "Jobs"
 msgstr ""
 
-#: module/Application/view/partial/company.phtml:33
-#: module/Company/view/company/company-account/highlights.phtml:2
-#: module/Company/view/company/company-account/highlights.phtml:5
+#: module/Application/view/partial/company.phtml:36
+#: module/Company/view/company/company-account/highlights.phtml:10
+#: module/Company/view/company/company-account/highlights.phtml:13
 msgid "Highlights"
 msgstr ""
 
-#: module/Application/view/partial/company.phtml:38
-#: module/Company/view/company/admin/edit-package.phtml:57
-#: module/Company/view/company/company-account/banner.phtml:2
-#: module/Company/view/company/company-account/banner.phtml:5
-#: module/Company/src/Form/Package.php:115
+#: module/Application/view/partial/company.phtml:41
+#: module/Company/view/company/admin/edit-package.phtml:70
+#: module/Company/view/company/company-account/banner.phtml:10
+#: module/Company/view/company/company-account/banner.phtml:13
+#: module/Company/src/Form/Package.php:112
 msgid "Banner"
 msgstr ""
 
-#: module/Application/view/partial/company.phtml:43
+#: module/Application/view/partial/company.phtml:46
 msgid "Settings"
 msgstr ""
 
-#: module/Application/view/partial/company.phtml:55
-#: module/Application/view/partial/main-nav.phtml:101
+#: module/Application/view/partial/company.phtml:58
+#: module/Application/view/partial/main-nav.phtml:116
 msgid "My Company"
 msgstr ""
 
-#: module/Application/view/partial/footer.phtml:11
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:255
+#: module/Application/view/partial/footer.phtml:21
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:273
 msgid "Infimum"
 msgstr ""
 
-#: module/Application/view/partial/footer.phtml:12
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:258
+#: module/Application/view/partial/footer.phtml:22
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:276
 msgid "Loading an infimum..."
 msgstr ""
 
-#: module/Application/view/partial/footer.phtml:26
-#: module/Application/view/partial/footer.phtml:31
-#: module/Application/src/Service/Infimum.php:62
+#: module/Application/view/partial/footer.phtml:36
+#: module/Application/view/partial/footer.phtml:41
+#: module/Application/src/Service/Infimum.php:66
 msgid "Unable to retrieve infimum."
 msgstr ""
 
-#: module/Application/view/partial/footer.phtml:38
+#: module/Application/view/partial/footer.phtml:50
 msgid "All rights reserved."
 msgstr ""
 
-#: module/Application/view/partial/footer.phtml:39
+#: module/Application/view/partial/footer.phtml:52
 msgid ""
 "Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
 "2022)."
 msgstr ""
 
-#: module/Application/view/partial/footer.phtml:44
-#: module/Application/view/partial/main-nav.phtml:297
-#: module/Company/view/company/company/companyStory.phtml:21
-#: module/Company/view/company/company/jobs.phtml:93
-#: module/Company/view/partial/company/company/list/company.phtml:31
+#: module/Application/view/partial/footer.phtml:58
+#: module/Application/view/partial/main-nav.phtml:318
+#: module/Company/view/company/company/companyStory.phtml:37
+#: module/Company/view/company/company/jobs.phtml:105
+#: module/Company/view/partial/company/company/list/company.phtml:41
 msgid "Contact"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:42
+#: module/Application/view/partial/main-nav.phtml:53
 msgid "Language settings"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:68
-#: module/Application/view/partial/main-nav.phtml:445
-#: module/Decision/view/decision/member/birthdays.phtml:4
-#: module/Decision/view/decision/member/index.phtml:8
-#: module/Decision/view/decision/member/index.phtml:17
-#: module/Decision/view/decision/member/search.phtml:4
-#: module/Decision/view/decision/member/view.phtml:13
+#: module/Application/view/partial/main-nav.phtml:81
+#: module/Application/view/partial/main-nav.phtml:485
+#: module/Decision/view/decision/member/birthdays.phtml:15
+#: module/Decision/view/decision/member/index.phtml:22
+#: module/Decision/view/decision/member/index.phtml:28
+#: module/Decision/view/decision/member/search.phtml:11
+#: module/Decision/view/decision/member/view.phtml:23
 msgid "Members"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:85
+#: module/Application/view/partial/main-nav.phtml:98
 msgid "Subscribe"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:106
-#: module/Application/view/partial/main-nav.phtml:137
-#: module/Decision/view/decision/member/index.phtml:31
-#: module/User/view/user/user/change-password.phtml:2
-#: module/User/view/user/user/change-password.phtml:23
-#: module/User/src/Form/Password.php:61
+#: module/Application/view/partial/main-nav.phtml:121
+#: module/Application/view/partial/main-nav.phtml:154
+#: module/Decision/view/decision/member/index.phtml:42
+#: module/User/view/user/user/change-password.phtml:15
+#: module/User/view/user/user/change-password.phtml:36
+#: module/User/src/Form/Password.php:59
 msgid "Change password"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:111
-#: module/Application/view/partial/main-nav.phtml:149
+#: module/Application/view/partial/main-nav.phtml:126
+#: module/Application/view/partial/main-nav.phtml:168
 msgid "Logout"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:127
+#: module/Application/view/partial/main-nav.phtml:144
 msgid "My information"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:132
-#: module/Decision/view/decision/member/index.phtml:45
+#: module/Application/view/partial/main-nav.phtml:149
+#: module/Decision/view/decision/member/index.phtml:56
 msgid "SudoSOS"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:157
+#: module/Application/view/partial/main-nav.phtml:177
 msgid "Toggle navigation"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:170
-#: module/Application/view/partial/main-nav.phtml:175
-#: module/Application/view/partial/main-nav.phtml:180
-#: module/Decision/view/decision/member/index.phtml:58
+#: module/Application/view/partial/main-nav.phtml:191
+#: module/Application/view/partial/main-nav.phtml:196
+#: module/Application/view/partial/main-nav.phtml:201
+#: module/Decision/view/decision/member/index.phtml:69
 msgid "Association"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:191
-#: module/Decision/view/decision/member/view.phtml:82
+#: module/Application/view/partial/main-nav.phtml:212
+#: module/Decision/view/decision/member/view.phtml:72
 msgid "Board"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:196
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:3
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:9
-#: module/Frontpage/view/frontpage/organ/organ.phtml:48
+#: module/Application/view/partial/main-nav.phtml:217
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:14
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:20
+#: module/Frontpage/view/frontpage/organ/organ.phtml:64
 msgid "Committees"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:201
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:3
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:7
-#: module/Frontpage/view/frontpage/organ/organ.phtml:44
+#: module/Application/view/partial/main-nav.phtml:222
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:15
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:19
+#: module/Frontpage/view/frontpage/organ/organ.phtml:60
 msgid "Fraternities"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:212
+#: module/Application/view/partial/main-nav.phtml:233
 msgid "Exceptional Members"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:223
+#: module/Application/view/partial/main-nav.phtml:244
 msgid "GEWIS song"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:234
-#: module/Decision/view/decision/member/index.phtml:215
+#: module/Application/view/partial/main-nav.phtml:255
+#: module/Decision/view/decision/member/index.phtml:226
 msgid "Regulations"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:241
-#: module/Application/view/partial/main-nav.phtml:246
+#: module/Application/view/partial/main-nav.phtml:262
+#: module/Application/view/partial/main-nav.phtml:267
 msgid "Useful Information"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:252
-#: module/Decision/view/decision/member/index.phtml:82
+#: module/Application/view/partial/main-nav.phtml:273
+#: module/Decision/view/decision/member/index.phtml:93
 msgid "Links"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:257
+#: module/Application/view/partial/main-nav.phtml:278
 msgid "Well-being"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:268
+#: module/Application/view/partial/main-nav.phtml:289
 msgid "Confidential Contact Person (CCP)"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:273
+#: module/Application/view/partial/main-nav.phtml:294
 msgid "FAQ"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:284
+#: module/Application/view/partial/main-nav.phtml:305
 msgid "Housing"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:321
-#: module/Company/view/company/admin/index.phtml:147
+#: module/Application/view/partial/main-nav.phtml:343
+#: module/Company/view/company/admin/index.phtml:161
 msgid "Featured"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:365
+#: module/Application/view/partial/main-nav.phtml:390
 msgid "My activities"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:372
+#: module/Application/view/partial/main-nav.phtml:399
 msgid "Activity Archive"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:379
+#: module/Application/view/partial/main-nav.phtml:408
 msgid "Create an activity"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:392
+#: module/Application/view/partial/main-nav.phtml:424
 msgid "Career related"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:421
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:200
+#: module/Application/view/partial/main-nav.phtml:457
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:218
 msgid "Photo of the week"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:433
-#: module/Decision/view/decision/member/index.phtml:41
+#: module/Application/view/partial/main-nav.phtml:470
+#: module/Decision/view/decision/member/index.phtml:52
 msgid "My photo's"
 msgstr ""
 
-#: module/Application/view/partial/main-nav.phtml:457
+#: module/Application/view/partial/main-nav.phtml:499
 msgid "You are currently using administrator privileges to use the website!"
 msgstr ""
 
-#: module/Application/view/partial/paginator.phtml:8
-#: module/Photo/view/photo/album/index.phtml:428
+#: module/Application/view/partial/paginator.phtml:19
+#: module/Photo/view/photo/album/index.phtml:437
 msgid "Previous"
 msgstr ""
 
-#: module/Application/view/partial/paginator.phtml:22
-#: module/Photo/view/photo/album/index.phtml:429
+#: module/Application/view/partial/paginator.phtml:37
+#: module/Photo/view/photo/album/index.phtml:438
 msgid "Next"
 msgstr ""
 
-#: module/Application/view/partial/privacy-widget.phtml:3
+#: module/Application/view/partial/privacy-widget.phtml:13
 msgid ""
 "S.v. GEWIS uses cookies on this website, these are required for the website "
 "to function. Additionally, we may collection information about how you use "
@@ -1751,211 +1752,211 @@ msgid ""
 "behaviour to be tracked please opt out below."
 msgstr ""
 
-#: module/Application/view/partial/privacy-widget.phtml:8
+#: module/Application/view/partial/privacy-widget.phtml:19
 msgid "Tracking is currently"
 msgstr ""
 
-#: module/Application/view/partial/privacy-widget.phtml:9
+#: module/Application/view/partial/privacy-widget.phtml:20
 msgid "enabled"
 msgstr ""
 
-#: module/Application/view/partial/privacy-widget.phtml:10
+#: module/Application/view/partial/privacy-widget.phtml:21
 msgid "disabled"
 msgstr ""
 
-#: module/Application/view/partial/privacy-widget.phtml:11
+#: module/Application/view/partial/privacy-widget.phtml:23
 msgid "disabled (Do Not Track)"
 msgstr ""
 
-#: module/Application/view/partial/privacy-widget.phtml:12
+#: module/Application/view/partial/privacy-widget.phtml:25
 msgid "unavailable"
 msgstr ""
 
-#: module/Application/view/partial/privacy-widget.phtml:17
-#: module/Decision/view/decision/member/index.phtml:283
+#: module/Application/view/partial/privacy-widget.phtml:31
+#: module/Decision/view/decision/member/index.phtml:294
 msgid "Privacy Policy"
 msgstr ""
 
-#: module/Application/view/partial/privacy-widget.phtml:18
+#: module/Application/view/partial/privacy-widget.phtml:33
 #: module/User/src/Form/ApiAppAuthorisation.php:48
 msgid "Continue"
 msgstr ""
 
-#: module/Company/view/company/admin/add-category.phtml:2
-#: module/Company/view/company/admin/add-category.phtml:10
-#: module/Company/view/company/admin/add-category.phtml:25
+#: module/Company/view/company/admin/add-category.phtml:14
+#: module/Company/view/company/admin/add-category.phtml:22
+#: module/Company/view/company/admin/add-category.phtml:37
 msgid "Create Job Category"
 msgstr ""
 
-#: module/Company/view/company/admin/add-company.phtml:2
-#: module/Company/view/company/admin/add-company.phtml:16
-#: module/Company/view/company/admin/add-company.phtml:31
+#: module/Company/view/company/admin/add-company.phtml:14
+#: module/Company/view/company/admin/add-company.phtml:28
+#: module/Company/view/company/admin/add-company.phtml:43
 msgid "Create Company"
 msgstr ""
 
-#: module/Company/view/company/admin/add-job.phtml:2
-#: module/Company/view/company/admin/add-job.phtml:21
-#: module/Company/view/company/admin/add-job.phtml:36
-#: module/Company/view/company/admin/edit-package.phtml:126
-#: module/Company/view/company/company-account/jobs.phtml:78
-#: module/Company/view/company/company-account/jobs.phtml:263
+#: module/Company/view/company/admin/add-job.phtml:14
+#: module/Company/view/company/admin/add-job.phtml:33
+#: module/Company/view/company/admin/add-job.phtml:48
+#: module/Company/view/company/admin/edit-package.phtml:140
+#: module/Company/view/company/company-account/jobs.phtml:97
+#: module/Company/view/company/company-account/jobs.phtml:282
 msgid "Add Job"
 msgstr ""
 
-#: module/Company/view/company/admin/add-label.phtml:2
-#: module/Company/view/company/admin/add-label.phtml:16
-#: module/Company/view/company/admin/add-label.phtml:31
+#: module/Company/view/company/admin/add-label.phtml:14
+#: module/Company/view/company/admin/add-label.phtml:28
+#: module/Company/view/company/admin/add-label.phtml:43
 msgid "Create Job Label"
 msgstr ""
 
-#: module/Company/view/company/admin/add-package.phtml:2
-#: module/Company/view/company/admin/add-package.phtml:16
-#: module/Company/view/company/admin/add-package.phtml:32
+#: module/Company/view/company/admin/add-package.phtml:15
+#: module/Company/view/company/admin/add-package.phtml:29
+#: module/Company/view/company/admin/add-package.phtml:45
 msgid "Add Package"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/index.phtml:8
+#: module/Company/view/company/admin-approval/index.phtml:24
 msgid "Unapproved Companies"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/index.phtml:22
+#: module/Company/view/company/admin-approval/index.phtml:38
 msgid "There is no company or update proposal that requires your approval."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/index.phtml:34
+#: module/Company/view/company/admin-approval/index.phtml:50
 msgid "Unapproved Jobs"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/index.phtml:40
+#: module/Company/view/company/admin-approval/index.phtml:56
 msgid "Dutch Name"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/index.phtml:41
+#: module/Company/view/company/admin-approval/index.phtml:57
 msgid "English Name"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/index.phtml:50
+#: module/Company/view/company/admin-approval/index.phtml:66
 msgid "There is no job or update proposal that requires your approval."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/index.phtml:66
+#: module/Company/view/company/admin-approval/index.phtml:82
 msgid "View Update"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/index.phtml:74
+#: module/Company/view/company/admin-approval/index.phtml:90
 msgid "View Proposal"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:21
+#: module/Company/view/company/admin-approval/job-approval.phtml:35
 #, php-format
 msgid "This job is proposed by <strong>%s</strong> as part of job package %s."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:30
-#: module/Company/view/company/admin-approval/job-approval.phtml:34
-#: module/Company/view/company/admin-approval/job-proposal.phtml:59
-#: module/Company/view/company/admin-approval/job-proposal.phtml:63
-#: module/Company/view/partial/company/admin/editors/company.phtml:5
-#: module/Company/view/partial/company/admin/editors/job.phtml:5
-#: module/Company/src/Form/Company.php:62
+#: module/Company/view/company/admin-approval/job-approval.phtml:44
+#: module/Company/view/company/admin-approval/job-approval.phtml:48
+#: module/Company/view/company/admin-approval/job-proposal.phtml:69
+#: module/Company/view/company/admin-approval/job-proposal.phtml:73
+#: module/Company/view/partial/company/admin/editors/company.phtml:18
+#: module/Company/view/partial/company/admin/editors/job.phtml:18
+#: module/Company/src/Form/Company.php:61
 #: module/Company/src/Form/JobCategory.php:85
 #: module/Company/src/Form/JobCategory.php:95
-#: module/Company/src/Form/Job.php:65
+#: module/Company/src/Form/Job.php:69
 msgid "Slug"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:41
-#: module/Company/view/company/admin-approval/job-approval.phtml:45
-#: module/Company/view/company/admin-approval/job-proposal.phtml:73
-#: module/Company/view/company/admin-approval/job-proposal.phtml:77
-#: module/Company/src/Form/Job.php:75
+#: module/Company/view/company/admin-approval/job-approval.phtml:55
+#: module/Company/view/company/admin-approval/job-approval.phtml:59
+#: module/Company/view/company/admin-approval/job-proposal.phtml:83
+#: module/Company/view/company/admin-approval/job-proposal.phtml:87
+#: module/Company/src/Form/Job.php:79
 msgid "Category"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:63
-#: module/Company/view/company/admin-approval/job-approval.phtml:67
-#: module/Company/view/company/admin-approval/job-proposal.phtml:101
-#: module/Company/view/company/admin-approval/job-proposal.phtml:105
-#: module/Decision/view/decision/member/self.phtml:158
+#: module/Company/view/company/admin-approval/job-approval.phtml:77
+#: module/Company/view/company/admin-approval/job-approval.phtml:81
+#: module/Company/view/company/admin-approval/job-proposal.phtml:111
+#: module/Company/view/company/admin-approval/job-proposal.phtml:115
+#: module/Decision/view/decision/member/self.phtml:174
 msgid "Phone number"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:74
-#: module/Company/view/company/admin-approval/job-approval.phtml:78
-#: module/Company/view/company/admin-approval/job-proposal.phtml:115
-#: module/Company/view/company/admin-approval/job-proposal.phtml:119
-#: module/User/src/Form/UserReset.php:42
-#: module/User/src/Model/Enums/JWTClaims.php:37
+#: module/Company/view/company/admin-approval/job-approval.phtml:88
+#: module/Company/view/company/admin-approval/job-approval.phtml:92
+#: module/Company/view/company/admin-approval/job-proposal.phtml:125
+#: module/Company/view/company/admin-approval/job-proposal.phtml:129
+#: module/User/src/Form/UserReset.php:40
+#: module/User/src/Model/Enums/JWTClaims.php:39
 msgid "E-mail address"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:124
-#: module/Company/view/company/admin-approval/job-approval.phtml:129
-#: module/Company/view/company/admin-approval/job-approval.phtml:136
-#: module/Company/view/company/admin-approval/job-proposal.phtml:174
-#: module/Company/view/company/admin-approval/job-proposal.phtml:179
+#: module/Company/view/company/admin-approval/job-approval.phtml:138
+#: module/Company/view/company/admin-approval/job-approval.phtml:143
+#: module/Company/view/company/admin-approval/job-approval.phtml:150
+#: module/Company/view/company/admin-approval/job-proposal.phtml:184
 #: module/Company/view/company/admin-approval/job-proposal.phtml:189
-#: module/Frontpage/view/frontpage/organ/organ.phtml:94
-#: module/Company/src/Form/Company.php:179
-#: module/Company/src/Form/Company.php:189 module/Company/src/Form/Job.php:157
-#: module/Company/src/Form/Job.php:167
-#: module/Decision/src/Form/OrganInformation.php:44
+#: module/Company/view/company/admin-approval/job-proposal.phtml:199
+#: module/Frontpage/view/frontpage/organ/organ.phtml:110
+#: module/Company/src/Form/Company.php:178
+#: module/Company/src/Form/Company.php:188 module/Company/src/Form/Job.php:161
+#: module/Company/src/Form/Job.php:171
+#: module/Decision/src/Form/OrganInformation.php:42
 msgid "Website"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:181
-#: module/Company/view/company/admin-approval/job-approval.phtml:186
-#: module/Company/view/company/admin-approval/job-approval.phtml:197
-#: module/Company/view/company/admin-approval/job-proposal.phtml:249
-#: module/Company/view/company/admin-approval/job-proposal.phtml:254
-#: module/Company/view/company/admin-approval/job-proposal.phtml:270
-#: module/Company/src/Form/Job.php:217 module/Company/src/Form/Job.php:227
+#: module/Company/view/company/admin-approval/job-approval.phtml:195
+#: module/Company/view/company/admin-approval/job-approval.phtml:200
+#: module/Company/view/company/admin-approval/job-approval.phtml:211
+#: module/Company/view/company/admin-approval/job-proposal.phtml:259
+#: module/Company/view/company/admin-approval/job-proposal.phtml:264
+#: module/Company/view/company/admin-approval/job-proposal.phtml:280
+#: module/Company/src/Form/Job.php:221 module/Company/src/Form/Job.php:231
 msgid "Attachment"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:190
-#: module/Company/view/company/admin-approval/job-approval.phtml:201
-#: module/Company/view/company/admin-approval/job-proposal.phtml:274
-#: module/Company/view/company/company/jobs.phtml:121
+#: module/Company/view/company/admin-approval/job-approval.phtml:204
+#: module/Company/view/company/admin-approval/job-approval.phtml:215
+#: module/Company/view/company/admin-approval/job-proposal.phtml:284
+#: module/Company/view/company/company/jobs.phtml:133
 msgid "View Attachment"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:230
+#: module/Company/view/company/admin-approval/job-approval.phtml:244
 msgid ""
 "If approved, this job will be <strong>published</strong>, however, its "
 "actual visiblity depends on the company and associated job package."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:232
+#: module/Company/view/company/admin-approval/job-approval.phtml:246
 msgid "If approved, this job will be <strong>hidden</strong>."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:277
-#: module/Company/view/company/admin-approval/job-proposal.phtml:387
+#: module/Company/view/company/admin-approval/job-approval.phtml:291
+#: module/Company/view/company/admin-approval/job-proposal.phtml:397
 msgid "Optional message..."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:298
+#: module/Company/view/company/admin-approval/job-approval.phtml:312
 #, php-format
 msgid "This job was approved by <strong>%s</strong>."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:327
+#: module/Company/view/company/admin-approval/job-approval.phtml:341
 #, php-format
 msgid ""
 "This job was disapproved by <strong>%s</strong> with the message \"%s\"."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:333
+#: module/Company/view/company/admin-approval/job-approval.phtml:347
 #, php-format
 msgid "This job was disapproved by <strong>%s</strong>."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:17
+#: module/Company/view/company/admin-approval/job-proposal.phtml:27
 msgid "Proposals"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:49
+#: module/Company/view/company/admin-approval/job-proposal.phtml:59
 #, php-format
 msgid ""
 "This job update is proposed by <strong>%s</strong> as part of job package "
@@ -1963,565 +1964,565 @@ msgid ""
 "changes to a certain attribute, you will see the existing data."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:258
+#: module/Company/view/company/admin-approval/job-proposal.phtml:268
 msgid "View Original Attachment"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:263
-#: module/Company/view/company/admin-approval/job-proposal.phtml:279
+#: module/Company/view/company/admin-approval/job-proposal.phtml:273
+#: module/Company/view/company/admin-approval/job-proposal.phtml:289
 msgid "View New Attachment"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:287
-#: module/Company/view/partial/company/admin/editors/job.phtml:315
+#: module/Company/view/company/admin-approval/job-proposal.phtml:297
+#: module/Company/view/partial/company/admin/editors/job.phtml:328
 msgid "Job Labels"
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:318
+#: module/Company/view/company/admin-approval/job-proposal.phtml:328
 msgid ""
 "Original job and proposed update do not have any job labels applied to them."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:330
+#: module/Company/view/company/admin-approval/job-proposal.phtml:340
 msgid ""
 "Warning! This is an update to an unapproved job. Applying this update will "
 "approve the job."
 msgstr ""
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:340
+#: module/Company/view/company/admin-approval/job-proposal.phtml:350
 msgid ""
 "Warning! This is an update to rejected job. Applying this update will "
 "approve the job."
 msgstr ""
 
-#: module/Company/view/company/admin/categories.phtml:23
-#: module/Company/view/company/admin/labels.phtml:22
+#: module/Company/view/company/admin/categories.phtml:36
+#: module/Company/view/company/admin/labels.phtml:35
 msgid "edit"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-category.phtml:2
-#: module/Company/view/company/admin/edit-category.phtml:9
+#: module/Company/view/company/admin/edit-category.phtml:14
+#: module/Company/view/company/admin/edit-category.phtml:21
 msgid "Edit Job Category"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-category.phtml:24
+#: module/Company/view/company/admin/edit-category.phtml:36
 msgid "Update Job Category"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:5
+#: module/Company/view/company/admin/edit-company.phtml:17
 msgid "Edit Company"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:41
+#: module/Company/view/company/admin/edit-company.phtml:53
 #, php-format
 msgid "Edit %s"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:47
-#: module/Company/src/Form/JobsTransfer.php:41
+#: module/Company/view/company/admin/edit-company.phtml:59
+#: module/Company/src/Form/JobsTransfer.php:39
 msgid "Packages"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:58
+#: module/Company/view/company/admin/edit-company.phtml:70
 msgid "Add Job Package"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:68
+#: module/Company/view/company/admin/edit-company.phtml:80
 msgid "Add Spotlight Package"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:78
+#: module/Company/view/company/admin/edit-company.phtml:90
 msgid "Add Banner Package"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:89
-#: module/Company/view/company/company-account/jobs.phtml:35
-#: module/Company/src/Form/Package.php:82
+#: module/Company/view/company/admin/edit-company.phtml:101
+#: module/Company/view/company/company-account/jobs.phtml:54
+#: module/Company/src/Form/Package.php:79
 msgid "Contract Number"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:92
-#: module/Company/view/company/admin/edit-package.phtml:70
-#: module/Company/view/company/company-account/jobs.phtml:178
+#: module/Company/view/company/admin/edit-company.phtml:104
+#: module/Company/view/company/admin/edit-package.phtml:84
+#: module/Company/view/company/company-account/jobs.phtml:197
 msgid "Active"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:98
-#: module/Company/view/company/company-account/jobs.phtml:41
+#: module/Company/view/company/admin/edit-company.phtml:110
+#: module/Company/view/company/company-account/jobs.phtml:60
 msgid "Expiration date"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:101
+#: module/Company/view/company/admin/edit-company.phtml:113
 msgid "Jobs (Active) / Type"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:124
-#: module/Company/view/company/admin/index.phtml:36
-#: module/Company/view/company/admin/index.phtml:68
+#: module/Company/view/company/admin/edit-company.phtml:136
+#: module/Company/view/company/admin/index.phtml:50
+#: module/Company/view/company/admin/index.phtml:82
 msgid "Banner Package"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:127
-#: module/Company/view/company/admin/index.phtml:39
-#: module/Company/view/company/admin/index.phtml:71
+#: module/Company/view/company/admin/edit-company.phtml:139
+#: module/Company/view/company/admin/index.phtml:53
+#: module/Company/view/company/admin/index.phtml:85
 msgid "Featured Package"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:175
+#: module/Company/view/company/admin/edit-company.phtml:187
 msgid "Update Company"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:194
+#: module/Company/view/company/admin/edit-company.phtml:206
 msgid "Are you sure you want to delete this package?"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-company.phtml:200
+#: module/Company/view/company/admin/edit-company.phtml:212
 msgid "Delete package"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-job.phtml:2
-#: module/Company/view/company/admin/edit-job.phtml:21
+#: module/Company/view/company/admin/edit-job.phtml:19
+#: module/Company/view/company/admin/edit-job.phtml:38
 msgid "Edit Job"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-job.phtml:30
+#: module/Company/view/company/admin/edit-job.phtml:47
 #, php-format
 msgid ""
 "You are currently updating an update proposal that was previously rejected "
 "for the following reason: %s"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-job.phtml:36
+#: module/Company/view/company/admin/edit-job.phtml:53
 msgid ""
 "You are currently updating an update proposal that was previously rejected, "
 "however, no reason was provided."
 msgstr ""
 
-#: module/Company/view/company/admin/edit-job.phtml:41
+#: module/Company/view/company/admin/edit-job.phtml:58
 #, php-format
 msgid ""
 "You are currently updating a job that was previously rejected for the "
 "following reason: %s"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-job.phtml:47
+#: module/Company/view/company/admin/edit-job.phtml:64
 msgid ""
 "You are currently updating a job that was previously rejected, however, no "
 "reason was provided."
 msgstr ""
 
-#: module/Company/view/company/admin/edit-job.phtml:68
+#: module/Company/view/company/admin/edit-job.phtml:85
 msgid "Update Job"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-label.phtml:2
-#: module/Company/view/company/admin/edit-label.phtml:16
+#: module/Company/view/company/admin/edit-label.phtml:14
+#: module/Company/view/company/admin/edit-label.phtml:28
 msgid "Edit Job Label"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-label.phtml:31
+#: module/Company/view/company/admin/edit-label.phtml:43
 msgid "Update Job Label"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-package.phtml:7
-#: module/Company/view/company/admin/edit-package.phtml:28
+#: module/Company/view/company/admin/edit-package.phtml:19
+#: module/Company/view/company/admin/edit-package.phtml:40
 msgid "Edit Package"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-package.phtml:44
+#: module/Company/view/company/admin/edit-package.phtml:56
 msgid "Update Package"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-package.phtml:87
+#: module/Company/view/company/admin/edit-package.phtml:101
 msgid "(Update Pending)"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-package.phtml:140
-#: module/Company/view/company/company-account/jobs.phtml:278
+#: module/Company/view/company/admin/edit-package.phtml:154
+#: module/Company/view/company/company-account/jobs.phtml:297
 msgid "Are you sure you want to delete this job?"
 msgstr ""
 
-#: module/Company/view/company/admin/edit-package.phtml:145
-#: module/Company/view/company/company-account/jobs.phtml:283
+#: module/Company/view/company/admin/edit-package.phtml:159
+#: module/Company/view/company/company-account/jobs.phtml:302
 msgid "Delete job"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:22
-#: module/Company/view/company/company-account/jobs.phtml:20
+#: module/Company/view/company/admin/index.phtml:36
+#: module/Company/view/company/company-account/jobs.phtml:39
 msgid "Notifications"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:24
+#: module/Company/view/company/admin/index.phtml:38
 msgid "No notifications"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:42
-#: module/Company/view/company/admin/index.phtml:74
+#: module/Company/view/company/admin/index.phtml:56
+#: module/Company/view/company/admin/index.phtml:88
 #, php-format
 msgid "Job Package (%s active)"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:49
+#: module/Company/view/company/admin/index.phtml:63
 #, php-format
 msgid "%s for company %s will start on %s"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:81
+#: module/Company/view/company/admin/index.phtml:95
 #, php-format
 msgid "%s for company %s will expire on %s"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:96
-#: module/Education/view/education/admin/course.phtml:15
+#: module/Company/view/company/admin/index.phtml:110
+#: module/Education/view/education/admin/course.phtml:27
 msgid "Filter..."
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:101
+#: module/Company/view/company/admin/index.phtml:115
 msgid "Add Company"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:130
-#: module/Company/view/company/admin/index.phtml:200
+#: module/Company/view/company/admin/index.phtml:144
+#: module/Company/view/company/admin/index.phtml:214
 msgid "Active jobs"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:138
-#: module/Company/view/company/admin/index.phtml:201
+#: module/Company/view/company/admin/index.phtml:152
+#: module/Company/view/company/admin/index.phtml:215
 msgid "Banner active"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:155
-#: module/Company/view/company/admin/index.phtml:203
+#: module/Company/view/company/admin/index.phtml:169
+#: module/Company/view/company/admin/index.phtml:217
 msgid "Expired packages"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:202
+#: module/Company/view/company/admin/index.phtml:216
 msgid "Featured in language"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:220
-#: module/Decision/view/decision/admin/document.phtml:155
+#: module/Company/view/company/admin/index.phtml:234
+#: module/Decision/view/decision/admin/document.phtml:169
 #, php-format
 msgid "Are you sure you want to delete %s?"
 msgstr ""
 
-#: module/Company/view/company/admin/index.phtml:227
+#: module/Company/view/company/admin/index.phtml:241
 msgid "Delete company"
 msgstr ""
 
-#: module/Company/view/company/admin/labels.phtml:4
+#: module/Company/view/company/admin/labels.phtml:17
 msgid "Add Label"
 msgstr ""
 
-#: module/Company/view/company/company-account/banner.phtml:12
-#: module/Company/view/company/company-account/highlights.phtml:12
+#: module/Company/view/company/company-account/banner.phtml:20
+#: module/Company/view/company/company-account/highlights.phtml:20
 msgid ""
 "This functionality is currently unavailable. Our apologies for the "
 "inconvenience."
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:26
+#: module/Company/view/company/company-account/jobs.phtml:45
 msgid "Job Packages"
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:44
+#: module/Company/view/company/company-account/jobs.phtml:63
 msgid "Jobs (Active)"
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:87
-#: module/Company/view/company/company/job-list.phtml:138
+#: module/Company/view/company/company-account/jobs.phtml:106
+#: module/Company/view/company/company/job-list.phtml:152
 msgid "View"
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:99
+#: module/Company/view/company/company-account/jobs.phtml:118
 msgid "Recently Approved Jobs"
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:101
+#: module/Company/view/company/company-account/jobs.phtml:120
 msgid "You do not have recently approved jobs."
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:121
+#: module/Company/view/company/company-account/jobs.phtml:140
 msgid "Recently Rejected Jobs"
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:123
+#: module/Company/view/company/company-account/jobs.phtml:142
 msgid "You do not have recently rejected jobs."
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:143
+#: module/Company/view/company/company-account/jobs.phtml:162
 msgid "Recently Unapproved Jobs"
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:145
+#: module/Company/view/company/company-account/jobs.phtml:164
 msgid "You do not have any recent jobs pending approval."
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:179
+#: module/Company/view/company/company-account/jobs.phtml:198
 msgid "Approved (Has Updates)"
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:187
+#: module/Company/view/company/company-account/jobs.phtml:206
 msgid "This job package does not contain any jobs."
 msgstr ""
 
-#: module/Company/view/company/company-account/jobs.phtml:253
-#: module/Company/view/company/company-account/transfer-jobs.phtml:2
-#: module/Company/view/company/company-account/transfer-jobs.phtml:12
-#: module/Company/src/Form/JobsTransfer.php:52
+#: module/Company/view/company/company-account/jobs.phtml:272
+#: module/Company/view/company/company-account/transfer-jobs.phtml:14
+#: module/Company/view/company/company-account/transfer-jobs.phtml:24
+#: module/Company/src/Form/JobsTransfer.php:50
 msgid "Transfer Jobs"
 msgstr ""
 
-#: module/Company/view/company/company-account/self.phtml:2
+#: module/Company/view/company/company-account/self.phtml:10
 msgid "Company Account"
 msgstr ""
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:18
+#: module/Company/view/company/company-account/transfer-jobs.phtml:30
 msgid "Select the jobs that you want to transfer to another job package."
 msgstr ""
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:36
+#: module/Company/view/company/company-account/transfer-jobs.phtml:48
 msgid "There are no jobs that you can transfer..."
 msgstr ""
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:52
+#: module/Company/view/company/company-account/transfer-jobs.phtml:64
 msgid "Choose to which job package you want to transfer the selected jobs."
 msgstr ""
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:69
+#: module/Company/view/company/company-account/transfer-jobs.phtml:81
 msgid "Move Jobs"
 msgstr ""
 
-#: module/Company/view/company/company/companyStory.phtml:18
-#: module/Company/view/company/company/jobs.phtml:83
-#: module/Company/view/partial/company/company/grid/company.phtml:16
-#: module/Company/view/partial/company/company/list/company.phtml:26
+#: module/Company/view/company/company/companyStory.phtml:34
+#: module/Company/view/company/company/jobs.phtml:95
+#: module/Company/view/partial/company/company/grid/company.phtml:32
+#: module/Company/view/partial/company/company/list/company.phtml:36
 msgid "Logo of"
 msgstr ""
 
-#: module/Company/view/company/company/companyStory.phtml:47
-#: module/Company/view/partial/company/company/list/company.phtml:52
+#: module/Company/view/company/company/companyStory.phtml:63
+#: module/Company/view/partial/company/company/list/company.phtml:62
 msgid "Visit Website"
 msgstr ""
 
-#: module/Company/view/company/company/companyStory.phtml:52
+#: module/Company/view/company/company/companyStory.phtml:68
 msgid "Highlighted"
 msgstr ""
 
-#: module/Company/view/company/company/job-list.phtml:60
+#: module/Company/view/company/company/job-list.phtml:74
 msgid "What are you looking for?"
 msgstr ""
 
-#: module/Company/view/company/company/job-list.phtml:63
+#: module/Company/view/company/company/job-list.phtml:77
 msgid "Sort on"
 msgstr ""
 
-#: module/Company/view/company/company/job-list.phtml:65
+#: module/Company/view/company/company/job-list.phtml:79
 msgid "Random"
 msgstr ""
 
-#: module/Company/view/company/company/job-list.phtml:66
+#: module/Company/view/company/company/job-list.phtml:80
 msgid "Most recent"
 msgstr ""
 
-#: module/Company/view/company/company/job-list.phtml:94
+#: module/Company/view/company/company/job-list.phtml:108
 #, php-format
 msgid "Unfortunately, there aren't any %s at the moment."
 msgstr ""
 
-#: module/Company/view/company/company/job-list.phtml:169
+#: module/Company/view/company/company/job-list.phtml:183
 #, php-format
 msgid "Still haven't found what you're looking for? Take a look at %s."
 msgstr ""
 
-#: module/Company/view/company/company/jobs.phtml:64
+#: module/Company/view/company/company/jobs.phtml:76
 msgid "at"
 msgstr ""
 
-#: module/Company/view/company/company/jobs.phtml:114
+#: module/Company/view/company/company/jobs.phtml:126
 msgid "View Website"
 msgstr ""
 
-#: module/Company/view/company/company/list.phtml:23
-#: module/Company/view/company/company/spotlight.phtml:33
+#: module/Company/view/company/company/list.phtml:40
+#: module/Company/view/company/company/spotlight.phtml:49
 msgid "in the spotlight"
 msgstr ""
 
-#: module/Company/view/company/company/spotlight.phtml:21
+#: module/Company/view/company/company/spotlight.phtml:37
 msgid "Featured company"
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:8
+#: module/Company/view/partial/company/admin/editors/company.phtml:21
 msgid ""
 "Specify the permanent link for this company, it should be unique across all "
 "companies."
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:57
+#: module/Company/view/partial/company/admin/editors/company.phtml:70
 msgid "View current logo"
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:81
+#: module/Company/view/partial/company/admin/editors/company.phtml:94
 msgid "Representative Information"
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:82
+#: module/Company/view/partial/company/admin/editors/company.phtml:95
 msgid "Enter information about the representative of this company."
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:123
-#: module/Company/view/partial/company/admin/editors/job.phtml:65
+#: module/Company/view/partial/company/admin/editors/company.phtml:136
+#: module/Company/view/partial/company/admin/editors/job.phtml:78
 msgid "Contact Information"
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:124
+#: module/Company/view/partial/company/admin/editors/company.phtml:137
 msgid ""
 "Enter how someone can contact this company and who is responsible for this "
 "company."
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:192
-#: module/Company/view/partial/company/admin/editors/job.phtml:120
+#: module/Company/view/partial/company/admin/editors/company.phtml:205
+#: module/Company/view/partial/company/admin/editors/job.phtml:133
 msgid ""
 "What is this company about? Fill in the blanks below, please note that at "
 "least one language must be used."
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:8
+#: module/Company/view/partial/company/admin/editors/job.phtml:21
 msgid ""
 "Specify the permanent link for this job, it should be unique for this "
 "company."
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:66
+#: module/Company/view/partial/company/admin/editors/job.phtml:79
 msgid "Enter how someone can contact the person responsible for this job."
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:211
-#: module/Company/view/partial/company/admin/editors/job.phtml:307
+#: module/Company/view/partial/company/admin/editors/job.phtml:224
+#: module/Company/view/partial/company/admin/editors/job.phtml:320
 msgid "View current attachment"
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:316
+#: module/Company/view/partial/company/admin/editors/job.phtml:329
 msgid ""
 "Add job labels to your job to give viewers a better understanding of the job."
 msgstr ""
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:336
+#: module/Company/view/partial/company/admin/editors/job.phtml:349
 msgid "There are currently no job labels..."
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:20
+#: module/Decision/view/decision/admin/authorizations.phtml:31
 #, php-format
 msgid "GMM %d (%s)"
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:27
+#: module/Decision/view/decision/admin/authorizations.phtml:38
 msgid "No GMM available."
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:32
+#: module/Decision/view/decision/admin/authorizations.phtml:43
 #, php-format
 msgid "Valid authorizations for GMM %d"
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:37
-#: module/Decision/view/decision/admin/authorizations.phtml:61
+#: module/Decision/view/decision/admin/authorizations.phtml:48
+#: module/Decision/view/decision/admin/authorizations.phtml:72
 msgid "Authorizer"
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:38
-#: module/Decision/view/decision/admin/authorizations.phtml:62
+#: module/Decision/view/decision/admin/authorizations.phtml:49
+#: module/Decision/view/decision/admin/authorizations.phtml:73
 msgid "Recipient"
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:39
-#: module/Decision/view/decision/admin/authorizations.phtml:63
+#: module/Decision/view/decision/admin/authorizations.phtml:50
+#: module/Decision/view/decision/admin/authorizations.phtml:74
 msgid "Created"
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:53
+#: module/Decision/view/decision/admin/authorizations.phtml:64
 msgid "There are no valid authorizations for this GMM."
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:56
+#: module/Decision/view/decision/admin/authorizations.phtml:67
 #, php-format
 msgid "Revoked authorizations for GMM %d"
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:64
+#: module/Decision/view/decision/admin/authorizations.phtml:75
 msgid "Revoked"
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:79
+#: module/Decision/view/decision/admin/authorizations.phtml:90
 msgid "There are no revoked authorizations for this GMM."
 msgstr ""
 
-#: module/Decision/view/decision/admin/authorizations.phtml:82
+#: module/Decision/view/decision/admin/authorizations.phtml:93
 msgid "Please select a GMM to view authorizations."
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:18
+#: module/Decision/view/decision/admin/document.phtml:33
 msgid "There are no meetings for which you can upload documents."
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:22
+#: module/Decision/view/decision/admin/document.phtml:37
 msgid "Meeting document uploaded"
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:48
+#: module/Decision/view/decision/admin/document.phtml:62
 msgid "No meeting available."
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:89
+#: module/Decision/view/decision/admin/document.phtml:103
 msgid "Documents for this meeting"
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:92
+#: module/Decision/view/decision/admin/document.phtml:106
 msgid "This meeting does not have any associated documents."
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:131
-#: module/Decision/view/decision/admin/document.phtml:194
+#: module/Decision/view/decision/admin/document.phtml:145
+#: module/Decision/view/decision/admin/document.phtml:208
 msgid "Rename"
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:149
-#: module/Education/view/education/admin/course-documents.phtml:153
+#: module/Decision/view/decision/admin/document.phtml:163
+#: module/Education/view/education/admin/course-documents.phtml:163
 msgid "Delete Document"
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:181
+#: module/Decision/view/decision/admin/document.phtml:195
 msgid "Rename Meeting Document"
 msgstr ""
 
-#: module/Decision/view/decision/admin/document.phtml:184
+#: module/Decision/view/decision/admin/document.phtml:198
 msgid "Enter a new name for this document:"
 msgstr ""
 
-#: module/Decision/view/decision/admin/minutes.phtml:20
-#: module/Decision/src/Form/Document.php:31
-#: module/Decision/src/Form/Minutes.php:31
+#: module/Decision/view/decision/admin/minutes.phtml:31
+#: module/Decision/src/Form/Document.php:29
+#: module/Decision/src/Form/Minutes.php:33
 msgid "Meeting"
 msgstr ""
 
-#: module/Decision/view/decision/admin/minutes.phtml:44
+#: module/Decision/view/decision/admin/minutes.phtml:55
 msgid "Upload"
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:18
+#: module/Decision/view/decision/decision/authorizations.phtml:36
 msgid ""
 "There are no upcoming meetings for which you can authorize someone.\n"
 "You may still be able to authorize someone or revoke an authorization by "
 "contacting the board."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:22
+#: module/Decision/view/decision/decision/authorizations.phtml:40
 #, php-format
 msgid "You have authorized %s for the %s GMM (%s)."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:29
+#: module/Decision/view/decision/decision/authorizations.phtml:47
 #, php-format
 msgid ""
 "As per HR article 5 paragraph 4, you have the right to revoke your "
@@ -2531,29 +2532,29 @@ msgid ""
 "form below."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:45
-#: module/Decision/view/decision/decision/authorizations.phtml:100
+#: module/Decision/view/decision/decision/authorizations.phtml:63
+#: module/Decision/view/decision/decision/authorizations.phtml:118
 msgid "Terms"
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:50
+#: module/Decision/view/decision/decision/authorizations.phtml:68
 #, php-format
 msgid ""
 "I, %s am fully aware that by revoking my authorization, %s cannot represent "
 "me at the %s General Members Meeting (%s) of s.v. GEWIS."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:71
+#: module/Decision/view/decision/decision/authorizations.phtml:89
 #, php-format
 msgid "Authorize someone for the %s GMM (%s)"
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:87
-#: module/User/view/user/user/login.phtml:15
+#: module/Decision/view/decision/decision/authorizations.phtml:105
+#: module/User/view/user/user/login.phtml:29
 msgid "Member"
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:105
+#: module/Decision/view/decision/decision/authorizations.phtml:123
 #, php-format
 msgid ""
 "I, %s I am fully aware that by filling in this form I authorize the person "
@@ -2561,17 +2562,17 @@ msgid ""
 "GEWIS."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:115
-#: module/Decision/view/decision/decision/authorizations.phtml:121
+#: module/Decision/view/decision/decision/authorizations.phtml:133
+#: module/Decision/view/decision/decision/authorizations.phtml:139
 #: module/Decision/src/Form/Authorization.php:50
 msgid "Authorize"
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:157
+#: module/Decision/view/decision/decision/authorizations.phtml:175
 msgid "Are you sure you would like to authorize"
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:163
+#: module/Decision/view/decision/decision/authorizations.phtml:181
 msgid ""
 "This member has already received 2 or more authorizations through the "
 "website. Since you can only use two authorizations at the same time, this "
@@ -2581,1669 +2582,1707 @@ msgid ""
 "click on \"confirm authorization\"."
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:169
+#: module/Decision/view/decision/decision/authorizations.phtml:187
 msgid "Confirm authorization"
 msgstr ""
 
-#: module/Decision/view/decision/decision/authorizations.phtml:193
+#: module/Decision/view/decision/decision/authorizations.phtml:211
 #, php-format
 msgid "Are you sure you would like to authorize %s"
 msgstr ""
 
-#: module/Decision/view/decision/decision/files.phtml:14
-#: module/Decision/view/decision/decision/files.phtml:16
-#: module/Decision/view/decision/decision/files.phtml:35
-#: module/Decision/view/decision/decision/files.phtml:39
+#: module/Decision/view/decision/decision/files.phtml:26
+#: module/Decision/view/decision/decision/files.phtml:28
+#: module/Decision/view/decision/decision/files.phtml:47
+#: module/Decision/view/decision/decision/files.phtml:51
 msgid "Root"
 msgstr ""
 
-#: module/Decision/view/decision/decision/files.phtml:35
+#: module/Decision/view/decision/decision/files.phtml:47
 msgid "Public Archive"
 msgstr ""
 
-#: module/Decision/view/decision/decision/files.phtml:39
+#: module/Decision/view/decision/decision/files.phtml:51
 msgid "Browsing directory: "
 msgstr ""
 
-#: module/Decision/view/decision/decision/files.phtml:66
+#: module/Decision/view/decision/decision/files.phtml:78
 msgid "Filename"
 msgstr ""
 
-#: module/Decision/view/decision/decision/files.phtml:80
+#: module/Decision/view/decision/decision/files.phtml:92
 msgid ".. Move up a folder"
 msgstr ""
 
-#: module/Decision/view/decision/decision/files.phtml:89
+#: module/Decision/view/decision/decision/files.phtml:101
 msgid "Empty folder"
 msgstr ""
 
-#: module/Decision/view/decision/decision/index.phtml:10
+#: module/Decision/view/decision/decision/index.phtml:24
 msgid "Meeting number"
 msgstr ""
 
-#: module/Decision/view/decision/decision/index.phtml:11
-#: module/Decision/view/decision/member/birthdays.phtml:11
-#: module/Education/view/education/admin/course-documents.phtml:55
-#: module/Education/view/education/admin/course-documents.phtml:106
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:26
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:99
+#: module/Decision/view/decision/decision/index.phtml:25
+#: module/Decision/view/decision/member/birthdays.phtml:22
+#: module/Education/view/education/admin/course-documents.phtml:65
+#: module/Education/view/education/admin/course-documents.phtml:116
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:41
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:114
 msgid "Date"
 msgstr ""
 
-#: module/Decision/view/decision/decision/index.phtml:12
+#: module/Decision/view/decision/decision/index.phtml:26
 msgid "# Decisions"
 msgstr ""
 
-#: module/Decision/view/decision/decision/search.phtml:3
+#: module/Decision/view/decision/decision/search.phtml:14
 msgid "Search for decision"
 msgstr ""
 
-#: module/Decision/view/decision/decision/search.phtml:21
+#: module/Decision/view/decision/decision/search.phtml:32
 #: module/Decision/src/Form/SearchDecision.php:25
-#: module/Education/src/Form/SearchCourse.php:21
+#: module/Education/src/Form/SearchCourse.php:23
 msgid "Search query"
 msgstr ""
 
-#: module/Decision/view/decision/decision/search.phtml:30
-#: module/Decision/view/decision/member/index.phtml:146
-#: module/Education/view/education/education/index.phtml:46
+#: module/Decision/view/decision/decision/search.phtml:41
+#: module/Decision/view/decision/member/index.phtml:157
+#: module/Education/view/education/education/index.phtml:59
 #: module/Decision/src/Form/SearchDecision.php:35
 #: module/Decision/src/Form/SearchDecision.php:36
 msgid "Search"
 msgstr ""
 
-#: module/Decision/view/decision/decision/view.phtml:35
+#: module/Decision/view/decision/decision/search.phtml:50
+msgid "No decisions were found."
+msgstr ""
+
+#: module/Decision/view/decision/decision/search.phtml:52
+msgid "Check the spelling of your search term"
+msgstr ""
+
+#: module/Decision/view/decision/decision/search.phtml:53
+msgid "Try alternate words or selections"
+msgstr ""
+
+#: module/Decision/view/decision/decision/search.phtml:54
+msgid "Try using a more generic search term"
+msgstr ""
+
+#: module/Decision/view/decision/decision/search.phtml:55
+msgid "Try entering fewer keywords"
+msgstr ""
+
+#: module/Decision/view/decision/decision/search.phtml:56
+msgid ""
+"Looking for a specific decision but forgot the numbers? Try dropping the "
+"decision point and/or number"
+msgstr ""
+
+#: module/Decision/view/decision/decision/view.phtml:47
 msgid "No documents have been added."
 msgstr ""
 
-#: module/Decision/view/decision/decision/view.phtml:50
+#: module/Decision/view/decision/decision/view.phtml:62
 #, php-format
 msgid "View the minutes of the %s"
 msgstr ""
 
-#: module/Decision/view/decision/decision/view.phtml:59
+#: module/Decision/view/decision/decision/view.phtml:71
 msgid "Decisions"
 msgstr ""
 
-#: module/Decision/view/decision/member/birthdays.phtml:3
+#: module/Decision/view/decision/member/birthdays.phtml:14
 msgid "Birthdays"
 msgstr ""
 
-#: module/Decision/view/decision/member/birthdays.phtml:13
+#: module/Decision/view/decision/member/birthdays.phtml:24
 msgid "Age"
 msgstr ""
 
-#: module/Decision/view/decision/member/birthdays.phtml:33
+#: module/Decision/view/decision/member/birthdays.phtml:44
 msgid "years"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:22
+#: module/Decision/view/decision/member/index.phtml:33
 msgid "Personal"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:26
+#: module/Decision/view/decision/member/index.phtml:37
 msgid "Profile"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:67
+#: module/Decision/view/decision/member/index.phtml:78
 msgid "Public archive"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:72
+#: module/Decision/view/decision/member/index.phtml:83
 msgid "Find a member"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:107
+#: module/Decision/view/decision/member/index.phtml:106
+msgid "Upcoming meeting"
+msgid_plural "Upcoming meetings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: module/Decision/view/decision/member/index.phtml:118
 #, php-format
 msgid "The %s%s %s%s will be held on %s."
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:133
+#: module/Decision/view/decision/member/index.phtml:144
 #, php-format
 msgid ""
 "If you aren't able to attend a GMM in person but you want your voice to be "
 "heard, consider %sauthorizing another member%s to act on your behalf."
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:141
+#: module/Decision/view/decision/member/index.phtml:152
 msgid "Search through the list of decisions accumulated from past meetings:"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:144
+#: module/Decision/view/decision/member/index.phtml:155
 msgid "Search by keyword or meeting number"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:151
+#: module/Decision/view/decision/member/index.phtml:162
 #, php-format
 msgid "The latest %s that took place:"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:163
+#: module/Decision/view/decision/member/index.phtml:174
 #, php-format
 msgid "%s %s on %s"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:178
+#: module/Decision/view/decision/member/index.phtml:189
 msgid "View all meetings"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:183
-#: module/Decision/view/decision/organ/show.phtml:9
-#: module/Frontpage/view/frontpage/organ/organ.phtml:129
+#: module/Decision/view/decision/member/index.phtml:194
+#: module/Decision/view/decision/organ/show.phtml:25
+#: module/Frontpage/view/frontpage/organ/organ.phtml:145
 msgid "Active members"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:184
+#: module/Decision/view/decision/member/index.phtml:195
 msgid "A list of helpful resources for active members."
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:188
+#: module/Decision/view/decision/member/index.phtml:199
 msgid "Webmail"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:200
+#: module/Decision/view/decision/member/index.phtml:211
 msgid "GEWIKI"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:204
+#: module/Decision/view/decision/member/index.phtml:215
 msgid "Corporate Identity"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:208
+#: module/Decision/view/decision/member/index.phtml:219
 msgid "Administrator"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:226
+#: module/Decision/view/decision/member/index.phtml:237
 msgid "Bylaws"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:238
+#: module/Decision/view/decision/member/index.phtml:249
 msgid "Internal Regulations"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:253
+#: module/Decision/view/decision/member/index.phtml:264
 msgid "Board Policies"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:258
+#: module/Decision/view/decision/member/index.phtml:269
 msgid "Borrel Policy"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:263
+#: module/Decision/view/decision/member/index.phtml:274
 msgid "House Rules"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:268
+#: module/Decision/view/decision/member/index.phtml:279
 msgid "ICT Policy"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:273
+#: module/Decision/view/decision/member/index.phtml:284
 msgid "Key Policy"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:278
+#: module/Decision/view/decision/member/index.phtml:289
 msgid "Poster Policy"
 msgstr ""
 
-#: module/Decision/view/decision/member/index.phtml:289
+#: module/Decision/view/decision/member/index.phtml:300
 msgid "Organ Regulations"
 msgstr ""
 
-#: module/Decision/view/decision/member/search.phtml:3
-#: module/Decision/view/decision/member/search.phtml:9
+#: module/Decision/view/decision/member/search.phtml:10
+#: module/Decision/view/decision/member/search.phtml:16
 msgid "Zoeken op lid"
 msgstr ""
 
-#: module/Decision/view/decision/member/search.phtml:13
+#: module/Decision/view/decision/member/search.phtml:20
 msgid "Zoek"
 msgstr ""
 
-#: module/Decision/view/decision/member/search.phtml:23
+#: module/Decision/view/decision/member/search.phtml:30
 msgid "Naam"
 msgstr ""
 
-#: module/Decision/view/decision/member/search.phtml:24
+#: module/Decision/view/decision/member/search.phtml:31
 msgid "Generatie"
 msgstr ""
 
-#: module/Decision/view/decision/member/search.phtml:31
+#: module/Decision/view/decision/member/search.phtml:38
 msgid ""
 "Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
 "resultaten te zien."
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:10
+#: module/Decision/view/decision/member/self.phtml:20
 msgid "My Information"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:19
-#: module/User/src/Form/Register.php:34 module/User/src/Form/UserReset.php:32
+#: module/Decision/view/decision/member/self.phtml:29
+#: module/User/src/Form/Register.php:32 module/User/src/Form/UserReset.php:30
 msgid "Membership number"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:23
+#: module/Decision/view/decision/member/self.phtml:33
 msgid "Initials"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:27
+#: module/Decision/view/decision/member/self.phtml:37
 msgid "First name"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:31
-#: module/User/src/Model/Enums/JWTClaims.php:43
+#: module/Decision/view/decision/member/self.phtml:41
+#: module/User/src/Model/Enums/JWTClaims.php:45
 msgid "Middle name"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:35
+#: module/Decision/view/decision/member/self.phtml:45
 msgid "Last name"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:50
-#: module/Decision/view/decision/member/view.phtml:46
+#: module/Decision/view/decision/member/self.phtml:60
+#: module/Decision/view/decision/member/view.phtml:45
 msgid "Birth date"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:58
-#: module/Decision/view/decision/member/view.phtml:55
-#: module/User/src/Model/Enums/JWTClaims.php:42
+#: module/Decision/view/decision/member/self.phtml:68
+#: module/Decision/view/decision/member/view.phtml:54
+#: module/User/src/Model/Enums/JWTClaims.php:44
 msgid "Membership type"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:62
+#: module/Decision/view/decision/member/self.phtml:72
 msgid "Last membership change"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:66
+#: module/Decision/view/decision/member/self.phtml:76
 msgid "End date of membership"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:73
+#: module/Decision/view/decision/member/self.phtml:83
 msgid ""
 "If your information is no longer up to date and you would like to change it, "
 "you can contact the secretary of GEWIS."
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:74
+#: module/Decision/view/decision/member/self.phtml:84
 msgid "Also for data removal requests, you can contact"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:75
+#: module/Decision/view/decision/member/self.phtml:85
 msgid "Email the secretary of GEWIS"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:75
+#: module/Decision/view/decision/member/self.phtml:85
 msgid "the secretary of GEWIS"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:79
-#: module/Decision/view/decision/member/view.phtml:127
+#: module/Decision/view/decision/member/self.phtml:89
+#: module/Decision/view/decision/member/view.phtml:117
 msgid "Memberships of committees and fraternities"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:84
+#: module/Decision/view/decision/member/self.phtml:94
 msgid "You have not been a member of a committee or fraternity."
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:87
+#: module/Decision/view/decision/member/self.phtml:97
 msgid "You are currently a member of:"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:108
+#: module/Decision/view/decision/member/self.phtml:121
 msgid "You were a member of:"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:129
-#: module/Decision/view/decision/member/view.phtml:192
+#: module/Decision/view/decision/member/self.phtml:145
+#: module/Decision/view/decision/member/view.phtml:188
 msgid "Addresses"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:134
-#: module/Decision/view/decision/member/view.phtml:197
+#: module/Decision/view/decision/member/self.phtml:150
+#: module/Decision/view/decision/member/view.phtml:193
 msgid "Country"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:138
-#: module/Decision/view/decision/member/view.phtml:201
+#: module/Decision/view/decision/member/self.phtml:154
+#: module/Decision/view/decision/member/view.phtml:197
 msgid "Street and number"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:141
-#: module/Decision/view/decision/member/self.phtml:151
-#: module/Decision/view/decision/member/view.phtml:204
-#: module/Decision/view/decision/member/view.phtml:214
+#: module/Decision/view/decision/member/self.phtml:157
+#: module/Decision/view/decision/member/self.phtml:167
+#: module/Decision/view/decision/member/view.phtml:200
+#: module/Decision/view/decision/member/view.phtml:210
 #, php-format
 msgid "%s %s"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:148
-#: module/Decision/view/decision/member/view.phtml:211
+#: module/Decision/view/decision/member/self.phtml:164
+#: module/Decision/view/decision/member/view.phtml:207
 msgid "City and postal code"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:164
+#: module/Decision/view/decision/member/self.phtml:180
 msgid "External applications"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:167
+#: module/Decision/view/decision/member/self.phtml:183
 msgid "App"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:168
+#: module/Decision/view/decision/member/self.phtml:184
 msgid "First authentication"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:169
+#: module/Decision/view/decision/member/self.phtml:185
 msgid "Last authentication"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:214
+#: module/Decision/view/decision/member/self.phtml:230
 msgid "Remove this picture as your profile picture"
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:216
+#: module/Decision/view/decision/member/self.phtml:232
 msgid "Your profile picture will be chosen automatically instead."
 msgstr ""
 
-#: module/Decision/view/decision/member/self.phtml:231
+#: module/Decision/view/decision/member/self.phtml:247
 msgid "More of my photo's"
 msgstr ""
 
-#: module/Decision/view/decision/member/view.phtml:59
+#: module/Decision/view/decision/member/view.phtml:58
 msgid "Has key code?"
 msgstr ""
 
-#: module/Decision/view/decision/member/view.phtml:89
+#: module/Decision/view/decision/member/view.phtml:79
 #, php-format
 msgid "%s is the upcoming <strong>%s</strong>."
 msgstr ""
 
-#: module/Decision/view/decision/member/view.phtml:105
+#: module/Decision/view/decision/member/view.phtml:95
 #, php-format
 msgid "%s is currently the <strong>%s</strong>."
 msgstr ""
 
-#: module/Decision/view/decision/member/view.phtml:115
+#: module/Decision/view/decision/member/view.phtml:105
 #, php-format
 msgid "%s was the <strong>%s</strong> during the association year %d/%d."
 msgstr ""
 
-#: module/Decision/view/decision/member/view.phtml:134
+#: module/Decision/view/decision/member/view.phtml:124
 #, php-format
 msgid "%s has never been part of a committee or fraternity."
 msgstr ""
 
-#: module/Decision/view/decision/member/view.phtml:142
+#: module/Decision/view/decision/member/view.phtml:132
 #, php-format
 msgid "%s is currently a member of:"
 msgstr ""
 
-#: module/Decision/view/decision/member/view.phtml:168
+#: module/Decision/view/decision/member/view.phtml:161
 #, php-format
 msgid "%s was a member of:"
 msgstr ""
 
-#: module/Decision/view/decision/member/view.phtml:266
+#: module/Decision/view/decision/member/view.phtml:262
 #, php-format
 msgid "Photo's of %s"
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:64
+#: module/Decision/view/decision/organ-admin/edit.phtml:75
 msgid "Edit organ information"
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:139
+#: module/Decision/view/decision/organ-admin/edit.phtml:150
 msgid ""
 "To optimally display your image on the overview page, please crop it below"
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:155
+#: module/Decision/view/decision/organ-admin/edit.phtml:166
 msgid "To optimally display your image your page, please crop it below"
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:171
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:97
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:131
-#: module/Decision/src/Form/OrganInformation.php:125
+#: module/Decision/view/decision/organ-admin/edit.phtml:182
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:110
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:143
+#: module/Decision/src/Form/OrganInformation.php:123
 #: module/Frontpage/src/Form/NewsItem.php:78
-#: module/Frontpage/src/Form/Page.php:102
+#: module/Frontpage/src/Form/Page.php:100
 #: module/Photo/src/Form/EditAlbum.php:59
 msgid "Save"
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/index.phtml:6
+#: module/Decision/view/decision/organ-admin/index.phtml:18
 msgid ""
 "Select an organ to edit its information. Changes will not be displayed until "
 "they have been approved."
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/index.phtml:11
-#: module/Decision/view/decision/organ/index.phtml:13
-#: module/Company/src/Form/JobLabel.php:52
-#: module/Company/src/Form/JobLabel.php:62
+#: module/Decision/view/decision/organ-admin/index.phtml:23
+#: module/Decision/view/decision/organ/index.phtml:22
+#: module/Company/src/Form/JobLabel.php:51
+#: module/Company/src/Form/JobLabel.php:61
 msgid "Abbreviation"
 msgstr ""
 
-#: module/Decision/view/decision/organ-admin/index.phtml:13
+#: module/Decision/view/decision/organ-admin/index.phtml:25
 msgid "Approval status"
 msgstr ""
 
-#: module/Decision/view/decision/organ/index.phtml:6
+#: module/Decision/view/decision/organ/index.phtml:15
 msgid "Organ list"
 msgstr ""
 
-#: module/Decision/view/decision/organ/show.phtml:32
+#: module/Decision/view/decision/organ/show.phtml:50
 msgid "Inactive members"
 msgstr ""
 
-#: module/Decision/view/decision/organ/show.phtml:43
+#: module/Decision/view/decision/organ/show.phtml:61
 msgid "Old members"
 msgstr ""
 
-#: module/Decision/view/decision/organ/show.phtml:52
+#: module/Decision/view/decision/organ/show.phtml:70
 msgid "Organ mutations"
 msgstr ""
 
-#: module/Education/view/education/admin/add-course.phtml:5
+#: module/Education/view/education/admin/add-course.phtml:17
 msgid "Add"
 msgstr ""
 
-#: module/Education/view/education/admin/add-course.phtml:16
-#: module/Education/view/education/admin/course.phtml:19
+#: module/Education/view/education/admin/add-course.phtml:28
+#: module/Education/view/education/admin/course.phtml:31
 msgid "Add Course"
 msgstr ""
 
-#: module/Education/view/education/admin/bulk-exam.phtml:12
+#: module/Education/view/education/admin/bulk-exam.phtml:20
 msgid "Upload Exams"
 msgstr ""
 
-#: module/Education/view/education/admin/bulk-exam.phtml:27
+#: module/Education/view/education/admin/bulk-exam.phtml:35
 msgid "Finalize exam uploads"
 msgstr ""
 
-#: module/Education/view/education/admin/bulk-summary.phtml:12
+#: module/Education/view/education/admin/bulk-summary.phtml:20
 msgid "Upload Summaries"
 msgstr ""
 
-#: module/Education/view/education/admin/bulk-summary.phtml:27
+#: module/Education/view/education/admin/bulk-summary.phtml:35
 msgid "Finalize summary uploads"
 msgstr ""
 
-#: module/Education/view/education/admin/course-documents.phtml:37
+#: module/Education/view/education/admin/course-documents.phtml:47
 #, php-format
 msgid "Course Documents of %s"
 msgstr ""
 
-#: module/Education/view/education/admin/course-documents.phtml:47
-#: module/Education/view/education/education/index.phtml:22
+#: module/Education/view/education/admin/course-documents.phtml:57
+#: module/Education/view/education/education/index.phtml:36
 msgid "Exams"
 msgstr ""
 
-#: module/Education/view/education/admin/course-documents.phtml:61
-#: module/Education/view/education/admin/course-documents.phtml:112
-#: module/Education/src/Form/Fieldset/Exam.php:85
-#: module/Education/src/Form/Fieldset/Summary.php:81
+#: module/Education/view/education/admin/course-documents.phtml:71
+#: module/Education/view/education/admin/course-documents.phtml:122
+#: module/Education/src/Form/Fieldset/Exam.php:84
+#: module/Education/src/Form/Fieldset/Summary.php:78
 msgid "Language"
 msgstr ""
 
-#: module/Education/view/education/admin/course-documents.phtml:90
-#: module/Education/view/education/admin/course-documents.phtml:139
+#: module/Education/view/education/admin/course-documents.phtml:100
+#: module/Education/view/education/admin/course-documents.phtml:149
 msgid "This course does not have any exams."
 msgstr ""
 
-#: module/Education/view/education/admin/course-documents.phtml:98
+#: module/Education/view/education/admin/course-documents.phtml:108
 msgid "Summaries"
 msgstr ""
 
-#: module/Education/view/education/admin/course-documents.phtml:109
-#: module/Education/src/Form/Fieldset/Summary.php:71
+#: module/Education/view/education/admin/course-documents.phtml:119
+#: module/Education/src/Form/Fieldset/Summary.php:68
 #: module/Frontpage/src/Form/PollComment.php:27
 msgid "Author"
 msgstr ""
 
-#: module/Education/view/education/admin/course-documents.phtml:157
+#: module/Education/view/education/admin/course-documents.phtml:167
 msgid "Are you sure you want to delete this document?"
 msgstr ""
 
-#: module/Education/view/education/admin/course.phtml:10
+#: module/Education/view/education/admin/course.phtml:22
 msgid "Course Admin"
 msgstr ""
 
-#: module/Education/view/education/admin/course.phtml:29
+#: module/Education/view/education/admin/course.phtml:41
 msgid "Code"
 msgstr ""
 
-#: module/Education/view/education/admin/course.phtml:75
+#: module/Education/view/education/admin/course.phtml:87
 msgid "Delete Course"
 msgstr ""
 
-#: module/Education/view/education/admin/course.phtml:81
+#: module/Education/view/education/admin/course.phtml:93
 #, php-format
 msgid ""
 "Are you sure you want to delete %s? This will also delete all associated "
 "exams and summaries will be deleted."
 msgstr ""
 
-#: module/Education/view/education/admin/edit-course.phtml:23
+#: module/Education/view/education/admin/edit-course.phtml:37
 msgid "Edit Course"
 msgstr ""
 
-#: module/Education/view/education/admin/edit-exam.phtml:19
+#: module/Education/view/education/admin/edit-exam.phtml:32
 msgid "Edit Exam"
 msgstr ""
 
-#: module/Education/view/education/admin/edit-exam.phtml:22
+#: module/Education/view/education/admin/edit-exam.phtml:35
 msgid "Upload of all exams was finished."
 msgstr ""
 
-#: module/Education/view/education/admin/edit-exam.phtml:24
+#: module/Education/view/education/admin/edit-exam.phtml:37
 msgid "There are no exams to be edited. Upload exams to edit them."
 msgstr ""
 
-#: module/Education/view/education/admin/edit-exam.phtml:115
-#: module/Education/view/education/admin/edit-summary.phtml:117
+#: module/Education/view/education/admin/edit-exam.phtml:128
+#: module/Education/view/education/admin/edit-summary.phtml:130
 msgid ""
 "Check this if the document is scanned, as this will enable higher quality "
 "downloads. Please note that enabling setting this for non-scanned documents "
 "will significantly impact the ability to download the document."
 msgstr ""
 
-#: module/Education/view/education/admin/edit-summary.phtml:19
+#: module/Education/view/education/admin/edit-summary.phtml:32
 msgid "Edit Summary"
 msgstr ""
 
-#: module/Education/view/education/admin/edit-summary.phtml:22
+#: module/Education/view/education/admin/edit-summary.phtml:35
 msgid "Upload of all summaries was finished."
 msgstr ""
 
-#: module/Education/view/education/admin/edit-summary.phtml:24
+#: module/Education/view/education/admin/edit-summary.phtml:37
 msgid "There are no summaries to be edited. Upload exams to edit them."
 msgstr ""
 
-#: module/Education/view/education/admin/index.phtml:5
+#: module/Education/view/education/admin/index.phtml:13
 msgid "Education admin"
 msgstr ""
 
-#: module/Education/view/education/education/course.phtml:23
+#: module/Education/view/education/education/course.phtml:33
 msgid "Exams and summaries"
 msgstr ""
 
-#: module/Education/view/education/education/course.phtml:34
+#: module/Education/view/education/education/course.phtml:44
 #, php-format
 msgid "Summary by %s on %s (%s)"
 msgstr ""
 
-#: module/Education/view/education/education/course.phtml:43
+#: module/Education/view/education/education/course.phtml:53
 #, php-format
 msgid "Summary on %s (%s)"
 msgstr ""
 
-#: module/Education/view/education/education/course.phtml:54
+#: module/Education/view/education/education/course.phtml:64
 #, php-format
 msgid "Final test from %s (%s)"
 msgstr ""
 
-#: module/Education/view/education/education/course.phtml:57
+#: module/Education/view/education/education/course.phtml:67
 #, php-format
 msgid "Interim test from %s (%s)"
 msgstr ""
 
-#: module/Education/view/education/education/course.phtml:60
+#: module/Education/view/education/education/course.phtml:70
 #, php-format
 msgid "Answers from %s (%s)"
 msgstr ""
 
-#: module/Education/view/education/education/course.phtml:63
+#: module/Education/view/education/education/course.phtml:73
 #, php-format
 msgid "Other exam material from %s (%s)"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:41
+#: module/Education/view/education/education/index.phtml:54
 msgid "Course code or course description"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:58
+#: module/Education/view/education/education/index.phtml:76
 #, php-format
-msgid "Found %d course(s) matching your description"
+msgid "Found %d %s matching your description"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:65
-#: module/Education/src/Form/Course.php:32
-#: module/Education/src/Form/Fieldset/Exam.php:48
-#: module/Education/src/Form/Fieldset/Summary.php:50
+#: module/Education/view/education/education/index.phtml:79
+msgid "course"
+msgid_plural "courses"
+msgstr[0] ""
+msgstr[1] ""
+
+#: module/Education/view/education/education/index.phtml:91
+#: module/Education/src/Form/Course.php:33
+#: module/Education/src/Form/Fieldset/Exam.php:47
+#: module/Education/src/Form/Fieldset/Summary.php:47
 msgid "Course code"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:66
+#: module/Education/view/education/education/index.phtml:92
 msgid "Course name"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:67
+#: module/Education/view/education/education/index.phtml:93
 msgid "Available documents"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:78
+#: module/Education/view/education/education/index.phtml:104
 msgid "View available documents"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:97
+#: module/Education/view/education/education/index.phtml:123
 #, php-format
 msgid ""
 "Do you want to contribute to the collection of old exams and summaries? Send "
 "them to the %seducation officer%s so that your (future) peers can benefit."
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:98
-#: module/Education/view/education/education/index.phtml:156
+#: module/Education/view/education/education/index.phtml:124
+#: module/Education/view/education/education/index.phtml:182
 msgid "Mail the education officer"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:106
+#: module/Education/view/education/education/index.phtml:132
 msgid "For old exams of minor courses, you can also look at:"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:109
+#: module/Education/view/education/education/index.phtml:135
 msgid "Applied Physics"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:112
+#: module/Education/view/education/education/index.phtml:138
 msgid "Biomedical Engineering"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:115
+#: module/Education/view/education/education/index.phtml:141
 msgid "Electrical Engineering"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:118
+#: module/Education/view/education/education/index.phtml:144
 msgid "Chemical Engineering"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:121
+#: module/Education/view/education/education/index.phtml:147
 msgid "Innovation Sciences"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:128
+#: module/Education/view/education/education/index.phtml:154
 msgid "Useful links"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:133
+#: module/Education/view/education/education/index.phtml:159
 msgid "Books"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:136
+#: module/Education/view/education/education/index.phtml:162
 msgid ""
 "Order your course books via GEWIS to receive a discount. Specific ordering "
 "deadlines and pickup dates will be timely communicated to you via an email."
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:139
+#: module/Education/view/education/education/index.phtml:165
 msgid "Visit the webshop"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:141
+#: module/Education/view/education/education/index.phtml:167
 msgid "Visit webshop"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:149
+#: module/Education/view/education/education/index.phtml:175
 msgid "Complaint or suggestion about TU/e education?"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:155
+#: module/Education/view/education/education/index.phtml:181
 #, php-format
 msgid ""
 "Do you have a complaint or suggestion concerning the education at the TU/e? "
 "Contact the %seducation officer%s to share your ideas."
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:166
+#: module/Education/view/education/education/index.phtml:192
 msgid "Disclaimer on educational content"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:171
+#: module/Education/view/education/education/index.phtml:197
 msgid ""
 "The exams on the website of GEWIS are provided by Education & Student "
 "Affairs of the department of Mathematics and Computer Science of the TU/e."
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:172
+#: module/Education/view/education/education/index.phtml:198
 msgid ""
 "If an exam has been put online without the intention of the author, please "
 "let the board of GEWIS know by sending an"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:173
+#: module/Education/view/education/education/index.phtml:199
 msgid "Email the board of GEWIS"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:173
+#: module/Education/view/education/education/index.phtml:199
 msgid "email to the board of GEWIS"
 msgstr ""
 
-#: module/Education/view/education/education/index.phtml:174
+#: module/Education/view/education/education/index.phtml:200
 msgid ""
 "then this exam will be removed from the website. Using the summaries or "
 "exams on this website for commercial goals without the permission of the "
 "author is illegal."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/admin/index.phtml:1
+#: module/Frontpage/view/frontpage/admin/index.phtml:10
 msgid ""
 "Welcome to the admin interface of the GEWIS website. If you are experiencing "
 "any issues or have a question, please contact the ApplicatieBeheerCommissie."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/admin/index.phtml:3
+#: module/Frontpage/view/frontpage/admin/index.phtml:12
 msgid "Recent changes"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:29
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:47
 msgid "Studievereniging GEWIS"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:31
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:49
 msgid ""
 "Welcome to the website of Study association GEWIS, the study association of "
 "the department of Mathematics & Computer Science of the Eindhoven University "
 "of Technology."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:130
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:148
 msgid "Verjaardagen"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:135
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:153
 #, php-format
 msgid "%s wil be %s years old today!"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:150
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:168
 msgid "Agenda"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:167
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:185
 #, php-format
 msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:176
-#: module/Frontpage/view/frontpage/organ/organ.phtml:120
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:194
+#: module/Frontpage/view/frontpage/organ/organ.phtml:136
 msgid "Complete agenda"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:180
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:198
 msgid "Google Calendar"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:264
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
 msgid "Poll"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:277
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:296
 msgid "View details"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:301
 msgid "There currently is no poll."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:286
-#: module/Frontpage/view/frontpage/poll/request.phtml:162
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:305
+#: module/Frontpage/view/frontpage/poll/request.phtml:174
 msgid "Request poll"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:289
-#: module/Frontpage/view/frontpage/poll/index.phtml:20
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:308
+#: module/Frontpage/view/frontpage/poll/index.phtml:39
 msgid "Old polls"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:36
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:68
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:49
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:80
 #: module/Frontpage/src/Form/NewsItem.php:57
-#: module/Frontpage/src/Form/Page.php:81
+#: module/Frontpage/src/Form/Page.php:79
 msgid "English content"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:60
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:92
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:73
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:104
 #: module/Frontpage/src/Form/NewsItem.php:47
-#: module/Frontpage/src/Form/Page.php:71
+#: module/Frontpage/src/Form/Page.php:69
 msgid "Dutch content"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:88
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:101
 msgid "Pin news item"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:90
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:103
 msgid "Select this if you want this news item to stay at the top of the page."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:105
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:118
 msgid "Delete this news item"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:5
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:16
 msgid "News items"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:6
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:17
 msgid "Create news item"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:10
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:21
 msgid "GEWIS has many different committees, learn more about them below!"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:16
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:27
 msgid "Information for committees"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:8
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:20
 msgid ""
 "Study association GEWIS obviously has several fraternities which contribute "
 "to the atmosphere at GEWIS and organize fun activities. Some fraternities "
 "have retired, but luckily new fraternities continue to be founded."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:9
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:21
 msgid "The currently active fraternities of GEWIS (in arbitrary order)"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:24
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:36
 msgid "Retired fraternities"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:25
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:37
 msgid "The following fraternities have retired:"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:51
+#: module/Frontpage/view/frontpage/organ/organ.phtml:67
 msgid "GMM Committees"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:53
+#: module/Frontpage/view/frontpage/organ/organ.phtml:69
 msgid "GMM Taskforces"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:55
+#: module/Frontpage/view/frontpage/organ/organ.phtml:71
 msgid "Financial Audit Committees"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:57
+#: module/Frontpage/view/frontpage/organ/organ.phtml:73
 msgid "Advisory Boards"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:106
+#: module/Frontpage/view/frontpage/organ/organ.phtml:122
 #, php-format
 msgid "%s's activities"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:152
+#: module/Frontpage/view/frontpage/organ/organ.phtml:168
 msgid "Login to view more information"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:36
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:48
 msgid "URL options"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:49
 msgid ""
 "Make this page available at the following URL. Providing a category is "
 "required."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:116
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:128
 msgid "Permissions"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:139
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:151
 msgid "Delete this page"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:17
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:29
 msgid "Create a new page"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:19
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:31
 msgid "Or select a page to edit below."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:19
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:34
 msgid "Polls awaiting approval"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:24
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:36
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:97
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:109
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:51
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:124
 #: module/Frontpage/src/Form/Poll.php:28
 msgid "Dutch question"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:25
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:98
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:40
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:54
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:113
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:127
 #: module/Frontpage/src/Form/Poll.php:38
 msgid "English question"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:28
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:101
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:43
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:116
 msgid "Approver"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:45
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:118
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:60
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:133
 msgid "Dutch option"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:46
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:119
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:61
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:134
 msgid "English option"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:80
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:95
 msgid "Approved polls"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:163
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:178
 msgid "Are you sure you want to delete this poll?"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:169
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:184
 msgid "Delete poll"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:213
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:201
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:227
 #: module/Frontpage/src/Form/PollApproval.php:36
 msgid "Approve poll"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:189
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:204
 msgid "Are you sure that you want to approve this poll?"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/history.phtml:3
+#: module/Frontpage/view/frontpage/poll/history.phtml:14
 msgid "Poll history"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:22
+#: module/Frontpage/view/frontpage/poll/index.phtml:41
 #, php-format
 msgid "%sRequest a poll%s"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:37
+#: module/Frontpage/view/frontpage/poll/index.phtml:56
 msgid "Unfortunately there currently is no poll :("
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:42
+#: module/Frontpage/view/frontpage/poll/index.phtml:61
 msgid "Comments"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:44
+#: module/Frontpage/view/frontpage/poll/index.phtml:63
 msgid "This poll has no comments"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:65
+#: module/Frontpage/view/frontpage/poll/index.phtml:84
 msgid "Comment on this poll"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:3
-#: module/Frontpage/view/frontpage/poll/request.phtml:7
+#: module/Frontpage/view/frontpage/poll/request.phtml:14
+#: module/Frontpage/view/frontpage/poll/request.phtml:19
 msgid "Request a poll"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:9
+#: module/Frontpage/view/frontpage/poll/request.phtml:21
 msgid "Your poll request has been received and will be reviewed shortly."
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:146
+#: module/Frontpage/view/frontpage/poll/request.phtml:158
 msgid "Remove option"
 msgstr ""
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:151
+#: module/Frontpage/view/frontpage/poll/request.phtml:163
 msgid "Add option"
 msgstr ""
 
-#: module/Frontpage/view/partial/poll.phtml:40
-#: module/Frontpage/view/partial/poll.phtml:51
+#: module/Frontpage/view/partial/poll.phtml:61
+#: module/Frontpage/view/partial/poll.phtml:72
 msgid "1 vote"
 msgstr ""
 
-#: module/Frontpage/view/partial/poll.phtml:40
-#: module/Frontpage/view/partial/poll.phtml:51
+#: module/Frontpage/view/partial/poll.phtml:61
+#: module/Frontpage/view/partial/poll.phtml:72
 #, php-format
 msgid "%d votes"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:6
+#: module/Photo/view/partial/metadata.phtml:19
 msgid "Artist"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:13
+#: module/Photo/view/partial/metadata.phtml:26
 msgid "Camera"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:20
+#: module/Photo/view/partial/metadata.phtml:33
 msgid "Date/time"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:27
+#: module/Photo/view/partial/metadata.phtml:40
 msgid "Flash"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:34
+#: module/Photo/view/partial/metadata.phtml:47
 msgid "Focal length"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:41
+#: module/Photo/view/partial/metadata.phtml:54
 msgid "Exposure time"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:48
+#: module/Photo/view/partial/metadata.phtml:61
 msgid "Shutter speed"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:55
+#: module/Photo/view/partial/metadata.phtml:68
 msgid "Aperture"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:62
+#: module/Photo/view/partial/metadata.phtml:75
 msgid "ISO"
 msgstr ""
 
-#: module/Photo/view/partial/metadata.phtml:75
+#: module/Photo/view/partial/metadata.phtml:95
 msgid "View on map"
 msgstr ""
 
-#: module/Photo/view/partial/tags.phtml:10
-#: module/Photo/view/photo/album/index.phtml:665
+#: module/Photo/view/partial/tags.phtml:22
+#: module/Photo/view/photo/album/index.phtml:674
 msgid "In this photo:"
 msgstr ""
 
-#: module/Photo/view/partial/tags.phtml:11
-#: module/Photo/view/photo/album/index.phtml:666
+#: module/Photo/view/partial/tags.phtml:23
+#: module/Photo/view/photo/album/index.phtml:675
 msgid ""
 "No one has been tagged in this photo yet. Tag someone you recognise now!"
 msgstr ""
 
-#: module/Photo/view/partial/tags.phtml:49
-#: module/Photo/view/photo/album/index.phtml:694
+#: module/Photo/view/partial/tags.phtml:61
+#: module/Photo/view/photo/album/index.phtml:703
 msgid "Tag someone"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/add.phtml:29
+#: module/Photo/view/photo/album-admin/add.phtml:41
 msgid "Upload Photos"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/add.phtml:31
+#: module/Photo/view/photo/album-admin/add.phtml:43
 #, php-format
 msgid "Uploading photos to %s"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/create.phtml:4
+#: module/Photo/view/photo/album-admin/create.phtml:16
 msgid "Create Album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/create.phtml:16
+#: module/Photo/view/photo/album-admin/create.phtml:28
 #: module/Photo/src/Form/CreateAlbum.php:25
 #: module/Photo/src/Form/EditAlbum.php:27
 msgid "Album title"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/create.phtml:25
+#: module/Photo/view/photo/album-admin/create.phtml:37
 msgid "Create album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/edit.phtml:4
+#: module/Photo/view/photo/album-admin/edit.phtml:16
 msgid "Edit Album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/edit.phtml:10
+#: module/Photo/view/photo/album-admin/edit.phtml:22
 msgid "Update Album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:44
-#: module/Photo/view/photo/photo-admin/index.phtml:44
+#: module/Photo/view/photo/album-admin/index.phtml:55
+#: module/Photo/view/photo/photo-admin/index.phtml:62
 msgid "Photo admin"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:93
+#: module/Photo/view/photo/album-admin/index.phtml:104
 msgid "Other albums"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:106
+#: module/Photo/view/photo/album-admin/index.phtml:117
 msgid "Create new album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:111
+#: module/Photo/view/photo/album-admin/index.phtml:122
 msgid "Edit album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:114
+#: module/Photo/view/photo/album-admin/index.phtml:125
 msgid "Add photos"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:116
+#: module/Photo/view/photo/album-admin/index.phtml:127
 msgid "Move album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:119
+#: module/Photo/view/photo/album-admin/index.phtml:130
 msgid "Move %i photos"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:122
+#: module/Photo/view/photo/album-admin/index.phtml:133
 msgid "Regenerate album cover"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:126
-#: module/Photo/view/photo/album-admin/index.phtml:220
+#: module/Photo/view/photo/album-admin/index.phtml:137
+#: module/Photo/view/photo/album-admin/index.phtml:231
 msgid "Delete album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:129
+#: module/Photo/view/photo/album-admin/index.phtml:140
 msgid "Delete %i photos"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:147
+#: module/Photo/view/photo/album-admin/index.phtml:158
 msgid "Generate a new cover photo"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:153
+#: module/Photo/view/photo/album-admin/index.phtml:164
 msgid "An error occurred while trying to generate an album photo."
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:160
+#: module/Photo/view/photo/album-admin/index.phtml:171
 msgid "Regenerate"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:162
-#: module/Photo/view/photo/album/index.phtml:426
+#: module/Photo/view/photo/album-admin/index.phtml:173
+#: module/Photo/view/photo/album/index.phtml:435
 msgid "Close"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:175
+#: module/Photo/view/photo/album-admin/index.phtml:186
 msgid "Move the album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:180
+#: module/Photo/view/photo/album-admin/index.phtml:191
 msgid "Select a new parent for the album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:184
+#: module/Photo/view/photo/album-admin/index.phtml:195
 msgid "The album has been moved"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:189
-#: module/Photo/view/photo/album-admin/index.phtml:280
-#: module/Photo/view/photo/photo-admin/index.phtml:108
+#: module/Photo/view/photo/album-admin/index.phtml:200
+#: module/Photo/view/photo/album-admin/index.phtml:291
+#: module/Photo/view/photo/photo-admin/index.phtml:126
 msgid "Move"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:206
+#: module/Photo/view/photo/album-admin/index.phtml:217
 msgid ""
 "Are you sure you want to delete this album including all photos inside of "
 "it? <strong>This action can not be reverted.</strong>"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:209
+#: module/Photo/view/photo/album-admin/index.phtml:220
 msgid "Please wait while the album is being deleted."
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:215
+#: module/Photo/view/photo/album-admin/index.phtml:226
 msgid "The album has been deleted"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:238
+#: module/Photo/view/photo/album-admin/index.phtml:249
 msgid ""
 "Are you sure you want to delete the selected items? <strong>This action can "
 "not be reverted.</strong>"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:241
+#: module/Photo/view/photo/album-admin/index.phtml:252
 msgid "Please wait while the photos are being deleted."
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:247
+#: module/Photo/view/photo/album-admin/index.phtml:258
 msgid "The photos have been been deleted"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:252
+#: module/Photo/view/photo/album-admin/index.phtml:263
 msgid "Delete photos"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:266
+#: module/Photo/view/photo/album-admin/index.phtml:277
 msgid "Move the photos to another album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:271
-#: module/Photo/view/photo/photo-admin/index.phtml:99
+#: module/Photo/view/photo/album-admin/index.phtml:282
+#: module/Photo/view/photo/photo-admin/index.phtml:117
 msgid "Select a new parent album"
 msgstr ""
 
-#: module/Photo/view/photo/album-admin/index.phtml:275
+#: module/Photo/view/photo/album-admin/index.phtml:286
 msgid "The photos have been moved"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:77
-#: module/Photo/view/photo/photo/weekly.phtml:2
-#: module/Photo/view/photo/photo/weekly.phtml:8
+#: module/Photo/view/photo/album/index.phtml:86
+#: module/Photo/view/photo/photo/weekly.phtml:13
+#: module/Photo/view/photo/photo/weekly.phtml:20
 msgid "Photos of the Week"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:131
+#: module/Photo/view/photo/album/index.phtml:140
 msgid "View user profile"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:143
+#: module/Photo/view/photo/album/index.phtml:152
 msgid "No date"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:192
-#: module/Photo/view/photo/photo/index.phtml:58
+#: module/Photo/view/photo/album/index.phtml:201
+#: module/Photo/view/photo/photo/index.phtml:71
 msgid "NEW"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:216
+#: module/Photo/view/photo/album/index.phtml:225
 msgid "This album does not contain any photos."
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:389
+#: module/Photo/view/photo/album/index.phtml:398
 msgid "Already voted!"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:392
-#: module/Photo/view/photo/album/index.phtml:563
+#: module/Photo/view/photo/album/index.phtml:401
+#: module/Photo/view/photo/album/index.phtml:572
 msgid "Vote for photo of the week"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:427
+#: module/Photo/view/photo/album/index.phtml:436
 msgid "Zoom (z)"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:430
+#: module/Photo/view/photo/album/index.phtml:439
 msgid "The image could not be loaded."
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:443
+#: module/Photo/view/photo/album/index.phtml:452
 msgid "Download"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:467
+#: module/Photo/view/photo/album/index.phtml:476
 msgid "Share"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:478
+#: module/Photo/view/photo/album/index.phtml:487
 msgid "Copied URL!"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:489
+#: module/Photo/view/photo/album/index.phtml:498
 msgid "Go to album"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:532
+#: module/Photo/view/photo/album/index.phtml:541
 msgid "Set as profile picture"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:549
+#: module/Photo/view/photo/album/index.phtml:558
 msgid "Set as profile picture!"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:552
+#: module/Photo/view/photo/album/index.phtml:561
 msgid "Could not set as profile photo, try again"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:585
+#: module/Photo/view/photo/album/index.phtml:594
 msgid "Cannot load vote"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:605
+#: module/Photo/view/photo/album/index.phtml:614
 msgid "Voted!"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:617
+#: module/Photo/view/photo/album/index.phtml:626
 msgid "Could not vote, try again"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:632
+#: module/Photo/view/photo/album/index.phtml:641
 msgid "Loading tags..."
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:653
+#: module/Photo/view/photo/album/index.phtml:662
 msgid "Cannot load tags"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:748
+#: module/Photo/view/photo/album/index.phtml:757
 msgid "Cannot load metadata"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:774
+#: module/Photo/view/photo/album/index.phtml:783
 msgid "Photo of the Week:<br> Week"
 msgstr ""
 
-#: module/Photo/view/photo/album/index.phtml:774
+#: module/Photo/view/photo/album/index.phtml:783
 msgid "of"
 msgstr ""
 
-#: module/Photo/view/photo/photo-admin/index.phtml:33
+#: module/Photo/view/photo/photo-admin/index.phtml:51
 #, php-format
 msgid "Photo #%d"
 msgstr ""
 
-#: module/Photo/view/photo/photo-admin/index.phtml:71
+#: module/Photo/view/photo/photo-admin/index.phtml:89
 msgid "Move photo"
 msgstr ""
 
-#: module/Photo/view/photo/photo-admin/index.phtml:73
-#: module/Photo/view/photo/photo-admin/index.phtml:139
+#: module/Photo/view/photo/photo-admin/index.phtml:91
+#: module/Photo/view/photo/photo-admin/index.phtml:157
 msgid "Delete photo"
 msgstr ""
 
-#: module/Photo/view/photo/photo-admin/index.phtml:94
+#: module/Photo/view/photo/photo-admin/index.phtml:112
 msgid "Move the photo to another album"
 msgstr ""
 
-#: module/Photo/view/photo/photo-admin/index.phtml:103
+#: module/Photo/view/photo/photo-admin/index.phtml:121
 msgid "The photo has been moved"
 msgstr ""
 
-#: module/Photo/view/photo/photo-admin/index.phtml:125
+#: module/Photo/view/photo/photo-admin/index.phtml:143
 msgid ""
 "Are you sure you want to delete this photo? <strong>This action can not be "
 "reverted.</strong>"
 msgstr ""
 
-#: module/Photo/view/photo/photo-admin/index.phtml:128
+#: module/Photo/view/photo/photo-admin/index.phtml:146
 msgid "Please wait while your photo is being deleted."
 msgstr ""
 
-#: module/Photo/view/photo/photo-admin/index.phtml:134
+#: module/Photo/view/photo/photo-admin/index.phtml:152
 msgid "The photo has been deleted"
 msgstr ""
 
-#: module/Photo/view/photo/photo/index.phtml:69
+#: module/Photo/view/photo/photo/index.phtml:82
 msgid "There are no photos in this year."
 msgstr ""
 
-#: module/Photo/view/photo/photo/weekly.phtml:6
+#: module/Photo/view/photo/photo/weekly.phtml:18
 msgid "Currently, no pictures of the week are available."
 msgstr ""
 
-#: module/Photo/view/photo/photo/weekly.phtml:9
+#: module/Photo/view/photo/photo/weekly.phtml:21
 msgid "Current photo of the week"
 msgstr ""
 
-#: module/Photo/view/photo/photo/weekly.phtml:40
+#: module/Photo/view/photo/photo/weekly.phtml:52
 msgid "Old photos of the week"
 msgstr ""
 
-#: module/User/view/partial/login/company.phtml:64
-#: module/User/view/partial/login/member.phtml:74
+#: module/User/view/partial/login/company.phtml:77
+#: module/User/view/partial/login/member.phtml:87
 #, php-format
 msgid "If you forgot your password, go to the %sPassword reset page%s"
 msgstr ""
 
-#: module/User/view/partial/login/member.phtml:70
+#: module/User/view/partial/login/member.phtml:83
 #, php-format
 msgid "If you don't have an account yet, go to the %sRegistration page%s"
 msgstr ""
 
-#: module/User/view/partial/reset/company.phtml:33
-#: module/User/view/partial/reset/member.phtml:47
-#: module/User/view/user/user/reset-password.phtml:2
-#: module/User/view/user/user/reset-password.phtml:13
-#: module/User/src/Form/UserReset.php:52
+#: module/User/view/partial/reset/company.phtml:46
+#: module/User/view/partial/reset/member.phtml:59
+#: module/User/view/user/user/reset-password.phtml:18
+#: module/User/view/user/user/reset-password.phtml:29
+#: module/User/src/Form/UserReset.php:50
 msgid "Reset password"
 msgstr ""
 
-#: module/User/view/partial/reset/member.phtml:39
+#: module/User/view/partial/reset/member.phtml:51
 msgid ""
 "Have you forgotten your e-mail address and do you want to change it? Ask the "
 "secretary by going to GEWIS (preferred) or by sending an e-mail."
 msgstr ""
 
-#: module/User/view/user/api-admin/add.phtml:3
-#: module/User/view/user/api-admin/index.phtml:3
-#: module/User/view/user/api-admin/index.phtml:5
-#: module/User/view/user/api-admin/remove.phtml:3
+#: module/User/view/user/api-admin/add.phtml:15
+#: module/User/view/user/api-admin/index.phtml:15
+#: module/User/view/user/api-admin/index.phtml:17
+#: module/User/view/user/api-admin/remove.phtml:15
 msgid "API Tokens"
 msgstr ""
 
-#: module/User/view/user/api-admin/add.phtml:4
+#: module/User/view/user/api-admin/add.phtml:16
 msgid "Add Token"
 msgstr ""
 
-#: module/User/view/user/api-admin/add.phtml:6
+#: module/User/view/user/api-admin/add.phtml:18
 msgid "Add a token"
 msgstr ""
 
-#: module/User/view/user/api-admin/add.phtml:33
+#: module/User/view/user/api-admin/add.phtml:45
 #: module/User/src/Form/ApiToken.php:35
 msgid "Create API token"
 msgstr ""
 
-#: module/User/view/user/api-admin/add.phtml:41
+#: module/User/view/user/api-admin/add.phtml:53
 msgid "Token was successfully generated"
 msgstr ""
 
-#: module/User/view/user/api-admin/add.phtml:49
-#: module/User/view/user/api-admin/index.phtml:11
+#: module/User/view/user/api-admin/add.phtml:61
+#: module/User/view/user/api-admin/index.phtml:23
 msgid "Token"
 msgstr ""
 
-#: module/User/view/user/api-admin/index.phtml:23
-#: module/Activity/src/Controller/AdminController.php:244
-#: module/Activity/src/Controller/AdminController.php:388
+#: module/User/view/user/api-admin/index.phtml:35
+#: module/Activity/src/Controller/AdminController.php:234
+#: module/Activity/src/Controller/AdminController.php:372
 msgid "Remove"
 msgstr ""
 
-#: module/User/view/user/api-admin/index.phtml:30
+#: module/User/view/user/api-admin/index.phtml:42
 msgid "Add new Token"
 msgstr ""
 
-#: module/User/view/user/api-admin/remove.phtml:4
+#: module/User/view/user/api-admin/remove.phtml:16
 msgid "Remove Token"
 msgstr ""
 
-#: module/User/view/user/api-authentication/redirect.phtml:13
+#: module/User/view/user/api-authentication/redirect.phtml:21
 #, php-format
 msgid "You are being redirected to %s"
 msgstr ""
 
-#: module/User/view/user/api-authentication/redirect.phtml:22
+#: module/User/view/user/api-authentication/redirect.phtml:30
 #, php-format
 msgid ""
 "If your browser does not redirect you back, please <a href=\"%s\">click "
 "here</a> to continue."
 msgstr ""
 
-#: module/User/view/user/api-authentication/token.phtml:16
+#: module/User/view/user/api-authentication/token.phtml:28
 #, php-format
 msgid "Authorize %s to use your account?"
 msgstr ""
 
-#: module/User/view/user/api-authentication/token.phtml:25
+#: module/User/view/user/api-authentication/token.phtml:37
 #, php-format
 msgid ""
 "It has been more than 90 days since you last used <strong>%s</strong>. As a "
 "reminder, the application has access to:"
 msgstr ""
 
-#: module/User/view/user/api-authentication/token.phtml:30
+#: module/User/view/user/api-authentication/token.phtml:42
 msgid "The application will get the following information:"
 msgstr ""
 
-#: module/User/view/user/user/activate.phtml:2
-#: module/User/view/user/user/activate.phtml:23
-#: module/User/src/Form/Activate.php:51
+#: module/User/view/user/user/activate.phtml:20
+#: module/User/view/user/user/activate.phtml:40
+#: module/User/src/Form/Activate.php:49
 msgid "Activate"
 msgstr ""
 
-#: module/User/view/user/user/activate.phtml:7
+#: module/User/view/user/user/activate.phtml:25
 msgid "Your account has been activated. You are now able to login."
 msgstr ""
 
-#: module/User/view/user/user/activate.phtml:36
+#: module/User/view/user/user/activate.phtml:53
 #, php-format
 msgid ""
 "Welcome %s. Create your password for the website and activate your account."
 msgstr ""
 
-#: module/User/view/user/user/activate.phtml:41
-#: module/User/src/Form/CompanyUserLogin.php:46
+#: module/User/view/user/user/activate.phtml:58
+#: module/User/src/Form/CompanyUserLogin.php:44
 msgid "Password"
 msgstr ""
 
-#: module/User/view/user/user/activate.phtml:54
+#: module/User/view/user/user/activate.phtml:72
 msgid "Verify password"
 msgstr ""
 
-#: module/User/view/user/user/change-password.phtml:7
+#: module/User/view/user/user/change-password.phtml:20
 msgid "Password changed successfully"
 msgstr ""
 
-#: module/User/view/user/user/login.phtml:2
+#: module/User/view/user/user/login.phtml:16
 msgid "Log in"
 msgstr ""
 
-#: module/User/view/user/user/logout.phtml:1
+#: module/User/view/user/user/logout.phtml:10
 msgid "You are logged out."
 msgstr ""
 
-#: module/User/view/user/user/register.phtml:2
-#: module/User/view/user/user/register.phtml:23
-#: module/User/src/Form/Register.php:44
+#: module/User/view/user/user/register.phtml:14
+#: module/User/view/user/user/register.phtml:34
+#: module/User/src/Form/Register.php:42
 msgid "Register"
 msgstr ""
 
-#: module/User/view/user/user/register.phtml:7
+#: module/User/view/user/user/register.phtml:19
 msgid ""
 "Your account for the GEWIS website has been registered, check your inbox for "
 "an activation e-mail."
 msgstr ""
 
-#: module/User/view/user/user/register.phtml:60
+#: module/User/view/user/user/register.phtml:71
 #, php-format
 msgid ""
 "To read more about the benefits of becoming a member and how to become a "
 "member, go to this %sinformation page%s."
 msgstr ""
 
-#: module/User/view/user/user/reset-password.phtml:7
+#: module/User/view/user/user/reset-password.phtml:23
 msgid ""
 "An e-mail has been sent with instructions for resetting your password. If "
 "you have not received an e-mail, try again in 20 minutes."
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityCalendarController.php:79
+#: module/Activity/src/Controller/ActivityCalendarController.php:82
 msgid "You are not allowed to create activity proposals"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:266
-#: module/Activity/src/Controller/ActivityController.php:363
-#: module/Activity/src/Controller/AdminController.php:304
-#: module/Activity/src/Controller/AdminController.php:397
+#: module/Activity/src/Controller/ActivityController.php:258
+#: module/Activity/src/Controller/ActivityController.php:351
+#: module/Activity/src/Controller/AdminController.php:294
+#: module/Activity/src/Controller/AdminController.php:381
 msgid "Invalid form"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:275
-#: module/Activity/src/Controller/ActivityController.php:372
+#: module/Activity/src/Controller/ActivityController.php:267
+#: module/Activity/src/Controller/ActivityController.php:360
 msgid "You need to log in to subscribe"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:285
-#: module/Activity/src/Controller/ActivityController.php:382
+#: module/Activity/src/Controller/ActivityController.php:277
+#: module/Activity/src/Controller/ActivityController.php:370
 msgid "You cannot subscribe to this activity at this moment in time"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:294
+#: module/Activity/src/Controller/ActivityController.php:286
 msgid "You have already been subscribed for this activity"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:300
+#: module/Activity/src/Controller/ActivityController.php:292
 msgid "Successfully subscribed"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:305
-#: module/Activity/src/Controller/ActivityController.php:398
-#: module/Activity/src/Controller/AdminController.php:328
+#: module/Activity/src/Controller/ActivityController.php:297
+#: module/Activity/src/Controller/ActivityController.php:386
+#: module/Activity/src/Controller/AdminController.php:318
 msgid "Use the form to subscribe"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:393
+#: module/Activity/src/Controller/ActivityController.php:381
 msgid "Successfully subscribed as external participant"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:425
+#: module/Activity/src/Controller/ActivityController.php:413
 msgid "Wrong form"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:432
+#: module/Activity/src/Controller/ActivityController.php:420
 msgid "You have to be logged in to subscribe for this activity"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:443
+#: module/Activity/src/Controller/ActivityController.php:431
 msgid "You cannot unsubscribe from this activity at this moment in time"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:453
+#: module/Activity/src/Controller/ActivityController.php:441
 msgid "You are not subscribed to this activity!"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:459
+#: module/Activity/src/Controller/ActivityController.php:447
 msgid "Successfully unsubscribed"
 msgstr ""
 
-#: module/Activity/src/Controller/ActivityController.php:464
+#: module/Activity/src/Controller/ActivityController.php:452
 msgid "Use the form to unsubscribe"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminApprovalController.php:43
+#: module/Activity/src/Controller/AdminApprovalController.php:41
 msgid "You are not allowed to view the approval of this activity"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:52
-#: module/Activity/src/Service/ActivityCategory.php:82
+#: module/Activity/src/Controller/AdminCategoryController.php:50
+#: module/Activity/src/Service/ActivityCategory.php:76
 msgid "You are not allowed to create an activity category"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:65
+#: module/Activity/src/Controller/AdminCategoryController.php:63
 msgid "The activity category was created successfully!"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:75
+#: module/Activity/src/Controller/AdminCategoryController.php:73
 #: module/Activity/src/Form/ActivityCategory.php:44
 msgid "Create Activity Category"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:130
+#: module/Activity/src/Controller/AdminCategoryController.php:122
 msgid "You are not allowed to edit an activity category"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:150
+#: module/Activity/src/Controller/AdminCategoryController.php:142
 msgid "The activity category was successfully updated!"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminCategoryController.php:167
+#: module/Activity/src/Controller/AdminCategoryController.php:159
 msgid "Update Activity Category"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:65
+#: module/Activity/src/Controller/AdminController.php:62
 msgid "You are not allowed to update this activity"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:79
+#: module/Activity/src/Controller/AdminController.php:76
 msgid ""
 "Activities that have sign-up lists which are open or approved cannot be "
 "updated."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:90
+#: module/Activity/src/Controller/AdminController.php:87
 msgid "This activity has already started/ended and can no longer be updated."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:108
+#: module/Activity/src/Controller/AdminController.php:106
 msgid ""
 "You have successfully created an update proposal for the activity! If the "
 "activity was already approved, the proposal will be applied after it has "
@@ -4251,78 +4290,78 @@ msgid ""
 "to the activity."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:145
+#: module/Activity/src/Controller/AdminController.php:143
 msgid "Update Activity"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:198
-#: module/Activity/src/Controller/AdminController.php:210
-#: module/Activity/src/Controller/AdminController.php:222
+#: module/Activity/src/Controller/AdminController.php:188
+#: module/Activity/src/Controller/AdminController.php:200
+#: module/Activity/src/Controller/AdminController.php:212
 msgid "You are not allowed to view the participants of this activity"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:283
-#: module/Activity/src/Controller/AdminController.php:380
+#: module/Activity/src/Controller/AdminController.php:273
+#: module/Activity/src/Controller/AdminController.php:364
 msgid "You are not allowed to use this form"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:320
+#: module/Activity/src/Controller/AdminController.php:310
 msgid "Successfully subscribed external participant"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:407
+#: module/Activity/src/Controller/AdminController.php:391
 msgid "Successfully removed external participant"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:415
+#: module/Activity/src/Controller/AdminController.php:399
 msgid "Use the form to unsubscribe an external participant"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminController.php:425
+#: module/Activity/src/Controller/AdminController.php:409
 msgid "You are not allowed to administer activities"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:40
+#: module/Activity/src/Controller/AdminOptionController.php:41
 msgid "You are not allowed to administer option calendar periods"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:54
+#: module/Activity/src/Controller/AdminOptionController.php:57
 msgid "You are not allowed to create option calendar periods"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:73
+#: module/Activity/src/Controller/AdminOptionController.php:77
 msgid "Option planning period created successfully."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:105
+#: module/Activity/src/Controller/AdminOptionController.php:109
 msgid "You are not allowed to delete option calendar periods"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:120
+#: module/Activity/src/Controller/AdminOptionController.php:124
 msgid "Past option planning periods cannot be deleted."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:128
+#: module/Activity/src/Controller/AdminOptionController.php:132
 msgid "Option planning period deleted."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:140
+#: module/Activity/src/Controller/AdminOptionController.php:145
 msgid "You are not allowed to edit option calendar periods"
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:155
+#: module/Activity/src/Controller/AdminOptionController.php:161
 msgid "This option planning period cannot be edited."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:174
+#: module/Activity/src/Controller/AdminOptionController.php:185
 msgid "Option planning period has been updated."
 msgstr ""
 
-#: module/Activity/src/Controller/AdminOptionController.php:196
+#: module/Activity/src/Controller/AdminOptionController.php:207
 msgid "Edit Option Period"
 msgstr ""
 
-#: module/Activity/src/Controller/ApiController.php:29
+#: module/Activity/src/Controller/ApiController.php:30
 msgid "You are not allowed to access the activities through the API"
 msgstr ""
 
@@ -4350,43 +4389,43 @@ msgstr ""
 msgid "Select a type"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarOption.php:83
+#: module/Activity/src/Form/ActivityCalendarOption.php:84
 msgid "The activity must start before it ends"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarOption.php:94
+#: module/Activity/src/Form/ActivityCalendarOption.php:97
 msgid "The activity must start after today"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:32
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:30
 msgid "Start date and time of planning period"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:43
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:41
 msgid "End date and time of planning period"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:54
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:52
 msgid "Start date and time of option period"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:65
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:63
 msgid "End date and time of option period"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:91
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:89
 msgid "Create Option Period"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:128
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:126
 msgid "The planning period must end after it starts."
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:151
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:149
 msgid "The option period must start after the planning period ends."
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:174
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:172
 msgid "The option period must end after it starts."
 msgstr ""
 
@@ -4398,193 +4437,193 @@ msgstr ""
 msgid "Select an option"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:130
-#: module/Activity/src/Form/ActivityCalendarProposal.php:141
-#: module/Activity/src/Form/ActivityCalendarProposal.php:149
-#: module/Activity/src/Form/Activity.php:289
-#: module/Activity/src/Form/Activity.php:301
-#: module/Activity/src/Form/Activity.php:315
-#: module/Activity/src/Form/Activity.php:327
-#: module/Activity/src/Form/Activity.php:339
-#: module/Activity/src/Form/Activity.php:351
-#: module/Education/src/Form/Bulk.php:59
+#: module/Activity/src/Form/ActivityCalendarProposal.php:128
+#: module/Activity/src/Form/ActivityCalendarProposal.php:142
+#: module/Activity/src/Form/ActivityCalendarProposal.php:150
+#: module/Activity/src/Form/Activity.php:282
+#: module/Activity/src/Form/Activity.php:294
+#: module/Activity/src/Form/Activity.php:308
+#: module/Activity/src/Form/Activity.php:320
+#: module/Activity/src/Form/Activity.php:335
+#: module/Activity/src/Form/Activity.php:350
+#: module/Education/src/Form/Bulk.php:57
 msgid "Value is required and can't be empty"
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:161
+#: module/Activity/src/Form/ActivityCalendarProposal.php:165
 msgid "Option should end after it starts."
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:169
+#: module/Activity/src/Form/ActivityCalendarProposal.php:176
 msgid "Option does not fall within option period (also check the end date)."
 msgstr ""
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:216
+#: module/Activity/src/Form/ActivityCalendarProposal.php:220
 msgid "The activity does now have an acceptable amount of options"
 msgstr ""
 
-#: module/Activity/src/Form/Activity.php:34
+#: module/Activity/src/Form/Activity.php:35
 msgid "No organ"
 msgstr ""
 
-#: module/Activity/src/Form/Activity.php:35
+#: module/Activity/src/Form/Activity.php:36
 msgid "No Company"
 msgstr ""
 
-#: module/Activity/src/Form/Activity.php:372
+#: module/Activity/src/Form/Activity.php:373
 msgid ""
 "The sign-up list closing date and time must be before the activity starts."
 msgstr ""
 
-#: module/Activity/src/Form/Activity.php:407
+#: module/Activity/src/Form/Activity.php:409
 msgid "The activity must start before it ends."
 msgstr ""
 
-#: module/Activity/src/Form/SignupListField.php:89
-#: module/Activity/src/Form/SignupListField.php:102
+#: module/Activity/src/Form/SignupListField.php:90
+#: module/Activity/src/Form/SignupListField.php:103
 msgid "Option 1, Option 2, ..."
 msgstr ""
 
-#: module/Activity/src/Form/SignupListField.php:159
+#: module/Activity/src/Form/SignupListField.php:160
 msgid "Some of the required fields for this type are empty"
 msgstr ""
 
-#: module/Activity/src/Form/SignupListField.php:190
+#: module/Activity/src/Form/SignupListField.php:191
 msgid "The number of English options must equal the number of Dutch options"
 msgstr ""
 
-#: module/Activity/src/Form/SignupList.php:184
+#: module/Activity/src/Form/SignupList.php:180
 msgid ""
 "The sign-up list opening date and time must be before the sign-up list "
 "closes."
 msgstr ""
 
-#: module/Activity/src/Service/ActivityCalendar.php:167
+#: module/Activity/src/Service/ActivityCalendar.php:169
 msgid "You are not allowed to approve this option"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityCalendar.php:215
+#: module/Activity/src/Service/ActivityCalendar.php:209
 msgid "You are not allowed to delete this option"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityCategory.php:35
-#: module/Activity/src/Service/ActivityCategory.php:51
+#: module/Activity/src/Service/ActivityCategory.php:31
+#: module/Activity/src/Service/ActivityCategory.php:47
 msgid "You are not allowed to view activity categories"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityCategory.php:115
+#: module/Activity/src/Service/ActivityCategory.php:105
 msgid "You are not allowed to delete an activity category"
 msgstr ""
 
-#: module/Activity/src/Service/Activity.php:57
-#: module/Activity/src/Service/Activity.php:98
+#: module/Activity/src/Service/Activity.php:66
+#: module/Activity/src/Service/Activity.php:105
 msgid "You are not allowed to create an activity"
 msgstr ""
 
-#: module/Activity/src/Service/Activity.php:138
+#: module/Activity/src/Service/Activity.php:145
 msgid "You are not allowed to create an activity for this organ"
 msgstr ""
 
-#: module/Activity/src/Service/Activity.php:398
+#: module/Activity/src/Service/Activity.php:406
 msgid "You are not allowed to create activity option proposals"
 msgstr ""
 
-#: module/Activity/src/Service/Activity.php:731
-#: module/Activity/src/Service/Activity.php:749
-#: module/Activity/src/Service/Activity.php:767
+#: module/Activity/src/Service/Activity.php:754
+#: module/Activity/src/Service/Activity.php:772
+#: module/Activity/src/Service/Activity.php:790
 msgid "You are not allowed to change the status of the activity"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityQuery.php:91
+#: module/Activity/src/Service/ActivityQuery.php:86
 msgid "You are not allowed to view this activity"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityQuery.php:107
-#: module/Activity/src/Service/ActivityQuery.php:274
-#: module/Activity/src/Service/Signup.php:149
+#: module/Activity/src/Service/ActivityQuery.php:102
+#: module/Activity/src/Service/ActivityQuery.php:262
+#: module/Activity/src/Service/Signup.php:128
 msgid "You are not allowed to view the activities"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityQuery.php:122
+#: module/Activity/src/Service/ActivityQuery.php:117
 msgid "You are not allowed to view unapproved activities"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityQuery.php:137
+#: module/Activity/src/Service/ActivityQuery.php:132
 msgid "You are not allowed to view activities"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityQuery.php:167
+#: module/Activity/src/Service/ActivityQuery.php:159
 msgid "You are not allowed to view the disapproved activities"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityQuery.php:185
+#: module/Activity/src/Service/ActivityQuery.php:177
 msgid "You are not allowed to view upcoming the activities"
 msgstr ""
 
-#: module/Activity/src/Service/ActivityQuery.php:193
+#: module/Activity/src/Service/ActivityQuery.php:185
 msgid ""
 "You are not allowed to view upcoming activities coupled to a member account"
 msgstr ""
 
-#: module/Activity/src/Service/SignupListQuery.php:30
+#: module/Activity/src/Service/SignupListQuery.php:26
 msgid "You are not allowed to view sign-up lists"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:54
-#: module/Activity/src/Service/Signup.php:168
+#: module/Activity/src/Service/Signup.php:47
+#: module/Activity/src/Service/Signup.php:147
 msgid "You need to be logged in to sign up for this activity"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:73
+#: module/Activity/src/Service/Signup.php:61
 msgid "You are not allowed to use the external admin signup"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:92
+#: module/Activity/src/Service/Signup.php:75
 msgid "You are not allowed to use the external signup"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:112
+#: module/Activity/src/Service/Signup.php:96
 msgid "You are not allowed to view the sign up data"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:248
+#: module/Activity/src/Service/Signup.php:229
 msgid "You are not allowed to subscribe an external user to this sign-up list"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:301
+#: module/Activity/src/Service/Signup.php:276
 msgid "You are not allowed to subscribe to this sign-up list"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:320
+#: module/Activity/src/Service/Signup.php:292
 msgid "You need to be logged in to sign off for this activity"
 msgstr ""
 
-#: module/Activity/src/Service/Signup.php:369
+#: module/Activity/src/Service/Signup.php:333
 msgid "You are not allowed to remove external signups for this activity"
 msgstr ""
 
-#: module/Application/src/Service/FileStorage.php:62
+#: module/Application/src/Service/FileStorage.php:91
 msgid "An unknown error occurred during uploading (%i)"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:46
-#: module/Company/src/Controller/AdminApprovalController.php:72
+#: module/Company/src/Controller/AdminApprovalController.php:45
+#: module/Company/src/Controller/AdminApprovalController.php:71
 msgid "You are not allowed to view the approval status of jobs"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:90
+#: module/Company/src/Controller/AdminApprovalController.php:89
 msgid "Approve Job"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:94
+#: module/Company/src/Controller/AdminApprovalController.php:93
 msgid "Disapprove Job"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:98
+#: module/Company/src/Controller/AdminApprovalController.php:97
 msgid "Reset Approval Status"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:108
+#: module/Company/src/Controller/AdminApprovalController.php:107
 msgid "You are not allowed to change the approval status of jobs"
 msgstr ""
 
@@ -4613,200 +4652,200 @@ msgstr ""
 msgid "Reject Update"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:213
+#: module/Company/src/Controller/AdminApprovalController.php:218
 msgid ""
 "An unknown error occurred while try to change the status of a job update "
 "proposal. Please try again."
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:223
+#: module/Company/src/Controller/AdminApprovalController.php:230
 msgid "Job has been updated!"
 msgstr ""
 
-#: module/Company/src/Controller/AdminApprovalController.php:230
+#: module/Company/src/Controller/AdminApprovalController.php:238
 msgid "Job update has been rejected!"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:44
+#: module/Company/src/Controller/AdminController.php:47
 msgid "You are not allowed to administer career settings"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:77
+#: module/Company/src/Controller/AdminController.php:80
 msgid "You are not allowed to create companies"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:120
+#: module/Company/src/Controller/AdminController.php:123
 msgid "You are not allowed to edit companies"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:187
-#: module/Company/src/Service/Company.php:852
+#: module/Company/src/Controller/AdminController.php:190
+#: module/Company/src/Service/Company.php:856
 msgid "You are not allowed to delete companies"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:212
+#: module/Company/src/Controller/AdminController.php:215
 msgid "You are not allowed to create packages"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:281
-#: module/Company/src/Service/Company.php:917
+#: module/Company/src/Controller/AdminController.php:284
+#: module/Company/src/Service/Company.php:905
 msgid "You are not allowed to edit packages"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:366
-#: module/Company/src/Service/Company.php:749
+#: module/Company/src/Controller/AdminController.php:372
+#: module/Company/src/Service/Company.php:741
 msgid "You are not allowed to delete packages"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:408
-#: module/Company/src/Controller/CompanyAccountController.php:116
+#: module/Company/src/Controller/AdminController.php:414
+#: module/Company/src/Controller/CompanyAccountController.php:120
 msgid "You are not allowed to create jobs"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:447
+#: module/Company/src/Controller/AdminController.php:453
 msgid "Job successfully created!"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:487
-#: module/Company/src/Controller/CompanyAccountController.php:193
-#: module/Company/src/Service/Company.php:944
-#: module/Company/src/Service/Company.php:1015
+#: module/Company/src/Controller/AdminController.php:493
+#: module/Company/src/Controller/CompanyAccountController.php:203
+#: module/Company/src/Service/Company.php:931
+#: module/Company/src/Service/Company.php:1002
 msgid "You are not allowed to edit jobs"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:526
+#: module/Company/src/Controller/AdminController.php:532
 msgid "Job successfully edited!"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:562
-#: module/Company/src/Controller/CompanyAccountController.php:296
+#: module/Company/src/Controller/AdminController.php:568
+#: module/Company/src/Controller/CompanyAccountController.php:310
 msgid "You are not allowed to delete jobs"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:604
+#: module/Company/src/Controller/AdminController.php:610
 msgid "You are not allowed to create job categories"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:623
+#: module/Company/src/Controller/AdminController.php:629
 msgid "Job category successfully created!"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:658
-#: module/Company/src/Service/Company.php:885
+#: module/Company/src/Controller/AdminController.php:665
+#: module/Company/src/Service/Company.php:881
 msgid "You are not allowed to edit job categories"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:698
+#: module/Company/src/Controller/AdminController.php:705
 msgid "You are not allowed to create job labels"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:717
+#: module/Company/src/Controller/AdminController.php:724
 msgid "Job label successfully created!"
 msgstr ""
 
-#: module/Company/src/Controller/AdminController.php:751
-#: module/Company/src/Service/Company.php:901
+#: module/Company/src/Controller/AdminController.php:758
+#: module/Company/src/Service/Company.php:893
 msgid "You are not allowed to edit job labels"
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:46
-#: module/Company/src/Controller/CompanyAccountController.php:57
-#: module/Company/src/Controller/CompanyAccountController.php:68
+#: module/Company/src/Controller/CompanyAccountController.php:47
+#: module/Company/src/Controller/CompanyAccountController.php:58
+#: module/Company/src/Controller/CompanyAccountController.php:69
 msgid "You are not allowed to view the company accounts"
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:136
+#: module/Company/src/Controller/CompanyAccountController.php:143
 msgid "You cannot create new jobs in expired job packages."
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:157
+#: module/Company/src/Controller/CompanyAccountController.php:166
 msgid ""
 "Job proposal successfully created! It will become active after it has been "
 "approved."
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:213
+#: module/Company/src/Controller/CompanyAccountController.php:223
 msgid "You cannot update jobs in expired job packages."
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:236
+#: module/Company/src/Controller/CompanyAccountController.php:249
 msgid ""
 "Update proposal for job successfully created! It will become active after it "
 "has been approved."
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:319
+#: module/Company/src/Controller/CompanyAccountController.php:335
 msgid "Job successfully deleted."
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:328
+#: module/Company/src/Controller/CompanyAccountController.php:344
 msgid "You are not allowed to view the status of a job"
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:353
+#: module/Company/src/Controller/CompanyAccountController.php:369
 msgid "You are not allowed to transfer jobs"
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:386
+#: module/Company/src/Controller/CompanyAccountController.php:406
 msgid "Jobs successfully transferred"
 msgstr ""
 
-#: module/Company/src/Controller/CompanyAccountController.php:396
+#: module/Company/src/Controller/CompanyAccountController.php:417
 msgid ""
 "An unknown error occurred while trying to transfer jobs, please try again."
 msgstr ""
 
-#: module/Company/src/Form/Company.php:72
+#: module/Company/src/Form/Company.php:71
 msgid "Logo"
 msgstr ""
 
-#: module/Company/src/Form/Company.php:82 module/Company/src/Form/Job.php:87
-#: module/Company/src/Form/Package.php:69
+#: module/Company/src/Form/Company.php:81 module/Company/src/Form/Job.php:91
+#: module/Company/src/Form/Package.php:66
 msgid "Published"
 msgstr ""
 
-#: module/Company/src/Form/Company.php:104
-#: module/Company/src/Form/Company.php:134 module/Company/src/Form/Job.php:112
+#: module/Company/src/Form/Company.php:103
+#: module/Company/src/Form/Company.php:133 module/Company/src/Form/Job.php:116
 msgid "E-mail Address"
 msgstr ""
 
-#: module/Company/src/Form/Company.php:124
+#: module/Company/src/Form/Company.php:123
 msgid "Address"
 msgstr ""
 
-#: module/Company/src/Form/Company.php:144 module/Company/src/Form/Job.php:122
+#: module/Company/src/Form/Company.php:143 module/Company/src/Form/Job.php:126
 msgid "Phone Number"
 msgstr ""
 
-#: module/Company/src/Form/Company.php:155
-#: module/Company/src/Form/Company.php:165
+#: module/Company/src/Form/Company.php:154
+#: module/Company/src/Form/Company.php:164
 msgid "Slogan"
 msgstr ""
 
 #: module/Company/src/Form/Company.php:261
 #: module/Company/src/Form/JobCategory.php:194
-#: module/Company/src/Form/Job.php:283
+#: module/Company/src/Form/Job.php:282
 msgid "This slug is already taken"
 msgstr ""
 
-#: module/Company/src/Form/Company.php:270
-#: module/Company/src/Form/JobCategory.php:203
-#: module/Company/src/Form/Job.php:292
+#: module/Company/src/Form/Company.php:272
+#: module/Company/src/Form/JobCategory.php:204
+#: module/Company/src/Form/Job.php:293
 msgid "This slug contains invalid characters"
 msgstr ""
 
-#: module/Company/src/Form/Company.php:338
+#: module/Company/src/Form/Company.php:346
 msgid "E-mail address format is not valid."
 msgstr ""
 
-#: module/Company/src/Form/Company.php:348
+#: module/Company/src/Form/Company.php:356
 msgid "The e-mail address must be unique across companies."
 msgstr ""
 
-#: module/Company/src/Form/Company.php:392 module/Company/src/Form/Job.php:339
-#: module/User/src/Form/CompanyUserLogin.php:127
-#: module/User/src/Form/CompanyUserReset.php:71
-#: module/User/src/Form/UserReset.php:95
+#: module/Company/src/Form/Company.php:400 module/Company/src/Form/Job.php:341
+#: module/User/src/Form/CompanyUserLogin.php:125
+#: module/User/src/Form/CompanyUserReset.php:64
+#: module/User/src/Form/UserReset.php:93
 msgid "E-mail address format is not valid"
 msgstr ""
 
@@ -4819,117 +4858,117 @@ msgstr ""
 msgid "Hidden"
 msgstr ""
 
-#: module/Company/src/Form/Job.php:76
+#: module/Company/src/Form/Job.php:80
 msgid "Select a job category"
 msgstr ""
 
-#: module/Company/src/Form/JobsTransfer.php:40
+#: module/Company/src/Form/JobsTransfer.php:38
 msgid "Select a target job package"
 msgstr ""
 
-#: module/Company/src/Form/Package.php:41
+#: module/Company/src/Form/Package.php:38
 msgid "Start Date"
 msgstr ""
 
-#: module/Company/src/Form/Package.php:55
+#: module/Company/src/Form/Package.php:52
 msgid "Expiration Date"
 msgstr ""
 
-#: module/Company/src/Form/Package.php:93
-#: module/Company/src/Form/Package.php:103
+#: module/Company/src/Form/Package.php:90
+#: module/Company/src/Form/Package.php:100
 msgid "Article"
 msgstr ""
 
-#: module/Company/src/Form/Package.php:182
+#: module/Company/src/Form/Package.php:179
 msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
 msgstr ""
 
-#: module/Company/src/Service/Company.php:83
+#: module/Company/src/Service/Company.php:92
 msgid "You are not allowed to view the banner"
 msgstr ""
 
-#: module/Company/src/Service/Company.php:96
+#: module/Company/src/Service/Company.php:102
 msgid "You are not allowed to view the featured company"
 msgstr ""
 
-#: module/Company/src/Service/Company.php:165
-#: module/Company/src/Service/Company.php:185
-#: module/Company/src/Service/Company.php:217
+#: module/Company/src/Service/Company.php:170
+#: module/Company/src/Service/Company.php:190
+#: module/Company/src/Service/Company.php:218
 msgid "You are not allowed to list the companies"
 msgstr ""
 
-#: module/Company/src/Service/Company.php:200
+#: module/Company/src/Service/Company.php:205
 msgid "You are not allowed to access the admin interface"
 msgstr ""
 
-#: module/Company/src/Service/Company.php:961
+#: module/Company/src/Service/Company.php:948
 msgid "You are not allowed to edit categories"
 msgstr ""
 
-#: module/Company/src/Service/Company.php:978
+#: module/Company/src/Service/Company.php:965
 msgid "You are not allowed to edit labels"
 msgstr ""
 
-#: module/Company/src/Service/Company.php:1031
+#: module/Company/src/Service/Company.php:1015
 msgid "You are not allowed to create a company"
 msgstr ""
 
-#: module/Company/src/Service/CompanyQuery.php:109
+#: module/Company/src/Service/CompanyQuery.php:98
 msgid "You are not allowed to list all job categories"
 msgstr ""
 
-#: module/Company/src/Service/CompanyQuery.php:117
+#: module/Company/src/Service/CompanyQuery.php:106
 msgid "You are not allowed to list job categories"
 msgstr ""
 
-#: module/Company/src/Service/CompanyQuery.php:157
+#: module/Company/src/Service/CompanyQuery.php:146
 msgid "You are not allowed to list all job labels"
 msgstr ""
 
-#: module/Company/src/Service/CompanyQuery.php:165
+#: module/Company/src/Service/CompanyQuery.php:154
 msgid "You are not allowed to list job labels"
 msgstr ""
 
-#: module/Decision/src/Controller/AdminController.php:53
+#: module/Decision/src/Controller/AdminController.php:55
 msgid "Meeting minutes uploaded"
 msgstr ""
 
-#: module/Decision/src/Controller/AdminController.php:134
+#: module/Decision/src/Controller/AdminController.php:137
 msgid "You are not allowed to rename meeting documents"
 msgstr ""
 
-#: module/Decision/src/Controller/AdminController.php:168
-#: module/Decision/src/Service/Decision.php:293
+#: module/Decision/src/Controller/AdminController.php:177
+#: module/Decision/src/Service/Decision.php:279
 msgid "You are not allowed to delete meeting documents."
 msgstr ""
 
-#: module/Decision/src/Controller/DecisionController.php:102
+#: module/Decision/src/Controller/DecisionController.php:109
 msgid "You are not allowed to search decisions."
 msgstr ""
 
-#: module/Decision/src/Controller/DecisionController.php:137
+#: module/Decision/src/Controller/DecisionController.php:142
 msgid "You are not allowed to authorize someone"
 msgstr ""
 
-#: module/Decision/src/Controller/DecisionController.php:184
-#: module/Decision/src/Service/Decision.php:595
+#: module/Decision/src/Controller/DecisionController.php:190
+#: module/Decision/src/Service/Decision.php:571
 msgid "You are not allowed to revoke authorizations."
 msgstr ""
 
-#: module/Decision/src/Controller/DecisionController.php:212
+#: module/Decision/src/Controller/DecisionController.php:219
 msgid "You are not allowed to browse files."
 msgstr ""
 
-#: module/Decision/src/Controller/MemberController.php:37
-#: module/Decision/src/Service/Decision.php:140
+#: module/Decision/src/Controller/MemberController.php:40
+#: module/Decision/src/Service/Decision.php:137
 msgid "You are not allowed to view meetings."
 msgstr ""
 
-#: module/Decision/src/Controller/MemberController.php:95
+#: module/Decision/src/Controller/MemberController.php:98
 msgid "Not allowed to search for members."
 msgstr ""
 
-#: module/Decision/src/Controller/MemberController.php:148
+#: module/Decision/src/Controller/MemberController.php:151
 msgid "You are not allowed to view the list of birthdays."
 msgstr ""
 
@@ -4937,270 +4976,266 @@ msgstr ""
 msgid "Revoke authorization"
 msgstr ""
 
-#: module/Decision/src/Form/Document.php:41
+#: module/Decision/src/Form/Document.php:39
 msgid "Document name"
 msgstr ""
 
-#: module/Decision/src/Form/Document.php:51
+#: module/Decision/src/Form/Document.php:49
 msgid "Document to upload"
 msgstr ""
 
-#: module/Decision/src/Form/Document.php:61
+#: module/Decision/src/Form/Document.php:59
 msgid "Upload document"
 msgstr ""
 
-#: module/Decision/src/Form/Minutes.php:32
+#: module/Decision/src/Form/Minutes.php:34
 msgid "Choose a meeting"
 msgstr ""
 
-#: module/Decision/src/Form/Minutes.php:43
+#: module/Decision/src/Form/Minutes.php:45
 msgid "Minutes to upload"
 msgstr ""
 
-#: module/Decision/src/Form/Minutes.php:90
+#: module/Decision/src/Form/Minutes.php:94
 msgid "There already are minutes for this meeting"
 msgstr ""
 
-#: module/Decision/src/Form/OrganInformation.php:54
+#: module/Decision/src/Form/OrganInformation.php:52
 msgid "Short dutch description"
 msgstr ""
 
-#: module/Decision/src/Form/OrganInformation.php:64
+#: module/Decision/src/Form/OrganInformation.php:62
 msgid "Short english description"
 msgstr ""
 
-#: module/Decision/src/Form/OrganInformation.php:74
+#: module/Decision/src/Form/OrganInformation.php:72
 msgid "Long dutch description"
 msgstr ""
 
-#: module/Decision/src/Form/OrganInformation.php:84
+#: module/Decision/src/Form/OrganInformation.php:82
 msgid "Long english description"
 msgstr ""
 
-#: module/Decision/src/Form/OrganInformation.php:94
+#: module/Decision/src/Form/OrganInformation.php:92
 msgid "Thumbnail photo to upload"
 msgstr ""
 
-#: module/Decision/src/Form/OrganInformation.php:104
+#: module/Decision/src/Form/OrganInformation.php:102
 msgid "Cover photo to upload"
 msgstr ""
 
-#: module/Decision/src/Form/ReorderDocument.php:48
+#: module/Decision/src/Form/ReorderDocument.php:46
 msgid "Move up"
 msgstr ""
 
-#: module/Decision/src/Form/ReorderDocument.php:52
+#: module/Decision/src/Form/ReorderDocument.php:50
 msgid "Move down"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:19
+#: module/Decision/src/Model/Enums/AddressTypes.php:21
 msgid "Home address (parents)"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:20
+#: module/Decision/src/Model/Enums/AddressTypes.php:22
 msgid "Student address"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:21
+#: module/Decision/src/Model/Enums/AddressTypes.php:23
 msgid "Mail address"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:20
+#: module/Decision/src/Model/Enums/MeetingTypes.php:22
 msgid "Board Meeting"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:21
+#: module/Decision/src/Model/Enums/MeetingTypes.php:23
 msgid "General Members Meeting"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:22
+#: module/Decision/src/Model/Enums/MeetingTypes.php:24
 msgid "Chair's Meeting"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:23
+#: module/Decision/src/Model/Enums/MeetingTypes.php:25
 msgid "Virtual Meeting"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:30
+#: module/Decision/src/Model/Enums/MeetingTypes.php:32
 msgid "BM"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:31
+#: module/Decision/src/Model/Enums/MeetingTypes.php:33
 msgid "GMM"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:32
+#: module/Decision/src/Model/Enums/MeetingTypes.php:34
 msgid "CM"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:33
+#: module/Decision/src/Model/Enums/MeetingTypes.php:35
 msgid "VIRT"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:20
+#: module/Decision/src/Model/Enums/MembershipTypes.php:22
 msgid "Ordinary"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:22
+#: module/Decision/src/Model/Enums/MembershipTypes.php:24
 msgid "Graduate"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:23
+#: module/Decision/src/Model/Enums/MembershipTypes.php:25
 msgid "Honorary"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:22
+#: module/Decision/src/Model/Enums/OrganTypes.php:24
 msgid "Committee"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:23
+#: module/Decision/src/Model/Enums/OrganTypes.php:25
 msgid "GMM Committee"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:24
+#: module/Decision/src/Model/Enums/OrganTypes.php:26
 msgid "Fraternity"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:25
+#: module/Decision/src/Model/Enums/OrganTypes.php:27
 msgid "Financial Audit Committee"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:26
+#: module/Decision/src/Model/Enums/OrganTypes.php:28
 msgid "GMM Taskforce"
 msgstr ""
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:27
+#: module/Decision/src/Model/Enums/OrganTypes.php:29
 msgid "Advisory Board"
 msgstr ""
 
-#: module/Decision/src/Service/Decision.php:87
-#: module/Decision/src/Service/Decision.php:106
-#: module/Decision/src/Service/Decision.php:120
+#: module/Decision/src/Service/Decision.php:90
+#: module/Decision/src/Service/Decision.php:109
+#: module/Decision/src/Service/Decision.php:121
 msgid "You are not allowed to list meetings."
 msgstr ""
 
-#: module/Decision/src/Service/Decision.php:191
+#: module/Decision/src/Service/Decision.php:178
 msgid "You are not allowed to view meeting documents."
 msgstr ""
 
-#: module/Decision/src/Service/Decision.php:212
+#: module/Decision/src/Service/Decision.php:195
 msgid "You are not allowed to view meeting minutes."
 msgstr ""
 
-#: module/Decision/src/Service/Decision.php:399
+#: module/Decision/src/Service/Decision.php:388
 msgid "You are not allowed to view all authorizations."
 msgstr ""
 
-#: module/Decision/src/Service/Decision.php:419
+#: module/Decision/src/Service/Decision.php:404
 msgid "You are not allowed to view authorizations."
 msgstr ""
 
-#: module/Decision/src/Service/Decision.php:529
+#: module/Decision/src/Service/Decision.php:514
 msgid "You are not allowed to upload meeting minutes."
 msgstr ""
 
-#: module/Decision/src/Service/Decision.php:544
+#: module/Decision/src/Service/Decision.php:528
 msgid "You are not allowed to upload meeting documents."
 msgstr ""
 
-#: module/Decision/src/Service/Decision.php:581
+#: module/Decision/src/Service/Decision.php:558
 msgid "You are not allowed authorize people."
 msgstr ""
 
-#: module/Decision/src/Service/MemberInfo.php:43
+#: module/Decision/src/Service/MemberInfo.php:65
 msgid "You are not allowed to view membership info."
 msgstr ""
 
-#: module/Decision/src/Service/MemberInfo.php:45
-#: module/Decision/src/Service/Member.php:56
+#: module/Decision/src/Service/MemberInfo.php:69
+#: module/Decision/src/Service/Member.php:50
 msgid "You are not allowed to view members."
 msgstr ""
 
-#: module/Decision/src/Service/Member.php:100
-msgid "Name must be at least "
-msgstr ""
-
-#: module/Decision/src/Service/Organ.php:56
+#: module/Decision/src/Service/Organ.php:66
 msgid "Not allowed to view the list of organs"
 msgstr ""
 
-#: module/Decision/src/Service/Organ.php:72
+#: module/Decision/src/Service/Organ.php:78
 msgid "Not allowed to view organ information"
 msgstr ""
 
-#: module/Decision/src/Service/Organ.php:87
+#: module/Decision/src/Service/Organ.php:93
 msgid "You are not allowed to edit organ information"
 msgstr ""
 
-#: module/Decision/src/Service/Organ.php:317
+#: module/Decision/src/Service/Organ.php:305
 msgid "You are not allowed to edit this organ's information"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:43
+#: module/Education/src/Controller/AdminController.php:41
 msgid "You are not allowed to administer education settings"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:53
+#: module/Education/src/Controller/AdminController.php:51
 msgid "You are not allowed to administer courses"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:62
-#: module/Education/src/Service/Exam.php:482
+#: module/Education/src/Controller/AdminController.php:60
+#: module/Education/src/Service/Exam.php:473
 msgid "You are not allowed to add courses"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:78
+#: module/Education/src/Controller/AdminController.php:76
 msgid "Successfully added course!"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:84
-#: module/Education/src/Controller/AdminController.php:127
+#: module/Education/src/Controller/AdminController.php:83
+#: module/Education/src/Controller/AdminController.php:125
 msgid "An error occurred while saving the course!"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:100
-#: module/Education/src/Controller/AdminController.php:164
+#: module/Education/src/Controller/AdminController.php:98
+#: module/Education/src/Controller/AdminController.php:162
 msgid "You are not allowed to edit courses"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:123
+#: module/Education/src/Controller/AdminController.php:121
 msgid "Successfully updated course information!"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:142
+#: module/Education/src/Controller/AdminController.php:140
 msgid "You are not allowed to delete courses"
 msgstr ""
 
-#: module/Education/src/Controller/AdminController.php:185
+#: module/Education/src/Controller/AdminController.php:183
 msgid "You are not allowed to delete course documents"
 msgstr ""
 
-#: module/Education/src/Form/Bulk.php:45
+#: module/Education/src/Form/Bulk.php:43
 msgid "Finalize uploads"
 msgstr ""
 
-#: module/Education/src/Form/Bulk.php:66
+#: module/Education/src/Form/Bulk.php:64
 msgid "Course does not exist"
 msgstr ""
 
-#: module/Education/src/Form/Course.php:52
+#: module/Education/src/Form/Course.php:53
 msgid "Add course"
 msgstr ""
 
-#: module/Education/src/Form/Course.php:83
+#: module/Education/src/Form/Course.php:84
 msgid "There already exists a course with this code"
 msgstr ""
 
-#: module/Education/src/Form/Fieldset/Exam.php:58
+#: module/Education/src/Form/Fieldset/Exam.php:57
 msgid "Exam date"
 msgstr ""
 
-#: module/Education/src/Form/Fieldset/Exam.php:99
-#: module/Education/src/Form/Fieldset/Summary.php:95
+#: module/Education/src/Form/Fieldset/Exam.php:98
+#: module/Education/src/Form/Fieldset/Summary.php:92
 msgid "Scanned?"
 msgstr ""
 
-#: module/Education/src/Form/Fieldset/Summary.php:60
+#: module/Education/src/Form/Fieldset/Summary.php:57
 msgid "Summary date"
 msgstr ""
 
@@ -5208,101 +5243,101 @@ msgstr ""
 msgid "Exam to upload"
 msgstr ""
 
-#: module/Education/src/Model/Enums/ExamTypes.php:20
+#: module/Education/src/Model/Enums/ExamTypes.php:25
 msgid "Final"
 msgstr ""
 
-#: module/Education/src/Model/Enums/ExamTypes.php:21
+#: module/Education/src/Model/Enums/ExamTypes.php:26
 msgid "Interim"
 msgstr ""
 
-#: module/Education/src/Model/Enums/ExamTypes.php:22
+#: module/Education/src/Model/Enums/ExamTypes.php:27
 msgid "Answers"
 msgstr ""
 
-#: module/Education/src/Model/Enums/ExamTypes.php:23
+#: module/Education/src/Model/Enums/ExamTypes.php:28
 msgid "Other"
 msgstr ""
 
-#: module/Education/src/Service/Exam.php:91
+#: module/Education/src/Service/Exam.php:98
 msgid "You are not allowed to download course documents"
 msgstr ""
 
-#: module/Education/src/Service/Exam.php:320
+#: module/Education/src/Service/Exam.php:318
 msgid "You are not allowed to delete exams"
 msgstr ""
 
-#: module/Education/src/Service/Exam.php:339
-#: module/Education/src/Service/Exam.php:464
+#: module/Education/src/Service/Exam.php:334
+#: module/Education/src/Service/Exam.php:456
 msgid "You are not allowed to upload exams"
 msgstr ""
 
-#: module/Frontpage/src/Controller/InfimumController.php:24
+#: module/Frontpage/src/Controller/InfimumController.php:26
 msgid "You are not allowed to view infima"
 msgstr ""
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:53
+#: module/Frontpage/src/Controller/NewsAdminController.php:51
 msgid "You are not allowed to create news items"
 msgstr ""
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:90
+#: module/Frontpage/src/Controller/NewsAdminController.php:88
 msgid "You are not allowed to edit news items"
 msgstr ""
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:135
+#: module/Frontpage/src/Controller/NewsAdminController.php:133
 msgid "You are not allowed to delete news items"
 msgstr ""
 
-#: module/Frontpage/src/Controller/PageAdminController.php:35
-#: module/Frontpage/src/Service/Page.php:110
+#: module/Frontpage/src/Controller/PageAdminController.php:31
+#: module/Frontpage/src/Service/Page.php:107
 msgid "You are not allowed to view the list of pages."
 msgstr ""
 
-#: module/Frontpage/src/Controller/PageAdminController.php:50
-#: module/Frontpage/src/Service/Page.php:270
+#: module/Frontpage/src/Controller/PageAdminController.php:46
+#: module/Frontpage/src/Service/Page.php:260
 msgid "You are not allowed to create new pages."
 msgstr ""
 
-#: module/Frontpage/src/Controller/PageAdminController.php:81
-#: module/Frontpage/src/Service/Page.php:201
+#: module/Frontpage/src/Controller/PageAdminController.php:77
+#: module/Frontpage/src/Service/Page.php:193
 msgid "You are not allowed to edit pages."
 msgstr ""
 
-#: module/Frontpage/src/Controller/PageAdminController.php:108
+#: module/Frontpage/src/Controller/PageAdminController.php:104
 msgid "You are not allowed to delete pages."
 msgstr ""
 
-#: module/Frontpage/src/Controller/PageAdminController.php:125
+#: module/Frontpage/src/Controller/PageAdminController.php:121
 msgid "You are not allowed to upload images."
 msgstr ""
 
-#: module/Frontpage/src/Controller/PollAdminController.php:34
+#: module/Frontpage/src/Controller/PollAdminController.php:32
 msgid "You are not allowed to administer polls"
 msgstr ""
 
-#: module/Frontpage/src/Controller/PollAdminController.php:66
+#: module/Frontpage/src/Controller/PollAdminController.php:64
 msgid "You are not allowed to approve polls"
 msgstr ""
 
-#: module/Frontpage/src/Controller/PollAdminController.php:98
+#: module/Frontpage/src/Controller/PollAdminController.php:96
 msgid "You are not allowed to delete polls"
 msgstr ""
 
-#: module/Frontpage/src/Controller/PollController.php:97
+#: module/Frontpage/src/Controller/PollController.php:96
 msgid "You are not allowed to create comments on this poll"
 msgstr ""
 
 #: module/Frontpage/src/Form/NewsItem.php:27
-#: module/Frontpage/src/Form/Page.php:51
+#: module/Frontpage/src/Form/Page.php:49
 msgid "Dutch title"
 msgstr ""
 
 #: module/Frontpage/src/Form/NewsItem.php:37
-#: module/Frontpage/src/Form/Page.php:61
+#: module/Frontpage/src/Form/Page.php:59
 msgid "English title"
 msgstr ""
 
-#: module/Frontpage/src/Form/Page.php:91
+#: module/Frontpage/src/Form/Page.php:89
 msgid "Required role"
 msgstr ""
 
@@ -5318,61 +5353,61 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: module/Frontpage/src/Service/News.php:47
+#: module/Frontpage/src/Service/News.php:45
 msgid "You are not allowed to list all news items."
 msgstr ""
 
-#: module/Frontpage/src/Service/Page.php:61
+#: module/Frontpage/src/Service/Page.php:56
 msgid "You are not allowed to view this page."
 msgstr ""
 
-#: module/Frontpage/src/Service/Page.php:250
-#: module/Photo/src/Service/Admin.php:189
+#: module/Frontpage/src/Service/Page.php:244
+#: module/Photo/src/Service/Admin.php:212
 msgid "The uploaded file does not have a valid extension"
 msgstr ""
 
-#: module/Frontpage/src/Service/Page.php:255
+#: module/Frontpage/src/Service/Page.php:249
 msgid "The uploaded file is not a valid image"
 msgstr ""
 
-#: module/Frontpage/src/Service/Poll.php:72
+#: module/Frontpage/src/Service/Poll.php:71
 msgid "You are not allowed to view unapproved polls"
 msgstr ""
 
-#: module/Frontpage/src/Service/Poll.php:192
+#: module/Frontpage/src/Service/Poll.php:183
 msgid "You are not allowed to vote on this poll."
 msgstr ""
 
-#: module/Frontpage/src/Service/Poll.php:347
+#: module/Frontpage/src/Service/Poll.php:329
 msgid "You are not allowed to request polls"
 msgstr ""
 
-#: module/Photo/src/Controller/AlbumController.php:49
-#: module/Photo/src/Service/Album.php:123
+#: module/Photo/src/Controller/AlbumController.php:50
+#: module/Photo/src/Service/Album.php:122
 msgid "Not allowed to view albums without dates"
 msgstr ""
 
-#: module/Photo/src/Controller/ApiController.php:48
+#: module/Photo/src/Controller/ApiController.php:50
 msgid "Not allowed to view photo details"
 msgstr ""
 
-#: module/Photo/src/Controller/PhotoController.php:38
-#: module/Photo/src/Service/Album.php:70 module/Photo/src/Service/Album.php:100
-#: module/Photo/src/Service/Album.php:239
-#: module/Photo/src/Service/Album.php:253
+#: module/Photo/src/Controller/PhotoController.php:44
+#: module/Photo/src/Service/Album.php:67 module/Photo/src/Service/Album.php:99
+#: module/Photo/src/Service/Album.php:234
+#: module/Photo/src/Service/Album.php:248
 msgid "Not allowed to view albums"
 msgstr ""
 
-#: module/Photo/src/Controller/PhotoController.php:85
-#: module/Photo/src/Service/Photo.php:93
+#: module/Photo/src/Controller/PhotoController.php:91
+#: module/Photo/src/Service/Photo.php:95
 msgid "Not allowed to download photos"
 msgstr ""
 
-#: module/Photo/src/Controller/PhotoController.php:100
+#: module/Photo/src/Controller/PhotoController.php:106
 msgid "Not allowed to view previous photos of the week"
 msgstr ""
 
-#: module/Photo/src/Controller/PhotoController.php:157
+#: module/Photo/src/Controller/PhotoController.php:163
 msgid "Not allowed to vote for a photo of the week"
 msgstr ""
 
@@ -5392,75 +5427,75 @@ msgstr ""
 msgid "End date"
 msgstr ""
 
-#: module/Photo/src/Service/Admin.php:58
+#: module/Photo/src/Service/Admin.php:66
 msgid "Not allowed to add photos."
 msgstr ""
 
-#: module/Photo/src/Service/Admin.php:172
+#: module/Photo/src/Service/Admin.php:185
 msgid "An unknown error occurred during uploading ("
 msgstr ""
 
-#: module/Photo/src/Service/Admin.php:195
+#: module/Photo/src/Service/Admin.php:201
 #, php-format
 msgid ""
 "The uploaded file is not a valid image \n"
 "Error: %s"
 msgstr ""
 
-#: module/Photo/src/Service/Admin.php:211
+#: module/Photo/src/Service/Admin.php:225
 msgid "Not allowed to upload photos."
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:194
+#: module/Photo/src/Service/Album.php:191
 msgid "Not allowed to create albums"
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:218
+#: module/Photo/src/Service/Album.php:213
 msgid "Not allowed to create albums."
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:331
+#: module/Photo/src/Service/Album.php:327
 #, php-format
 msgid "Photos of the Week in %d/%d"
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:360
+#: module/Photo/src/Service/Album.php:358
 msgid "Not allowed to edit albums"
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:379
+#: module/Photo/src/Service/Album.php:376
 msgid "Not allowed to edit albums."
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:404
+#: module/Photo/src/Service/Album.php:401
 msgid "Not allowed to move albums"
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:438
+#: module/Photo/src/Service/Album.php:435
 msgid "Not allowed to delete albums."
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:459
+#: module/Photo/src/Service/Album.php:456
 msgid "Not allowed to generate album covers."
 msgstr ""
 
-#: module/Photo/src/Service/Album.php:507
+#: module/Photo/src/Service/Album.php:504
 msgid "Not allowed to move photos"
 msgstr ""
 
-#: module/Photo/src/Service/Photo.php:67 module/Photo/src/Service/Photo.php:112
-#: module/Photo/src/Service/Photo.php:154
-#: module/Photo/src/Service/Photo.php:205
-#: module/Photo/src/Service/Photo.php:221
+#: module/Photo/src/Service/Photo.php:73 module/Photo/src/Service/Photo.php:114
+#: module/Photo/src/Service/Photo.php:159
+#: module/Photo/src/Service/Photo.php:210
+#: module/Photo/src/Service/Photo.php:226
 msgid "Not allowed to view photos"
 msgstr ""
 
-#: module/Photo/src/Service/Photo.php:239
+#: module/Photo/src/Service/Photo.php:245
 msgid "Not allowed to delete photos."
 msgstr ""
 
-#: module/Photo/src/Service/Photo.php:669
-#: module/Photo/src/Service/Photo.php:731
+#: module/Photo/src/Service/Photo.php:623
+#: module/Photo/src/Service/Photo.php:672
 msgid "Not allowed to view tags."
 msgstr ""
 
@@ -5476,8 +5511,8 @@ msgstr ""
 msgid "Too many login attempts, try again later."
 msgstr ""
 
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:77
-#: module/User/src/Authentication/Adapter/UserAdapter.php:91
+#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:78
+#: module/User/src/Authentication/Adapter/UserAdapter.php:92
 msgid ""
 "Your password was found in a public data breach and is therefore considered "
 "insecure. Please request a password reset before continuing. We recommend "
@@ -5489,23 +5524,23 @@ msgstr ""
 msgid "You cannot sign in to this account at this moment."
 msgstr ""
 
-#: module/User/src/Authorization/GenericAclService.php:98
-#: module/User/src/Authorization/GenericAclService.php:122
+#: module/User/src/Authorization/GenericAclService.php:108
+#: module/User/src/Authorization/GenericAclService.php:135
 msgid ""
 "You are not allowed to perform this action. If you are not logged in please "
 "do so before continuing. If you are already logged in this action may "
 "require you to login in with a different account."
 msgstr ""
 
-#: module/User/src/Controller/UserController.php:184
+#: module/User/src/Controller/UserController.php:178
 msgid "You are not allowed to change passwords"
 msgstr ""
 
-#: module/User/src/Form/Activate.php:31 module/User/src/Form/UserLogin.php:45
+#: module/User/src/Form/Activate.php:29 module/User/src/Form/UserLogin.php:43
 msgid "Your password"
 msgstr ""
 
-#: module/User/src/Form/Activate.php:41
+#: module/User/src/Form/Activate.php:39
 msgid "Verify your password"
 msgstr ""
 
@@ -5513,104 +5548,104 @@ msgstr ""
 msgid "Authorise"
 msgstr ""
 
-#: module/User/src/Form/CompanyUserLogin.php:36
-#: module/User/src/Form/CompanyUserReset.php:34
+#: module/User/src/Form/CompanyUserLogin.php:34
+#: module/User/src/Form/CompanyUserReset.php:27
 msgid "Email address"
 msgstr ""
 
-#: module/User/src/Form/CompanyUserLogin.php:56
+#: module/User/src/Form/CompanyUserLogin.php:54
 msgid "Log in as company"
 msgstr ""
 
-#: module/User/src/Form/CompanyUserReset.php:44
+#: module/User/src/Form/CompanyUserReset.php:37
 msgid "Request password reset"
 msgstr ""
 
-#: module/User/src/Form/Password.php:31
+#: module/User/src/Form/Password.php:29
 msgid "Old password"
 msgstr ""
 
-#: module/User/src/Form/Password.php:41
+#: module/User/src/Form/Password.php:39
 msgid "New password"
 msgstr ""
 
-#: module/User/src/Form/Password.php:51
+#: module/User/src/Form/Password.php:49
 msgid "Verify new password"
 msgstr ""
 
-#: module/User/src/Form/Register.php:69
+#: module/User/src/Form/Register.php:65
 msgid ""
 "This member cannot create an account, please contact the secretary for more "
 "information."
 msgstr ""
 
-#: module/User/src/Form/Register.php:77
+#: module/User/src/Form/Register.php:73
 msgid "There is no member with this membership number."
 msgstr ""
 
-#: module/User/src/Form/Register.php:85
+#: module/User/src/Form/Register.php:81
 msgid ""
 "You already attempted to register, please check your email or try again "
 "after 20 minutes."
 msgstr ""
 
-#: module/User/src/Form/Register.php:93
+#: module/User/src/Form/Register.php:89
 msgid "This member already has an account."
 msgstr ""
 
-#: module/User/src/Form/UserLogin.php:35
+#: module/User/src/Form/UserLogin.php:33
 msgid "Membership number or email address"
 msgstr ""
 
-#: module/User/src/Form/UserLogin.php:55
+#: module/User/src/Form/UserLogin.php:53
 msgid "Log in as member"
 msgstr ""
 
-#: module/User/src/Form/UserLogin.php:65
+#: module/User/src/Form/UserLogin.php:63
 msgid "Remember me"
 msgstr ""
 
-#: module/User/src/Model/Enums/JWTClaims.php:38
+#: module/User/src/Model/Enums/JWTClaims.php:40
 msgid "Family name"
 msgstr ""
 
-#: module/User/src/Model/Enums/JWTClaims.php:39
+#: module/User/src/Model/Enums/JWTClaims.php:41
 msgid "Given name"
 msgstr ""
 
-#: module/User/src/Model/Enums/JWTClaims.php:40
+#: module/User/src/Model/Enums/JWTClaims.php:42
 msgid "Is 18+?"
 msgstr ""
 
-#: module/User/src/Model/Enums/JWTClaims.php:41
+#: module/User/src/Model/Enums/JWTClaims.php:43
 msgid "Member number"
 msgstr ""
 
-#: module/User/src/Service/ApiUser.php:43
-#: module/User/src/Service/ApiUser.php:75
+#: module/User/src/Service/ApiUser.php:46
+#: module/User/src/Service/ApiUser.php:74
 msgid "You are not allowed to view API tokens"
 msgstr ""
 
-#: module/User/src/Service/ApiUser.php:59
+#: module/User/src/Service/ApiUser.php:60
 msgid "You are not allowed to remove API tokens"
 msgstr ""
 
-#: module/User/src/Service/ApiUser.php:119
+#: module/User/src/Service/ApiUser.php:115
 msgid "You are not allowed to add API tokens"
 msgstr ""
 
-#: module/User/src/Service/User.php:104 module/User/src/Service/User.php:327
+#: module/User/src/Service/User.php:105 module/User/src/Service/User.php:339
 msgid ""
 "You cannot use this password, it was found in a public data breach and is "
 "therefore considered insecure. We recommend using a password generated by a "
 "good password manager, such as Bitwarden or 1Password."
 msgstr ""
 
-#: module/User/src/Service/User.php:316
+#: module/User/src/Service/User.php:326
 msgid "Password incorrect"
 msgstr ""
 
-#: module/User/src/Service/User.php:476
+#: module/User/src/Service/User.php:481
 msgid "You are not allowed to change your password"
 msgstr ""
 

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-22 13:08+0200\n"
-"PO-Revision-Date: 2023-04-22 13:16+0200\n"
+"POT-Creation-Date: 2023-06-25 00:26+0200\n"
+"PO-Revision-Date: 2023-06-25 00:28+0200\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: nl\n"
@@ -19,111 +19,111 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: module/Activity/src/Controller/ActivityCalendarController.php:79
+#: module/Activity/src/Controller/ActivityCalendarController.php:82
 msgid "You are not allowed to create activity proposals"
 msgstr "Je hebt niet de rechten om opties voor activiteiten te maken"
 
-#: module/Activity/src/Controller/ActivityController.php:236
-#: module/Activity/view/activity/activity/index.phtml:32
+#: module/Activity/src/Controller/ActivityController.php:228
+#: module/Activity/view/activity/activity/index.phtml:45
 msgid "Create Activity"
 msgstr "Maak nieuwe activiteit"
 
-#: module/Activity/src/Controller/ActivityController.php:266
-#: module/Activity/src/Controller/ActivityController.php:363
-#: module/Activity/src/Controller/AdminController.php:304
-#: module/Activity/src/Controller/AdminController.php:397
+#: module/Activity/src/Controller/ActivityController.php:258
+#: module/Activity/src/Controller/ActivityController.php:351
+#: module/Activity/src/Controller/AdminController.php:294
+#: module/Activity/src/Controller/AdminController.php:381
 msgid "Invalid form"
 msgstr "De ingevulde gegevens zijn niet geldig"
 
-#: module/Activity/src/Controller/ActivityController.php:275
-#: module/Activity/src/Controller/ActivityController.php:372
+#: module/Activity/src/Controller/ActivityController.php:267
+#: module/Activity/src/Controller/ActivityController.php:360
 msgid "You need to log in to subscribe"
 msgstr "Je moet inloggen om in te schrijven"
 
-#: module/Activity/src/Controller/ActivityController.php:285
-#: module/Activity/src/Controller/ActivityController.php:382
+#: module/Activity/src/Controller/ActivityController.php:277
+#: module/Activity/src/Controller/ActivityController.php:370
 msgid "You cannot subscribe to this activity at this moment in time"
 msgstr "Je kunt je op dit moment niet inschrijven voor deze activiteit"
 
-#: module/Activity/src/Controller/ActivityController.php:294
+#: module/Activity/src/Controller/ActivityController.php:286
 msgid "You have already been subscribed for this activity"
 msgstr "Je bent al ingeschreven voor deze activiteit"
 
-#: module/Activity/src/Controller/ActivityController.php:300
+#: module/Activity/src/Controller/ActivityController.php:292
 msgid "Successfully subscribed"
 msgstr "Succesvol geregistreerd"
 
-#: module/Activity/src/Controller/ActivityController.php:305
-#: module/Activity/src/Controller/ActivityController.php:398
-#: module/Activity/src/Controller/AdminController.php:328
+#: module/Activity/src/Controller/ActivityController.php:297
+#: module/Activity/src/Controller/ActivityController.php:386
+#: module/Activity/src/Controller/AdminController.php:318
 msgid "Use the form to subscribe"
 msgstr "Gebruik het formulier om in te schrijven"
 
-#: module/Activity/src/Controller/ActivityController.php:393
+#: module/Activity/src/Controller/ActivityController.php:381
 msgid "Successfully subscribed as external participant"
 msgstr "Succesvol geregistreerd"
 
-#: module/Activity/src/Controller/ActivityController.php:425
+#: module/Activity/src/Controller/ActivityController.php:413
 msgid "Wrong form"
 msgstr "Verkeerd formulier"
 
-#: module/Activity/src/Controller/ActivityController.php:432
+#: module/Activity/src/Controller/ActivityController.php:420
 msgid "You have to be logged in to subscribe for this activity"
 msgstr "Je moet ingelogd zijn om je voor deze activiteit in te schrijven"
 
-#: module/Activity/src/Controller/ActivityController.php:443
+#: module/Activity/src/Controller/ActivityController.php:431
 msgid "You cannot unsubscribe from this activity at this moment in time"
 msgstr "Je kunt je op dit moment niet afmelden voor deze activiteit"
 
-#: module/Activity/src/Controller/ActivityController.php:453
+#: module/Activity/src/Controller/ActivityController.php:441
 msgid "You are not subscribed to this activity!"
 msgstr "Je bent niet ingeschreven voor deze activiteit!"
 
-#: module/Activity/src/Controller/ActivityController.php:459
+#: module/Activity/src/Controller/ActivityController.php:447
 msgid "Successfully unsubscribed"
 msgstr "Succesvol uitgeschreven"
 
-#: module/Activity/src/Controller/ActivityController.php:464
+#: module/Activity/src/Controller/ActivityController.php:452
 msgid "Use the form to unsubscribe"
 msgstr "Gebruik het formulier om in te schrijven"
 
-#: module/Activity/src/Controller/AdminApprovalController.php:43
+#: module/Activity/src/Controller/AdminApprovalController.php:41
 msgid "You are not allowed to view the approval of this activity"
 msgstr ""
 "Je hebt niet de rechten om de goedkeuringsstatus van deze activiteit te "
 "bekijken"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:52
-#: module/Activity/src/Service/ActivityCategory.php:82
+#: module/Activity/src/Controller/AdminCategoryController.php:50
+#: module/Activity/src/Service/ActivityCategory.php:76
 msgid "You are not allowed to create an activity category"
 msgstr "Je hebt niet de rechten om een activiteitencategorie te maken"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:65
+#: module/Activity/src/Controller/AdminCategoryController.php:63
 msgid "The activity category was created successfully!"
 msgstr "De activiteitencategorie is succesvol aangemaakt!"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:75
+#: module/Activity/src/Controller/AdminCategoryController.php:73
 #: module/Activity/src/Form/ActivityCategory.php:44
 msgid "Create Activity Category"
 msgstr "Activiteitencategorie aanmaken"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:130
+#: module/Activity/src/Controller/AdminCategoryController.php:122
 msgid "You are not allowed to edit an activity category"
 msgstr "Je hebt niet de rechten om een activiteitencategorie bij te werken"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:150
+#: module/Activity/src/Controller/AdminCategoryController.php:142
 msgid "The activity category was successfully updated!"
 msgstr "De activiteitencategorie is succesvol bijgewerkt!"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:167
+#: module/Activity/src/Controller/AdminCategoryController.php:159
 msgid "Update Activity Category"
 msgstr "Activiteitencategorie bijwerken"
 
-#: module/Activity/src/Controller/AdminController.php:65
+#: module/Activity/src/Controller/AdminController.php:62
 msgid "You are not allowed to update this activity"
 msgstr "Je hebt niet de rechten om deze activiteit te wijzigen"
 
-#: module/Activity/src/Controller/AdminController.php:79
+#: module/Activity/src/Controller/AdminController.php:76
 msgid ""
 "Activities that have sign-up lists which are open or approved cannot be "
 "updated."
@@ -131,12 +131,12 @@ msgstr ""
 "Activiteiten met inschrijflijsten die open of goedgekeurd zijn, kunnen niet "
 "worden bijgewerkt."
 
-#: module/Activity/src/Controller/AdminController.php:90
+#: module/Activity/src/Controller/AdminController.php:87
 msgid "This activity has already started/ended and can no longer be updated."
 msgstr ""
 "Deze activiteit is al gestart/geëindigd en kan niet meer worden bijgewerkt."
 
-#: module/Activity/src/Controller/AdminController.php:108
+#: module/Activity/src/Controller/AdminController.php:106
 msgid ""
 "You have successfully created an update proposal for the activity! If the "
 "activity was already approved, the proposal will be applied after it has "
@@ -148,122 +148,122 @@ msgstr ""
 "is goedgekeurd door het bestuur. Anders is de update al toegepast op de "
 "activiteit."
 
-#: module/Activity/src/Controller/AdminController.php:145
+#: module/Activity/src/Controller/AdminController.php:143
 msgid "Update Activity"
 msgstr "Activiteit bijwerken"
 
-#: module/Activity/src/Controller/AdminController.php:198
-#: module/Activity/src/Controller/AdminController.php:210
-#: module/Activity/src/Controller/AdminController.php:222
+#: module/Activity/src/Controller/AdminController.php:188
+#: module/Activity/src/Controller/AdminController.php:200
+#: module/Activity/src/Controller/AdminController.php:212
 msgid "You are not allowed to view the participants of this activity"
 msgstr ""
 "Je hebt niet de rechten om de deelnemers van deze activiteit te bekijken"
 
-#: module/Activity/src/Controller/AdminController.php:244
-#: module/Activity/src/Controller/AdminController.php:388
-#: module/User/view/user/api-admin/index.phtml:23
+#: module/Activity/src/Controller/AdminController.php:234
+#: module/Activity/src/Controller/AdminController.php:372
+#: module/User/view/user/api-admin/index.phtml:35
 msgid "Remove"
 msgstr "Verwijder"
 
-#: module/Activity/src/Controller/AdminController.php:283
-#: module/Activity/src/Controller/AdminController.php:380
+#: module/Activity/src/Controller/AdminController.php:273
+#: module/Activity/src/Controller/AdminController.php:364
 msgid "You are not allowed to use this form"
 msgstr "Je hebt niet de rechten om dit formulier te gebruiken"
 
-#: module/Activity/src/Controller/AdminController.php:320
+#: module/Activity/src/Controller/AdminController.php:310
 msgid "Successfully subscribed external participant"
 msgstr "Succesvol geregistreerd"
 
-#: module/Activity/src/Controller/AdminController.php:407
+#: module/Activity/src/Controller/AdminController.php:391
 msgid "Successfully removed external participant"
 msgstr "Deelnemer succesvol verwijderd"
 
-#: module/Activity/src/Controller/AdminController.php:415
+#: module/Activity/src/Controller/AdminController.php:399
 msgid "Use the form to unsubscribe an external participant"
 msgstr "Gebruik het formulier om iemand uit te schrijven"
 
-#: module/Activity/src/Controller/AdminController.php:425
+#: module/Activity/src/Controller/AdminController.php:409
 msgid "You are not allowed to administer activities"
 msgstr "Je hebt niet de rechten om activiteiten te beheren"
 
-#: module/Activity/src/Controller/AdminOptionController.php:40
+#: module/Activity/src/Controller/AdminOptionController.php:41
 msgid "You are not allowed to administer option calendar periods"
 msgstr "Je hebt niet de rechten om optieperiodes te beheren"
 
-#: module/Activity/src/Controller/AdminOptionController.php:54
+#: module/Activity/src/Controller/AdminOptionController.php:57
 msgid "You are not allowed to create option calendar periods"
 msgstr "Je hebt niet de rechten om optieperiodes toe te voegen"
 
-#: module/Activity/src/Controller/AdminOptionController.php:73
+#: module/Activity/src/Controller/AdminOptionController.php:77
 msgid "Option planning period created successfully."
 msgstr "Optie planningsperiode succesvol aangemaakt."
 
-#: module/Activity/src/Controller/AdminOptionController.php:97
-#: module/Activity/view/activity/admin-option/index.phtml:105
+#: module/Activity/src/Controller/AdminOptionController.php:101
+#: module/Activity/view/activity/admin-option/index.phtml:113
 msgid "Add Option Period"
 msgstr "Voeg optieperiode toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:105
+#: module/Activity/src/Controller/AdminOptionController.php:109
 msgid "You are not allowed to delete option calendar periods"
 msgstr "Je hebt niet de rechten om optieperiodes te verwijderen"
 
-#: module/Activity/src/Controller/AdminOptionController.php:120
+#: module/Activity/src/Controller/AdminOptionController.php:124
 msgid "Past option planning periods cannot be deleted."
 msgstr "Eerdere optieplanningsperioden kunnen niet worden verwijderd."
 
-#: module/Activity/src/Controller/AdminOptionController.php:128
+#: module/Activity/src/Controller/AdminOptionController.php:132
 msgid "Option planning period deleted."
 msgstr "Optieplanningsperiode geschrapt."
 
-#: module/Activity/src/Controller/AdminOptionController.php:140
+#: module/Activity/src/Controller/AdminOptionController.php:145
 msgid "You are not allowed to edit option calendar periods"
 msgstr "Je hebt niet de rechten om optieplanningsperioden te wijzigen"
 
-#: module/Activity/src/Controller/AdminOptionController.php:155
+#: module/Activity/src/Controller/AdminOptionController.php:161
 msgid "This option planning period cannot be edited."
 msgstr "Deze optieplanningsperiode kan niet worden gewijzigd."
 
-#: module/Activity/src/Controller/AdminOptionController.php:174
+#: module/Activity/src/Controller/AdminOptionController.php:185
 msgid "Option planning period has been updated."
 msgstr "De optieplanningsperiode is bijgewerkt."
 
-#: module/Activity/src/Controller/AdminOptionController.php:196
+#: module/Activity/src/Controller/AdminOptionController.php:207
 msgid "Edit Option Period"
 msgstr "Bewerk optieperiode"
 
-#: module/Activity/src/Controller/ApiController.php:29
+#: module/Activity/src/Controller/ApiController.php:30
 msgid "You are not allowed to access the activities through the API"
 msgstr "Je hebt niet de rechten om de activiteiten in te zien via de API"
 
-#: module/Activity/src/Form/Activity.php:34
+#: module/Activity/src/Form/Activity.php:35
 msgid "No organ"
 msgstr "Geen orgaan"
 
-#: module/Activity/src/Form/Activity.php:35
+#: module/Activity/src/Form/Activity.php:36
 msgid "No Company"
 msgstr "Geen bedrijf"
 
-#: module/Activity/src/Form/Activity.php:289
-#: module/Activity/src/Form/Activity.php:301
-#: module/Activity/src/Form/Activity.php:315
-#: module/Activity/src/Form/Activity.php:327
-#: module/Activity/src/Form/Activity.php:339
-#: module/Activity/src/Form/Activity.php:351
-#: module/Activity/src/Form/ActivityCalendarProposal.php:130
-#: module/Activity/src/Form/ActivityCalendarProposal.php:141
-#: module/Activity/src/Form/ActivityCalendarProposal.php:149
-#: module/Education/src/Form/Bulk.php:59
+#: module/Activity/src/Form/Activity.php:282
+#: module/Activity/src/Form/Activity.php:294
+#: module/Activity/src/Form/Activity.php:308
+#: module/Activity/src/Form/Activity.php:320
+#: module/Activity/src/Form/Activity.php:335
+#: module/Activity/src/Form/Activity.php:350
+#: module/Activity/src/Form/ActivityCalendarProposal.php:128
+#: module/Activity/src/Form/ActivityCalendarProposal.php:142
+#: module/Activity/src/Form/ActivityCalendarProposal.php:150
+#: module/Education/src/Form/Bulk.php:57
 msgid "Value is required and can't be empty"
 msgstr "Waarde is vereist en kan niet leeg zijn"
 
-#: module/Activity/src/Form/Activity.php:372
+#: module/Activity/src/Form/Activity.php:373
 msgid ""
 "The sign-up list closing date and time must be before the activity starts."
 msgstr ""
 "De openingsdatum en -tijd van de inschrijflijst moeten vóór de startdatum en-"
 "tijd van de activiteit vallen."
 
-#: module/Activity/src/Form/Activity.php:407
+#: module/Activity/src/Form/Activity.php:409
 msgid "The activity must start before it ends."
 msgstr "De activiteit moet beginnen voordat deze eindigt."
 
@@ -284,7 +284,7 @@ msgid "Evening"
 msgstr "Avond"
 
 #: module/Activity/src/Form/ActivityCalendarOption.php:30
-#: module/Activity/view/activity/activity-calendar/index.phtml:142
+#: module/Activity/view/activity/activity-calendar/index.phtml:160
 msgid "Day"
 msgstr "Dag"
 
@@ -296,43 +296,43 @@ msgstr "Meerdere dagen"
 msgid "Select a type"
 msgstr "Selecteer een type"
 
-#: module/Activity/src/Form/ActivityCalendarOption.php:83
+#: module/Activity/src/Form/ActivityCalendarOption.php:84
 msgid "The activity must start before it ends"
 msgstr "De starttijd van de activiteit moet voor de eindtijd zijn"
 
-#: module/Activity/src/Form/ActivityCalendarOption.php:94
+#: module/Activity/src/Form/ActivityCalendarOption.php:97
 msgid "The activity must start after today"
 msgstr "De starttijd van de activiteit moet in de toekomst zijn"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:32
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:30
 msgid "Start date and time of planning period"
 msgstr "Begindatum en -tijd van de planningsperiode"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:43
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:41
 msgid "End date and time of planning period"
 msgstr "Einddatum en -tijd van de planningsperiode"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:54
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:52
 msgid "Start date and time of option period"
 msgstr "Begindatum en -tijd van de optieperiode"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:65
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:63
 msgid "End date and time of option period"
 msgstr "Einddatum en -tijd van de optieperiode"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:91
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:89
 msgid "Create Option Period"
 msgstr "Optieperiode maken"
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:128
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:126
 msgid "The planning period must end after it starts."
 msgstr "De planningsperiode moet eindigen nadat deze begonnen is."
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:151
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:149
 msgid "The option period must start after the planning period ends."
 msgstr "De optieperiode moet ingaan na afloop van de planningsperiode."
 
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:174
+#: module/Activity/src/Form/ActivityCalendarPeriod.php:172
 msgid "The option period must end after it starts."
 msgstr "De optieperiode moet eindigen nadat deze begonnen is."
 
@@ -344,83 +344,83 @@ msgstr "Selecteer een periode"
 msgid "Select an option"
 msgstr "Selecteer een optie"
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:161
+#: module/Activity/src/Form/ActivityCalendarProposal.php:165
 msgid "Option should end after it starts."
 msgstr "De optie moet eindigen nadat deze is begonnen."
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:169
+#: module/Activity/src/Form/ActivityCalendarProposal.php:176
 msgid "Option does not fall within option period (also check the end date)."
 msgstr "Optie valt niet binnen optieperiode (controleer ook de einddatum)."
 
-#: module/Activity/src/Form/ActivityCalendarProposal.php:216
+#: module/Activity/src/Form/ActivityCalendarProposal.php:220
 msgid "The activity does now have an acceptable amount of options"
 msgstr "De activiteit heeft geen acceptabel aantal opties"
 
 #: module/Activity/src/Form/ActivityCategory.php:24
 #: module/Activity/src/Form/ActivityCategory.php:34
-#: module/Activity/src/Form/SignupList.php:36
-#: module/Activity/src/Form/SignupList.php:46
-#: module/Activity/src/Form/SignupListField.php:33
-#: module/Activity/src/Form/SignupListField.php:43
-#: module/Activity/view/activity/activity-calendar/create.phtml:81
-#: module/Activity/view/activity/activity-calendar/index.phtml:46
-#: module/Activity/view/activity/activity/view.phtml:248
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:112
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:117
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:129
-#: module/Activity/view/activity/admin-approval/view.phtml:64
-#: module/Activity/view/activity/admin-approval/view.phtml:69
-#: module/Activity/view/activity/admin-approval/view.phtml:76
-#: module/Activity/view/activity/admin-category/add.phtml:56
-#: module/Activity/view/activity/admin-category/add.phtml:93
-#: module/Activity/view/activity/admin/participantsTable.phtml:11
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:5
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:10
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:17
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:89
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:94
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:101
-#: module/Activity/view/partial/create.phtml:31
-#: module/Activity/view/partial/create.phtml:105
-#: module/Activity/view/partial/signuplist.phtml:41
-#: module/Activity/view/partial/signuplist.phtml:57
-#: module/Company/src/Form/Company.php:52
-#: module/Company/src/Form/Company.php:94
-#: module/Company/src/Form/Company.php:114 module/Company/src/Form/Job.php:102
-#: module/Company/src/Form/Job.php:133 module/Company/src/Form/Job.php:143
+#: module/Activity/src/Form/SignupList.php:35
+#: module/Activity/src/Form/SignupList.php:45
+#: module/Activity/src/Form/SignupListField.php:34
+#: module/Activity/src/Form/SignupListField.php:44
+#: module/Activity/view/activity/activity-calendar/create.phtml:90
+#: module/Activity/view/activity/activity-calendar/index.phtml:64
+#: module/Activity/view/activity/activity/view.phtml:268
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:133
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:138
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:150
+#: module/Activity/view/activity/admin-approval/view.phtml:80
+#: module/Activity/view/activity/admin-approval/view.phtml:85
+#: module/Activity/view/activity/admin-approval/view.phtml:92
+#: module/Activity/view/activity/admin-category/add.phtml:69
+#: module/Activity/view/activity/admin-category/add.phtml:106
+#: module/Activity/view/activity/admin/participantsTable.phtml:20
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:18
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:23
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:30
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:102
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:107
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:114
+#: module/Activity/view/partial/create.phtml:44
+#: module/Activity/view/partial/create.phtml:118
+#: module/Activity/view/partial/signuplist.phtml:54
+#: module/Activity/view/partial/signuplist.phtml:70
+#: module/Company/src/Form/Company.php:51
+#: module/Company/src/Form/Company.php:93
+#: module/Company/src/Form/Company.php:113 module/Company/src/Form/Job.php:106
+#: module/Company/src/Form/Job.php:137 module/Company/src/Form/Job.php:147
 #: module/Company/src/Form/JobCategory.php:45
 #: module/Company/src/Form/JobCategory.php:55
-#: module/Company/src/Form/JobLabel.php:32
-#: module/Company/src/Form/JobLabel.php:42
-#: module/Company/view/company/admin-approval/index.phtml:14
-#: module/Company/view/company/admin-approval/job-approval.phtml:52
-#: module/Company/view/company/admin-approval/job-approval.phtml:56
-#: module/Company/view/company/admin-approval/job-approval.phtml:105
-#: module/Company/view/company/admin-approval/job-approval.phtml:110
-#: module/Company/view/company/admin-approval/job-approval.phtml:117
-#: module/Company/view/company/admin-approval/job-proposal.phtml:87
-#: module/Company/view/company/admin-approval/job-proposal.phtml:91
-#: module/Company/view/company/admin-approval/job-proposal.phtml:149
-#: module/Company/view/company/admin-approval/job-proposal.phtml:154
+#: module/Company/src/Form/JobLabel.php:31
+#: module/Company/src/Form/JobLabel.php:41
+#: module/Company/view/company/admin-approval/index.phtml:30
+#: module/Company/view/company/admin-approval/job-approval.phtml:66
+#: module/Company/view/company/admin-approval/job-approval.phtml:70
+#: module/Company/view/company/admin-approval/job-approval.phtml:119
+#: module/Company/view/company/admin-approval/job-approval.phtml:124
+#: module/Company/view/company/admin-approval/job-approval.phtml:131
+#: module/Company/view/company/admin-approval/job-proposal.phtml:97
+#: module/Company/view/company/admin-approval/job-proposal.phtml:101
+#: module/Company/view/company/admin-approval/job-proposal.phtml:159
 #: module/Company/view/company/admin-approval/job-proposal.phtml:164
-#: module/Company/view/company/admin/edit-package.phtml:69
-#: module/Company/view/company/admin/index.phtml:112
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:177
-#: module/Decision/view/decision/admin/document.phtml:57
-#: module/Decision/view/decision/member/birthdays.phtml:12
-#: module/Decision/view/decision/organ-admin/index.phtml:12
-#: module/Decision/view/decision/organ/index.phtml:14
-#: module/Education/src/Form/Course.php:42
-#: module/Education/view/education/admin/course.phtml:32
-#: module/Photo/view/photo/album-admin/edit.phtml:23
+#: module/Company/view/company/admin-approval/job-proposal.phtml:174
+#: module/Company/view/company/admin/edit-package.phtml:83
+#: module/Company/view/company/admin/index.phtml:126
+#: module/Company/view/company/admin/index.phtml:212
+#: module/Company/view/company/company-account/jobs.phtml:196
+#: module/Decision/view/decision/admin/document.phtml:71
+#: module/Decision/view/decision/member/birthdays.phtml:23
+#: module/Decision/view/decision/organ-admin/index.phtml:24
+#: module/Decision/view/decision/organ/index.phtml:23
+#: module/Education/src/Form/Course.php:43
+#: module/Education/view/education/admin/course.phtml:44
+#: module/Photo/view/photo/album-admin/edit.phtml:35
 #: module/User/src/Form/ApiToken.php:25
-#: module/User/view/user/api-admin/add.phtml:45
-#: module/User/view/user/api-admin/index.phtml:10
+#: module/User/view/user/api-admin/add.phtml:57
+#: module/User/view/user/api-admin/index.phtml:22
 msgid "Name"
 msgstr "Naam"
 
-#: module/Activity/src/Form/SignupList.php:184
+#: module/Activity/src/Form/SignupList.php:180
 msgid ""
 "The sign-up list opening date and time must be before the sign-up list "
 "closes."
@@ -428,203 +428,203 @@ msgstr ""
 "De openingsdatum en -tijd van de inschrijflijst moeten vóór de "
 "sluitingsdatum en-tijd van de inschrijflijst vallen."
 
-#: module/Activity/src/Form/SignupListField.php:54
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:115
+#: module/Activity/src/Form/SignupListField.php:55
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:128
 msgid "Text"
 msgstr "Tekst"
 
-#: module/Activity/src/Form/SignupListField.php:55
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:118
+#: module/Activity/src/Form/SignupListField.php:56
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:131
 msgid "Yes/No"
 msgstr "Ja/Nee"
 
-#: module/Activity/src/Form/SignupListField.php:56
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
+#: module/Activity/src/Form/SignupListField.php:57
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
 msgid "Number"
 msgstr "Getal"
 
-#: module/Activity/src/Form/SignupListField.php:57
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:124
+#: module/Activity/src/Form/SignupListField.php:58
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:137
 msgid "Choice"
 msgstr "Keuze"
 
-#: module/Activity/src/Form/SignupListField.php:59
-#: module/Activity/view/activity/activity-calendar/index.phtml:47
-#: module/Activity/view/activity/admin/participantsTable.phtml:13
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:108
-#: module/Activity/view/partial/option.phtml:10
-#: module/Decision/view/decision/decision/index.phtml:9
-#: module/Decision/view/decision/organ/index.phtml:15
-#: module/Education/src/Form/Fieldset/Exam.php:69
-#: module/Education/view/education/admin/course-documents.phtml:58
+#: module/Activity/src/Form/SignupListField.php:60
+#: module/Activity/view/activity/activity-calendar/index.phtml:65
+#: module/Activity/view/activity/admin/participantsTable.phtml:22
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
+#: module/Activity/view/partial/option.phtml:19
+#: module/Decision/view/decision/decision/index.phtml:23
+#: module/Decision/view/decision/organ/index.phtml:24
+#: module/Education/src/Form/Fieldset/Exam.php:68
+#: module/Education/view/education/admin/course-documents.phtml:68
 msgid "Type"
 msgstr "Type"
 
-#: module/Activity/src/Form/SignupListField.php:69
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
+#: module/Activity/src/Form/SignupListField.php:70
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:147
 msgid "Min. value"
 msgstr "Min. waarde"
 
-#: module/Activity/src/Form/SignupListField.php:79
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:144
+#: module/Activity/src/Form/SignupListField.php:80
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:157
 msgid "Max. value"
 msgstr "Max. waarde"
 
-#: module/Activity/src/Form/SignupListField.php:89
-#: module/Activity/src/Form/SignupListField.php:102
+#: module/Activity/src/Form/SignupListField.php:90
+#: module/Activity/src/Form/SignupListField.php:103
 msgid "Option 1, Option 2, ..."
 msgstr "Optie 1, Optie 2, ..."
 
-#: module/Activity/src/Form/SignupListField.php:92
-#: module/Activity/src/Form/SignupListField.php:105
-#: module/Activity/view/activity/activity-calendar/create.phtml:110
-#: module/Activity/view/activity/activity-calendar/index.phtml:175
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:156
-#: module/Activity/view/partial/create.phtml:157
+#: module/Activity/src/Form/SignupListField.php:93
+#: module/Activity/src/Form/SignupListField.php:106
+#: module/Activity/view/activity/activity-calendar/create.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:193
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:169
+#: module/Activity/view/partial/create.phtml:170
 msgid "Options"
 msgstr "Opties"
 
-#: module/Activity/src/Form/SignupListField.php:159
+#: module/Activity/src/Form/SignupListField.php:160
 msgid "Some of the required fields for this type are empty"
 msgstr "Sommige van de verplichte velden voor dit type zijn leeg"
 
-#: module/Activity/src/Form/SignupListField.php:190
+#: module/Activity/src/Form/SignupListField.php:191
 msgid "The number of English options must equal the number of Dutch options"
 msgstr ""
 "Het aantal Engelse opties moet gelijk zijn aan het aantal Nederlandse opties"
 
-#: module/Activity/src/Service/Activity.php:57
-#: module/Activity/src/Service/Activity.php:98
+#: module/Activity/src/Service/Activity.php:66
+#: module/Activity/src/Service/Activity.php:105
 msgid "You are not allowed to create an activity"
 msgstr "Je hebt niet de rechten om een activiteit te maken"
 
-#: module/Activity/src/Service/Activity.php:138
+#: module/Activity/src/Service/Activity.php:145
 msgid "You are not allowed to create an activity for this organ"
 msgstr "Je hebt niet de rechten om een activiteit aan te maken voor dit orgaan"
 
-#: module/Activity/src/Service/Activity.php:398
+#: module/Activity/src/Service/Activity.php:406
 msgid "You are not allowed to create activity option proposals"
 msgstr "Je hebt niet de rechten om opties voor activiteiten te maken"
 
-#: module/Activity/src/Service/Activity.php:731
-#: module/Activity/src/Service/Activity.php:749
-#: module/Activity/src/Service/Activity.php:767
+#: module/Activity/src/Service/Activity.php:754
+#: module/Activity/src/Service/Activity.php:772
+#: module/Activity/src/Service/Activity.php:790
 msgid "You are not allowed to change the status of the activity"
 msgstr "Je hebt niet de rechten om de status van deze activiteit te wijzigen"
 
-#: module/Activity/src/Service/ActivityCalendar.php:167
+#: module/Activity/src/Service/ActivityCalendar.php:169
 msgid "You are not allowed to approve this option"
 msgstr "Je hebt niet de rechten om deze optie goed te keuren"
 
-#: module/Activity/src/Service/ActivityCalendar.php:215
+#: module/Activity/src/Service/ActivityCalendar.php:209
 msgid "You are not allowed to delete this option"
 msgstr "Je hebt niet de rechten om deze optie te verwijderen"
 
-#: module/Activity/src/Service/ActivityCategory.php:35
-#: module/Activity/src/Service/ActivityCategory.php:51
+#: module/Activity/src/Service/ActivityCategory.php:31
+#: module/Activity/src/Service/ActivityCategory.php:47
 msgid "You are not allowed to view activity categories"
 msgstr "Je hebt niet de rechten om activiteitencategorieën te bekijken"
 
-#: module/Activity/src/Service/ActivityCategory.php:115
+#: module/Activity/src/Service/ActivityCategory.php:105
 msgid "You are not allowed to delete an activity category"
 msgstr "Je hebt niet de rechten om een activiteitencategorie te verwijderen"
 
-#: module/Activity/src/Service/ActivityQuery.php:91
+#: module/Activity/src/Service/ActivityQuery.php:86
 msgid "You are not allowed to view this activity"
 msgstr "Je hebt niet de rechten om deze activiteit te bekijken"
 
-#: module/Activity/src/Service/ActivityQuery.php:107
-#: module/Activity/src/Service/ActivityQuery.php:274
-#: module/Activity/src/Service/Signup.php:149
+#: module/Activity/src/Service/ActivityQuery.php:102
+#: module/Activity/src/Service/ActivityQuery.php:262
+#: module/Activity/src/Service/Signup.php:128
 msgid "You are not allowed to view the activities"
 msgstr "Je hebt niet de rechten om de activiteiten in te zien"
 
-#: module/Activity/src/Service/ActivityQuery.php:122
+#: module/Activity/src/Service/ActivityQuery.php:117
 msgid "You are not allowed to view unapproved activities"
 msgstr "Je hebt niet de rechten om niet goedgekeurde activiteiten in te zien"
 
-#: module/Activity/src/Service/ActivityQuery.php:137
+#: module/Activity/src/Service/ActivityQuery.php:132
 msgid "You are not allowed to view activities"
 msgstr "Je hebt niet de rechten om de activiteiten in te zien"
 
-#: module/Activity/src/Service/ActivityQuery.php:167
+#: module/Activity/src/Service/ActivityQuery.php:159
 msgid "You are not allowed to view the disapproved activities"
 msgstr "Je hebt niet de rechten om afgekeurde activiteiten in te zien"
 
-#: module/Activity/src/Service/ActivityQuery.php:185
+#: module/Activity/src/Service/ActivityQuery.php:177
 msgid "You are not allowed to view upcoming the activities"
 msgstr "Je hebt niet de rechten om aankomende activiteiten te zien"
 
-#: module/Activity/src/Service/ActivityQuery.php:193
+#: module/Activity/src/Service/ActivityQuery.php:185
 msgid ""
 "You are not allowed to view upcoming activities coupled to a member account"
 msgstr ""
 "Je hebt niet de rechten om aankomende activiteiten te zien die gekoppeld "
 "zijn een het account van een lid"
 
-#: module/Activity/src/Service/Signup.php:54
-#: module/Activity/src/Service/Signup.php:168
+#: module/Activity/src/Service/Signup.php:47
+#: module/Activity/src/Service/Signup.php:147
 msgid "You need to be logged in to sign up for this activity"
 msgstr "Je moet ingelogd zijn om je voor deze activiteit in te schrijven"
 
-#: module/Activity/src/Service/Signup.php:73
+#: module/Activity/src/Service/Signup.php:61
 msgid "You are not allowed to use the external admin signup"
 msgstr "Je hebt niet de rechten om een externe admin inschrijving te maken"
 
-#: module/Activity/src/Service/Signup.php:92
+#: module/Activity/src/Service/Signup.php:75
 msgid "You are not allowed to use the external signup"
 msgstr "Je hebt niet de rechten om een externe inschrijving te maken"
 
-#: module/Activity/src/Service/Signup.php:112
+#: module/Activity/src/Service/Signup.php:96
 msgid "You are not allowed to view the sign up data"
 msgstr "Je hebt niet de rechten om ingeschreven leden te zien"
 
-#: module/Activity/src/Service/Signup.php:248
+#: module/Activity/src/Service/Signup.php:229
 msgid "You are not allowed to subscribe an external user to this sign-up list"
 msgstr ""
 "Je hebt niet de rechten om een externe gebruiker op deze inschrijflijst in "
 "te schrijven"
 
-#: module/Activity/src/Service/Signup.php:301
+#: module/Activity/src/Service/Signup.php:276
 msgid "You are not allowed to subscribe to this sign-up list"
 msgstr ""
 "Je hebt niet de rechten om jezelf op deze inschrijflijst in te schrijven"
 
-#: module/Activity/src/Service/Signup.php:320
+#: module/Activity/src/Service/Signup.php:292
 msgid "You need to be logged in to sign off for this activity"
 msgstr "Je moet ingelogd zijn om je uit te schrijven voor deze activiteit"
 
-#: module/Activity/src/Service/Signup.php:369
+#: module/Activity/src/Service/Signup.php:333
 msgid "You are not allowed to remove external signups for this activity"
 msgstr ""
 "Je hebt niet de rechten om externe inschrijvingen te verwijderen voor deze "
 "activiteit"
 
-#: module/Activity/src/Service/SignupListQuery.php:30
+#: module/Activity/src/Service/SignupListQuery.php:26
 msgid "You are not allowed to view sign-up lists"
 msgstr "Je hebt niet de rechten om inschrijflijsten te bekijken"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:5
+#: module/Activity/view/activity/activity-calendar/create.phtml:14
 msgid "Create activity proposal"
 msgstr "Creëer activiteitenvoorstel"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:21
-#: module/Activity/view/activity/activity-calendar/index.phtml:20
-#: module/Application/view/partial/main-nav.phtml:386
-#: module/Decision/view/decision/member/index.phtml:196
+#: module/Activity/view/activity/activity-calendar/create.phtml:30
+#: module/Activity/view/activity/activity-calendar/index.phtml:38
+#: module/Application/view/partial/main-nav.phtml:417
+#: module/Decision/view/decision/member/index.phtml:207
 msgid "Option calendar"
 msgstr "Optiekalender"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:22
+#: module/Activity/view/activity/activity-calendar/create.phtml:31
 msgid "Propose options for an activity"
 msgstr "Opties voor een activiteit voorstellen"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:30
+#: module/Activity/view/activity/activity-calendar/create.phtml:39
 msgid "Organisation"
 msgstr "Organisatie"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:31
-#: module/Activity/view/activity/activity-calendar/create.phtml:69
+#: module/Activity/view/activity/activity-calendar/create.phtml:40
+#: module/Activity/view/activity/activity-calendar/create.phtml:78
 msgid ""
 "Select the organ for which the options are and in which option period the "
 "options should be planned."
@@ -632,66 +632,66 @@ msgstr ""
 "Selecteer het orgaan waarvoor de opties zijn en in welke optieperiode de "
 "opties moeten worden gepland."
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:40
+#: module/Activity/view/activity/activity-calendar/create.phtml:49
 msgid "Period"
 msgstr "Periode"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:55
-#: module/Activity/view/activity/activity/create.phtml:49
+#: module/Activity/view/activity/activity-calendar/create.phtml:64
+#: module/Activity/view/activity/activity/create.phtml:62
 msgid "Committee / fraternity"
 msgstr "Commissee / dispuut"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:68
-#: module/Activity/view/activity/admin/list.phtml:59
-#: module/Company/view/company/admin-approval/job-approval.phtml:86
-#: module/Company/view/company/admin-approval/job-proposal.phtml:130
-#: module/Company/view/company/admin/edit-package.phtml:97
-#: module/Company/view/company/company-account/jobs.phtml:215
+#: module/Activity/view/activity/activity-calendar/create.phtml:77
+#: module/Activity/view/activity/admin/list.phtml:67
+#: module/Company/view/company/admin-approval/job-approval.phtml:100
+#: module/Company/view/company/admin-approval/job-proposal.phtml:140
+#: module/Company/view/company/admin/edit-package.phtml:111
+#: module/Company/view/company/company-account/jobs.phtml:234
 msgid "Details"
 msgstr "Details"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:97
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:199
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:204
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:216
-#: module/Activity/view/activity/admin-approval/view.phtml:121
-#: module/Activity/view/activity/admin-approval/view.phtml:126
-#: module/Activity/view/activity/admin-approval/view.phtml:133
-#: module/Activity/view/partial/create.phtml:74
-#: module/Activity/view/partial/create.phtml:148
-#: module/Company/src/Form/Company.php:199
-#: module/Company/src/Form/Company.php:209 module/Company/src/Form/Job.php:197
-#: module/Company/src/Form/Job.php:207
-#: module/Company/view/company/admin-approval/job-approval.phtml:162
-#: module/Company/view/company/admin-approval/job-approval.phtml:167
-#: module/Company/view/company/admin-approval/job-approval.phtml:174
-#: module/Company/view/company/admin-approval/job-proposal.phtml:224
-#: module/Company/view/company/admin-approval/job-proposal.phtml:229
+#: module/Activity/view/activity/activity-calendar/create.phtml:106
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:220
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:225
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:237
+#: module/Activity/view/activity/admin-approval/view.phtml:137
+#: module/Activity/view/activity/admin-approval/view.phtml:142
+#: module/Activity/view/activity/admin-approval/view.phtml:149
+#: module/Activity/view/partial/create.phtml:87
+#: module/Activity/view/partial/create.phtml:161
+#: module/Company/src/Form/Company.php:198
+#: module/Company/src/Form/Company.php:208 module/Company/src/Form/Job.php:201
+#: module/Company/src/Form/Job.php:211
+#: module/Company/view/company/admin-approval/job-approval.phtml:176
+#: module/Company/view/company/admin-approval/job-approval.phtml:181
+#: module/Company/view/company/admin-approval/job-approval.phtml:188
+#: module/Company/view/company/admin-approval/job-proposal.phtml:234
 #: module/Company/view/company/admin-approval/job-proposal.phtml:239
-#: module/Company/view/company/company/jobs.phtml:128
-#: module/Company/view/partial/company/company/list/company.phtml:89
+#: module/Company/view/company/admin-approval/job-proposal.phtml:249
+#: module/Company/view/company/company/jobs.phtml:140
+#: module/Company/view/partial/company/company/list/company.phtml:99
 msgid "Description"
 msgstr "Beschrijving"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:111
+#: module/Activity/view/activity/activity-calendar/create.phtml:120
 msgid "Add options for your activity proposal."
 msgstr "Voeg opties toe voor je activiteitenvoorstel."
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:133
+#: module/Activity/view/activity/activity-calendar/create.phtml:142
 msgid "Add an option"
 msgstr "Voeg optie toe"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:137
+#: module/Activity/view/activity/activity-calendar/create.phtml:146
 msgid "Remove the last option"
 msgstr "Verwijder de laatste optie"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:145
-#: module/Decision/src/Form/Minutes.php:53
+#: module/Activity/view/activity/activity-calendar/create.phtml:154
+#: module/Decision/src/Form/Minutes.php:55
 #: module/Frontpage/src/Form/Poll.php:63
 msgid "Submit"
 msgstr "Verzend"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:21
+#: module/Activity/view/activity/activity-calendar/index.phtml:39
 msgid ""
 "Welcome on the page of the digital Option Calendar. In the calendar below "
 "you can place options for GEWIS activities, just like you were used to do in "
@@ -707,11 +707,11 @@ msgstr ""
 "opties voor activiteiten. Als je een optie plaatst, geef deze dan een "
 "duidelijke naam waaruit blijkt waar de optie voor is."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:23
+#: module/Activity/view/activity/activity-calendar/index.phtml:41
 msgid "There are a few rules:"
 msgstr "Er zijn een paar regels:"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:25
+#: module/Activity/view/activity/activity-calendar/index.phtml:43
 msgid ""
 "It is not allowed to put more than 3 options for the same activity in the "
 "calendar."
@@ -719,7 +719,7 @@ msgstr ""
 "Er mogen niet meer dan 3 opties voor dezelfde activiteit in de optiekalender "
 "geplaatst worden."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:26
+#: module/Activity/view/activity/activity-calendar/index.phtml:44
 msgid ""
 "The first to put an option for an activity on a particular date, has the "
 "first dibs to let the activity take place on this date. Five weeks before "
@@ -738,7 +738,7 @@ msgstr ""
 "ingediend, dan vervalt de optie, en krijgt de volgende in de rij de kans om "
 "deze dag te gebruiken."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:27
+#: module/Activity/view/activity/activity-calendar/index.phtml:45
 msgid ""
 "The board can always decide to make an exception to the rules written above, "
 "for example in case of dependence on a third party, or when it concerns very "
@@ -748,134 +748,134 @@ msgstr ""
 "te maken, bijvoorbeeld in het geval van afhankelijkheid van een derde "
 "partij, of als het gaat om grote activiteiten en weekenden."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:33
+#: module/Activity/view/activity/activity-calendar/index.phtml:51
 msgid "Your option has been added successfully"
 msgstr "De optie is succesvol toegevoegd"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:41
+#: module/Activity/view/activity/activity-calendar/index.phtml:59
 msgid "My options"
 msgstr "Mijn opties"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:45
+#: module/Activity/view/activity/activity-calendar/index.phtml:63
 msgid "Creator"
 msgstr "Aangemaakt door"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:48
-#: module/Activity/view/activity/activity/list.phtml:37
-#: module/Activity/view/activity/activity/view.phtml:70
+#: module/Activity/view/activity/activity-calendar/index.phtml:66
+#: module/Activity/view/activity/activity/list.phtml:50
+#: module/Activity/view/activity/activity/view.phtml:90
 msgid "Start"
 msgstr "Start"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:49
-#: module/Activity/view/activity/activity/list.phtml:39
-#: module/Activity/view/activity/activity/view.phtml:73
+#: module/Activity/view/activity/activity-calendar/index.phtml:67
+#: module/Activity/view/activity/activity/list.phtml:52
+#: module/Activity/view/activity/activity/view.phtml:93
 msgid "End"
 msgstr "Einde"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:70
-#: module/Activity/view/activity/activity-calendar/index.phtml:103
-#: module/Activity/view/activity/admin-option/index.phtml:40
-#: module/Activity/view/activity/admin-option/index.phtml:90
-#: module/Activity/view/activity/admin-option/index.phtml:130
-#: module/Company/view/company/admin/edit-company.phtml:150
-#: module/Company/view/company/admin/edit-package.phtml:112
-#: module/Company/view/company/admin/index.phtml:190
-#: module/Company/view/company/company-account/jobs.phtml:235
-#: module/Decision/view/decision/admin/document.phtml:136
-#: module/Decision/view/decision/admin/document.phtml:167
-#: module/Education/view/education/admin/course-documents.phtml:82
-#: module/Education/view/education/admin/course-documents.phtml:131
-#: module/Education/view/education/admin/course-documents.phtml:166
-#: module/Education/view/education/admin/course.phtml:58
-#: module/Education/view/education/admin/course.phtml:93
-#: module/Education/view/education/admin/edit-exam.phtml:49
-#: module/Education/view/education/admin/edit-summary.phtml:49
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:73
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:143
+#: module/Activity/view/activity/activity-calendar/index.phtml:88
+#: module/Activity/view/activity/activity-calendar/index.phtml:121
+#: module/Activity/view/activity/admin-option/index.phtml:48
+#: module/Activity/view/activity/admin-option/index.phtml:98
+#: module/Activity/view/activity/admin-option/index.phtml:138
+#: module/Company/view/company/admin/edit-company.phtml:162
+#: module/Company/view/company/admin/edit-package.phtml:126
+#: module/Company/view/company/admin/index.phtml:204
+#: module/Company/view/company/company-account/jobs.phtml:254
+#: module/Decision/view/decision/admin/document.phtml:150
+#: module/Decision/view/decision/admin/document.phtml:181
+#: module/Education/view/education/admin/course-documents.phtml:92
+#: module/Education/view/education/admin/course-documents.phtml:141
+#: module/Education/view/education/admin/course-documents.phtml:176
+#: module/Education/view/education/admin/course.phtml:70
+#: module/Education/view/education/admin/course.phtml:105
+#: module/Education/view/education/admin/edit-exam.phtml:62
+#: module/Education/view/education/admin/edit-summary.phtml:62
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:88
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:158
 msgid "Delete"
 msgstr "Verwijder"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:74
-#: module/Activity/view/activity/activity-calendar/index.phtml:127
-#: module/Activity/view/activity/admin-approval/view.phtml:192
-#: module/Decision/view/decision/organ-admin/edit.phtml:170
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:69
+#: module/Activity/view/activity/activity-calendar/index.phtml:92
+#: module/Activity/view/activity/activity-calendar/index.phtml:145
+#: module/Activity/view/activity/admin-approval/view.phtml:208
+#: module/Decision/view/decision/organ-admin/edit.phtml:181
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:84
 msgid "Approve"
 msgstr "Goedkeuren"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:78
+#: module/Activity/view/activity/activity-calendar/index.phtml:96
 msgid "Modified by"
 msgstr "Aangepast door"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:92
+#: module/Activity/view/activity/activity-calendar/index.phtml:110
 msgid "Delete option"
 msgstr "Verwijder optie"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:95
+#: module/Activity/view/activity/activity-calendar/index.phtml:113
 msgid "Are you sure you want to delete this option?"
 msgstr "Weet je zeker dat je deze optie wil verwijderen?"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:101
-#: module/Activity/view/activity/activity-calendar/index.phtml:125
-#: module/Activity/view/activity/admin-category/index.phtml:56
-#: module/Activity/view/activity/admin-option/index.phtml:127
-#: module/Company/view/company/admin/edit-company.phtml:202
-#: module/Company/view/company/admin/edit-package.phtml:146
-#: module/Company/view/company/admin/index.phtml:230
-#: module/Company/view/company/company-account/jobs.phtml:285
-#: module/Decision/view/decision/admin/document.phtml:164
-#: module/Decision/view/decision/admin/document.phtml:191
-#: module/Decision/view/decision/decision/authorizations.phtml:167
-#: module/Education/view/education/admin/course-documents.phtml:163
-#: module/Education/view/education/admin/course.phtml:90
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:171
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:217
-#: module/Photo/view/photo/album-admin/index.phtml:221
-#: module/Photo/view/photo/album-admin/index.phtml:253
-#: module/Photo/view/photo/photo-admin/index.phtml:140
+#: module/Activity/view/activity/activity-calendar/index.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:143
+#: module/Activity/view/activity/admin-category/index.phtml:64
+#: module/Activity/view/activity/admin-option/index.phtml:135
+#: module/Company/view/company/admin/edit-company.phtml:214
+#: module/Company/view/company/admin/edit-package.phtml:160
+#: module/Company/view/company/admin/index.phtml:244
+#: module/Company/view/company/company-account/jobs.phtml:304
+#: module/Decision/view/decision/admin/document.phtml:178
+#: module/Decision/view/decision/admin/document.phtml:205
+#: module/Decision/view/decision/decision/authorizations.phtml:185
+#: module/Education/view/education/admin/course-documents.phtml:173
+#: module/Education/view/education/admin/course.phtml:102
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:231
+#: module/Photo/view/photo/album-admin/index.phtml:232
+#: module/Photo/view/photo/album-admin/index.phtml:264
+#: module/Photo/view/photo/photo-admin/index.phtml:158
 #: module/User/src/Form/ApiAppAuthorisation.php:26
 msgid "Cancel"
 msgstr "Annuleer"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:116
+#: module/Activity/view/activity/activity-calendar/index.phtml:134
 msgid "Approve option"
 msgstr "Keur optie goed"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:119
+#: module/Activity/view/activity/activity-calendar/index.phtml:137
 msgid "Are you sure you want to approve this option?"
 msgstr "Weet je zeker dat je deze optie wilt goedkeuren?"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:162
+#: module/Activity/view/activity/activity-calendar/index.phtml:180
 msgid "Planned Activities"
 msgstr "Geplande activiteiten"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:163
-#: module/Activity/view/activity/activity/list.phtml:55
+#: module/Activity/view/activity/activity-calendar/index.phtml:181
+#: module/Activity/view/activity/activity/list.phtml:68
 msgid "There are no activities."
 msgstr "Er zijn geen activiteiten."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:176
+#: module/Activity/view/activity/activity-calendar/index.phtml:194
 msgid "There are no options."
 msgstr "Er zijn geen opties."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:218
+#: module/Activity/view/activity/activity-calendar/index.phtml:236
 msgid "Plan activity"
 msgstr "Plan activiteit"
 
-#: module/Activity/view/activity/activity/archive.phtml:20
-#: module/Photo/view/photo/photo/index.phtml:23
+#: module/Activity/view/activity/activity/archive.phtml:34
+#: module/Photo/view/photo/photo/index.phtml:36
 msgid "Older"
 msgstr "Ouder"
 
-#: module/Activity/view/activity/activity/archive.phtml:40
+#: module/Activity/view/activity/activity/archive.phtml:54
 msgid "There are no activities in the archive."
 msgstr "Er zijn geen activiteiten in het archief."
 
-#: module/Activity/view/activity/activity/create.phtml:38
+#: module/Activity/view/activity/activity/create.phtml:51
 msgid "Organizer"
 msgstr "Organisator"
 
-#: module/Activity/view/activity/activity/create.phtml:39
+#: module/Activity/view/activity/activity/create.phtml:52
 msgid ""
 "Select whether an organ (committee, fraternity, etc.) or a company is "
 "responsible for this activity, or both."
@@ -883,43 +883,43 @@ msgstr ""
 "Selecteer of een orgaan (commissie, dispuut, enz.) of een bedrijf "
 "verantwoordelijk is voor deze activiteit, of beide."
 
-#: module/Activity/view/activity/activity/create.phtml:63
-#: module/Activity/view/activity/admin/list.phtml:17
-#: module/Activity/view/activity/admin/view.phtml:57
-#: module/Company/view/company/admin-approval/index.phtml:42
-#: module/Company/view/company/company/job-list.phtml:71
-#: module/User/view/user/user/login.phtml:20
+#: module/Activity/view/activity/activity/create.phtml:76
+#: module/Activity/view/activity/admin/list.phtml:25
+#: module/Activity/view/activity/admin/view.phtml:74
+#: module/Company/view/company/admin-approval/index.phtml:58
+#: module/Company/view/company/company/job-list.phtml:85
+#: module/User/view/user/user/login.phtml:34
 msgid "Company"
 msgstr "Bedrijf"
 
-#: module/Activity/view/activity/activity/create.phtml:74
-#: module/Activity/view/activity/admin/participantsTable.phtml:16
+#: module/Activity/view/activity/activity/create.phtml:87
+#: module/Activity/view/activity/admin/participantsTable.phtml:25
 msgid "Date and time"
 msgstr "Datum en tijd"
 
-#: module/Activity/view/activity/activity/create.phtml:75
+#: module/Activity/view/activity/activity/create.phtml:88
 msgid "Enter the start and end date and time of this activity."
 msgstr "Vul de begin- en einddatum en -tijd van deze activiteit in."
 
-#: module/Activity/view/activity/activity/create.phtml:88
+#: module/Activity/view/activity/activity/create.phtml:101
 msgid "Start date and time"
 msgstr "Begindatum en -tijd"
 
-#: module/Activity/view/activity/activity/create.phtml:103
+#: module/Activity/view/activity/activity/create.phtml:116
 msgid "End date and time"
 msgstr "Einddatum en -tijd"
 
-#: module/Activity/view/activity/activity/create.phtml:117
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:242
-#: module/Activity/view/activity/admin-approval/view.phtml:149
-#: module/Activity/view/activity/admin-category/add.phtml:4
-#: module/Activity/view/activity/admin-category/index.phtml:2
-#: module/Activity/view/activity/admin-category/index.phtml:6
-#: module/Activity/view/activity/admin-category/index.phtml:11
+#: module/Activity/view/activity/activity/create.phtml:130
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:263
+#: module/Activity/view/activity/admin-approval/view.phtml:165
+#: module/Activity/view/activity/admin-category/add.phtml:17
+#: module/Activity/view/activity/admin-category/index.phtml:10
+#: module/Activity/view/activity/admin-category/index.phtml:14
+#: module/Activity/view/activity/admin-category/index.phtml:19
 msgid "Activity Categories"
 msgstr "Activiteitencategorieën"
 
-#: module/Activity/view/activity/activity/create.phtml:118
+#: module/Activity/view/activity/activity/create.phtml:131
 msgid ""
 "Add activity categories to your activity to give potential subscribers a "
 "better understanding of the activity."
@@ -927,19 +927,19 @@ msgstr ""
 "Voeg activiteitencategorieën toe aan deze activiteit om potentiële "
 "deelnemers een beter inzicht te geven in de activiteit."
 
-#: module/Activity/view/activity/activity/create.phtml:138
-#: module/Activity/view/activity/admin-category/index.phtml:16
+#: module/Activity/view/activity/activity/create.phtml:151
+#: module/Activity/view/activity/admin-category/index.phtml:24
 msgid "There are currently no activity categories..."
 msgstr "Er zijn momenteel geen activiteitencategorieën..."
 
-#: module/Activity/view/activity/activity/create.phtml:164
-#: module/Activity/view/activity/activity/view.phtml:114
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:269
-#: module/Activity/view/activity/admin-approval/view.phtml:163
+#: module/Activity/view/activity/activity/create.phtml:177
+#: module/Activity/view/activity/activity/view.phtml:134
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:290
+#: module/Activity/view/activity/admin-approval/view.phtml:179
 msgid "Sign-up Lists"
 msgstr "Inschrijflijsten"
 
-#: module/Activity/view/activity/activity/create.phtml:165
+#: module/Activity/view/activity/activity/create.phtml:178
 msgid ""
 "Add sign-up lists to allow people to sign up for this activity. Each list "
 "can have optional fields to collect specific information from the "
@@ -949,135 +949,135 @@ msgstr ""
 "activiteit in te schrijven. Elke lijst kan optionele velden hebben om "
 "specifieke informatie van de deelnemers te verzamelen."
 
-#: module/Activity/view/activity/activity/create.phtml:171
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:99
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:279
-#: module/Activity/view/activity/admin-approval/view.phtml:51
-#: module/Activity/view/activity/admin-approval/view.phtml:169
-#: module/Activity/view/activity/admin-category/add.phtml:40
-#: module/Activity/view/partial/create.phtml:17
-#: module/Application/src/Model/Enums/Languages.php:19
-#: module/Company/view/company/admin-approval/job-approval.phtml:92
-#: module/Company/view/company/admin-approval/job-proposal.phtml:136
-#: module/Company/view/partial/company/admin/editors/category.phtml:7
-#: module/Company/view/partial/company/admin/editors/company.phtml:205
-#: module/Company/view/partial/company/admin/editors/job.phtml:133
-#: module/Company/view/partial/company/admin/editors/label.phtml:16
-#: module/Company/view/partial/company/admin/editors/package.phtml:87
+#: module/Activity/view/activity/activity/create.phtml:184
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:120
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:300
+#: module/Activity/view/activity/admin-approval/view.phtml:67
+#: module/Activity/view/activity/admin-approval/view.phtml:185
+#: module/Activity/view/activity/admin-category/add.phtml:53
+#: module/Activity/view/partial/create.phtml:30
+#: module/Application/src/Model/Enums/Languages.php:24
+#: module/Company/view/company/admin-approval/job-approval.phtml:106
+#: module/Company/view/company/admin-approval/job-proposal.phtml:146
+#: module/Company/view/partial/company/admin/editors/category.phtml:20
+#: module/Company/view/partial/company/admin/editors/company.phtml:218
+#: module/Company/view/partial/company/admin/editors/job.phtml:146
+#: module/Company/view/partial/company/admin/editors/label.phtml:29
+#: module/Company/view/partial/company/admin/editors/package.phtml:96
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: module/Activity/view/activity/activity/create.phtml:176
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:104
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:284
-#: module/Activity/view/activity/admin-approval/view.phtml:56
-#: module/Activity/view/activity/admin-approval/view.phtml:174
-#: module/Activity/view/activity/admin-category/add.phtml:77
-#: module/Activity/view/partial/create.phtml:91
-#: module/Application/src/Model/Enums/Languages.php:18
-#: module/Company/view/company/admin-approval/job-approval.phtml:97
-#: module/Company/view/company/admin-approval/job-proposal.phtml:141
-#: module/Company/view/partial/company/admin/editors/category.phtml:52
-#: module/Company/view/partial/company/admin/editors/company.phtml:266
-#: module/Company/view/partial/company/admin/editors/job.phtml:227
-#: module/Company/view/partial/company/admin/editors/label.phtml:61
-#: module/Company/view/partial/company/admin/editors/package.phtml:119
+#: module/Activity/view/activity/activity/create.phtml:189
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:125
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:305
+#: module/Activity/view/activity/admin-approval/view.phtml:72
+#: module/Activity/view/activity/admin-approval/view.phtml:190
+#: module/Activity/view/activity/admin-category/add.phtml:90
+#: module/Activity/view/partial/create.phtml:104
+#: module/Application/src/Model/Enums/Languages.php:23
+#: module/Company/view/company/admin-approval/job-approval.phtml:111
+#: module/Company/view/company/admin-approval/job-proposal.phtml:151
+#: module/Company/view/partial/company/admin/editors/category.phtml:65
+#: module/Company/view/partial/company/admin/editors/company.phtml:279
+#: module/Company/view/partial/company/admin/editors/job.phtml:240
+#: module/Company/view/partial/company/admin/editors/label.phtml:74
+#: module/Company/view/partial/company/admin/editors/package.phtml:128
 msgid "English"
 msgstr "Engels"
 
-#: module/Activity/view/activity/activity/create.phtml:204
+#: module/Activity/view/activity/activity/create.phtml:217
 msgid "Remove the last sign-up list"
 msgstr "Verwijder de laatste inschrijflijst"
 
-#: module/Activity/view/activity/activity/create.phtml:208
+#: module/Activity/view/activity/activity/create.phtml:221
 msgid "Add a sign-up list"
 msgstr "Voeg een inschrijflijst toe"
 
-#: module/Activity/view/activity/activity/createSuccess.phtml:6
+#: module/Activity/view/activity/activity/createSuccess.phtml:15
 msgid "The activity has been successfully created."
 msgstr "De activiteit is gemaakt."
 
-#: module/Activity/view/activity/activity/createSuccess.phtml:7
+#: module/Activity/view/activity/activity/createSuccess.phtml:16
 msgid "It will become visible after it has been approved by the board."
 msgstr ""
 "Het zal zichtbaar worden als de activiteit goedgekeurd is door het bestuur."
 
-#: module/Activity/view/activity/activity/index.phtml:2
-#: module/Activity/view/activity/activity/index.phtml:8
-#: module/Activity/view/activity/activity/view.phtml:10
-#: module/Activity/view/activity/activity/view.phtml:18
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:9
-#: module/Activity/view/activity/admin-approval/view.phtml:9
-#: module/Activity/view/activity/admin/participants.phtml:7
-#: module/Activity/view/activity/admin/view.phtml:3
-#: module/Application/view/partial/admin.phtml:32
-#: module/Application/view/partial/main-nav.phtml:350
-#: module/Application/view/partial/main-nav.phtml:354
-#: module/Application/view/partial/main-nav.phtml:359
-#: module/Decision/view/decision/member/index.phtml:192
+#: module/Activity/view/activity/activity/index.phtml:15
+#: module/Activity/view/activity/activity/index.phtml:21
+#: module/Activity/view/activity/activity/view.phtml:30
+#: module/Activity/view/activity/activity/view.phtml:38
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:24
+#: module/Activity/view/activity/admin-approval/view.phtml:22
+#: module/Activity/view/activity/admin/participants.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:19
+#: module/Application/view/partial/admin.phtml:38
+#: module/Application/view/partial/main-nav.phtml:374
+#: module/Application/view/partial/main-nav.phtml:378
+#: module/Application/view/partial/main-nav.phtml:383
+#: module/Decision/view/decision/member/index.phtml:203
 msgid "Activities"
 msgstr "Activiteiten"
 
-#: module/Activity/view/activity/activity/index.phtml:14
+#: module/Activity/view/activity/activity/index.phtml:27
 msgid "All Activities"
 msgstr "Alle Activiteiten"
 
-#: module/Activity/view/activity/activity/index.phtml:17
+#: module/Activity/view/activity/activity/index.phtml:30
 msgid "Career Activities"
 msgstr "Carrière Activiteiten"
 
-#: module/Activity/view/activity/activity/index.phtml:21
+#: module/Activity/view/activity/activity/index.phtml:34
 msgid "My Activities"
 msgstr "Mijn Activiteiten"
 
-#: module/Activity/view/activity/activity/list.phtml:9
+#: module/Activity/view/activity/activity/list.phtml:22
 msgid "MMM d"
 msgstr "MMM d"
 
-#: module/Activity/view/activity/activity/list.phtml:33
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:61
+#: module/Activity/view/activity/activity/list.phtml:46
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:79
 msgid "Continue reading"
 msgstr "Lees meer"
 
-#: module/Activity/view/activity/activity/list.phtml:42
-#: module/Activity/view/activity/activity/view.phtml:76
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:141
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:146
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:158
-#: module/Activity/view/activity/admin-approval/view.phtml:83
-#: module/Activity/view/activity/admin-approval/view.phtml:88
-#: module/Activity/view/activity/admin-approval/view.phtml:95
-#: module/Activity/view/partial/create.phtml:45
-#: module/Activity/view/partial/create.phtml:119
-#: module/Company/src/Form/Job.php:177 module/Company/src/Form/Job.php:187
-#: module/Company/view/company/admin-approval/job-approval.phtml:143
-#: module/Company/view/company/admin-approval/job-approval.phtml:148
-#: module/Company/view/company/admin-approval/job-approval.phtml:155
-#: module/Company/view/company/admin-approval/job-proposal.phtml:199
-#: module/Company/view/company/admin-approval/job-proposal.phtml:204
+#: module/Activity/view/activity/activity/list.phtml:55
+#: module/Activity/view/activity/activity/view.phtml:96
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:162
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:167
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:179
+#: module/Activity/view/activity/admin-approval/view.phtml:99
+#: module/Activity/view/activity/admin-approval/view.phtml:104
+#: module/Activity/view/activity/admin-approval/view.phtml:111
+#: module/Activity/view/partial/create.phtml:58
+#: module/Activity/view/partial/create.phtml:132
+#: module/Company/src/Form/Job.php:181 module/Company/src/Form/Job.php:191
+#: module/Company/view/company/admin-approval/job-approval.phtml:157
+#: module/Company/view/company/admin-approval/job-approval.phtml:162
+#: module/Company/view/company/admin-approval/job-approval.phtml:169
+#: module/Company/view/company/admin-approval/job-proposal.phtml:209
 #: module/Company/view/company/admin-approval/job-proposal.phtml:214
-#: module/Photo/view/partial/metadata.phtml:69
+#: module/Company/view/company/admin-approval/job-proposal.phtml:224
+#: module/Photo/view/partial/metadata.phtml:82
 msgid "Location"
 msgstr "Locatie"
 
-#: module/Activity/view/activity/activity/list.phtml:45
-#: module/Activity/view/activity/activity/view.phtml:79
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:170
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:175
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:187
-#: module/Activity/view/activity/admin-approval/view.phtml:102
-#: module/Activity/view/activity/admin-approval/view.phtml:107
-#: module/Activity/view/activity/admin-approval/view.phtml:114
-#: module/Activity/view/partial/create.phtml:59
-#: module/Activity/view/partial/create.phtml:133
+#: module/Activity/view/activity/activity/list.phtml:58
+#: module/Activity/view/activity/activity/view.phtml:99
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:191
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:196
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:208
+#: module/Activity/view/activity/admin-approval/view.phtml:118
+#: module/Activity/view/activity/admin-approval/view.phtml:123
+#: module/Activity/view/activity/admin-approval/view.phtml:130
+#: module/Activity/view/partial/create.phtml:72
+#: module/Activity/view/partial/create.phtml:146
 msgid "Costs"
 msgstr "Kosten"
 
-#: module/Activity/view/activity/activity/view.phtml:130
+#: module/Activity/view/activity/activity/view.phtml:150
 msgid "the organizing party"
 msgstr "de organiserende partij"
 
-#: module/Activity/view/activity/activity/view.phtml:142
+#: module/Activity/view/activity/activity/view.phtml:162
 #, php-format
 msgid ""
 "Please contact %s or the board (%s) with any questions, concerns or if you "
@@ -1088,7 +1088,7 @@ msgstr ""
 "of als je na het verstrijken van de afmeldtermijn niet aanwezig kunt zijn. "
 "Veel plezier!"
 
-#: module/Activity/view/activity/activity/view.phtml:145
+#: module/Activity/view/activity/activity/view.phtml:165
 #, php-format
 msgid ""
 "Please contact %s or the board (%s) with any questions or concerns. Have fun!"
@@ -1096,83 +1096,83 @@ msgstr ""
 "Neem contact op met %s of het bestuur (%s) als je vragen of opmerkingen "
 "hebt. Veel plezier!"
 
-#: module/Activity/view/activity/activity/view.phtml:160
+#: module/Activity/view/activity/activity/view.phtml:180
 #, php-format
 msgid ""
 "This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
 msgstr ""
 "Deze inschrijflijst%sis open van <strong>%s</strong> tot <strong>%s</strong>."
 
-#: module/Activity/view/activity/activity/view.phtml:161
+#: module/Activity/view/activity/activity/view.phtml:181
 msgid " <strong>has a limited capacity</strong> and "
 msgstr " <strong>heeft een beperkte capaciteit</strong> en "
 
-#: module/Activity/view/activity/activity/view.phtml:173
+#: module/Activity/view/activity/activity/view.phtml:193
 msgid "Already subscribed"
 msgstr "Je bent al ingeschreven"
 
-#: module/Activity/view/activity/activity/view.phtml:180
+#: module/Activity/view/activity/activity/view.phtml:200
 msgid "Subscription closed"
 msgstr "Inschrijving gesloten"
 
-#: module/Activity/view/activity/activity/view.phtml:186
+#: module/Activity/view/activity/activity/view.phtml:206
 msgid "Subscribe now"
 msgstr "Schrijf je in"
 
-#: module/Activity/view/activity/activity/view.phtml:193
+#: module/Activity/view/activity/activity/view.phtml:213
 msgid "Unsubscribe yourself"
 msgstr "Uitschrijven"
 
-#: module/Activity/view/activity/activity/view.phtml:196
+#: module/Activity/view/activity/activity/view.phtml:216
 msgid "You are not allowed to unsubscribe after the deadline!"
 msgstr "Uitschrijven na de uitschrijfdeadline is niet toegestaan!"
 
-#: module/Activity/view/activity/activity/view.phtml:215
-#: module/Activity/view/activity/activity/view.phtml:232
+#: module/Activity/view/activity/activity/view.phtml:235
+#: module/Activity/view/activity/activity/view.phtml:252
 msgid "Subscribe yourself"
 msgstr "Inschrijven"
 
-#: module/Activity/view/activity/activity/view.phtml:218
+#: module/Activity/view/activity/activity/view.phtml:238
 msgid "Login to subscribe"
 msgstr "Login om in te schrijven"
 
-#: module/Activity/view/activity/activity/view.phtml:222
+#: module/Activity/view/activity/activity/view.phtml:242
 msgid "Or subscribe without a GEWIS membership: "
 msgstr "Of schrijf je in zonder een GEWIS lidmaatschap: "
 
-#: module/Activity/view/activity/activity/view.phtml:243
+#: module/Activity/view/activity/activity/view.phtml:263
 msgid "Current subscriptions"
 msgstr "Huidige inschrijvingen"
 
-#: module/Activity/view/activity/activity/view.phtml:261
+#: module/Activity/view/activity/activity/view.phtml:281
 #, php-format
 msgid "The number of subscribed members is currently %d."
 msgstr "Het aantal ingeschreven leden is momenteel %d."
 
-#: module/Activity/view/activity/activity/view.phtml:265
+#: module/Activity/view/activity/activity/view.phtml:285
 msgid "Login to view the subscribed members."
 msgstr "Login om de lijst met deelnemers te bekijken."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:6
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:16
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:21
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:31
 msgid "Update Proposal"
 msgstr "Update voorstel"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:41
-#: module/Activity/view/activity/admin-approval/view.phtml:20
-#: module/Activity/view/partial/create.phtml:3
-#: module/Company/view/company/admin-approval/job-approval.phtml:16
-#: module/Company/view/company/admin-approval/job-proposal.phtml:44
-#: module/Company/view/partial/company/admin/editors/category.phtml:3
-#: module/Company/view/partial/company/admin/editors/company.phtml:191
-#: module/Company/view/partial/company/admin/editors/job.phtml:119
-#: module/Company/view/partial/company/admin/editors/label.phtml:3
-#: module/Company/view/partial/company/admin/editors/package.phtml:9
-#: module/Photo/view/photo/album/index.phtml:510
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:56
+#: module/Activity/view/activity/admin-approval/view.phtml:33
+#: module/Activity/view/partial/create.phtml:16
+#: module/Company/view/company/admin-approval/job-approval.phtml:30
+#: module/Company/view/company/admin-approval/job-proposal.phtml:54
+#: module/Company/view/partial/company/admin/editors/category.phtml:16
+#: module/Company/view/partial/company/admin/editors/company.phtml:204
+#: module/Company/view/partial/company/admin/editors/job.phtml:132
+#: module/Company/view/partial/company/admin/editors/label.phtml:16
+#: module/Company/view/partial/company/admin/editors/package.phtml:18
+#: module/Photo/view/photo/album/index.phtml:519
 msgid "Information"
 msgstr "Informatie"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:45
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:60
 #, php-format
 msgid ""
 "Changes in activity attributes are shown like this: %s. If there are no "
@@ -1188,28 +1188,28 @@ msgstr ""
 "inschrijflijst(en) worden getoond. Het kan zijn dat er geen verschil is "
 "tussen de twee!"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:46
-#: module/Company/view/company/admin-approval/job-proposal.phtml:52
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
+#: module/Company/view/company/admin-approval/job-proposal.phtml:62
 msgid "new"
 msgstr "nieuw"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:46
-#: module/Company/view/company/admin-approval/job-proposal.phtml:52
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
+#: module/Company/view/company/admin-approval/job-proposal.phtml:62
 msgid "old"
 msgstr "oud"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:55
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:68
-#: module/Activity/view/activity/admin-approval/view.phtml:26
-#: module/Activity/view/partial/signupForm.phtml:72
-#: module/Photo/view/partial/tags.phtml:40
-#: module/Photo/view/photo/album/index.phtml:333
-#: module/Photo/view/photo/album/index.phtml:678
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:73
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:89
+#: module/Activity/view/activity/admin-approval/view.phtml:42
+#: module/Activity/view/partial/signupForm.phtml:86
+#: module/Photo/view/partial/tags.phtml:52
+#: module/Photo/view/photo/album/index.phtml:342
+#: module/Photo/view/photo/album/index.phtml:687
 msgid "and"
 msgstr "en"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:79
-#: module/Activity/view/activity/admin-approval/view.phtml:37
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:100
+#: module/Activity/view/activity/admin-approval/view.phtml:53
 #, php-format
 msgid ""
 "This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
@@ -1219,61 +1219,61 @@ msgstr ""
 "strong>, en deze zal beginnen op <strong>%s</strong> en eindigen op "
 "<strong>%s</strong>."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:92
-#: module/Activity/view/activity/admin-approval/view.phtml:44
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:113
+#: module/Activity/view/activity/admin-approval/view.phtml:60
 msgid "More information about this activity is available below."
 msgstr "Meer informatie over deze activiteit is hieronder beschikbaar."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:229
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:250
 msgid "View details of the old activity"
 msgstr "Bekijk de details van de oude activiteit"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:234
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:255
 msgid "View details of the new activity"
 msgstr "Bekijk de details van de nieuwe activiteit"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:293
-#: module/Activity/view/activity/admin-approval/view.phtml:6
-#: module/Activity/view/activity/admin-approval/view.phtml:16
-#: module/Activity/view/activity/admin-approval/view.phtml:182
-#: module/Company/view/company/admin-approval/job-approval.phtml:7
-#: module/Company/view/company/admin-approval/job-approval.phtml:224
-#: module/Company/view/company/admin-approval/job-proposal.phtml:13
-#: module/Company/view/company/admin-approval/job-proposal.phtml:323
+#: module/Activity/view/activity/admin-approval/view-proposal.phtml:314
+#: module/Activity/view/activity/admin-approval/view.phtml:19
+#: module/Activity/view/activity/admin-approval/view.phtml:29
+#: module/Activity/view/activity/admin-approval/view.phtml:198
+#: module/Company/view/company/admin-approval/job-approval.phtml:21
+#: module/Company/view/company/admin-approval/job-approval.phtml:238
+#: module/Company/view/company/admin-approval/job-proposal.phtml:23
+#: module/Company/view/company/admin-approval/job-proposal.phtml:333
 msgid "Approval"
 msgstr "Goedkeuring"
 
-#: module/Activity/view/activity/admin-approval/view.phtml:141
+#: module/Activity/view/activity/admin-approval/view.phtml:157
 msgid "View details / subscriptions"
 msgstr "Bekijk details / inschrijvingen"
 
-#: module/Activity/view/activity/admin-approval/view.phtml:204
+#: module/Activity/view/activity/admin-approval/view.phtml:220
 msgid "Disapprove"
 msgstr "Afkeuren"
 
-#: module/Activity/view/activity/admin-approval/view.phtml:214
+#: module/Activity/view/activity/admin-approval/view.phtml:230
 #, php-format
 msgid "This activity was approved by <strong>%s</strong>."
 msgstr "Deze activiteit is goedgekeurd door <strong>%s</strong>."
 
-#: module/Activity/view/activity/admin-approval/view.phtml:236
+#: module/Activity/view/activity/admin-approval/view.phtml:252
 #, php-format
 msgid "This activity was disapproved by <strong>%s</strong>."
 msgstr "Deze activiteit is afgekeurd door <strong>%s</strong>."
 
-#: module/Activity/view/activity/admin-category/add.phtml:37
-#: module/Activity/view/partial/create.phtml:14
-#: module/Application/src/Form/Localisable.php:27
+#: module/Activity/view/activity/admin-category/add.phtml:50
+#: module/Activity/view/partial/create.phtml:27
+#: module/Application/src/Form/Localisable.php:32
 msgid "Enable Dutch Translations"
 msgstr "Nederlandse vertalingen inschakelen"
 
-#: module/Activity/view/activity/admin-category/add.phtml:74
-#: module/Activity/view/partial/create.phtml:88
-#: module/Application/src/Form/Localisable.php:39
+#: module/Activity/view/activity/admin-category/add.phtml:87
+#: module/Activity/view/partial/create.phtml:101
+#: module/Application/src/Form/Localisable.php:44
 msgid "Enable English Translations"
 msgstr "Engelse vertalingen inschakelen"
 
-#: module/Activity/view/activity/admin-category/index.phtml:12
+#: module/Activity/view/activity/admin-category/index.phtml:20
 msgid ""
 "Here you can add, edit, or remove activity categories. Click on 'Add "
 "Category' to add a new category or click on a category to edit/remove it."
@@ -1282,62 +1282,62 @@ msgstr ""
 "op 'Nieuwe categorie' om een nieuwe categorie toe te voegen of klik op een "
 "categorie om deze te bewerken/verwijderen."
 
-#: module/Activity/view/activity/admin-category/index.phtml:34
-#: module/Company/view/company/admin/categories.phtml:4
+#: module/Activity/view/activity/admin-category/index.phtml:42
+#: module/Company/view/company/admin/categories.phtml:17
 msgid "Add Category"
 msgstr "Nieuwe categorie"
 
-#: module/Activity/view/activity/admin-category/index.phtml:45
-#: module/Company/view/company/admin/edit-company.phtml:191
-#: module/Company/view/company/admin/edit-package.phtml:137
-#: module/Company/view/company/admin/index.phtml:217
-#: module/Company/view/company/company-account/jobs.phtml:275
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:160
-#: module/Photo/view/photo/album-admin/index.phtml:202
-#: module/Photo/view/photo/album-admin/index.phtml:234
-#: module/Photo/view/photo/photo-admin/index.phtml:121
+#: module/Activity/view/activity/admin-category/index.phtml:53
+#: module/Company/view/company/admin/edit-company.phtml:203
+#: module/Company/view/company/admin/edit-package.phtml:151
+#: module/Company/view/company/admin/index.phtml:231
+#: module/Company/view/company/company-account/jobs.phtml:294
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:175
+#: module/Photo/view/photo/album-admin/index.phtml:213
+#: module/Photo/view/photo/album-admin/index.phtml:245
+#: module/Photo/view/photo/photo-admin/index.phtml:139
 msgid "Delete confirmation"
 msgstr "Bevestig verwijderen"
 
-#: module/Activity/view/activity/admin-category/index.phtml:48
+#: module/Activity/view/activity/admin-category/index.phtml:56
 msgid "Are you sure you want to delete this activity category?"
 msgstr "Weet je zeker dat je deze activiteitencategorie wilt verwijderen?"
 
-#: module/Activity/view/activity/admin-category/index.phtml:54
+#: module/Activity/view/activity/admin-category/index.phtml:62
 msgid "Delete Activity Category"
 msgstr "Activiteitencategorie verwijderen"
 
-#: module/Activity/view/activity/admin-option/add.phtml:3
-#: module/Activity/view/activity/admin-option/index.phtml:5
-#: module/Application/view/partial/admin.phtml:45
+#: module/Activity/view/activity/admin-option/add.phtml:16
+#: module/Activity/view/activity/admin-option/index.phtml:13
+#: module/Application/view/partial/admin.phtml:62
 msgid "Option Calendar"
 msgstr "Optiekalender"
 
-#: module/Activity/view/activity/admin-option/add.phtml:12
-#: module/Activity/view/activity/admin-option/index.phtml:15
-#: module/Activity/view/activity/admin-option/index.phtml:57
+#: module/Activity/view/activity/admin-option/add.phtml:25
+#: module/Activity/view/activity/admin-option/index.phtml:23
+#: module/Activity/view/activity/admin-option/index.phtml:65
 msgid "Planning Period"
 msgstr "Planningsperiode"
 
-#: module/Activity/view/activity/admin-option/add.phtml:13
+#: module/Activity/view/activity/admin-option/add.phtml:26
 msgid "Enter the start and end date and time of the planning period."
 msgstr "Vul de begin- en einddatum en -tijd van de planningsperiode in."
 
-#: module/Activity/view/activity/admin-option/add.phtml:52
-#: module/Activity/view/activity/admin-option/index.phtml:16
-#: module/Activity/view/activity/admin-option/index.phtml:58
+#: module/Activity/view/activity/admin-option/add.phtml:65
+#: module/Activity/view/activity/admin-option/index.phtml:24
+#: module/Activity/view/activity/admin-option/index.phtml:66
 msgid "Option Period"
 msgstr "Optieperiode"
 
-#: module/Activity/view/activity/admin-option/add.phtml:53
+#: module/Activity/view/activity/admin-option/add.phtml:66
 msgid "Enter the start and end date and time of the option period."
 msgstr "Vul de begin- en einddatum en -tijd van de optieperiode in."
 
-#: module/Activity/view/activity/admin-option/add.phtml:92
+#: module/Activity/view/activity/admin-option/add.phtml:105
 msgid "Max Activities"
 msgstr "Max. activiteiten"
 
-#: module/Activity/view/activity/admin-option/add.phtml:93
+#: module/Activity/view/activity/admin-option/add.phtml:106
 msgid ""
 "Enter the maximum number of activities for which options can be created. You "
 "can either set the number globally or individually for each organ."
@@ -1345,68 +1345,68 @@ msgstr ""
 "Vul het maximum aantal activiteiten in waarvoor opties kunnen worden "
 "aangemaakt. Dit kan globaal of voor elk orgaan afzonderlijk worden ingesteld."
 
-#: module/Activity/view/activity/admin-option/add.phtml:100
+#: module/Activity/view/activity/admin-option/add.phtml:113
 msgid "Global Value"
 msgstr "Globale waarde"
 
-#: module/Activity/view/activity/admin-option/index.phtml:6
-#: module/Activity/view/activity/admin/view.phtml:4
-#: module/Application/view/partial/admin.phtml:36
+#: module/Activity/view/activity/admin-option/index.phtml:14
+#: module/Activity/view/activity/admin/view.phtml:20
+#: module/Application/view/partial/admin.phtml:43
 msgid "Overview"
 msgstr "Overzicht"
 
-#: module/Activity/view/activity/admin-option/index.phtml:10
+#: module/Activity/view/activity/admin-option/index.phtml:18
 msgid "Active Option Planning Periods"
 msgstr "Actieve optieplanningsperioden"
 
-#: module/Activity/view/activity/admin-option/index.phtml:17
-#: module/Activity/view/activity/admin-option/index.phtml:59
-#: module/Company/view/company/admin-approval/index.phtml:15
-#: module/Company/view/company/admin-approval/index.phtml:43
-#: module/Company/view/company/admin/edit-company.phtml:104
-#: module/Company/view/company/admin/edit-package.phtml:72
-#: module/Company/view/company/admin/index.phtml:163
-#: module/Company/view/company/admin/index.phtml:204
-#: module/Company/view/company/company-account/jobs.phtml:47
-#: module/Company/view/company/company-account/jobs.phtml:180
-#: module/Education/view/education/admin/course-documents.phtml:64
-#: module/Education/view/education/admin/course-documents.phtml:115
-#: module/Education/view/education/admin/course.phtml:35
+#: module/Activity/view/activity/admin-option/index.phtml:25
+#: module/Activity/view/activity/admin-option/index.phtml:67
+#: module/Company/view/company/admin-approval/index.phtml:31
+#: module/Company/view/company/admin-approval/index.phtml:59
+#: module/Company/view/company/admin/edit-company.phtml:116
+#: module/Company/view/company/admin/edit-package.phtml:86
+#: module/Company/view/company/admin/index.phtml:177
+#: module/Company/view/company/admin/index.phtml:218
+#: module/Company/view/company/company-account/jobs.phtml:66
+#: module/Company/view/company/company-account/jobs.phtml:199
+#: module/Education/view/education/admin/course-documents.phtml:74
+#: module/Education/view/education/admin/course-documents.phtml:125
+#: module/Education/view/education/admin/course.phtml:47
 msgid "Actions"
 msgstr "Acties"
 
-#: module/Activity/view/activity/admin-option/index.phtml:48
+#: module/Activity/view/activity/admin-option/index.phtml:56
 msgid "There is currently no option creation period planned."
 msgstr "Er is momenteel geen optieperiode gepland."
 
-#: module/Activity/view/activity/admin-option/index.phtml:52
+#: module/Activity/view/activity/admin-option/index.phtml:60
 msgid "Planned Option Planning Periods"
 msgstr "Geplande optieplanningsperioden"
 
-#: module/Activity/view/activity/admin-option/index.phtml:86
-#: module/Activity/view/activity/admin/list.phtml:55
-#: module/Company/view/company/admin/edit-company.phtml:145
-#: module/Company/view/company/admin/edit-package.phtml:108
-#: module/Company/view/company/company-account/jobs.phtml:226
-#: module/Decision/view/decision/organ-admin/edit.phtml:37
-#: module/Education/view/education/admin/course-documents.phtml:24
-#: module/Education/view/education/admin/course.phtml:53
-#: module/Education/view/education/admin/edit-course.phtml:10
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:26
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:26
+#: module/Activity/view/activity/admin-option/index.phtml:94
+#: module/Activity/view/activity/admin/list.phtml:63
+#: module/Company/view/company/admin/edit-company.phtml:157
+#: module/Company/view/company/admin/edit-package.phtml:122
+#: module/Company/view/company/company-account/jobs.phtml:245
+#: module/Decision/view/decision/organ-admin/edit.phtml:49
+#: module/Education/view/education/admin/course-documents.phtml:34
+#: module/Education/view/education/admin/course.phtml:65
+#: module/Education/view/education/admin/edit-course.phtml:24
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:40
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:38
 msgid "Edit"
 msgstr "Bewerken"
 
-#: module/Activity/view/activity/admin-option/index.phtml:98
+#: module/Activity/view/activity/admin-option/index.phtml:106
 msgid "There are no planned option creation periods in the future."
 msgstr ""
 "Er zijn geen geplande perioden voor het creëren van opties in de toekomst."
 
-#: module/Activity/view/activity/admin-option/index.phtml:117
+#: module/Activity/view/activity/admin-option/index.phtml:125
 msgid "Delete period"
 msgstr "Verwijder periode"
 
-#: module/Activity/view/activity/admin-option/index.phtml:121
+#: module/Activity/view/activity/admin-option/index.phtml:129
 msgid ""
 "Are you sure you want to delete this option planning period? This will "
 "<strong>not</strong> delete proposed options."
@@ -1414,71 +1414,71 @@ msgstr ""
 "Weet je zeker dat u deze optieplanningsperiode wilt verwijderen? Hiermee "
 "worden voorgestelde opties <strong>niet</strong> verwijderd."
 
-#: module/Activity/view/activity/admin/list.phtml:13
-#: module/Activity/view/activity/admin/view.phtml:53
+#: module/Activity/view/activity/admin/list.phtml:21
+#: module/Activity/view/activity/admin/view.phtml:70
 msgid "Dutch name"
 msgstr "Nederlandse naam"
 
-#: module/Activity/view/activity/admin/list.phtml:14
-#: module/Activity/view/activity/admin/view.phtml:54
+#: module/Activity/view/activity/admin/list.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:71
 msgid "English name"
 msgstr "Engelse naam"
 
-#: module/Activity/view/activity/admin/list.phtml:15
-#: module/Activity/view/activity/admin/view.phtml:55
-#: module/Company/view/company/admin/edit-company.phtml:95
-#: module/Company/view/company/company-account/jobs.phtml:38
+#: module/Activity/view/activity/admin/list.phtml:23
+#: module/Activity/view/activity/admin/view.phtml:72
+#: module/Company/view/company/admin/edit-company.phtml:107
+#: module/Company/view/company/company-account/jobs.phtml:57
 #: module/Photo/src/Form/EditAlbum.php:37
 msgid "Start date"
 msgstr "Startdatum"
 
-#: module/Activity/view/activity/admin/list.phtml:16
-#: module/Activity/view/activity/admin/view.phtml:56
+#: module/Activity/view/activity/admin/list.phtml:24
+#: module/Activity/view/activity/admin/view.phtml:73
 msgid "Organ"
 msgstr "Orgaan"
 
-#: module/Activity/view/activity/admin/list.phtml:18
-#: module/Activity/view/activity/admin/view.phtml:58
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:27
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:100
+#: module/Activity/view/activity/admin/list.phtml:26
+#: module/Activity/view/activity/admin/view.phtml:75
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:42
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:115
 msgid "Submitter"
 msgstr "Verzender"
 
-#: module/Activity/view/activity/admin/list.phtml:19
+#: module/Activity/view/activity/admin/list.phtml:27
 msgid "Update status"
 msgstr "Bewerkings status"
 
-#: module/Activity/view/activity/admin/list.phtml:21
-#: module/Company/view/company/admin/edit-package.phtml:71
+#: module/Activity/view/activity/admin/list.phtml:29
+#: module/Company/view/company/admin/edit-package.phtml:85
 msgid "Approved"
 msgstr "Goedgekeurd"
 
-#: module/Activity/view/activity/admin/list.phtml:37
-#: module/Activity/view/activity/admin/list.phtml:38
-#: module/Activity/view/activity/admin/view.phtml:76
-#: module/Activity/view/activity/admin/view.phtml:77
-#: module/Education/view/education/education/index.phtml:86
+#: module/Activity/view/activity/admin/list.phtml:45
+#: module/Activity/view/activity/admin/list.phtml:46
+#: module/Activity/view/activity/admin/view.phtml:91
+#: module/Activity/view/activity/admin/view.phtml:92
+#: module/Education/view/education/education/index.phtml:112
 msgid "None"
 msgstr "Geen"
 
-#: module/Activity/view/activity/admin/list.phtml:42
-#: module/Activity/view/activity/admin/list.phtml:44
+#: module/Activity/view/activity/admin/list.phtml:50
+#: module/Activity/view/activity/admin/list.phtml:52
 msgid "Update pending"
 msgstr "Update pending"
 
-#: module/Activity/view/activity/admin/list.phtml:63
-#: module/Activity/view/activity/admin/participants.phtml:4
-#: module/Activity/view/activity/admin/participants.phtml:14
-#: module/Activity/view/activity/admin/participants.phtml:46
-#: module/Activity/view/activity/admin/view.phtml:82
+#: module/Activity/view/activity/admin/list.phtml:71
+#: module/Activity/view/activity/admin/participants.phtml:19
+#: module/Activity/view/activity/admin/participants.phtml:29
+#: module/Activity/view/activity/admin/participants.phtml:61
+#: module/Activity/view/activity/admin/view.phtml:97
 msgid "Participants"
 msgstr "Deelnemers"
 
-#: module/Activity/view/activity/admin/participants.phtml:26
+#: module/Activity/view/activity/admin/participants.phtml:41
 msgid "General"
 msgstr "Algemeen"
 
-#: module/Activity/view/activity/admin/participants.phtml:40
+#: module/Activity/view/activity/admin/participants.phtml:55
 msgid ""
 "Here you can find everyone who signed up for this activity (may contain "
 "duplicates). Using the tabs above you can navigate to the different sign-up "
@@ -1491,7 +1491,7 @@ msgstr ""
 "externe deelnemers verwijderen en (indien aanwezig) extra "
 "inschrijfinformatie van elke deelnemer bekijken."
 
-#: module/Activity/view/activity/admin/participants.phtml:42
+#: module/Activity/view/activity/admin/participants.phtml:57
 msgid ""
 "Here you can find everyone who signed up to this sign-up list. Here you can "
 "add or remove external participants and view detailed information regarding "
@@ -1501,142 +1501,142 @@ msgstr ""
 "Hier kan je externe deelnemers toevoegen of verwijderen en gedetailleerde "
 "informatie bekijken over de inschrijving van alle deelnemers."
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:12
-#: module/Decision/src/Form/OrganInformation.php:34
-#: module/Decision/view/decision/member/self.phtml:39
-#: module/Decision/view/decision/member/view.phtml:34
-#: module/Frontpage/view/frontpage/organ/organ.phtml:83
+#: module/Activity/view/activity/admin/participantsTable.phtml:21
+#: module/Decision/src/Form/OrganInformation.php:32
+#: module/Decision/view/decision/member/self.phtml:49
+#: module/Decision/view/decision/member/view.phtml:33
+#: module/Frontpage/view/frontpage/organ/organ.phtml:99
 msgid "Email"
 msgstr "Email"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:14
-#: module/Decision/view/decision/member/self.phtml:54
-#: module/Decision/view/decision/member/view.phtml:50
+#: module/Activity/view/activity/admin/participantsTable.phtml:23
+#: module/Decision/view/decision/member/self.phtml:64
+#: module/Decision/view/decision/member/view.phtml:49
 msgid "Generation"
 msgstr "Generatie"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:19
+#: module/Activity/view/activity/admin/participantsTable.phtml:28
 msgid "Sign-up List"
 msgstr "Inschrijflijst"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:61
-#: module/Decision/view/decision/member/self.phtml:45
-#: module/Decision/view/decision/member/view.phtml:40
-#: module/Photo/view/partial/metadata.phtml:8
-#: module/Photo/view/partial/metadata.phtml:15
-#: module/Photo/view/partial/metadata.phtml:36
-#: module/Photo/view/partial/metadata.phtml:43
-#: module/Photo/view/partial/metadata.phtml:50
-#: module/Photo/view/partial/metadata.phtml:57
-#: module/Photo/view/partial/metadata.phtml:64
-#: module/Photo/view/partial/metadata.phtml:73
+#: module/Activity/view/activity/admin/participantsTable.phtml:70
+#: module/Decision/view/decision/member/self.phtml:55
+#: module/Decision/view/decision/member/view.phtml:39
+#: module/Photo/view/partial/metadata.phtml:21
+#: module/Photo/view/partial/metadata.phtml:28
+#: module/Photo/view/partial/metadata.phtml:49
+#: module/Photo/view/partial/metadata.phtml:56
+#: module/Photo/view/partial/metadata.phtml:63
+#: module/Photo/view/partial/metadata.phtml:70
+#: module/Photo/view/partial/metadata.phtml:77
+#: module/Photo/view/partial/metadata.phtml:86
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:67
+#: module/Activity/view/activity/admin/participantsTable.phtml:76
 #, php-format
 msgid "User (%s)"
 msgstr "Gebruiker (%s)"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:74
-#: module/Decision/src/Model/Enums/MembershipTypes.php:21
+#: module/Activity/view/activity/admin/participantsTable.phtml:83
+#: module/Decision/src/Model/Enums/MembershipTypes.php:23
 msgid "External"
 msgstr "Extern"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:87
-#: module/Education/view/education/admin/course-documents.phtml:123
+#: module/Activity/view/activity/admin/participantsTable.phtml:96
+#: module/Education/view/education/admin/course-documents.phtml:133
 msgid "N/A"
 msgstr "N.V.T."
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:107
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:49
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:52
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:60
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:63
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:71
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:74
+#: module/Activity/view/activity/admin/participantsTable.phtml:116
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
 #: module/Application/language/additional-strings:20
-#: module/Company/view/company/admin/edit-company.phtml:114
-#: module/Company/view/company/admin/edit-package.phtml:78
-#: module/Company/view/company/admin/index.phtml:183
-#: module/Company/view/company/admin/index.phtml:184
-#: module/Company/view/company/company-account/jobs.phtml:195
-#: module/Company/view/company/company-account/jobs.phtml:203
-#: module/Decision/view/decision/member/view.phtml:60
-#: module/Photo/view/partial/metadata.phtml:29
+#: module/Company/view/company/admin/edit-company.phtml:126
+#: module/Company/view/company/admin/edit-package.phtml:92
+#: module/Company/view/company/admin/index.phtml:197
+#: module/Company/view/company/admin/index.phtml:198
+#: module/Company/view/company/company-account/jobs.phtml:214
+#: module/Company/view/company/company-account/jobs.phtml:222
+#: module/Decision/view/decision/member/view.phtml:59
+#: module/Photo/view/partial/metadata.phtml:42
 msgid "Yes"
 msgstr "Ja"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:109
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:49
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:52
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:60
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:63
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:71
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:74
+#: module/Activity/view/activity/admin/participantsTable.phtml:118
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
 #: module/Application/language/additional-strings:21
-#: module/Company/view/company/admin/edit-company.phtml:114
-#: module/Company/view/company/admin/edit-package.phtml:78
-#: module/Company/view/company/admin/index.phtml:183
-#: module/Company/view/company/admin/index.phtml:184
-#: module/Company/view/company/company-account/jobs.phtml:195
-#: module/Decision/view/decision/member/view.phtml:60
-#: module/Photo/view/partial/metadata.phtml:29
+#: module/Company/view/company/admin/edit-company.phtml:126
+#: module/Company/view/company/admin/edit-package.phtml:92
+#: module/Company/view/company/admin/index.phtml:197
+#: module/Company/view/company/admin/index.phtml:198
+#: module/Company/view/company/company-account/jobs.phtml:214
+#: module/Decision/view/decision/member/view.phtml:59
+#: module/Photo/view/partial/metadata.phtml:42
 msgid "No"
 msgstr "Nee"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:132
+#: module/Activity/view/activity/admin/participantsTable.phtml:141
 msgid "Additional actions"
 msgstr "Aanvullende acties"
 
-#: module/Activity/view/activity/admin/participantsTable.phtml:136
+#: module/Activity/view/activity/admin/participantsTable.phtml:145
 msgid "Mail everybody"
 msgstr "E-mail iedereen"
 
-#: module/Activity/view/activity/admin/view.phtml:8
+#: module/Activity/view/activity/admin/view.phtml:24
 msgid "Unapproved Activities"
 msgstr "Niet goedgekeurde activiteiten"
 
-#: module/Activity/view/activity/admin/view.phtml:15
+#: module/Activity/view/activity/admin/view.phtml:31
 msgid "Approved Activities"
 msgstr "Goedgekeurde activiteiten"
 
-#: module/Activity/view/activity/admin/view.phtml:22
+#: module/Activity/view/activity/admin/view.phtml:38
 msgid "Disapproved Activities"
 msgstr "Afgekeurde activiteiten"
 
-#: module/Activity/view/activity/admin/view.phtml:30
+#: module/Activity/view/activity/admin/view.phtml:46
 msgid "Upcoming Activities"
 msgstr "Aankomende activiteiten"
 
-#: module/Activity/view/activity/admin/view.phtml:37
+#: module/Activity/view/activity/admin/view.phtml:53
 msgid "Old activities"
 msgstr "Oude activiteiten"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:24
-#: module/Activity/view/partial/signuplist.phtml:12
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:37
+#: module/Activity/view/partial/signuplist.phtml:25
 msgid "Open date and time"
 msgstr "Openingsdatum en -tijd"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:35
-#: module/Activity/view/partial/signuplist.phtml:26
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:48
+#: module/Activity/view/partial/signuplist.phtml:39
 msgid "Close date and time"
 msgstr "Sluitingsdatum en -tijd"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:46
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:59
 msgid "GEWIS members only"
 msgstr "Alleen GEWIS leden"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:57
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:70
 msgid "Display GEWIS member count"
 msgstr "Toon aantal GEWIS leden"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:68
-#: module/Activity/view/partial/signuplist.phtml:107
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:81
+#: module/Activity/view/partial/signuplist.phtml:120
 msgid "Has limited capacity"
 msgstr "Heeft beperkte capaciteit"
 
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:80
+#: module/Activity/view/partial/admin-approval/signuplists.phtml:93
 msgid ""
 "This sign-up list contains additional fields which require input from "
 "subscribers, they are shown below."
@@ -1644,7 +1644,7 @@ msgstr ""
 "Deze inschrijflijst bevat extra velden die door de deelnemers moeten worden "
 "ingevuld, deze worden hieronder getoond."
 
-#: module/Activity/view/partial/create.phtml:4
+#: module/Activity/view/partial/create.phtml:17
 msgid ""
 "What is this activity about? Fill in the blanks below, please note that at "
 "least one language must be used."
@@ -1652,15 +1652,15 @@ msgstr ""
 "Waar gaat deze activiteit over? Vul de lege plekken hieronder in, let op dat "
 "er ten minste één taal gebruikt moet worden."
 
-#: module/Activity/view/partial/create.phtml:158
+#: module/Activity/view/partial/create.phtml:171
 msgid "Choose which options are applicable to this activity."
 msgstr "Kies welke opties van toepassing zijn op deze activiteit."
 
-#: module/Activity/view/partial/create.phtml:168
+#: module/Activity/view/partial/create.phtml:181
 msgid "This is a career related activity"
 msgstr "Dit is een carrière gerelateerde activiteit"
 
-#: module/Activity/view/partial/create.phtml:170
+#: module/Activity/view/partial/create.phtml:183
 msgid ""
 "If this is checked the My Future logo will be displayed on the activity page "
 "and the activity will be included on the career activities page."
@@ -1669,11 +1669,11 @@ msgstr ""
 "pagina van de activiteit en zal de activiteit op de carrière activiteiten "
 "pagina weergegeven worden."
 
-#: module/Activity/view/partial/create.phtml:182
+#: module/Activity/view/partial/create.phtml:195
 msgid "This activity needs a GEFLITST member to take photos"
 msgstr "Ik wil foto’s door GEFLITST van deze activiteit"
 
-#: module/Activity/view/partial/create.phtml:184
+#: module/Activity/view/partial/create.phtml:197
 msgid ""
 "When this is checked, GEFLITST will be notified that this activity needs a "
 "photographer."
@@ -1681,30 +1681,30 @@ msgstr ""
 "Door dit te selecteren zal GEFLITST van deze activiteit op de hoogte "
 "gebracht worden."
 
-#: module/Activity/view/partial/option.phtml:24
+#: module/Activity/view/partial/option.phtml:33
 msgid "From"
 msgstr "Van"
 
-#: module/Activity/view/partial/option.phtml:38
+#: module/Activity/view/partial/option.phtml:47
 msgid "Until"
 msgstr "Tot"
 
-#: module/Activity/view/partial/signupForm.phtml:7
-#: module/Activity/view/partial/signupForm.phtml:12
+#: module/Activity/view/partial/signupForm.phtml:21
+#: module/Activity/view/partial/signupForm.phtml:26
 msgid "By subscribing to this activity, you agree to the terms outlined in the"
 msgstr ""
 "Door je in te schrijven voor deze activiteit ga je akkoord met de "
 "voorwaarden in het"
 
-#: module/Activity/view/partial/signupForm.phtml:9
+#: module/Activity/view/partial/signupForm.phtml:23
 msgid "Confirm subscription"
 msgstr "Bevestig inschrijving"
 
-#: module/Activity/view/partial/signupForm.phtml:14
+#: module/Activity/view/partial/signupForm.phtml:28
 msgid "Subscribe as external participant"
 msgstr "Inschrijven zonder GEWIS lidmaatschap"
 
-#: module/Activity/view/partial/signupForm.phtml:19
+#: module/Activity/view/partial/signupForm.phtml:33
 msgid ""
 "By subscribing an external participant to this activity, they must agree to "
 "the terms outlined in the"
@@ -1712,51 +1712,51 @@ msgstr ""
 "Door iemand zonder GEWIS lidmaatschap in te schrijven voor deze activiteit "
 "moet deze persoon akkoord gaan met de voorwaarden in het"
 
-#: module/Activity/view/partial/signupForm.phtml:21
+#: module/Activity/view/partial/signupForm.phtml:35
 msgid "Subscribe an external participant"
 msgstr "Inschrijven zonder GEWIS lidmaatschap"
 
-#: module/Activity/view/partial/signupForm.phtml:53
+#: module/Activity/view/partial/signupForm.phtml:67
 msgid "Full name:"
 msgstr "Volledige naam:"
 
-#: module/Activity/view/partial/signupForm.phtml:54
+#: module/Activity/view/partial/signupForm.phtml:68
 msgid "Email address:"
 msgstr "E-mail adres:"
 
-#: module/Activity/view/partial/signupForm.phtml:58
+#: module/Activity/view/partial/signupForm.phtml:72
 msgid "Please fill in this CAPTCHA:"
 msgstr "CAPTCHA:"
 
-#: module/Activity/view/partial/signupForm.phtml:72
-#: module/Decision/view/decision/member/index.phtml:243
+#: module/Activity/view/partial/signupForm.phtml:86
+#: module/Decision/view/decision/member/index.phtml:254
 msgid "Activity Policy"
 msgstr "Activiteitenbeleid"
 
-#: module/Activity/view/partial/signupForm.phtml:74
-#: module/Decision/view/decision/member/index.phtml:248
+#: module/Activity/view/partial/signupForm.phtml:88
+#: module/Decision/view/decision/member/index.phtml:259
 msgid "Alcohol Policy"
 msgstr "Alcoholreglement"
 
-#: module/Activity/view/partial/signuplist-fields.phtml:86
+#: module/Activity/view/partial/signuplist-fields.phtml:95
 msgid "Please note that numbers are not dependant on the selected language(s)."
 msgstr "De nummers zijn niet afhankelijk van de geselecteerde taal of talen."
 
-#: module/Activity/view/partial/signuplist.phtml:75
+#: module/Activity/view/partial/signuplist.phtml:88
 msgid "Only allow GEWIS members"
 msgstr "Sta alleen GEWIS leden toe"
 
-#: module/Activity/view/partial/signuplist.phtml:77
+#: module/Activity/view/partial/signuplist.phtml:90
 msgid "Deselect this to allow people without a GEWIS account to subscribe."
 msgstr ""
 "Deselecteer dit om mensen zonder GEWIS account toe te staan zich in te "
 "schrijven."
 
-#: module/Activity/view/partial/signuplist.phtml:90
+#: module/Activity/view/partial/signuplist.phtml:103
 msgid "Display number of subscribed members"
 msgstr "Toon aantal deelnemers"
 
-#: module/Activity/view/partial/signuplist.phtml:92
+#: module/Activity/view/partial/signuplist.phtml:105
 msgid ""
 "Select this to display the number of subscribed GEWIS members to external "
 "visitors."
@@ -1764,7 +1764,7 @@ msgstr ""
 "Selecteer dit om het aantal ingeschreven GEWIS-leden aan externe bezoekers "
 "te tonen."
 
-#: module/Activity/view/partial/signuplist.phtml:109
+#: module/Activity/view/partial/signuplist.phtml:122
 msgid ""
 "Select this if this sign-up list has limited capacity or is expected to have "
 "limited capacity. Please ensure that you also write this in the description "
@@ -1774,11 +1774,11 @@ msgstr ""
 "dit wordt verwacht. Vergeet niet om dit ook in de beschrijving van de "
 "activiteit."
 
-#: module/Activity/view/partial/signuplist.phtml:140
+#: module/Activity/view/partial/signuplist.phtml:153
 msgid "Remove the last sign-up list field"
 msgstr "Verwijder het laatste inschrijflijst veld"
 
-#: module/Activity/view/partial/signuplist.phtml:145
+#: module/Activity/view/partial/signuplist.phtml:158
 msgid "Add a sign-up list field"
 msgstr "Voeg een inschrijflijst veld toe"
 
@@ -1858,344 +1858,344 @@ msgstr "Inkoper"
 msgid "Inactief Lid"
 msgstr "Inactief Lid"
 
-#: module/Application/src/Service/FileStorage.php:62
+#: module/Application/src/Service/FileStorage.php:91
 msgid "An unknown error occurred during uploading (%i)"
 msgstr "Een onbekende fout vond plaats tijdens het uploaden van (%i)"
 
-#: module/Application/src/Service/Infimum.php:62
-#: module/Application/view/partial/footer.phtml:26
-#: module/Application/view/partial/footer.phtml:31
+#: module/Application/src/Service/Infimum.php:66
+#: module/Application/view/partial/footer.phtml:36
+#: module/Application/view/partial/footer.phtml:41
 msgid "Unable to retrieve infimum."
 msgstr "Kan infimum niet ophalen."
 
-#: module/Application/view/error/403.phtml:6
+#: module/Application/view/error/403.phtml:17
 msgid "You do not have the required privileges to view this page"
 msgstr "Je beschikt niet over de juiste rechten om deze pagina te bekijken"
 
-#: module/Application/view/error/403.phtml:9
+#: module/Application/view/error/403.phtml:22
 msgid "You might be able to view this page by logging in"
 msgstr "Mogelijk kun je deze pagina wel bekijken door in te loggen"
 
-#: module/Application/view/error/403.phtml:15
-#: module/Application/view/partial/admin.phtml:24
-#: module/Application/view/partial/main-nav.phtml:74
-#: module/User/view/user/user/login.phtml:25
+#: module/Application/view/error/403.phtml:28
+#: module/Application/view/partial/admin.phtml:28
+#: module/Application/view/partial/main-nav.phtml:87
+#: module/User/view/user/user/login.phtml:39
 msgid "Login"
 msgstr "Login"
 
-#: module/Application/view/error/404.phtml:3
-#: module/Application/view/error/debug/404.phtml:3
+#: module/Application/view/error/404.phtml:12
+#: module/Application/view/error/debug/404.phtml:12
 msgid "A 404 error occurred"
 msgstr "404: De pagina kon niet worden gevonden"
 
-#: module/Application/view/error/500.phtml:3
-#: module/Application/view/error/debug/500.phtml:3
+#: module/Application/view/error/500.phtml:12
+#: module/Application/view/error/debug/500.phtml:13
 msgid "An error occurred"
 msgstr "Er is een fout opgetreden"
 
-#: module/Application/view/error/500.phtml:4
+#: module/Application/view/error/500.phtml:13
 msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
 msgstr ""
 "Blijft dit gebeuren, neem dan contact op met de ApplicatieBeheerCommissie."
 
-#: module/Application/view/error/debug/403.phtml:3
+#: module/Application/view/error/debug/403.phtml:12
 msgid "403 Forbidden"
 msgstr "403 Verboden Toegang"
 
-#: module/Application/view/error/debug/404.phtml:12
+#: module/Application/view/error/debug/404.phtml:22
 msgid "The requested controller was unable to dispatch the request."
 msgstr "De opgevraagde controller kon deze aanvraag niet verwerken."
 
-#: module/Application/view/error/debug/404.phtml:15
+#: module/Application/view/error/debug/404.phtml:26
 msgid ""
 "The requested controller could not be mapped to an existing controller class."
 msgstr "Er is geen mapping beschikbaar voor de opgevraagde controller."
 
-#: module/Application/view/error/debug/404.phtml:18
+#: module/Application/view/error/debug/404.phtml:30
 msgid "The requested controller was not dispatchable."
 msgstr "De opgevraagde controller is niet bruikbaar."
 
-#: module/Application/view/error/debug/404.phtml:21
+#: module/Application/view/error/debug/404.phtml:33
 msgid "The requested URL could not be matched by routing."
 msgstr "Er is geen route gevonden die overeenkomt met de opgevraagde URL."
 
-#: module/Application/view/error/debug/404.phtml:24
+#: module/Application/view/error/debug/404.phtml:36
 msgid "We cannot determine at this time why a 404 was generated."
 msgstr ""
 "We kunnen op dit moment niet achterhalen waarom de pagina niet kon worden "
 "gevonden."
 
-#: module/Application/view/error/debug/404.phtml:36
+#: module/Application/view/error/debug/404.phtml:50
 msgid "Controller"
 msgstr "Controller"
 
-#: module/Application/view/error/debug/404.phtml:43
+#: module/Application/view/error/debug/404.phtml:58
 #, php-format
 msgid "resolves to %s"
 msgstr "verwijst naar %s"
 
-#: module/Application/view/error/debug/404.phtml:55
-#: module/Application/view/error/debug/500.phtml:10
+#: module/Application/view/error/debug/404.phtml:75
+#: module/Application/view/error/debug/500.phtml:24
 msgid "Additional information"
 msgstr "Meer informatie"
 
-#: module/Application/view/error/debug/404.phtml:58
-#: module/Application/view/error/debug/404.phtml:83
-#: module/Application/view/error/debug/500.phtml:13
-#: module/Application/view/error/debug/500.phtml:40
+#: module/Application/view/error/debug/404.phtml:78
+#: module/Application/view/error/debug/404.phtml:104
+#: module/Application/view/error/debug/500.phtml:29
+#: module/Application/view/error/debug/500.phtml:69
 msgid "File"
 msgstr "Bestand"
 
-#: module/Application/view/error/debug/404.phtml:63
-#: module/Application/view/error/debug/404.phtml:88
-#: module/Application/view/error/debug/500.phtml:18
-#: module/Application/view/error/debug/500.phtml:45
+#: module/Application/view/error/debug/404.phtml:83
+#: module/Application/view/error/debug/404.phtml:109
+#: module/Application/view/error/debug/500.phtml:38
+#: module/Application/view/error/debug/500.phtml:78
 msgid "Message"
 msgstr "Bericht"
 
-#: module/Application/view/error/debug/404.phtml:67
-#: module/Application/view/error/debug/404.phtml:92
-#: module/Application/view/error/debug/500.phtml:23
-#: module/Application/view/error/debug/500.phtml:50
+#: module/Application/view/error/debug/404.phtml:87
+#: module/Application/view/error/debug/404.phtml:113
+#: module/Application/view/error/debug/500.phtml:46
+#: module/Application/view/error/debug/500.phtml:86
 msgid "Stack trace"
 msgstr "Stack trace"
 
-#: module/Application/view/error/debug/404.phtml:77
-#: module/Application/view/error/debug/500.phtml:34
+#: module/Application/view/error/debug/404.phtml:97
+#: module/Application/view/error/debug/500.phtml:60
 msgid "Previous exceptions"
 msgstr "Vorige excepties"
 
-#: module/Application/view/error/debug/404.phtml:107
-#: module/Application/view/error/debug/500.phtml:66
+#: module/Application/view/error/debug/404.phtml:130
+#: module/Application/view/error/debug/500.phtml:107
 msgid "No Exception available"
 msgstr "Geen exceptie beschikbaar"
 
-#: module/Application/view/layout/layout.phtml:6
+#: module/Application/view/layout/layout.phtml:15
 msgid "Study Association GEWIS"
 msgstr "Studievereniging GEWIS"
 
-#: module/Application/view/partial/admin.phtml:40
-#: module/Application/view/partial/admin.phtml:80
-#: module/Company/view/company/admin/categories.phtml:10
-#: module/Company/view/company/admin/categories.phtml:30
+#: module/Application/view/partial/admin.phtml:50
+#: module/Application/view/partial/admin.phtml:105
+#: module/Company/view/company/admin/categories.phtml:23
+#: module/Company/view/company/admin/categories.phtml:43
 msgid "Categories"
 msgstr "Categorieën"
 
-#: module/Application/view/partial/admin.phtml:55
-#: module/Application/view/partial/main-nav.phtml:305
-#: module/Application/view/partial/main-nav.phtml:309
-#: module/Application/view/partial/main-nav.phtml:314
-#: module/Company/view/company/admin-approval/index.phtml:3
-#: module/Company/view/company/admin-approval/job-approval.phtml:10
-#: module/Company/view/company/admin-approval/job-proposal.phtml:16
-#: module/Company/view/company/admin/edit-company.phtml:7
-#: module/Company/view/company/admin/index.phtml:6
+#: module/Application/view/partial/admin.phtml:76
+#: module/Application/view/partial/main-nav.phtml:326
+#: module/Application/view/partial/main-nav.phtml:330
+#: module/Application/view/partial/main-nav.phtml:335
+#: module/Company/view/company/admin-approval/index.phtml:19
+#: module/Company/view/company/admin-approval/job-approval.phtml:24
+#: module/Company/view/company/admin-approval/job-proposal.phtml:26
+#: module/Company/view/company/admin/edit-company.phtml:19
+#: module/Company/view/company/admin/index.phtml:20
 msgid "Career"
 msgstr "Carrière"
 
-#: module/Application/view/partial/admin.phtml:61
-#: module/Company/view/company/admin/index.phtml:7
-#: module/Company/view/company/company/job-list.phtml:22
-#: module/Company/view/company/company/jobs.phtml:22
-#: module/Company/view/company/company/list.phtml:4
-#: module/Company/view/company/company/show.phtml:5
-#: module/Company/view/company/company/show.phtml:12
-#: module/Company/view/company/company/spotlight.phtml:17
+#: module/Application/view/partial/admin.phtml:83
+#: module/Company/view/company/admin/index.phtml:21
+#: module/Company/view/company/company/job-list.phtml:36
+#: module/Company/view/company/company/jobs.phtml:34
+#: module/Company/view/company/company/list.phtml:21
+#: module/Company/view/company/company/show.phtml:17
+#: module/Company/view/company/company/show.phtml:24
+#: module/Company/view/company/company/spotlight.phtml:33
 msgid "Companies"
 msgstr "Bedrijven"
 
-#: module/Application/view/partial/admin.phtml:73
-#: module/Company/view/company/admin-approval/index.phtml:4
-#: module/Company/view/company/admin-approval/job-approval.phtml:11
+#: module/Application/view/partial/admin.phtml:96
+#: module/Company/view/company/admin-approval/index.phtml:20
+#: module/Company/view/company/admin-approval/job-approval.phtml:25
 msgid "Approvals"
 msgstr "Goedkeuringen"
 
-#: module/Application/view/partial/admin.phtml:87
-#: module/Company/src/Form/Job.php:237
-#: module/Company/view/company/admin-approval/job-approval.phtml:210
-#: module/Company/view/company/admin/labels.phtml:10
-#: module/Company/view/company/admin/labels.phtml:29
+#: module/Application/view/partial/admin.phtml:114
+#: module/Company/src/Form/Job.php:241
+#: module/Company/view/company/admin-approval/job-approval.phtml:224
+#: module/Company/view/company/admin/labels.phtml:23
+#: module/Company/view/company/admin/labels.phtml:42
 msgid "Labels"
 msgstr "Labels"
 
-#: module/Application/view/partial/admin.phtml:98
-#: module/Application/view/partial/main-nav.phtml:344
-#: module/Education/view/education/admin/add-course.phtml:3
-#: module/Education/view/education/admin/bulk-exam.phtml:11
-#: module/Education/view/education/admin/bulk-summary.phtml:11
-#: module/Education/view/education/admin/course-documents.phtml:17
-#: module/Education/view/education/admin/course.phtml:5
-#: module/Education/view/education/admin/edit-course.phtml:3
-#: module/Education/view/education/admin/edit-exam.phtml:18
-#: module/Education/view/education/admin/edit-summary.phtml:18
-#: module/Education/view/education/admin/index.phtml:3
-#: module/Education/view/education/education/course.phtml:11
-#: module/Education/view/education/education/index.phtml:2
-#: module/Education/view/education/education/index.phtml:17
+#: module/Application/view/partial/admin.phtml:128
+#: module/Application/view/partial/main-nav.phtml:368
+#: module/Education/view/education/admin/add-course.phtml:15
+#: module/Education/view/education/admin/bulk-exam.phtml:19
+#: module/Education/view/education/admin/bulk-summary.phtml:19
+#: module/Education/view/education/admin/course-documents.phtml:27
+#: module/Education/view/education/admin/course.phtml:17
+#: module/Education/view/education/admin/edit-course.phtml:17
+#: module/Education/view/education/admin/edit-exam.phtml:31
+#: module/Education/view/education/admin/edit-summary.phtml:31
+#: module/Education/view/education/admin/index.phtml:11
+#: module/Education/view/education/education/course.phtml:21
+#: module/Education/view/education/education/index.phtml:16
+#: module/Education/view/education/education/index.phtml:31
 msgid "Education"
 msgstr "Onderwijs"
 
-#: module/Application/view/partial/admin.phtml:103
-#: module/Education/view/education/admin/add-course.phtml:4
-#: module/Education/view/education/admin/course-documents.phtml:18
-#: module/Education/view/education/admin/course.phtml:6
-#: module/Education/view/education/admin/edit-course.phtml:4
+#: module/Application/view/partial/admin.phtml:133
+#: module/Education/view/education/admin/add-course.phtml:16
+#: module/Education/view/education/admin/course-documents.phtml:28
+#: module/Education/view/education/admin/course.phtml:18
+#: module/Education/view/education/admin/edit-course.phtml:18
 msgid "Courses"
 msgstr "Vakken"
 
-#: module/Application/view/partial/admin.phtml:108
-#: module/Education/view/education/admin/bulk-exam.phtml:16
+#: module/Application/view/partial/admin.phtml:138
+#: module/Education/view/education/admin/bulk-exam.phtml:24
 msgid "Upload exams"
 msgstr "Upload tentamens"
 
-#: module/Application/view/partial/admin.phtml:113
-#: module/Education/view/education/admin/bulk-summary.phtml:16
+#: module/Application/view/partial/admin.phtml:143
+#: module/Education/view/education/admin/bulk-summary.phtml:24
 msgid "Upload summaries"
 msgstr "Upload samenvattingen"
 
-#: module/Application/view/partial/admin.phtml:123
-#: module/Decision/view/decision/admin/authorizations.phtml:3
-#: module/Decision/view/decision/admin/document.phtml:14
-#: module/Decision/view/decision/admin/minutes.phtml:3
-#: module/Decision/view/decision/decision/index.phtml:3
-#: module/Decision/view/decision/member/index.phtml:89
+#: module/Application/view/partial/admin.phtml:155
+#: module/Decision/view/decision/admin/authorizations.phtml:14
+#: module/Decision/view/decision/admin/document.phtml:29
+#: module/Decision/view/decision/admin/minutes.phtml:15
+#: module/Decision/view/decision/decision/index.phtml:17
+#: module/Decision/view/decision/member/index.phtml:100
 msgid "Meetings"
 msgstr "Vergaderingen"
 
-#: module/Application/view/partial/admin.phtml:127
-#: module/Decision/view/decision/admin/minutes.phtml:4
-#: module/Decision/view/decision/decision/view.phtml:41
+#: module/Application/view/partial/admin.phtml:160
+#: module/Decision/view/decision/admin/minutes.phtml:16
+#: module/Decision/view/decision/decision/view.phtml:53
 msgid "Minutes"
 msgstr "Notulen"
 
-#: module/Application/view/partial/admin.phtml:130
-#: module/Decision/view/decision/admin/document.phtml:15
-#: module/Decision/view/decision/decision/view.phtml:19
-#: module/Education/view/education/admin/course.phtml:48
+#: module/Application/view/partial/admin.phtml:165
+#: module/Decision/view/decision/admin/document.phtml:30
+#: module/Decision/view/decision/decision/view.phtml:31
+#: module/Education/view/education/admin/course.phtml:60
 msgid "Documents"
 msgstr "Documenten"
 
-#: module/Application/view/partial/admin.phtml:133
-#: module/Decision/view/decision/admin/authorizations.phtml:4
-#: module/Decision/view/decision/decision/authorizations.phtml:3
-#: module/Decision/view/decision/decision/authorizations.phtml:16
-#: module/Decision/view/decision/member/index.phtml:50
+#: module/Application/view/partial/admin.phtml:170
+#: module/Decision/view/decision/admin/authorizations.phtml:15
+#: module/Decision/view/decision/decision/authorizations.phtml:27
+#: module/Decision/view/decision/decision/authorizations.phtml:34
+#: module/Decision/view/decision/member/index.phtml:61
 msgid "Authorizations"
 msgstr "Machtigingen"
 
-#: module/Application/view/partial/admin.phtml:141
-#: module/Decision/view/decision/member/index.phtml:62
-#: module/Decision/view/decision/organ-admin/edit.phtml:36
-#: module/Decision/view/decision/organ-admin/index.phtml:3
+#: module/Application/view/partial/admin.phtml:181
+#: module/Decision/view/decision/member/index.phtml:73
+#: module/Decision/view/decision/organ-admin/edit.phtml:48
+#: module/Decision/view/decision/organ-admin/index.phtml:15
 msgid "Organs"
 msgstr "Organen"
 
-#: module/Application/view/partial/admin.phtml:147
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:36
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:25
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:3
+#: module/Application/view/partial/admin.phtml:189
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:54
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:39
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:14
 msgid "News"
 msgstr "Nieuws"
 
-#: module/Application/view/partial/admin.phtml:152
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:25
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:11
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:13
+#: module/Application/view/partial/admin.phtml:196
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:23
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:25
 msgid "Pages"
 msgstr "Pagina's"
 
-#: module/Application/view/partial/admin.phtml:157
-#: module/Application/view/partial/main-nav.phtml:401
-#: module/Application/view/partial/main-nav.phtml:405
-#: module/Application/view/partial/main-nav.phtml:409
-#: module/Application/view/partial/main-nav.phtml:416
-#: module/Photo/view/photo/album-admin/add.phtml:21
-#: module/Photo/view/photo/album-admin/create.phtml:3
-#: module/Photo/view/photo/album-admin/edit.phtml:3
-#: module/Photo/view/photo/album-admin/index.phtml:22
-#: module/Photo/view/photo/album/index.phtml:20
-#: module/Photo/view/photo/album/index.phtml:60
-#: module/Photo/view/photo/photo-admin/index.phtml:20
-#: module/Photo/view/photo/photo/index.phtml:3
+#: module/Application/view/partial/admin.phtml:203
+#: module/Application/view/partial/main-nav.phtml:434
+#: module/Application/view/partial/main-nav.phtml:438
+#: module/Application/view/partial/main-nav.phtml:443
+#: module/Application/view/partial/main-nav.phtml:452
+#: module/Photo/view/photo/album-admin/add.phtml:33
+#: module/Photo/view/photo/album-admin/create.phtml:15
+#: module/Photo/view/photo/album-admin/edit.phtml:15
+#: module/Photo/view/photo/album-admin/index.phtml:33
+#: module/Photo/view/photo/album/index.phtml:29
+#: module/Photo/view/photo/album/index.phtml:69
+#: module/Photo/view/photo/photo-admin/index.phtml:38
+#: module/Photo/view/photo/photo/index.phtml:15
 msgid "Photos"
 msgstr "Foto's"
 
-#: module/Application/view/partial/admin.phtml:162
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:17
-#: module/Frontpage/view/frontpage/poll/index.phtml:3
-#: module/Frontpage/view/frontpage/poll/index.phtml:11
+#: module/Application/view/partial/admin.phtml:210
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:32
+#: module/Frontpage/view/frontpage/poll/index.phtml:22
+#: module/Frontpage/view/frontpage/poll/index.phtml:30
 msgid "Polls"
 msgstr "Polls"
 
-#: module/Application/view/partial/admin.phtml:169
+#: module/Application/view/partial/admin.phtml:219
 msgid "Users"
 msgstr "Gebruikers"
 
-#: module/Application/view/partial/admin.phtml:173
+#: module/Application/view/partial/admin.phtml:224
 msgid "API Users"
 msgstr "API gebruikers"
 
-#: module/Application/view/partial/admin.phtml:192
-#: module/Application/view/partial/main-nav.phtml:143
+#: module/Application/view/partial/admin.phtml:245
+#: module/Application/view/partial/main-nav.phtml:161
 msgid "Admin"
 msgstr "Admin"
 
-#: module/Application/view/partial/company.phtml:23
-#: module/Frontpage/view/frontpage/page/page.phtml:5
+#: module/Application/view/partial/company.phtml:26
+#: module/Frontpage/view/frontpage/page/page.phtml:20
 msgid "Home"
 msgstr "Home"
 
-#: module/Application/view/partial/company.phtml:28
-#: module/Company/src/Form/JobsTransfer.php:29
-#: module/Company/view/company/admin/edit-package.phtml:65
-#: module/Company/view/company/admin/index.phtml:121
-#: module/Company/view/company/admin/index.phtml:199
-#: module/Company/view/company/company-account/jobs.phtml:7
-#: module/Company/view/company/company-account/jobs.phtml:11
-#: module/Company/view/company/company-account/jobs.phtml:14
-#: module/Company/view/company/company-account/jobs.phtml:169
-#: module/Company/view/company/company-account/transfer-jobs.phtml:5
+#: module/Application/view/partial/company.phtml:31
+#: module/Company/src/Form/JobsTransfer.php:27
+#: module/Company/view/company/admin/edit-package.phtml:79
+#: module/Company/view/company/admin/index.phtml:135
+#: module/Company/view/company/admin/index.phtml:213
+#: module/Company/view/company/company-account/jobs.phtml:26
+#: module/Company/view/company/company-account/jobs.phtml:30
+#: module/Company/view/company/company-account/jobs.phtml:33
+#: module/Company/view/company/company-account/jobs.phtml:188
+#: module/Company/view/company/company-account/transfer-jobs.phtml:17
 msgid "Jobs"
 msgstr "Vacatures"
 
-#: module/Application/view/partial/company.phtml:33
-#: module/Company/view/company/company-account/highlights.phtml:2
-#: module/Company/view/company/company-account/highlights.phtml:5
+#: module/Application/view/partial/company.phtml:36
+#: module/Company/view/company/company-account/highlights.phtml:10
+#: module/Company/view/company/company-account/highlights.phtml:13
 msgid "Highlights"
 msgstr "Highlights"
 
-#: module/Application/view/partial/company.phtml:38
-#: module/Company/src/Form/Package.php:115
-#: module/Company/view/company/admin/edit-package.phtml:57
-#: module/Company/view/company/company-account/banner.phtml:2
-#: module/Company/view/company/company-account/banner.phtml:5
+#: module/Application/view/partial/company.phtml:41
+#: module/Company/src/Form/Package.php:112
+#: module/Company/view/company/admin/edit-package.phtml:70
+#: module/Company/view/company/company-account/banner.phtml:10
+#: module/Company/view/company/company-account/banner.phtml:13
 msgid "Banner"
 msgstr "Banner"
 
-#: module/Application/view/partial/company.phtml:43
+#: module/Application/view/partial/company.phtml:46
 msgid "Settings"
 msgstr "Instellingen"
 
-#: module/Application/view/partial/company.phtml:55
-#: module/Application/view/partial/main-nav.phtml:101
+#: module/Application/view/partial/company.phtml:58
+#: module/Application/view/partial/main-nav.phtml:116
 msgid "My Company"
 msgstr "Mijn Bedrijf"
 
-#: module/Application/view/partial/footer.phtml:11
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:255
+#: module/Application/view/partial/footer.phtml:21
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:273
 msgid "Infimum"
 msgstr "Infimum"
 
-#: module/Application/view/partial/footer.phtml:12
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:258
+#: module/Application/view/partial/footer.phtml:22
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:276
 msgid "Loading an infimum..."
 msgstr "Een infimum aan het laden..."
 
-#: module/Application/view/partial/footer.phtml:38
+#: module/Application/view/partial/footer.phtml:50
 msgid "All rights reserved."
 msgstr "Alle rechten voorbehouden."
 
-#: module/Application/view/partial/footer.phtml:39
+#: module/Application/view/partial/footer.phtml:52
 msgid ""
 "Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
 "2022)."
@@ -2203,170 +2203,170 @@ msgstr ""
 "Met <3 gemaakt door de ApplicatieBeheerCommissie en Web Commissie (2013 - "
 "2022)."
 
-#: module/Application/view/partial/footer.phtml:44
-#: module/Application/view/partial/main-nav.phtml:297
-#: module/Company/view/company/company/companyStory.phtml:21
-#: module/Company/view/company/company/jobs.phtml:93
-#: module/Company/view/partial/company/company/list/company.phtml:31
+#: module/Application/view/partial/footer.phtml:58
+#: module/Application/view/partial/main-nav.phtml:318
+#: module/Company/view/company/company/companyStory.phtml:37
+#: module/Company/view/company/company/jobs.phtml:105
+#: module/Company/view/partial/company/company/list/company.phtml:41
 msgid "Contact"
 msgstr "Contact"
 
-#: module/Application/view/partial/main-nav.phtml:42
+#: module/Application/view/partial/main-nav.phtml:53
 msgid "Language settings"
 msgstr "Taalinstellingen"
 
-#: module/Application/view/partial/main-nav.phtml:68
-#: module/Application/view/partial/main-nav.phtml:445
-#: module/Decision/view/decision/member/birthdays.phtml:4
-#: module/Decision/view/decision/member/index.phtml:8
-#: module/Decision/view/decision/member/index.phtml:17
-#: module/Decision/view/decision/member/search.phtml:4
-#: module/Decision/view/decision/member/view.phtml:13
+#: module/Application/view/partial/main-nav.phtml:81
+#: module/Application/view/partial/main-nav.phtml:485
+#: module/Decision/view/decision/member/birthdays.phtml:15
+#: module/Decision/view/decision/member/index.phtml:22
+#: module/Decision/view/decision/member/index.phtml:28
+#: module/Decision/view/decision/member/search.phtml:11
+#: module/Decision/view/decision/member/view.phtml:23
 msgid "Members"
 msgstr "Leden"
 
-#: module/Application/view/partial/main-nav.phtml:85
+#: module/Application/view/partial/main-nav.phtml:98
 msgid "Subscribe"
 msgstr "Inschrijven"
 
-#: module/Application/view/partial/main-nav.phtml:106
-#: module/Application/view/partial/main-nav.phtml:137
-#: module/Decision/view/decision/member/index.phtml:31
-#: module/User/src/Form/Password.php:61
-#: module/User/view/user/user/change-password.phtml:2
-#: module/User/view/user/user/change-password.phtml:23
+#: module/Application/view/partial/main-nav.phtml:121
+#: module/Application/view/partial/main-nav.phtml:154
+#: module/Decision/view/decision/member/index.phtml:42
+#: module/User/src/Form/Password.php:59
+#: module/User/view/user/user/change-password.phtml:15
+#: module/User/view/user/user/change-password.phtml:36
 msgid "Change password"
 msgstr "Wijzig wachtwoord"
 
-#: module/Application/view/partial/main-nav.phtml:111
-#: module/Application/view/partial/main-nav.phtml:149
+#: module/Application/view/partial/main-nav.phtml:126
+#: module/Application/view/partial/main-nav.phtml:168
 msgid "Logout"
 msgstr "Uitloggen"
 
-#: module/Application/view/partial/main-nav.phtml:127
+#: module/Application/view/partial/main-nav.phtml:144
 msgid "My information"
 msgstr "Mijn informatie"
 
-#: module/Application/view/partial/main-nav.phtml:132
-#: module/Decision/view/decision/member/index.phtml:45
+#: module/Application/view/partial/main-nav.phtml:149
+#: module/Decision/view/decision/member/index.phtml:56
 msgid "SudoSOS"
 msgstr "SudoSOS"
 
-#: module/Application/view/partial/main-nav.phtml:157
+#: module/Application/view/partial/main-nav.phtml:177
 msgid "Toggle navigation"
 msgstr "Klap navigatie in/uit"
 
-#: module/Application/view/partial/main-nav.phtml:170
-#: module/Application/view/partial/main-nav.phtml:175
-#: module/Application/view/partial/main-nav.phtml:180
-#: module/Decision/view/decision/member/index.phtml:58
+#: module/Application/view/partial/main-nav.phtml:191
+#: module/Application/view/partial/main-nav.phtml:196
+#: module/Application/view/partial/main-nav.phtml:201
+#: module/Decision/view/decision/member/index.phtml:69
 msgid "Association"
 msgstr "Vereniging"
 
-#: module/Application/view/partial/main-nav.phtml:191
-#: module/Decision/view/decision/member/view.phtml:82
+#: module/Application/view/partial/main-nav.phtml:212
+#: module/Decision/view/decision/member/view.phtml:72
 msgid "Board"
 msgstr "Bestuur"
 
-#: module/Application/view/partial/main-nav.phtml:196
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:3
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:9
-#: module/Frontpage/view/frontpage/organ/organ.phtml:48
+#: module/Application/view/partial/main-nav.phtml:217
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:14
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:20
+#: module/Frontpage/view/frontpage/organ/organ.phtml:64
 msgid "Committees"
 msgstr "Commissies"
 
-#: module/Application/view/partial/main-nav.phtml:201
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:3
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:7
-#: module/Frontpage/view/frontpage/organ/organ.phtml:44
+#: module/Application/view/partial/main-nav.phtml:222
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:15
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:19
+#: module/Frontpage/view/frontpage/organ/organ.phtml:60
 msgid "Fraternities"
 msgstr "Disputen"
 
-#: module/Application/view/partial/main-nav.phtml:212
+#: module/Application/view/partial/main-nav.phtml:233
 msgid "Exceptional Members"
 msgstr "Uitzonderlijke leden"
 
-#: module/Application/view/partial/main-nav.phtml:223
+#: module/Application/view/partial/main-nav.phtml:244
 msgid "GEWIS song"
 msgstr "GEWIS-lied"
 
-#: module/Application/view/partial/main-nav.phtml:234
-#: module/Decision/view/decision/member/index.phtml:215
+#: module/Application/view/partial/main-nav.phtml:255
+#: module/Decision/view/decision/member/index.phtml:226
 msgid "Regulations"
 msgstr "Reguleringen"
 
-#: module/Application/view/partial/main-nav.phtml:241
-#: module/Application/view/partial/main-nav.phtml:246
+#: module/Application/view/partial/main-nav.phtml:262
+#: module/Application/view/partial/main-nav.phtml:267
 msgid "Useful Information"
 msgstr "Praktische informatie"
 
-#: module/Application/view/partial/main-nav.phtml:252
-#: module/Decision/view/decision/member/index.phtml:82
+#: module/Application/view/partial/main-nav.phtml:273
+#: module/Decision/view/decision/member/index.phtml:93
 msgid "Links"
 msgstr "Links"
 
-#: module/Application/view/partial/main-nav.phtml:257
+#: module/Application/view/partial/main-nav.phtml:278
 msgid "Well-being"
 msgstr "Welzijn"
 
-#: module/Application/view/partial/main-nav.phtml:268
+#: module/Application/view/partial/main-nav.phtml:289
 msgid "Confidential Contact Person (CCP)"
 msgstr "Vertrouwenscontactpersonen (VCP)"
 
-#: module/Application/view/partial/main-nav.phtml:273
+#: module/Application/view/partial/main-nav.phtml:294
 msgid "FAQ"
 msgstr "FAQ"
 
-#: module/Application/view/partial/main-nav.phtml:284
+#: module/Application/view/partial/main-nav.phtml:305
 msgid "Housing"
 msgstr "Huisvesting"
 
-#: module/Application/view/partial/main-nav.phtml:321
-#: module/Company/view/company/admin/index.phtml:147
+#: module/Application/view/partial/main-nav.phtml:343
+#: module/Company/view/company/admin/index.phtml:161
 msgid "Featured"
 msgstr "Uitgelicht"
 
-#: module/Application/view/partial/main-nav.phtml:365
+#: module/Application/view/partial/main-nav.phtml:390
 msgid "My activities"
 msgstr "Mijn activiteiten"
 
-#: module/Application/view/partial/main-nav.phtml:372
+#: module/Application/view/partial/main-nav.phtml:399
 msgid "Activity Archive"
 msgstr "Archief"
 
-#: module/Application/view/partial/main-nav.phtml:379
+#: module/Application/view/partial/main-nav.phtml:408
 msgid "Create an activity"
 msgstr "Maak een activiteit"
 
-#: module/Application/view/partial/main-nav.phtml:392
+#: module/Application/view/partial/main-nav.phtml:424
 msgid "Career related"
 msgstr "Carrière gerelateerd"
 
-#: module/Application/view/partial/main-nav.phtml:421
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:200
+#: module/Application/view/partial/main-nav.phtml:457
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:218
 msgid "Photo of the week"
 msgstr "Foto van de week"
 
-#: module/Application/view/partial/main-nav.phtml:433
-#: module/Decision/view/decision/member/index.phtml:41
+#: module/Application/view/partial/main-nav.phtml:470
+#: module/Decision/view/decision/member/index.phtml:52
 msgid "My photo's"
 msgstr "Mijn foto’s"
 
-#: module/Application/view/partial/main-nav.phtml:457
+#: module/Application/view/partial/main-nav.phtml:499
 msgid "You are currently using administrator privileges to use the website!"
 msgstr "Je gebruikt momenteel beheerdersprivileges om de website te gebruiken!"
 
-#: module/Application/view/partial/paginator.phtml:8
-#: module/Photo/view/photo/album/index.phtml:428
+#: module/Application/view/partial/paginator.phtml:19
+#: module/Photo/view/photo/album/index.phtml:437
 msgid "Previous"
 msgstr "Vorige"
 
-#: module/Application/view/partial/paginator.phtml:22
-#: module/Photo/view/photo/album/index.phtml:429
+#: module/Application/view/partial/paginator.phtml:37
+#: module/Photo/view/photo/album/index.phtml:438
 msgid "Next"
 msgstr "Volgende"
 
-#: module/Application/view/partial/privacy-widget.phtml:3
+#: module/Application/view/partial/privacy-widget.phtml:13
 msgid ""
 "S.v. GEWIS uses cookies on this website, these are required for the website "
 "to function. Additionally, we may collection information about how you use "
@@ -2378,56 +2378,56 @@ msgstr ""
 "over hoe je onze website gebruikt om je ervaring te verbeteren. Als je niet "
 "wilt dat je gedrag wordt bijgehouden, kan je je hieronder afmelden."
 
-#: module/Application/view/partial/privacy-widget.phtml:8
+#: module/Application/view/partial/privacy-widget.phtml:19
 msgid "Tracking is currently"
 msgstr "Volgen is momenteel"
 
-#: module/Application/view/partial/privacy-widget.phtml:9
+#: module/Application/view/partial/privacy-widget.phtml:20
 msgid "enabled"
 msgstr "ingeschakeld"
 
-#: module/Application/view/partial/privacy-widget.phtml:10
+#: module/Application/view/partial/privacy-widget.phtml:21
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-#: module/Application/view/partial/privacy-widget.phtml:11
+#: module/Application/view/partial/privacy-widget.phtml:23
 msgid "disabled (Do Not Track)"
 msgstr "uitgeschakeld (volg-me-niet)"
 
-#: module/Application/view/partial/privacy-widget.phtml:12
+#: module/Application/view/partial/privacy-widget.phtml:25
 msgid "unavailable"
 msgstr "niet beschikbaar"
 
-#: module/Application/view/partial/privacy-widget.phtml:17
-#: module/Decision/view/decision/member/index.phtml:283
+#: module/Application/view/partial/privacy-widget.phtml:31
+#: module/Decision/view/decision/member/index.phtml:294
 msgid "Privacy Policy"
 msgstr "Privacybeleid"
 
-#: module/Application/view/partial/privacy-widget.phtml:18
+#: module/Application/view/partial/privacy-widget.phtml:33
 #: module/User/src/Form/ApiAppAuthorisation.php:48
 msgid "Continue"
 msgstr "Doorgaan"
 
-#: module/Company/src/Controller/AdminApprovalController.php:46
-#: module/Company/src/Controller/AdminApprovalController.php:72
+#: module/Company/src/Controller/AdminApprovalController.php:45
+#: module/Company/src/Controller/AdminApprovalController.php:71
 msgid "You are not allowed to view the approval status of jobs"
 msgstr ""
 "Je hebt niet de rechten om de goedkeuringsstatus van deze vacature te "
 "bekijken"
 
-#: module/Company/src/Controller/AdminApprovalController.php:90
+#: module/Company/src/Controller/AdminApprovalController.php:89
 msgid "Approve Job"
 msgstr "Keur vacature goed"
 
-#: module/Company/src/Controller/AdminApprovalController.php:94
+#: module/Company/src/Controller/AdminApprovalController.php:93
 msgid "Disapprove Job"
 msgstr "Keur vacature af"
 
-#: module/Company/src/Controller/AdminApprovalController.php:98
+#: module/Company/src/Controller/AdminApprovalController.php:97
 msgid "Reset Approval Status"
 msgstr "Goedkeuringsstatus intrekken"
 
-#: module/Company/src/Controller/AdminApprovalController.php:108
+#: module/Company/src/Controller/AdminApprovalController.php:107
 msgid "You are not allowed to change the approval status of jobs"
 msgstr ""
 "Je hebt niet de rechten om de goedkeuringsstatus van deze vacatures te "
@@ -2459,7 +2459,7 @@ msgstr "Update toepassen"
 msgid "Reject Update"
 msgstr "Update afwijzen"
 
-#: module/Company/src/Controller/AdminApprovalController.php:213
+#: module/Company/src/Controller/AdminApprovalController.php:218
 msgid ""
 "An unknown error occurred while try to change the status of a job update "
 "proposal. Please try again."
@@ -2467,107 +2467,107 @@ msgstr ""
 "Er is een onbekende fout opgetreden tijdens het veranderen van de status van "
 "het vacature updatevoorstel. Probeer het opnieuw."
 
-#: module/Company/src/Controller/AdminApprovalController.php:223
+#: module/Company/src/Controller/AdminApprovalController.php:230
 msgid "Job has been updated!"
 msgstr "Vacature is bijgewerkt!"
 
-#: module/Company/src/Controller/AdminApprovalController.php:230
+#: module/Company/src/Controller/AdminApprovalController.php:238
 msgid "Job update has been rejected!"
 msgstr "Vacature update is afgewezen!"
 
-#: module/Company/src/Controller/AdminController.php:44
+#: module/Company/src/Controller/AdminController.php:47
 msgid "You are not allowed to administer career settings"
 msgstr "Je hebt niet de rechten om carrière-instellingen te beheren"
 
-#: module/Company/src/Controller/AdminController.php:77
+#: module/Company/src/Controller/AdminController.php:80
 msgid "You are not allowed to create companies"
 msgstr "Je hebt niet de rechten om bedrijven toe te voegen"
 
-#: module/Company/src/Controller/AdminController.php:120
+#: module/Company/src/Controller/AdminController.php:123
 msgid "You are not allowed to edit companies"
 msgstr "Je hebt niet de rechten om bedrijven te wijzigen"
 
-#: module/Company/src/Controller/AdminController.php:187
-#: module/Company/src/Service/Company.php:852
+#: module/Company/src/Controller/AdminController.php:190
+#: module/Company/src/Service/Company.php:856
 msgid "You are not allowed to delete companies"
 msgstr "Je hebt niet de rechten om bedrijven te verwijderen"
 
-#: module/Company/src/Controller/AdminController.php:212
+#: module/Company/src/Controller/AdminController.php:215
 msgid "You are not allowed to create packages"
 msgstr "Je hebt niet de rechten om pakketten toe te voegen"
 
-#: module/Company/src/Controller/AdminController.php:281
-#: module/Company/src/Service/Company.php:917
+#: module/Company/src/Controller/AdminController.php:284
+#: module/Company/src/Service/Company.php:905
 msgid "You are not allowed to edit packages"
 msgstr "Je hebt niet de rechten om pakketten te wijzigen"
 
-#: module/Company/src/Controller/AdminController.php:366
-#: module/Company/src/Service/Company.php:749
+#: module/Company/src/Controller/AdminController.php:372
+#: module/Company/src/Service/Company.php:741
 msgid "You are not allowed to delete packages"
 msgstr "Je hebt niet de rechten om pakketten te verwijderen"
 
-#: module/Company/src/Controller/AdminController.php:408
-#: module/Company/src/Controller/CompanyAccountController.php:116
+#: module/Company/src/Controller/AdminController.php:414
+#: module/Company/src/Controller/CompanyAccountController.php:120
 msgid "You are not allowed to create jobs"
 msgstr "Je hebt niet de rechten om vacatures toe te voegen"
 
-#: module/Company/src/Controller/AdminController.php:447
+#: module/Company/src/Controller/AdminController.php:453
 msgid "Job successfully created!"
 msgstr "Vacature succesvol aangemaakt!"
 
-#: module/Company/src/Controller/AdminController.php:487
-#: module/Company/src/Controller/CompanyAccountController.php:193
-#: module/Company/src/Service/Company.php:944
-#: module/Company/src/Service/Company.php:1015
+#: module/Company/src/Controller/AdminController.php:493
+#: module/Company/src/Controller/CompanyAccountController.php:203
+#: module/Company/src/Service/Company.php:931
+#: module/Company/src/Service/Company.php:1002
 msgid "You are not allowed to edit jobs"
 msgstr "Je hebt niet de rechten om vacatures te wijzigen"
 
-#: module/Company/src/Controller/AdminController.php:526
+#: module/Company/src/Controller/AdminController.php:532
 msgid "Job successfully edited!"
 msgstr "Vacature succesvol aangepast!"
 
-#: module/Company/src/Controller/AdminController.php:562
-#: module/Company/src/Controller/CompanyAccountController.php:296
+#: module/Company/src/Controller/AdminController.php:568
+#: module/Company/src/Controller/CompanyAccountController.php:310
 msgid "You are not allowed to delete jobs"
 msgstr "Je hebt niet de rechten om vacatures te verwijderen"
 
-#: module/Company/src/Controller/AdminController.php:604
+#: module/Company/src/Controller/AdminController.php:610
 msgid "You are not allowed to create job categories"
 msgstr "Je hebt niet de rechten om vacaturecategorieën te wijzigen"
 
-#: module/Company/src/Controller/AdminController.php:623
+#: module/Company/src/Controller/AdminController.php:629
 msgid "Job category successfully created!"
 msgstr "Vacaturecategorie succesvol aangemaakt!"
 
-#: module/Company/src/Controller/AdminController.php:658
-#: module/Company/src/Service/Company.php:885
+#: module/Company/src/Controller/AdminController.php:665
+#: module/Company/src/Service/Company.php:881
 msgid "You are not allowed to edit job categories"
 msgstr "Je hebt niet de rechten om vacature categorieën te wijzigen"
 
-#: module/Company/src/Controller/AdminController.php:698
+#: module/Company/src/Controller/AdminController.php:705
 msgid "You are not allowed to create job labels"
 msgstr "Je hebt niet de rechten om vacature-labels te wijzigen"
 
-#: module/Company/src/Controller/AdminController.php:717
+#: module/Company/src/Controller/AdminController.php:724
 msgid "Job label successfully created!"
 msgstr "Vacature-label succesvol aangemaakt!"
 
-#: module/Company/src/Controller/AdminController.php:751
-#: module/Company/src/Service/Company.php:901
+#: module/Company/src/Controller/AdminController.php:758
+#: module/Company/src/Service/Company.php:893
 msgid "You are not allowed to edit job labels"
 msgstr "Je hebt niet de rechten om vacature-labels te wijzigen"
 
-#: module/Company/src/Controller/CompanyAccountController.php:46
-#: module/Company/src/Controller/CompanyAccountController.php:57
-#: module/Company/src/Controller/CompanyAccountController.php:68
+#: module/Company/src/Controller/CompanyAccountController.php:47
+#: module/Company/src/Controller/CompanyAccountController.php:58
+#: module/Company/src/Controller/CompanyAccountController.php:69
 msgid "You are not allowed to view the company accounts"
 msgstr "Je hebt niet de rechten om bedrijfsprofielen te bekijken"
 
-#: module/Company/src/Controller/CompanyAccountController.php:136
+#: module/Company/src/Controller/CompanyAccountController.php:143
 msgid "You cannot create new jobs in expired job packages."
 msgstr "Je kan geen nieuwe vacatures maken in verlopen vacaturepakketen."
 
-#: module/Company/src/Controller/CompanyAccountController.php:157
+#: module/Company/src/Controller/CompanyAccountController.php:166
 msgid ""
 "Job proposal successfully created! It will become active after it has been "
 "approved."
@@ -2575,11 +2575,11 @@ msgstr ""
 "Voorstel voor vacature succesvol aangemaakt! Deze zal actief worden zodra "
 "deze is goedgekeurd."
 
-#: module/Company/src/Controller/CompanyAccountController.php:213
+#: module/Company/src/Controller/CompanyAccountController.php:223
 msgid "You cannot update jobs in expired job packages."
 msgstr "Je kan vacatures in verlopen vacaturepakketten niet bijwerken."
 
-#: module/Company/src/Controller/CompanyAccountController.php:236
+#: module/Company/src/Controller/CompanyAccountController.php:249
 msgid ""
 "Update proposal for job successfully created! It will become active after it "
 "has been approved."
@@ -2587,127 +2587,127 @@ msgstr ""
 "Updatevoorstel voor vacature succesvol aangemaakt! Deze zal actief worden "
 "zodra deze is goedgekeurd."
 
-#: module/Company/src/Controller/CompanyAccountController.php:319
+#: module/Company/src/Controller/CompanyAccountController.php:335
 msgid "Job successfully deleted."
 msgstr "Vacature succesvol verwijderd."
 
-#: module/Company/src/Controller/CompanyAccountController.php:328
+#: module/Company/src/Controller/CompanyAccountController.php:344
 msgid "You are not allowed to view the status of a job"
 msgstr ""
 "Je hebt niet de rechten om de goedkeuringsstatus van vacatures te bekijken"
 
-#: module/Company/src/Controller/CompanyAccountController.php:353
+#: module/Company/src/Controller/CompanyAccountController.php:369
 msgid "You are not allowed to transfer jobs"
 msgstr "Je hebt niet de rechten om vacatures te verplaatsen"
 
-#: module/Company/src/Controller/CompanyAccountController.php:386
+#: module/Company/src/Controller/CompanyAccountController.php:406
 msgid "Jobs successfully transferred"
 msgstr "Vacature succesvol verplaatst"
 
-#: module/Company/src/Controller/CompanyAccountController.php:396
+#: module/Company/src/Controller/CompanyAccountController.php:417
 msgid ""
 "An unknown error occurred while trying to transfer jobs, please try again."
 msgstr ""
 "Er is een onbekende fout opgetreden tijdens het verplaatsen van de "
 "vacatures, probeer het opnieuw."
 
-#: module/Company/src/Form/Company.php:62 module/Company/src/Form/Job.php:65
+#: module/Company/src/Form/Company.php:61 module/Company/src/Form/Job.php:69
 #: module/Company/src/Form/JobCategory.php:85
 #: module/Company/src/Form/JobCategory.php:95
-#: module/Company/view/company/admin-approval/job-approval.phtml:30
-#: module/Company/view/company/admin-approval/job-approval.phtml:34
-#: module/Company/view/company/admin-approval/job-proposal.phtml:59
-#: module/Company/view/company/admin-approval/job-proposal.phtml:63
-#: module/Company/view/partial/company/admin/editors/company.phtml:5
-#: module/Company/view/partial/company/admin/editors/job.phtml:5
+#: module/Company/view/company/admin-approval/job-approval.phtml:44
+#: module/Company/view/company/admin-approval/job-approval.phtml:48
+#: module/Company/view/company/admin-approval/job-proposal.phtml:69
+#: module/Company/view/company/admin-approval/job-proposal.phtml:73
+#: module/Company/view/partial/company/admin/editors/company.phtml:18
+#: module/Company/view/partial/company/admin/editors/job.phtml:18
 msgid "Slug"
 msgstr "Permalink"
 
-#: module/Company/src/Form/Company.php:72
+#: module/Company/src/Form/Company.php:71
 msgid "Logo"
 msgstr "Logo"
 
-#: module/Company/src/Form/Company.php:82 module/Company/src/Form/Job.php:87
-#: module/Company/src/Form/Package.php:69
+#: module/Company/src/Form/Company.php:81 module/Company/src/Form/Job.php:91
+#: module/Company/src/Form/Package.php:66
 msgid "Published"
 msgstr "Gepubliceerd"
 
-#: module/Company/src/Form/Company.php:104
-#: module/Company/src/Form/Company.php:134 module/Company/src/Form/Job.php:112
+#: module/Company/src/Form/Company.php:103
+#: module/Company/src/Form/Company.php:133 module/Company/src/Form/Job.php:116
 msgid "E-mail Address"
 msgstr "E-mailadres"
 
-#: module/Company/src/Form/Company.php:124
+#: module/Company/src/Form/Company.php:123
 msgid "Address"
 msgstr "Adres"
 
-#: module/Company/src/Form/Company.php:144 module/Company/src/Form/Job.php:122
+#: module/Company/src/Form/Company.php:143 module/Company/src/Form/Job.php:126
 msgid "Phone Number"
 msgstr "Telefoonnummer"
 
-#: module/Company/src/Form/Company.php:155
-#: module/Company/src/Form/Company.php:165
+#: module/Company/src/Form/Company.php:154
+#: module/Company/src/Form/Company.php:164
 msgid "Slogan"
 msgstr "Slogan"
 
-#: module/Company/src/Form/Company.php:179
-#: module/Company/src/Form/Company.php:189 module/Company/src/Form/Job.php:157
-#: module/Company/src/Form/Job.php:167
-#: module/Company/view/company/admin-approval/job-approval.phtml:124
-#: module/Company/view/company/admin-approval/job-approval.phtml:129
-#: module/Company/view/company/admin-approval/job-approval.phtml:136
-#: module/Company/view/company/admin-approval/job-proposal.phtml:174
-#: module/Company/view/company/admin-approval/job-proposal.phtml:179
+#: module/Company/src/Form/Company.php:178
+#: module/Company/src/Form/Company.php:188 module/Company/src/Form/Job.php:161
+#: module/Company/src/Form/Job.php:171
+#: module/Company/view/company/admin-approval/job-approval.phtml:138
+#: module/Company/view/company/admin-approval/job-approval.phtml:143
+#: module/Company/view/company/admin-approval/job-approval.phtml:150
+#: module/Company/view/company/admin-approval/job-proposal.phtml:184
 #: module/Company/view/company/admin-approval/job-proposal.phtml:189
-#: module/Decision/src/Form/OrganInformation.php:44
-#: module/Frontpage/view/frontpage/organ/organ.phtml:94
+#: module/Company/view/company/admin-approval/job-proposal.phtml:199
+#: module/Decision/src/Form/OrganInformation.php:42
+#: module/Frontpage/view/frontpage/organ/organ.phtml:110
 msgid "Website"
 msgstr "Website"
 
-#: module/Company/src/Form/Company.php:261 module/Company/src/Form/Job.php:283
+#: module/Company/src/Form/Company.php:261 module/Company/src/Form/Job.php:282
 #: module/Company/src/Form/JobCategory.php:194
 msgid "This slug is already taken"
 msgstr "Deze permalink is al in gebruik"
 
-#: module/Company/src/Form/Company.php:270 module/Company/src/Form/Job.php:292
-#: module/Company/src/Form/JobCategory.php:203
+#: module/Company/src/Form/Company.php:272 module/Company/src/Form/Job.php:293
+#: module/Company/src/Form/JobCategory.php:204
 msgid "This slug contains invalid characters"
 msgstr "Deze permalink bevat ongeldige tekens"
 
-#: module/Company/src/Form/Company.php:338
+#: module/Company/src/Form/Company.php:346
 msgid "E-mail address format is not valid."
 msgstr "E-mailadres formaat is niet geldig."
 
-#: module/Company/src/Form/Company.php:348
+#: module/Company/src/Form/Company.php:356
 msgid "The e-mail address must be unique across companies."
 msgstr "Het e-mailadres moet uniek zijn onder alle bedrijven."
 
-#: module/Company/src/Form/Company.php:392 module/Company/src/Form/Job.php:339
-#: module/User/src/Form/CompanyUserLogin.php:127
-#: module/User/src/Form/CompanyUserReset.php:71
-#: module/User/src/Form/UserReset.php:95
+#: module/Company/src/Form/Company.php:400 module/Company/src/Form/Job.php:341
+#: module/User/src/Form/CompanyUserLogin.php:125
+#: module/User/src/Form/CompanyUserReset.php:64
+#: module/User/src/Form/UserReset.php:93
 msgid "E-mail address format is not valid"
 msgstr "E-mailadres formaat is niet geldig"
 
-#: module/Company/src/Form/Job.php:75
-#: module/Company/view/company/admin-approval/job-approval.phtml:41
-#: module/Company/view/company/admin-approval/job-approval.phtml:45
-#: module/Company/view/company/admin-approval/job-proposal.phtml:73
-#: module/Company/view/company/admin-approval/job-proposal.phtml:77
+#: module/Company/src/Form/Job.php:79
+#: module/Company/view/company/admin-approval/job-approval.phtml:55
+#: module/Company/view/company/admin-approval/job-approval.phtml:59
+#: module/Company/view/company/admin-approval/job-proposal.phtml:83
+#: module/Company/view/company/admin-approval/job-proposal.phtml:87
 msgid "Category"
 msgstr "Categorie"
 
-#: module/Company/src/Form/Job.php:76
+#: module/Company/src/Form/Job.php:80
 msgid "Select a job category"
 msgstr "Selecteer een vacaturecategorie"
 
-#: module/Company/src/Form/Job.php:217 module/Company/src/Form/Job.php:227
-#: module/Company/view/company/admin-approval/job-approval.phtml:181
-#: module/Company/view/company/admin-approval/job-approval.phtml:186
-#: module/Company/view/company/admin-approval/job-approval.phtml:197
-#: module/Company/view/company/admin-approval/job-proposal.phtml:249
-#: module/Company/view/company/admin-approval/job-proposal.phtml:254
-#: module/Company/view/company/admin-approval/job-proposal.phtml:270
+#: module/Company/src/Form/Job.php:221 module/Company/src/Form/Job.php:231
+#: module/Company/view/company/admin-approval/job-approval.phtml:195
+#: module/Company/view/company/admin-approval/job-approval.phtml:200
+#: module/Company/view/company/admin-approval/job-approval.phtml:211
+#: module/Company/view/company/admin-approval/job-proposal.phtml:259
+#: module/Company/view/company/admin-approval/job-proposal.phtml:264
+#: module/Company/view/company/admin-approval/job-proposal.phtml:280
 msgid "Attachment"
 msgstr "Bijlage"
 
@@ -2720,163 +2720,163 @@ msgstr "Naam (meervoud)"
 msgid "Hidden"
 msgstr "Verborgen"
 
-#: module/Company/src/Form/JobLabel.php:52
-#: module/Company/src/Form/JobLabel.php:62
-#: module/Decision/view/decision/organ-admin/index.phtml:11
-#: module/Decision/view/decision/organ/index.phtml:13
+#: module/Company/src/Form/JobLabel.php:51
+#: module/Company/src/Form/JobLabel.php:61
+#: module/Decision/view/decision/organ-admin/index.phtml:23
+#: module/Decision/view/decision/organ/index.phtml:22
 msgid "Abbreviation"
 msgstr "Afkorting"
 
-#: module/Company/src/Form/JobsTransfer.php:40
+#: module/Company/src/Form/JobsTransfer.php:38
 msgid "Select a target job package"
 msgstr "Selecteer een vacaturepakket als bestemming"
 
-#: module/Company/src/Form/JobsTransfer.php:41
-#: module/Company/view/company/admin/edit-company.phtml:47
+#: module/Company/src/Form/JobsTransfer.php:39
+#: module/Company/view/company/admin/edit-company.phtml:59
 msgid "Packages"
 msgstr "Pakketten"
 
-#: module/Company/src/Form/JobsTransfer.php:52
-#: module/Company/view/company/company-account/jobs.phtml:253
-#: module/Company/view/company/company-account/transfer-jobs.phtml:2
-#: module/Company/view/company/company-account/transfer-jobs.phtml:12
+#: module/Company/src/Form/JobsTransfer.php:50
+#: module/Company/view/company/company-account/jobs.phtml:272
+#: module/Company/view/company/company-account/transfer-jobs.phtml:14
+#: module/Company/view/company/company-account/transfer-jobs.phtml:24
 msgid "Transfer Jobs"
 msgstr "Verplaats vacatures"
 
-#: module/Company/src/Form/Package.php:41
+#: module/Company/src/Form/Package.php:38
 msgid "Start Date"
 msgstr "Startdatum"
 
-#: module/Company/src/Form/Package.php:55
+#: module/Company/src/Form/Package.php:52
 msgid "Expiration Date"
 msgstr "Afloopdatum"
 
-#: module/Company/src/Form/Package.php:82
-#: module/Company/view/company/admin/edit-company.phtml:89
-#: module/Company/view/company/company-account/jobs.phtml:35
+#: module/Company/src/Form/Package.php:79
+#: module/Company/view/company/admin/edit-company.phtml:101
+#: module/Company/view/company/company-account/jobs.phtml:54
 msgid "Contract Number"
 msgstr "Contractnummer"
 
-#: module/Company/src/Form/Package.php:93
-#: module/Company/src/Form/Package.php:103
+#: module/Company/src/Form/Package.php:90
+#: module/Company/src/Form/Package.php:100
 msgid "Article"
 msgstr "Artikel"
 
-#: module/Company/src/Form/Package.php:182
+#: module/Company/src/Form/Package.php:179
 msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
 msgstr ""
 "Contractnummers kunnen alleen letters, cijfers, _, -, ., en spaties bevatten"
 
-#: module/Company/src/Service/Company.php:83
+#: module/Company/src/Service/Company.php:92
 msgid "You are not allowed to view the banner"
 msgstr "Je hebt niet de rechten om de banner te zien"
 
-#: module/Company/src/Service/Company.php:96
+#: module/Company/src/Service/Company.php:102
 msgid "You are not allowed to view the featured company"
 msgstr "Je hebt niet de rechten om het uitgelichte bedrijf te zien"
 
-#: module/Company/src/Service/Company.php:165
-#: module/Company/src/Service/Company.php:185
-#: module/Company/src/Service/Company.php:217
+#: module/Company/src/Service/Company.php:170
+#: module/Company/src/Service/Company.php:190
+#: module/Company/src/Service/Company.php:218
 msgid "You are not allowed to list the companies"
 msgstr "Je hebt niet de rechten om de lijst met bedrijven te zien"
 
-#: module/Company/src/Service/Company.php:200
+#: module/Company/src/Service/Company.php:205
 msgid "You are not allowed to access the admin interface"
 msgstr "Je hebt niet de rechten om de admin interface te zien"
 
-#: module/Company/src/Service/Company.php:961
+#: module/Company/src/Service/Company.php:948
 msgid "You are not allowed to edit categories"
 msgstr "Je hebt niet de rechten om alle categorieën te wijzigen"
 
-#: module/Company/src/Service/Company.php:978
+#: module/Company/src/Service/Company.php:965
 msgid "You are not allowed to edit labels"
 msgstr "Je hebt niet de rechten om labels te wijzigen"
 
-#: module/Company/src/Service/Company.php:1031
+#: module/Company/src/Service/Company.php:1015
 msgid "You are not allowed to create a company"
 msgstr "Je hebt niet de rechten om een bedrijf toe te voegen"
 
-#: module/Company/src/Service/CompanyQuery.php:109
+#: module/Company/src/Service/CompanyQuery.php:98
 msgid "You are not allowed to list all job categories"
 msgstr "Je hebt niet de rechten om alle vacaturecategorieën te bekijken"
 
-#: module/Company/src/Service/CompanyQuery.php:117
+#: module/Company/src/Service/CompanyQuery.php:106
 msgid "You are not allowed to list job categories"
 msgstr "Je hebt niet de rechten om vacaturecategorieën te bekijken"
 
-#: module/Company/src/Service/CompanyQuery.php:157
+#: module/Company/src/Service/CompanyQuery.php:146
 msgid "You are not allowed to list all job labels"
 msgstr "Je hebt niet de rechten om alle vacature-labels te bekijken"
 
-#: module/Company/src/Service/CompanyQuery.php:165
+#: module/Company/src/Service/CompanyQuery.php:154
 msgid "You are not allowed to list job labels"
 msgstr "Je hebt niet de rechten om vacature-labels te bekijken"
 
-#: module/Company/view/company/admin-approval/index.phtml:8
+#: module/Company/view/company/admin-approval/index.phtml:24
 msgid "Unapproved Companies"
 msgstr "Niet goedgekeurde bedrijven"
 
-#: module/Company/view/company/admin-approval/index.phtml:22
+#: module/Company/view/company/admin-approval/index.phtml:38
 msgid "There is no company or update proposal that requires your approval."
 msgstr "Er is geen bedrijfs- of updatevoorstel die jouw goedkeuring vereist."
 
-#: module/Company/view/company/admin-approval/index.phtml:34
+#: module/Company/view/company/admin-approval/index.phtml:50
 msgid "Unapproved Jobs"
 msgstr "Niet goedgekeurde vacatures"
 
-#: module/Company/view/company/admin-approval/index.phtml:40
+#: module/Company/view/company/admin-approval/index.phtml:56
 msgid "Dutch Name"
 msgstr "Nederlandse naam"
 
-#: module/Company/view/company/admin-approval/index.phtml:41
+#: module/Company/view/company/admin-approval/index.phtml:57
 msgid "English Name"
 msgstr "Engelse naam"
 
-#: module/Company/view/company/admin-approval/index.phtml:50
+#: module/Company/view/company/admin-approval/index.phtml:66
 msgid "There is no job or update proposal that requires your approval."
 msgstr "Er is geen vacature- of updatevoorstel die jouw goedkeuring vereist."
 
-#: module/Company/view/company/admin-approval/index.phtml:66
+#: module/Company/view/company/admin-approval/index.phtml:82
 msgid "View Update"
 msgstr "Bekijk updatevoorstel"
 
-#: module/Company/view/company/admin-approval/index.phtml:74
+#: module/Company/view/company/admin-approval/index.phtml:90
 msgid "View Proposal"
 msgstr "Bekijk voorstel"
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:21
+#: module/Company/view/company/admin-approval/job-approval.phtml:35
 #, php-format
 msgid "This job is proposed by <strong>%s</strong> as part of job package %s."
 msgstr ""
 "Deze vacature is voorgesteld door <strong>%s</strong> als onderdeel van "
 "vacaturepakket %s."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:63
-#: module/Company/view/company/admin-approval/job-approval.phtml:67
-#: module/Company/view/company/admin-approval/job-proposal.phtml:101
-#: module/Company/view/company/admin-approval/job-proposal.phtml:105
-#: module/Decision/view/decision/member/self.phtml:158
+#: module/Company/view/company/admin-approval/job-approval.phtml:77
+#: module/Company/view/company/admin-approval/job-approval.phtml:81
+#: module/Company/view/company/admin-approval/job-proposal.phtml:111
+#: module/Company/view/company/admin-approval/job-proposal.phtml:115
+#: module/Decision/view/decision/member/self.phtml:174
 msgid "Phone number"
 msgstr "Telefoonnummer"
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:74
-#: module/Company/view/company/admin-approval/job-approval.phtml:78
-#: module/Company/view/company/admin-approval/job-proposal.phtml:115
-#: module/Company/view/company/admin-approval/job-proposal.phtml:119
-#: module/User/src/Form/UserReset.php:42
-#: module/User/src/Model/Enums/JWTClaims.php:37
+#: module/Company/view/company/admin-approval/job-approval.phtml:88
+#: module/Company/view/company/admin-approval/job-approval.phtml:92
+#: module/Company/view/company/admin-approval/job-proposal.phtml:125
+#: module/Company/view/company/admin-approval/job-proposal.phtml:129
+#: module/User/src/Form/UserReset.php:40
+#: module/User/src/Model/Enums/JWTClaims.php:39
 msgid "E-mail address"
 msgstr "E-mail adres"
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:190
-#: module/Company/view/company/admin-approval/job-approval.phtml:201
-#: module/Company/view/company/admin-approval/job-proposal.phtml:274
-#: module/Company/view/company/company/jobs.phtml:121
+#: module/Company/view/company/admin-approval/job-approval.phtml:204
+#: module/Company/view/company/admin-approval/job-approval.phtml:215
+#: module/Company/view/company/admin-approval/job-proposal.phtml:284
+#: module/Company/view/company/company/jobs.phtml:133
 msgid "View Attachment"
 msgstr "Bijlage bekijken"
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:230
+#: module/Company/view/company/admin-approval/job-approval.phtml:244
 msgid ""
 "If approved, this job will be <strong>published</strong>, however, its "
 "actual visiblity depends on the company and associated job package."
@@ -2885,37 +2885,37 @@ msgstr ""
 "daadwerkelijke zichtbaarheid hangt af van het bedrijf en het bijbehorende "
 "vacaturepakket."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:232
+#: module/Company/view/company/admin-approval/job-approval.phtml:246
 msgid "If approved, this job will be <strong>hidden</strong>."
 msgstr "Bij goedkeuring wordt deze vacature <strong>verborgen</strong>."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:277
-#: module/Company/view/company/admin-approval/job-proposal.phtml:387
+#: module/Company/view/company/admin-approval/job-approval.phtml:291
+#: module/Company/view/company/admin-approval/job-proposal.phtml:397
 msgid "Optional message..."
 msgstr "Optioneel bericht..."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:298
+#: module/Company/view/company/admin-approval/job-approval.phtml:312
 #, php-format
 msgid "This job was approved by <strong>%s</strong>."
 msgstr "Deze vacature is goedgekeurd door <strong>%s</strong>."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:327
+#: module/Company/view/company/admin-approval/job-approval.phtml:341
 #, php-format
 msgid ""
 "This job was disapproved by <strong>%s</strong> with the message \"%s\"."
 msgstr ""
 "Deze vacature is afgekeurd door <strong>%s</strong> met het bericht \"%s\"."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:333
+#: module/Company/view/company/admin-approval/job-approval.phtml:347
 #, php-format
 msgid "This job was disapproved by <strong>%s</strong>."
 msgstr "Deze vacature is afgekeurd door <strong>%s</strong>."
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:17
+#: module/Company/view/company/admin-approval/job-proposal.phtml:27
 msgid "Proposals"
 msgstr "Voorstellen"
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:49
+#: module/Company/view/company/admin-approval/job-proposal.phtml:59
 #, php-format
 msgid ""
 "This job update is proposed by <strong>%s</strong> as part of job package "
@@ -2927,27 +2927,27 @@ msgstr ""
 "worden als volgt weergegeven: %s. Als er geen wijzigingen zijn in een "
 "bepaald kenmerk, zie je de bestaande gegevens."
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:258
+#: module/Company/view/company/admin-approval/job-proposal.phtml:268
 msgid "View Original Attachment"
 msgstr "Bekijk originele bijlage"
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:263
-#: module/Company/view/company/admin-approval/job-proposal.phtml:279
+#: module/Company/view/company/admin-approval/job-proposal.phtml:273
+#: module/Company/view/company/admin-approval/job-proposal.phtml:289
 msgid "View New Attachment"
 msgstr "Bekijk nieuwe bijlage"
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:287
-#: module/Company/view/partial/company/admin/editors/job.phtml:315
+#: module/Company/view/company/admin-approval/job-proposal.phtml:297
+#: module/Company/view/partial/company/admin/editors/job.phtml:328
 msgid "Job Labels"
 msgstr "Vacature-labels"
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:318
+#: module/Company/view/company/admin-approval/job-proposal.phtml:328
 msgid ""
 "Original job and proposed update do not have any job labels applied to them."
 msgstr ""
 "De originele vacature en het updatevoorstel hebben geen vacature-labels."
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:330
+#: module/Company/view/company/admin-approval/job-proposal.phtml:340
 msgid ""
 "Warning! This is an update to an unapproved job. Applying this update will "
 "approve the job."
@@ -2955,7 +2955,7 @@ msgstr ""
 "Waarschuwing! Dit is een update van een nog niet goedgekeurde vacature. Het "
 "toepassen van deze update zal de vacature goedkeuren."
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:340
+#: module/Company/view/company/admin-approval/job-proposal.phtml:350
 msgid ""
 "Warning! This is an update to rejected job. Applying this update will "
 "approve the job."
@@ -2963,119 +2963,119 @@ msgstr ""
 "Waarschuwing! Dit is een update voor een afgewezen vacature. Het toepassen "
 "van deze update zal de vacature goedkeuren."
 
-#: module/Company/view/company/admin/add-category.phtml:2
-#: module/Company/view/company/admin/add-category.phtml:10
-#: module/Company/view/company/admin/add-category.phtml:25
+#: module/Company/view/company/admin/add-category.phtml:14
+#: module/Company/view/company/admin/add-category.phtml:22
+#: module/Company/view/company/admin/add-category.phtml:37
 msgid "Create Job Category"
 msgstr "Vacaturecategorie aanmaken"
 
-#: module/Company/view/company/admin/add-company.phtml:2
-#: module/Company/view/company/admin/add-company.phtml:16
-#: module/Company/view/company/admin/add-company.phtml:31
+#: module/Company/view/company/admin/add-company.phtml:14
+#: module/Company/view/company/admin/add-company.phtml:28
+#: module/Company/view/company/admin/add-company.phtml:43
 msgid "Create Company"
 msgstr "Bedrijf aanmaken"
 
-#: module/Company/view/company/admin/add-job.phtml:2
-#: module/Company/view/company/admin/add-job.phtml:21
-#: module/Company/view/company/admin/add-job.phtml:36
-#: module/Company/view/company/admin/edit-package.phtml:126
-#: module/Company/view/company/company-account/jobs.phtml:78
-#: module/Company/view/company/company-account/jobs.phtml:263
+#: module/Company/view/company/admin/add-job.phtml:14
+#: module/Company/view/company/admin/add-job.phtml:33
+#: module/Company/view/company/admin/add-job.phtml:48
+#: module/Company/view/company/admin/edit-package.phtml:140
+#: module/Company/view/company/company-account/jobs.phtml:97
+#: module/Company/view/company/company-account/jobs.phtml:282
 msgid "Add Job"
 msgstr "Voeg vacature toe"
 
-#: module/Company/view/company/admin/add-label.phtml:2
-#: module/Company/view/company/admin/add-label.phtml:16
-#: module/Company/view/company/admin/add-label.phtml:31
+#: module/Company/view/company/admin/add-label.phtml:14
+#: module/Company/view/company/admin/add-label.phtml:28
+#: module/Company/view/company/admin/add-label.phtml:43
 msgid "Create Job Label"
 msgstr "Vacature-label aanmaken"
 
-#: module/Company/view/company/admin/add-package.phtml:2
-#: module/Company/view/company/admin/add-package.phtml:16
-#: module/Company/view/company/admin/add-package.phtml:32
+#: module/Company/view/company/admin/add-package.phtml:15
+#: module/Company/view/company/admin/add-package.phtml:29
+#: module/Company/view/company/admin/add-package.phtml:45
 msgid "Add Package"
 msgstr "Voeg pakket toe"
 
-#: module/Company/view/company/admin/categories.phtml:23
-#: module/Company/view/company/admin/labels.phtml:22
+#: module/Company/view/company/admin/categories.phtml:36
+#: module/Company/view/company/admin/labels.phtml:35
 msgid "edit"
 msgstr "wijzig"
 
-#: module/Company/view/company/admin/edit-category.phtml:2
-#: module/Company/view/company/admin/edit-category.phtml:9
+#: module/Company/view/company/admin/edit-category.phtml:14
+#: module/Company/view/company/admin/edit-category.phtml:21
 msgid "Edit Job Category"
 msgstr "Vacaturecategorie aanpassen"
 
-#: module/Company/view/company/admin/edit-category.phtml:24
+#: module/Company/view/company/admin/edit-category.phtml:36
 msgid "Update Job Category"
 msgstr "Vacaturecategorie bijwerken"
 
-#: module/Company/view/company/admin/edit-company.phtml:5
+#: module/Company/view/company/admin/edit-company.phtml:17
 msgid "Edit Company"
 msgstr "Wijzig bedrijf"
 
-#: module/Company/view/company/admin/edit-company.phtml:41
+#: module/Company/view/company/admin/edit-company.phtml:53
 #, php-format
 msgid "Edit %s"
 msgstr "%s bewerken"
 
-#: module/Company/view/company/admin/edit-company.phtml:58
+#: module/Company/view/company/admin/edit-company.phtml:70
 msgid "Add Job Package"
 msgstr "Voeg vacaturepakket toe"
 
-#: module/Company/view/company/admin/edit-company.phtml:68
+#: module/Company/view/company/admin/edit-company.phtml:80
 msgid "Add Spotlight Package"
 msgstr "Voeg spotlight-pakket toe"
 
-#: module/Company/view/company/admin/edit-company.phtml:78
+#: module/Company/view/company/admin/edit-company.phtml:90
 msgid "Add Banner Package"
 msgstr "Voeg bannerpakket toe"
 
-#: module/Company/view/company/admin/edit-company.phtml:92
-#: module/Company/view/company/admin/edit-package.phtml:70
-#: module/Company/view/company/company-account/jobs.phtml:178
+#: module/Company/view/company/admin/edit-company.phtml:104
+#: module/Company/view/company/admin/edit-package.phtml:84
+#: module/Company/view/company/company-account/jobs.phtml:197
 msgid "Active"
 msgstr "Actief"
 
-#: module/Company/view/company/admin/edit-company.phtml:98
-#: module/Company/view/company/company-account/jobs.phtml:41
+#: module/Company/view/company/admin/edit-company.phtml:110
+#: module/Company/view/company/company-account/jobs.phtml:60
 msgid "Expiration date"
 msgstr "Verloopdatum"
 
-#: module/Company/view/company/admin/edit-company.phtml:101
+#: module/Company/view/company/admin/edit-company.phtml:113
 msgid "Jobs (Active) / Type"
 msgstr "Vacatures (Actief) / Type"
 
-#: module/Company/view/company/admin/edit-company.phtml:124
-#: module/Company/view/company/admin/index.phtml:36
-#: module/Company/view/company/admin/index.phtml:68
+#: module/Company/view/company/admin/edit-company.phtml:136
+#: module/Company/view/company/admin/index.phtml:50
+#: module/Company/view/company/admin/index.phtml:82
 msgid "Banner Package"
 msgstr "Bannerpakket"
 
-#: module/Company/view/company/admin/edit-company.phtml:127
-#: module/Company/view/company/admin/index.phtml:39
-#: module/Company/view/company/admin/index.phtml:71
+#: module/Company/view/company/admin/edit-company.phtml:139
+#: module/Company/view/company/admin/index.phtml:53
+#: module/Company/view/company/admin/index.phtml:85
 msgid "Featured Package"
 msgstr "Uitgelicht pakket"
 
-#: module/Company/view/company/admin/edit-company.phtml:175
+#: module/Company/view/company/admin/edit-company.phtml:187
 msgid "Update Company"
 msgstr "Bedrijf bijwerken"
 
-#: module/Company/view/company/admin/edit-company.phtml:194
+#: module/Company/view/company/admin/edit-company.phtml:206
 msgid "Are you sure you want to delete this package?"
 msgstr "Weet je zeker dat je dit pakket wilt verwijderen?"
 
-#: module/Company/view/company/admin/edit-company.phtml:200
+#: module/Company/view/company/admin/edit-company.phtml:212
 msgid "Delete package"
 msgstr "Verwijder pakket"
 
-#: module/Company/view/company/admin/edit-job.phtml:2
-#: module/Company/view/company/admin/edit-job.phtml:21
+#: module/Company/view/company/admin/edit-job.phtml:19
+#: module/Company/view/company/admin/edit-job.phtml:38
 msgid "Edit Job"
 msgstr "Vacature aanpassen"
 
-#: module/Company/view/company/admin/edit-job.phtml:30
+#: module/Company/view/company/admin/edit-job.phtml:47
 #, php-format
 msgid ""
 "You are currently updating an update proposal that was previously rejected "
@@ -3084,7 +3084,7 @@ msgstr ""
 "Je werkt momenteel een updatevoorstel bij dat eerder is afgewezen met de "
 "volgende reden: %s"
 
-#: module/Company/view/company/admin/edit-job.phtml:36
+#: module/Company/view/company/admin/edit-job.phtml:53
 msgid ""
 "You are currently updating an update proposal that was previously rejected, "
 "however, no reason was provided."
@@ -3092,7 +3092,7 @@ msgstr ""
 "Je werkt momenteel een updatevoorstel bij dat eerder is afgewezen, maar er "
 "is hiervoor geen reden opgegeven."
 
-#: module/Company/view/company/admin/edit-job.phtml:41
+#: module/Company/view/company/admin/edit-job.phtml:58
 #, php-format
 msgid ""
 "You are currently updating a job that was previously rejected for the "
@@ -3101,7 +3101,7 @@ msgstr ""
 "Je werkt momenteel een vacature bij die eerder is afgewezen met de volgende "
 "reden: %s"
 
-#: module/Company/view/company/admin/edit-job.phtml:47
+#: module/Company/view/company/admin/edit-job.phtml:64
 msgid ""
 "You are currently updating a job that was previously rejected, however, no "
 "reason was provided."
@@ -3109,111 +3109,111 @@ msgstr ""
 "Je werkt momenteel een vacature bij die eerder is afgewezen, maar er is "
 "hiervoor geen reden opgegeven."
 
-#: module/Company/view/company/admin/edit-job.phtml:68
+#: module/Company/view/company/admin/edit-job.phtml:85
 msgid "Update Job"
 msgstr "Vacature bijwerken"
 
-#: module/Company/view/company/admin/edit-label.phtml:2
-#: module/Company/view/company/admin/edit-label.phtml:16
+#: module/Company/view/company/admin/edit-label.phtml:14
+#: module/Company/view/company/admin/edit-label.phtml:28
 msgid "Edit Job Label"
 msgstr "Vacature-label aanpassen"
 
-#: module/Company/view/company/admin/edit-label.phtml:31
+#: module/Company/view/company/admin/edit-label.phtml:43
 msgid "Update Job Label"
 msgstr "Vacature-label bijwerken"
 
-#: module/Company/view/company/admin/edit-package.phtml:7
-#: module/Company/view/company/admin/edit-package.phtml:28
+#: module/Company/view/company/admin/edit-package.phtml:19
+#: module/Company/view/company/admin/edit-package.phtml:40
 msgid "Edit Package"
 msgstr "Pakket aanpassen"
 
-#: module/Company/view/company/admin/edit-package.phtml:44
+#: module/Company/view/company/admin/edit-package.phtml:56
 msgid "Update Package"
 msgstr "Pakket bijwerken"
 
-#: module/Company/view/company/admin/edit-package.phtml:87
+#: module/Company/view/company/admin/edit-package.phtml:101
 msgid "(Update Pending)"
 msgstr "(Update in behandeling)"
 
-#: module/Company/view/company/admin/edit-package.phtml:140
-#: module/Company/view/company/company-account/jobs.phtml:278
+#: module/Company/view/company/admin/edit-package.phtml:154
+#: module/Company/view/company/company-account/jobs.phtml:297
 msgid "Are you sure you want to delete this job?"
 msgstr "Weet je zeker dat je deze vacature wilt verwijderen?"
 
-#: module/Company/view/company/admin/edit-package.phtml:145
-#: module/Company/view/company/company-account/jobs.phtml:283
+#: module/Company/view/company/admin/edit-package.phtml:159
+#: module/Company/view/company/company-account/jobs.phtml:302
 msgid "Delete job"
 msgstr "Verwijder vacature"
 
-#: module/Company/view/company/admin/index.phtml:22
-#: module/Company/view/company/company-account/jobs.phtml:20
+#: module/Company/view/company/admin/index.phtml:36
+#: module/Company/view/company/company-account/jobs.phtml:39
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: module/Company/view/company/admin/index.phtml:24
+#: module/Company/view/company/admin/index.phtml:38
 msgid "No notifications"
 msgstr "Geen meldingen"
 
-#: module/Company/view/company/admin/index.phtml:42
-#: module/Company/view/company/admin/index.phtml:74
+#: module/Company/view/company/admin/index.phtml:56
+#: module/Company/view/company/admin/index.phtml:88
 #, php-format
 msgid "Job Package (%s active)"
 msgstr "Vacaturepakket (%s actief)"
 
-#: module/Company/view/company/admin/index.phtml:49
+#: module/Company/view/company/admin/index.phtml:63
 #, php-format
 msgid "%s for company %s will start on %s"
 msgstr "%s voor bedrijf %s begint op %s"
 
-#: module/Company/view/company/admin/index.phtml:81
+#: module/Company/view/company/admin/index.phtml:95
 #, php-format
 msgid "%s for company %s will expire on %s"
 msgstr "%s voor bedrijf %s verloopt op %s"
 
-#: module/Company/view/company/admin/index.phtml:96
-#: module/Education/view/education/admin/course.phtml:15
+#: module/Company/view/company/admin/index.phtml:110
+#: module/Education/view/education/admin/course.phtml:27
 msgid "Filter..."
 msgstr "Filter..."
 
-#: module/Company/view/company/admin/index.phtml:101
+#: module/Company/view/company/admin/index.phtml:115
 msgid "Add Company"
 msgstr "Voeg bedrijf toe"
 
-#: module/Company/view/company/admin/index.phtml:130
-#: module/Company/view/company/admin/index.phtml:200
+#: module/Company/view/company/admin/index.phtml:144
+#: module/Company/view/company/admin/index.phtml:214
 msgid "Active jobs"
 msgstr "Actieve vacatures"
 
-#: module/Company/view/company/admin/index.phtml:138
-#: module/Company/view/company/admin/index.phtml:201
+#: module/Company/view/company/admin/index.phtml:152
+#: module/Company/view/company/admin/index.phtml:215
 msgid "Banner active"
 msgstr "Banner actief"
 
-#: module/Company/view/company/admin/index.phtml:155
-#: module/Company/view/company/admin/index.phtml:203
+#: module/Company/view/company/admin/index.phtml:169
+#: module/Company/view/company/admin/index.phtml:217
 msgid "Expired packages"
 msgstr "Verlopen pakketten"
 
-#: module/Company/view/company/admin/index.phtml:202
+#: module/Company/view/company/admin/index.phtml:216
 msgid "Featured in language"
 msgstr "Uitgelicht in taal"
 
-#: module/Company/view/company/admin/index.phtml:220
-#: module/Decision/view/decision/admin/document.phtml:155
+#: module/Company/view/company/admin/index.phtml:234
+#: module/Decision/view/decision/admin/document.phtml:169
 #, php-format
 msgid "Are you sure you want to delete %s?"
 msgstr "Weet je zeker dat je %s wil verwijderen?"
 
-#: module/Company/view/company/admin/index.phtml:227
+#: module/Company/view/company/admin/index.phtml:241
 msgid "Delete company"
 msgstr "Verwijder bedrijf"
 
-#: module/Company/view/company/admin/labels.phtml:4
+#: module/Company/view/company/admin/labels.phtml:17
 msgid "Add Label"
 msgstr "Voeg een label toe"
 
-#: module/Company/view/company/company-account/banner.phtml:12
-#: module/Company/view/company/company-account/highlights.phtml:12
+#: module/Company/view/company/company-account/banner.phtml:20
+#: module/Company/view/company/company-account/highlights.phtml:20
 msgid ""
 "This functionality is currently unavailable. Our apologies for the "
 "inconvenience."
@@ -3221,157 +3221,157 @@ msgstr ""
 "Deze functionaliteit is momenteel niet beschikbaar. Onze excuses voor het "
 "ongemak."
 
-#: module/Company/view/company/company-account/jobs.phtml:26
+#: module/Company/view/company/company-account/jobs.phtml:45
 msgid "Job Packages"
 msgstr "Vacaturepakketten"
 
-#: module/Company/view/company/company-account/jobs.phtml:44
+#: module/Company/view/company/company-account/jobs.phtml:63
 msgid "Jobs (Active)"
 msgstr "Vacatures (actief)"
 
-#: module/Company/view/company/company-account/jobs.phtml:87
-#: module/Company/view/company/company/job-list.phtml:138
+#: module/Company/view/company/company-account/jobs.phtml:106
+#: module/Company/view/company/company/job-list.phtml:152
 msgid "View"
 msgstr "Toon"
 
-#: module/Company/view/company/company-account/jobs.phtml:99
+#: module/Company/view/company/company-account/jobs.phtml:118
 msgid "Recently Approved Jobs"
 msgstr "Onlangs goedgekeurde vacatures"
 
-#: module/Company/view/company/company-account/jobs.phtml:101
+#: module/Company/view/company/company-account/jobs.phtml:120
 msgid "You do not have recently approved jobs."
 msgstr "Je hebt geen vacatures die recentelijk zijn goedgekeurd."
 
-#: module/Company/view/company/company-account/jobs.phtml:121
+#: module/Company/view/company/company-account/jobs.phtml:140
 msgid "Recently Rejected Jobs"
 msgstr "Onlangs afgekeurde vacatures"
 
-#: module/Company/view/company/company-account/jobs.phtml:123
+#: module/Company/view/company/company-account/jobs.phtml:142
 msgid "You do not have recently rejected jobs."
 msgstr "Je hebt geen vacatures die recentelijk zijn afgekeurd."
 
-#: module/Company/view/company/company-account/jobs.phtml:143
+#: module/Company/view/company/company-account/jobs.phtml:162
 msgid "Recently Unapproved Jobs"
 msgstr "Nog niet goedgekeurde vacatures"
 
-#: module/Company/view/company/company-account/jobs.phtml:145
+#: module/Company/view/company/company-account/jobs.phtml:164
 msgid "You do not have any recent jobs pending approval."
 msgstr "Je hebt geen vacatures die nog niet zijn goedgekeurd."
 
-#: module/Company/view/company/company-account/jobs.phtml:179
+#: module/Company/view/company/company-account/jobs.phtml:198
 msgid "Approved (Has Updates)"
 msgstr "Goedgekeurd (heeft updates)"
 
-#: module/Company/view/company/company-account/jobs.phtml:187
+#: module/Company/view/company/company-account/jobs.phtml:206
 msgid "This job package does not contain any jobs."
 msgstr "Dit vacaturepakket bevat geen vacatures."
 
-#: module/Company/view/company/company-account/self.phtml:2
+#: module/Company/view/company/company-account/self.phtml:10
 msgid "Company Account"
 msgstr "Bedrijfsprofiel"
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:18
+#: module/Company/view/company/company-account/transfer-jobs.phtml:30
 msgid "Select the jobs that you want to transfer to another job package."
 msgstr ""
 "Selecteer de vacatures die je wilt verplaatsen naar een ander vacaturepakket."
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:36
+#: module/Company/view/company/company-account/transfer-jobs.phtml:48
 msgid "There are no jobs that you can transfer..."
 msgstr "Er zijn geen vacatures die je kunt verplaatsen..."
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:52
+#: module/Company/view/company/company-account/transfer-jobs.phtml:64
 msgid "Choose to which job package you want to transfer the selected jobs."
 msgstr ""
 "Kies naar welk vacaturepakket je de geselecteerde vacatures wilt verplaatsen."
 
-#: module/Company/view/company/company-account/transfer-jobs.phtml:69
+#: module/Company/view/company/company-account/transfer-jobs.phtml:81
 msgid "Move Jobs"
 msgstr "Verplaats vacatures"
 
-#: module/Company/view/company/company/companyStory.phtml:18
-#: module/Company/view/company/company/jobs.phtml:83
-#: module/Company/view/partial/company/company/grid/company.phtml:16
-#: module/Company/view/partial/company/company/list/company.phtml:26
+#: module/Company/view/company/company/companyStory.phtml:34
+#: module/Company/view/company/company/jobs.phtml:95
+#: module/Company/view/partial/company/company/grid/company.phtml:32
+#: module/Company/view/partial/company/company/list/company.phtml:36
 msgid "Logo of"
 msgstr "Logo van"
 
-#: module/Company/view/company/company/companyStory.phtml:47
-#: module/Company/view/partial/company/company/list/company.phtml:52
+#: module/Company/view/company/company/companyStory.phtml:63
+#: module/Company/view/partial/company/company/list/company.phtml:62
 msgid "Visit Website"
 msgstr "Website bezoeken"
 
-#: module/Company/view/company/company/companyStory.phtml:52
+#: module/Company/view/company/company/companyStory.phtml:68
 msgid "Highlighted"
 msgstr "Uitgelicht"
 
-#: module/Company/view/company/company/job-list.phtml:60
+#: module/Company/view/company/company/job-list.phtml:74
 msgid "What are you looking for?"
 msgstr "Waar ben je naar op zoek?"
 
-#: module/Company/view/company/company/job-list.phtml:63
+#: module/Company/view/company/company/job-list.phtml:77
 msgid "Sort on"
 msgstr "Sorteer op"
 
-#: module/Company/view/company/company/job-list.phtml:65
+#: module/Company/view/company/company/job-list.phtml:79
 msgid "Random"
 msgstr "Willekeurig"
 
-#: module/Company/view/company/company/job-list.phtml:66
+#: module/Company/view/company/company/job-list.phtml:80
 msgid "Most recent"
 msgstr "Recentst"
 
-#: module/Company/view/company/company/job-list.phtml:94
+#: module/Company/view/company/company/job-list.phtml:108
 #, php-format
 msgid "Unfortunately, there aren't any %s at the moment."
 msgstr "Helaas zijn er momenteel geen %s."
 
-#: module/Company/view/company/company/job-list.phtml:169
+#: module/Company/view/company/company/job-list.phtml:183
 #, php-format
 msgid "Still haven't found what you're looking for? Take a look at %s."
 msgstr "Niet gevonden wat je zoekt? Bekijk ook %s."
 
-#: module/Company/view/company/company/jobs.phtml:64
+#: module/Company/view/company/company/jobs.phtml:76
 msgid "at"
 msgstr "bij"
 
-#: module/Company/view/company/company/jobs.phtml:114
+#: module/Company/view/company/company/jobs.phtml:126
 msgid "View Website"
 msgstr "Website bezoeken"
 
-#: module/Company/view/company/company/list.phtml:23
-#: module/Company/view/company/company/spotlight.phtml:33
+#: module/Company/view/company/company/list.phtml:40
+#: module/Company/view/company/company/spotlight.phtml:49
 msgid "in the spotlight"
 msgstr "uitgelicht"
 
-#: module/Company/view/company/company/spotlight.phtml:21
+#: module/Company/view/company/company/spotlight.phtml:37
 msgid "Featured company"
 msgstr "Uitgelicht bedrijf"
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:8
+#: module/Company/view/partial/company/admin/editors/company.phtml:21
 msgid ""
 "Specify the permanent link for this company, it should be unique across all "
 "companies."
 msgstr ""
 "Geef de permalink voor dit bedrijf, deze moet uniek zijn voor alle bedrijven."
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:57
+#: module/Company/view/partial/company/admin/editors/company.phtml:70
 msgid "View current logo"
 msgstr "Huidige logo weergeven"
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:81
+#: module/Company/view/partial/company/admin/editors/company.phtml:94
 msgid "Representative Information"
 msgstr "Informatie van vertegenwoordiger"
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:82
+#: module/Company/view/partial/company/admin/editors/company.phtml:95
 msgid "Enter information about the representative of this company."
 msgstr "Geef informatie over de vertegenwoordiger van dit bedrijf."
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:123
-#: module/Company/view/partial/company/admin/editors/job.phtml:65
+#: module/Company/view/partial/company/admin/editors/company.phtml:136
+#: module/Company/view/partial/company/admin/editors/job.phtml:78
 msgid "Contact Information"
 msgstr "Contactgegevens"
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:124
+#: module/Company/view/partial/company/admin/editors/company.phtml:137
 msgid ""
 "Enter how someone can contact this company and who is responsible for this "
 "company."
@@ -3379,8 +3379,8 @@ msgstr ""
 "Geef aan hoe iemand contact kan opnemen met dit bedrijf en wie er "
 "verantwoordelijk is voor dit bedrijf."
 
-#: module/Company/view/partial/company/admin/editors/company.phtml:192
-#: module/Company/view/partial/company/admin/editors/job.phtml:120
+#: module/Company/view/partial/company/admin/editors/company.phtml:205
+#: module/Company/view/partial/company/admin/editors/job.phtml:133
 msgid ""
 "What is this company about? Fill in the blanks below, please note that at "
 "least one language must be used."
@@ -3388,81 +3388,81 @@ msgstr ""
 "Waar gaat dit bedrijf over? Vul de lege plekken hieronder in, let op dat er "
 "ten minste één taal gebruikt moet worden."
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:8
+#: module/Company/view/partial/company/admin/editors/job.phtml:21
 msgid ""
 "Specify the permanent link for this job, it should be unique for this "
 "company."
 msgstr ""
 "Geef de permalink voor deze vacature, deze moet uniek zijn voor dit bedrijf."
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:66
+#: module/Company/view/partial/company/admin/editors/job.phtml:79
 msgid "Enter how someone can contact the person responsible for this job."
 msgstr ""
 "Geef aan hoe iemand contact kan opnemen met de persoon die verantwoordelijk "
 "is voor deze vacature."
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:211
-#: module/Company/view/partial/company/admin/editors/job.phtml:307
+#: module/Company/view/partial/company/admin/editors/job.phtml:224
+#: module/Company/view/partial/company/admin/editors/job.phtml:320
 msgid "View current attachment"
 msgstr "Huidige bijlage weergeven"
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:316
+#: module/Company/view/partial/company/admin/editors/job.phtml:329
 msgid ""
 "Add job labels to your job to give viewers a better understanding of the job."
 msgstr ""
 "Voeg vacature-labels toe aan deze activiteit om kijkers een beter inzicht te "
 "geven in de vacature."
 
-#: module/Company/view/partial/company/admin/editors/job.phtml:336
+#: module/Company/view/partial/company/admin/editors/job.phtml:349
 msgid "There are currently no job labels..."
 msgstr "Er zijn momenteel geen vacature-labels..."
 
-#: module/Decision/src/Controller/AdminController.php:53
+#: module/Decision/src/Controller/AdminController.php:55
 msgid "Meeting minutes uploaded"
 msgstr "Notulen geupload"
 
-#: module/Decision/src/Controller/AdminController.php:134
+#: module/Decision/src/Controller/AdminController.php:137
 msgid "You are not allowed to rename meeting documents"
 msgstr "Je hebt niet de rechten om vergaderstukken te hernoemen"
 
-#: module/Decision/src/Controller/AdminController.php:168
-#: module/Decision/src/Service/Decision.php:293
+#: module/Decision/src/Controller/AdminController.php:177
+#: module/Decision/src/Service/Decision.php:279
 msgid "You are not allowed to delete meeting documents."
 msgstr "Je hebt niet de rechten om vergaderstukken te verwijderen."
 
-#: module/Decision/src/Controller/DecisionController.php:102
+#: module/Decision/src/Controller/DecisionController.php:109
 msgid "You are not allowed to search decisions."
 msgstr "Je hebt niet de rechten om besluiten te doorzoeken."
 
-#: module/Decision/src/Controller/DecisionController.php:137
+#: module/Decision/src/Controller/DecisionController.php:142
 msgid "You are not allowed to authorize someone"
 msgstr "Je hebt niet de rechten om iemand te machtigen"
 
-#: module/Decision/src/Controller/DecisionController.php:184
-#: module/Decision/src/Service/Decision.php:595
+#: module/Decision/src/Controller/DecisionController.php:190
+#: module/Decision/src/Service/Decision.php:571
 msgid "You are not allowed to revoke authorizations."
 msgstr "Je hebt niet de rechten om machtigingen in te trekken."
 
-#: module/Decision/src/Controller/DecisionController.php:212
+#: module/Decision/src/Controller/DecisionController.php:219
 msgid "You are not allowed to browse files."
 msgstr "Je hebt niet de rechten om door bestanden te bladeren."
 
-#: module/Decision/src/Controller/MemberController.php:37
-#: module/Decision/src/Service/Decision.php:140
+#: module/Decision/src/Controller/MemberController.php:40
+#: module/Decision/src/Service/Decision.php:137
 msgid "You are not allowed to view meetings."
 msgstr "Het is niet toegestaan om vergaderingen te zien."
 
-#: module/Decision/src/Controller/MemberController.php:95
+#: module/Decision/src/Controller/MemberController.php:98
 msgid "Not allowed to search for members."
 msgstr "Het is niet toegestaan om te zoeken op leden."
 
-#: module/Decision/src/Controller/MemberController.php:148
+#: module/Decision/src/Controller/MemberController.php:151
 msgid "You are not allowed to view the list of birthdays."
 msgstr "Het is niet toegestaan om de lijst met verjaardagen te zien."
 
 #: module/Decision/src/Form/Authorization.php:50
-#: module/Decision/view/decision/decision/authorizations.phtml:115
-#: module/Decision/view/decision/decision/authorizations.phtml:121
+#: module/Decision/view/decision/decision/authorizations.phtml:133
+#: module/Decision/view/decision/decision/authorizations.phtml:139
 msgid "Authorize"
 msgstr "Machtig"
 
@@ -3470,328 +3470,324 @@ msgstr "Machtig"
 msgid "Revoke authorization"
 msgstr "Machtiging intrekken"
 
-#: module/Decision/src/Form/Document.php:31
-#: module/Decision/src/Form/Minutes.php:31
-#: module/Decision/view/decision/admin/minutes.phtml:20
+#: module/Decision/src/Form/Document.php:29
+#: module/Decision/src/Form/Minutes.php:33
+#: module/Decision/view/decision/admin/minutes.phtml:31
 msgid "Meeting"
 msgstr "Vergadering"
 
-#: module/Decision/src/Form/Document.php:41
+#: module/Decision/src/Form/Document.php:39
 msgid "Document name"
 msgstr "Naam document"
 
-#: module/Decision/src/Form/Document.php:51
+#: module/Decision/src/Form/Document.php:49
 msgid "Document to upload"
 msgstr "Te uploaden document"
 
-#: module/Decision/src/Form/Document.php:61
+#: module/Decision/src/Form/Document.php:59
 msgid "Upload document"
 msgstr "Upload document"
 
-#: module/Decision/src/Form/Minutes.php:32
+#: module/Decision/src/Form/Minutes.php:34
 msgid "Choose a meeting"
 msgstr "Kies een vergadering"
 
-#: module/Decision/src/Form/Minutes.php:43
+#: module/Decision/src/Form/Minutes.php:45
 msgid "Minutes to upload"
 msgstr "Te uploaden notulen"
 
-#: module/Decision/src/Form/Minutes.php:90
+#: module/Decision/src/Form/Minutes.php:94
 msgid "There already are minutes for this meeting"
 msgstr "Er zijn al notulen voor deze vergadering"
 
-#: module/Decision/src/Form/OrganInformation.php:54
+#: module/Decision/src/Form/OrganInformation.php:52
 msgid "Short dutch description"
 msgstr "Korte Nederlandse omschrijving"
 
-#: module/Decision/src/Form/OrganInformation.php:64
+#: module/Decision/src/Form/OrganInformation.php:62
 msgid "Short english description"
 msgstr "Korte Engelse omschrijving"
 
-#: module/Decision/src/Form/OrganInformation.php:74
+#: module/Decision/src/Form/OrganInformation.php:72
 msgid "Long dutch description"
 msgstr "Volledige Nederlandse omschrijving"
 
-#: module/Decision/src/Form/OrganInformation.php:84
+#: module/Decision/src/Form/OrganInformation.php:82
 msgid "Long english description"
 msgstr "Volledige Engelse omschrijving"
 
-#: module/Decision/src/Form/OrganInformation.php:94
+#: module/Decision/src/Form/OrganInformation.php:92
 msgid "Thumbnail photo to upload"
 msgstr "Profiel foto"
 
-#: module/Decision/src/Form/OrganInformation.php:104
+#: module/Decision/src/Form/OrganInformation.php:102
 msgid "Cover photo to upload"
 msgstr "Coverfoto om te uploaden"
 
-#: module/Decision/src/Form/OrganInformation.php:125
-#: module/Decision/view/decision/organ-admin/edit.phtml:171
+#: module/Decision/src/Form/OrganInformation.php:123
+#: module/Decision/view/decision/organ-admin/edit.phtml:182
 #: module/Frontpage/src/Form/NewsItem.php:78
-#: module/Frontpage/src/Form/Page.php:102
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:97
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:131
+#: module/Frontpage/src/Form/Page.php:100
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:110
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:143
 #: module/Photo/src/Form/EditAlbum.php:59
 msgid "Save"
 msgstr "Opslaan"
 
-#: module/Decision/src/Form/ReorderDocument.php:48
+#: module/Decision/src/Form/ReorderDocument.php:46
 msgid "Move up"
 msgstr "Verplaats omhoog"
 
-#: module/Decision/src/Form/ReorderDocument.php:52
+#: module/Decision/src/Form/ReorderDocument.php:50
 msgid "Move down"
 msgstr "Verplaats omlaag"
 
 #: module/Decision/src/Form/SearchDecision.php:25
-#: module/Decision/view/decision/decision/search.phtml:21
-#: module/Education/src/Form/SearchCourse.php:21
+#: module/Decision/view/decision/decision/search.phtml:32
+#: module/Education/src/Form/SearchCourse.php:23
 msgid "Search query"
 msgstr "Zoek query"
 
 #: module/Decision/src/Form/SearchDecision.php:35
 #: module/Decision/src/Form/SearchDecision.php:36
-#: module/Decision/view/decision/decision/search.phtml:30
-#: module/Decision/view/decision/member/index.phtml:146
-#: module/Education/view/education/education/index.phtml:46
+#: module/Decision/view/decision/decision/search.phtml:41
+#: module/Decision/view/decision/member/index.phtml:157
+#: module/Education/view/education/education/index.phtml:59
 msgid "Search"
 msgstr "Zoek"
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:19
+#: module/Decision/src/Model/Enums/AddressTypes.php:21
 msgid "Home address (parents)"
 msgstr "Thuisadres (ouders)"
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:20
+#: module/Decision/src/Model/Enums/AddressTypes.php:22
 msgid "Student address"
 msgstr "Studentadres"
 
-#: module/Decision/src/Model/Enums/AddressTypes.php:21
+#: module/Decision/src/Model/Enums/AddressTypes.php:23
 msgid "Mail address"
 msgstr "Post adres"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:20
+#: module/Decision/src/Model/Enums/MeetingTypes.php:22
 msgid "Board Meeting"
 msgstr "Bestuursvergadering"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:21
+#: module/Decision/src/Model/Enums/MeetingTypes.php:23
 msgid "General Members Meeting"
 msgstr "Algemene Ledenvergadering"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:22
+#: module/Decision/src/Model/Enums/MeetingTypes.php:24
 msgid "Chair's Meeting"
 msgstr "Voorzittersvergadering"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:23
+#: module/Decision/src/Model/Enums/MeetingTypes.php:25
 msgid "Virtual Meeting"
 msgstr "Virtuele Vergadering"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:30
+#: module/Decision/src/Model/Enums/MeetingTypes.php:32
 msgid "BM"
 msgstr "BV"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:31
+#: module/Decision/src/Model/Enums/MeetingTypes.php:33
 msgid "GMM"
 msgstr "ALV"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:32
+#: module/Decision/src/Model/Enums/MeetingTypes.php:34
 msgid "CM"
 msgstr "VV"
 
-#: module/Decision/src/Model/Enums/MeetingTypes.php:33
+#: module/Decision/src/Model/Enums/MeetingTypes.php:35
 msgid "VIRT"
 msgstr "VIRT"
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:20
+#: module/Decision/src/Model/Enums/MembershipTypes.php:22
 msgid "Ordinary"
 msgstr "Gewoon"
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:22
+#: module/Decision/src/Model/Enums/MembershipTypes.php:24
 msgid "Graduate"
 msgstr "Afgestudeerde"
 
-#: module/Decision/src/Model/Enums/MembershipTypes.php:23
+#: module/Decision/src/Model/Enums/MembershipTypes.php:25
 msgid "Honorary"
 msgstr "Erelidmaatschap"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:22
+#: module/Decision/src/Model/Enums/OrganTypes.php:24
 msgid "Committee"
 msgstr "Commissie"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:23
+#: module/Decision/src/Model/Enums/OrganTypes.php:25
 msgid "GMM Committee"
 msgstr "ALV-Commissie"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:24
+#: module/Decision/src/Model/Enums/OrganTypes.php:26
 msgid "Fraternity"
 msgstr "Dispuut"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:25
+#: module/Decision/src/Model/Enums/OrganTypes.php:27
 msgid "Financial Audit Committee"
 msgstr "Kas Controle Commissie"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:26
+#: module/Decision/src/Model/Enums/OrganTypes.php:28
 msgid "GMM Taskforce"
 msgstr "ALV-Werkgroep"
 
-#: module/Decision/src/Model/Enums/OrganTypes.php:27
+#: module/Decision/src/Model/Enums/OrganTypes.php:29
 msgid "Advisory Board"
 msgstr "Raad van Advies"
 
-#: module/Decision/src/Service/Decision.php:87
-#: module/Decision/src/Service/Decision.php:106
-#: module/Decision/src/Service/Decision.php:120
+#: module/Decision/src/Service/Decision.php:90
+#: module/Decision/src/Service/Decision.php:109
+#: module/Decision/src/Service/Decision.php:121
 msgid "You are not allowed to list meetings."
 msgstr "Het is niet toegestaan om de lijst van vergaderingen te zien."
 
-#: module/Decision/src/Service/Decision.php:191
+#: module/Decision/src/Service/Decision.php:178
 msgid "You are not allowed to view meeting documents."
 msgstr "Het is niet toegestaan om vergaderstukken te zien."
 
-#: module/Decision/src/Service/Decision.php:212
+#: module/Decision/src/Service/Decision.php:195
 msgid "You are not allowed to view meeting minutes."
 msgstr "Het is niet toegestaan om notulen te zien."
 
-#: module/Decision/src/Service/Decision.php:399
+#: module/Decision/src/Service/Decision.php:388
 msgid "You are not allowed to view all authorizations."
 msgstr "Je hebt niet de rechten om alle machtigingen te bekijken."
 
-#: module/Decision/src/Service/Decision.php:419
+#: module/Decision/src/Service/Decision.php:404
 msgid "You are not allowed to view authorizations."
 msgstr "Je hebt niet de rechten om all machtigingen te bekijken."
 
-#: module/Decision/src/Service/Decision.php:529
+#: module/Decision/src/Service/Decision.php:514
 msgid "You are not allowed to upload meeting minutes."
 msgstr "Het is niet toegestaan om notulen te uploaden."
 
-#: module/Decision/src/Service/Decision.php:544
+#: module/Decision/src/Service/Decision.php:528
 msgid "You are not allowed to upload meeting documents."
 msgstr "Het is niet toegestaan om vergaderstukken te uploaden."
 
-#: module/Decision/src/Service/Decision.php:581
+#: module/Decision/src/Service/Decision.php:558
 msgid "You are not allowed authorize people."
 msgstr "Je hebt niet de rechten om iemand te machtigen."
 
-#: module/Decision/src/Service/Member.php:56
-#: module/Decision/src/Service/MemberInfo.php:45
+#: module/Decision/src/Service/Member.php:50
+#: module/Decision/src/Service/MemberInfo.php:69
 msgid "You are not allowed to view members."
 msgstr "Het is niet toegestaan om lidinformatie in te zien."
 
-#: module/Decision/src/Service/Member.php:100
-msgid "Name must be at least "
-msgstr "Naam moet op zijn minst "
-
-#: module/Decision/src/Service/MemberInfo.php:43
+#: module/Decision/src/Service/MemberInfo.php:65
 msgid "You are not allowed to view membership info."
 msgstr "Het is niet toegestaan om lidinformatie in te zien."
 
-#: module/Decision/src/Service/Organ.php:56
+#: module/Decision/src/Service/Organ.php:66
 msgid "Not allowed to view the list of organs"
 msgstr "Niet toegestaan om de lijst van organen te bekijken"
 
-#: module/Decision/src/Service/Organ.php:72
+#: module/Decision/src/Service/Organ.php:78
 msgid "Not allowed to view organ information"
 msgstr "Het is niet toegestaan om informatie over organen in te zien"
 
-#: module/Decision/src/Service/Organ.php:87
+#: module/Decision/src/Service/Organ.php:93
 msgid "You are not allowed to edit organ information"
 msgstr "Je hebt niet de rechten om organen te wijzigen"
 
-#: module/Decision/src/Service/Organ.php:317
+#: module/Decision/src/Service/Organ.php:305
 msgid "You are not allowed to edit this organ's information"
 msgstr "Je hebt niet de rechten om de informatie van dit orgaan te wijzigen"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:20
+#: module/Decision/view/decision/admin/authorizations.phtml:31
 #, php-format
 msgid "GMM %d (%s)"
 msgstr "ALV %d (%s)"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:27
+#: module/Decision/view/decision/admin/authorizations.phtml:38
 msgid "No GMM available."
 msgstr "Geen ALV beschikbaar."
 
-#: module/Decision/view/decision/admin/authorizations.phtml:32
+#: module/Decision/view/decision/admin/authorizations.phtml:43
 #, php-format
 msgid "Valid authorizations for GMM %d"
 msgstr "Geldige machtigingen voor ALV %d"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:37
-#: module/Decision/view/decision/admin/authorizations.phtml:61
+#: module/Decision/view/decision/admin/authorizations.phtml:48
+#: module/Decision/view/decision/admin/authorizations.phtml:72
 msgid "Authorizer"
 msgstr "Machtiger"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:38
-#: module/Decision/view/decision/admin/authorizations.phtml:62
+#: module/Decision/view/decision/admin/authorizations.phtml:49
+#: module/Decision/view/decision/admin/authorizations.phtml:73
 msgid "Recipient"
 msgstr "Ontvanger"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:39
-#: module/Decision/view/decision/admin/authorizations.phtml:63
+#: module/Decision/view/decision/admin/authorizations.phtml:50
+#: module/Decision/view/decision/admin/authorizations.phtml:74
 msgid "Created"
 msgstr "Aangemaakt"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:53
+#: module/Decision/view/decision/admin/authorizations.phtml:64
 msgid "There are no valid authorizations for this GMM."
 msgstr "Er zijn geen geldige machtigingen voor deze ALV."
 
-#: module/Decision/view/decision/admin/authorizations.phtml:56
+#: module/Decision/view/decision/admin/authorizations.phtml:67
 #, php-format
 msgid "Revoked authorizations for GMM %d"
 msgstr "Ingetrokken machtigingen voor ALV %d"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:64
+#: module/Decision/view/decision/admin/authorizations.phtml:75
 msgid "Revoked"
 msgstr "Ingetrokken"
 
-#: module/Decision/view/decision/admin/authorizations.phtml:79
+#: module/Decision/view/decision/admin/authorizations.phtml:90
 msgid "There are no revoked authorizations for this GMM."
 msgstr "Er zijn geen ingetrokken machtigingen voor deze ALV."
 
-#: module/Decision/view/decision/admin/authorizations.phtml:82
+#: module/Decision/view/decision/admin/authorizations.phtml:93
 msgid "Please select a GMM to view authorizations."
 msgstr "Selecteer een ALV om machtigingen te bekijken."
 
-#: module/Decision/view/decision/admin/document.phtml:18
+#: module/Decision/view/decision/admin/document.phtml:33
 msgid "There are no meetings for which you can upload documents."
 msgstr "Er zijn geen vergaderingen waarvoor je documenten kunt uploaden."
 
-#: module/Decision/view/decision/admin/document.phtml:22
+#: module/Decision/view/decision/admin/document.phtml:37
 msgid "Meeting document uploaded"
 msgstr "Vergaderstuk geupload"
 
-#: module/Decision/view/decision/admin/document.phtml:48
+#: module/Decision/view/decision/admin/document.phtml:62
 msgid "No meeting available."
 msgstr "Geen vergaderingen beschikbaar."
 
-#: module/Decision/view/decision/admin/document.phtml:89
+#: module/Decision/view/decision/admin/document.phtml:103
 msgid "Documents for this meeting"
 msgstr "Documenten voor deze vergadering"
 
-#: module/Decision/view/decision/admin/document.phtml:92
+#: module/Decision/view/decision/admin/document.phtml:106
 msgid "This meeting does not have any associated documents."
 msgstr "Voor deze vergadering zijn geen documenten beschikbaar."
 
-#: module/Decision/view/decision/admin/document.phtml:131
-#: module/Decision/view/decision/admin/document.phtml:194
+#: module/Decision/view/decision/admin/document.phtml:145
+#: module/Decision/view/decision/admin/document.phtml:208
 msgid "Rename"
 msgstr "Hernoem"
 
-#: module/Decision/view/decision/admin/document.phtml:149
-#: module/Education/view/education/admin/course-documents.phtml:153
+#: module/Decision/view/decision/admin/document.phtml:163
+#: module/Education/view/education/admin/course-documents.phtml:163
 msgid "Delete Document"
 msgstr "Verwijder document"
 
-#: module/Decision/view/decision/admin/document.phtml:181
+#: module/Decision/view/decision/admin/document.phtml:195
 msgid "Rename Meeting Document"
 msgstr "Hernoem vergaderstuk"
 
-#: module/Decision/view/decision/admin/document.phtml:184
+#: module/Decision/view/decision/admin/document.phtml:198
 msgid "Enter a new name for this document:"
 msgstr "Voor een nieuwe naam in voor dit document:"
 
-#: module/Decision/view/decision/admin/minutes.phtml:44
+#: module/Decision/view/decision/admin/minutes.phtml:55
 msgid "Upload"
 msgstr "Upload"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:18
+#: module/Decision/view/decision/decision/authorizations.phtml:36
 msgid ""
 "There are no upcoming meetings for which you can authorize someone.\n"
 "You may still be able to authorize someone or revoke an authorization by "
@@ -3802,12 +3798,12 @@ msgstr ""
 "Mogelijk kun je nog wel iemand machtigen of een machtiging intrekken door "
 "contact op te nemen met het bestuur."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:22
+#: module/Decision/view/decision/decision/authorizations.phtml:40
 #, php-format
 msgid "You have authorized %s for the %s GMM (%s)."
 msgstr "Je hebt %s gemachtigd voor de %s ALV (%s)."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:29
+#: module/Decision/view/decision/decision/authorizations.phtml:47
 #, php-format
 msgid ""
 "As per HR article 5 paragraph 4, you have the right to revoke your "
@@ -3822,12 +3818,12 @@ msgstr ""
 "een machtiging die via deze website is verleend via onderstaand formulier "
 "intrekken."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:45
-#: module/Decision/view/decision/decision/authorizations.phtml:100
+#: module/Decision/view/decision/decision/authorizations.phtml:63
+#: module/Decision/view/decision/decision/authorizations.phtml:118
 msgid "Terms"
 msgstr "Voorwaarden"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:50
+#: module/Decision/view/decision/decision/authorizations.phtml:68
 #, php-format
 msgid ""
 "I, %s am fully aware that by revoking my authorization, %s cannot represent "
@@ -3837,17 +3833,17 @@ msgstr ""
 "machtiging, %s mij niet kan vertegenwoordigen op de %s Algemene "
 "Ledenvergadering (%s) der s.v. GEWIS."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:71
+#: module/Decision/view/decision/decision/authorizations.phtml:89
 #, php-format
 msgid "Authorize someone for the %s GMM (%s)"
 msgstr "Machtig iemand voor de %s ALV (%s)"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:87
-#: module/User/view/user/user/login.phtml:15
+#: module/Decision/view/decision/decision/authorizations.phtml:105
+#: module/User/view/user/user/login.phtml:29
 msgid "Member"
 msgstr "Lid"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:105
+#: module/Decision/view/decision/decision/authorizations.phtml:123
 #, php-format
 msgid ""
 "I, %s I am fully aware that by filling in this form I authorize the person "
@@ -3858,11 +3854,11 @@ msgstr ""
 "formulier de persoon op dit formulier machtig om mij te vertegenwoordigen op "
 "de %s Algemene Ledenvergadering (%s) der s.v. GEWIS."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:157
+#: module/Decision/view/decision/decision/authorizations.phtml:175
 msgid "Are you sure you would like to authorize"
 msgstr "Weet je zeker dat je wilt machtigen"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:163
+#: module/Decision/view/decision/decision/authorizations.phtml:181
 msgid ""
 "This member has already received 2 or more authorizations through the "
 "website. Since you can only use two authorizations at the same time, this "
@@ -3878,110 +3874,144 @@ msgstr ""
 "wordt. Als je iemand anders wilt machtigen, klik dan op \"annuleer\"; als je "
 "deze person toch wilt machtigen, klik dan op \"bevestig machtiging\"."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:169
+#: module/Decision/view/decision/decision/authorizations.phtml:187
 msgid "Confirm authorization"
 msgstr "Bevestig machtiging"
 
-#: module/Decision/view/decision/decision/authorizations.phtml:193
+#: module/Decision/view/decision/decision/authorizations.phtml:211
 #, php-format
 msgid "Are you sure you would like to authorize %s"
 msgstr "Weet je zeker dat je %s wilt machtigen"
 
-#: module/Decision/view/decision/decision/files.phtml:14
-#: module/Decision/view/decision/decision/files.phtml:16
-#: module/Decision/view/decision/decision/files.phtml:35
-#: module/Decision/view/decision/decision/files.phtml:39
+#: module/Decision/view/decision/decision/files.phtml:26
+#: module/Decision/view/decision/decision/files.phtml:28
+#: module/Decision/view/decision/decision/files.phtml:47
+#: module/Decision/view/decision/decision/files.phtml:51
 msgid "Root"
 msgstr "Root"
 
-#: module/Decision/view/decision/decision/files.phtml:35
+#: module/Decision/view/decision/decision/files.phtml:47
 msgid "Public Archive"
 msgstr "Openbaar Archief"
 
-#: module/Decision/view/decision/decision/files.phtml:39
+#: module/Decision/view/decision/decision/files.phtml:51
 msgid "Browsing directory: "
 msgstr "Huidige map: "
 
-#: module/Decision/view/decision/decision/files.phtml:66
+#: module/Decision/view/decision/decision/files.phtml:78
 msgid "Filename"
 msgstr "Bestandsnaam"
 
-#: module/Decision/view/decision/decision/files.phtml:80
+#: module/Decision/view/decision/decision/files.phtml:92
 msgid ".. Move up a folder"
 msgstr ".. Ga map omhoog"
 
-#: module/Decision/view/decision/decision/files.phtml:89
+#: module/Decision/view/decision/decision/files.phtml:101
 msgid "Empty folder"
 msgstr "Lege map"
 
-#: module/Decision/view/decision/decision/index.phtml:10
+#: module/Decision/view/decision/decision/index.phtml:24
 msgid "Meeting number"
 msgstr "Vergadernummer"
 
-#: module/Decision/view/decision/decision/index.phtml:11
-#: module/Decision/view/decision/member/birthdays.phtml:11
-#: module/Education/view/education/admin/course-documents.phtml:55
-#: module/Education/view/education/admin/course-documents.phtml:106
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:26
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:99
+#: module/Decision/view/decision/decision/index.phtml:25
+#: module/Decision/view/decision/member/birthdays.phtml:22
+#: module/Education/view/education/admin/course-documents.phtml:65
+#: module/Education/view/education/admin/course-documents.phtml:116
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:41
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:114
 msgid "Date"
 msgstr "Datum"
 
-#: module/Decision/view/decision/decision/index.phtml:12
+#: module/Decision/view/decision/decision/index.phtml:26
 msgid "# Decisions"
 msgstr "# Besluiten"
 
-#: module/Decision/view/decision/decision/search.phtml:3
+#: module/Decision/view/decision/decision/search.phtml:14
 msgid "Search for decision"
 msgstr "Zoek besluit"
 
-#: module/Decision/view/decision/decision/view.phtml:35
+#: module/Decision/view/decision/decision/search.phtml:50
+msgid "No decisions were found."
+msgstr "Er zijn geen besluiten gevonden."
+
+#: module/Decision/view/decision/decision/search.phtml:52
+msgid "Check the spelling of your search term"
+msgstr "Controleer de spelling van je zoekterm"
+
+#: module/Decision/view/decision/decision/search.phtml:53
+msgid "Try alternate words or selections"
+msgstr "Probeer alternatieve woorden of selecties"
+
+#: module/Decision/view/decision/decision/search.phtml:54
+msgid "Try using a more generic search term"
+msgstr "Probeer een meer algemene zoekterm te gebruiken"
+
+#: module/Decision/view/decision/decision/search.phtml:55
+msgid "Try entering fewer keywords"
+msgstr "Probeer minder trefwoorden in te voeren"
+
+#: module/Decision/view/decision/decision/search.phtml:56
+msgid ""
+"Looking for a specific decision but forgot the numbers? Try dropping the "
+"decision point and/or number"
+msgstr ""
+"Op zoek naar een specifiek besluit maar de nummers vergeten? Probeer het "
+"zonder besluitspunt en/of -nummer"
+
+#: module/Decision/view/decision/decision/view.phtml:47
 msgid "No documents have been added."
 msgstr "Er zijn geen documenten toegevoegd."
 
-#: module/Decision/view/decision/decision/view.phtml:50
+#: module/Decision/view/decision/decision/view.phtml:62
 #, php-format
 msgid "View the minutes of the %s"
 msgstr "Geef de notulen van de %s weer"
 
-#: module/Decision/view/decision/decision/view.phtml:59
+#: module/Decision/view/decision/decision/view.phtml:71
 msgid "Decisions"
 msgstr "Besluiten"
 
-#: module/Decision/view/decision/member/birthdays.phtml:3
+#: module/Decision/view/decision/member/birthdays.phtml:14
 msgid "Birthdays"
 msgstr "Verjaardagen"
 
-#: module/Decision/view/decision/member/birthdays.phtml:13
+#: module/Decision/view/decision/member/birthdays.phtml:24
 msgid "Age"
 msgstr "Leeftijd"
 
-#: module/Decision/view/decision/member/birthdays.phtml:33
+#: module/Decision/view/decision/member/birthdays.phtml:44
 msgid "years"
 msgstr "jaren"
 
-#: module/Decision/view/decision/member/index.phtml:22
+#: module/Decision/view/decision/member/index.phtml:33
 msgid "Personal"
 msgstr "Persoonlijk"
 
-#: module/Decision/view/decision/member/index.phtml:26
+#: module/Decision/view/decision/member/index.phtml:37
 msgid "Profile"
 msgstr "Profiel"
 
-#: module/Decision/view/decision/member/index.phtml:67
+#: module/Decision/view/decision/member/index.phtml:78
 msgid "Public archive"
 msgstr "Openbaar Archief"
 
-#: module/Decision/view/decision/member/index.phtml:72
+#: module/Decision/view/decision/member/index.phtml:83
 msgid "Find a member"
 msgstr "Vind een lid"
 
-#: module/Decision/view/decision/member/index.phtml:107
+#: module/Decision/view/decision/member/index.phtml:106
+msgid "Upcoming meeting"
+msgid_plural "Upcoming meetings"
+msgstr[0] "Aankomende vergadering"
+msgstr[1] "Aankomende vergaderingen"
+
+#: module/Decision/view/decision/member/index.phtml:118
 #, php-format
 msgid "The %s%s %s%s will be held on %s."
 msgstr "De %s%s %s%s zal plaatsvinden op %s."
 
-#: module/Decision/view/decision/member/index.phtml:133
+#: module/Decision/view/decision/member/index.phtml:144
 #, php-format
 msgid ""
 "If you aren't able to attend a GMM in person but you want your voice to be "
@@ -3991,108 +4021,108 @@ msgstr ""
 "toch dat je stem wordt gehoord, overweeg dan %seen ander lid%s te machtigen "
 "om jou te vertegenwoordingen."
 
-#: module/Decision/view/decision/member/index.phtml:141
+#: module/Decision/view/decision/member/index.phtml:152
 msgid "Search through the list of decisions accumulated from past meetings:"
 msgstr "Doorzoek de lijst van alle beslissingen van eerdere vergaderingen:"
 
-#: module/Decision/view/decision/member/index.phtml:144
+#: module/Decision/view/decision/member/index.phtml:155
 msgid "Search by keyword or meeting number"
 msgstr "Zoek met trefwoord of vergaderingsnummer"
 
-#: module/Decision/view/decision/member/index.phtml:151
+#: module/Decision/view/decision/member/index.phtml:162
 #, php-format
 msgid "The latest %s that took place:"
 msgstr "De laatste %s die plaatsvond:"
 
-#: module/Decision/view/decision/member/index.phtml:163
+#: module/Decision/view/decision/member/index.phtml:174
 #, php-format
 msgid "%s %s on %s"
 msgstr "%s %s op %s"
 
-#: module/Decision/view/decision/member/index.phtml:178
+#: module/Decision/view/decision/member/index.phtml:189
 msgid "View all meetings"
 msgstr "Toon alle vergaderingen"
 
-#: module/Decision/view/decision/member/index.phtml:183
-#: module/Decision/view/decision/organ/show.phtml:9
-#: module/Frontpage/view/frontpage/organ/organ.phtml:129
+#: module/Decision/view/decision/member/index.phtml:194
+#: module/Decision/view/decision/organ/show.phtml:25
+#: module/Frontpage/view/frontpage/organ/organ.phtml:145
 msgid "Active members"
 msgstr "Actieve leden"
 
-#: module/Decision/view/decision/member/index.phtml:184
+#: module/Decision/view/decision/member/index.phtml:195
 msgid "A list of helpful resources for active members."
 msgstr "Een lijst met nuttige pagina's voor actieve leden."
 
-#: module/Decision/view/decision/member/index.phtml:188
+#: module/Decision/view/decision/member/index.phtml:199
 msgid "Webmail"
 msgstr "Webmail"
 
-#: module/Decision/view/decision/member/index.phtml:200
+#: module/Decision/view/decision/member/index.phtml:211
 msgid "GEWIKI"
 msgstr "GEWIKI"
 
-#: module/Decision/view/decision/member/index.phtml:204
+#: module/Decision/view/decision/member/index.phtml:215
 msgid "Corporate Identity"
 msgstr "Huisstijl"
 
-#: module/Decision/view/decision/member/index.phtml:208
+#: module/Decision/view/decision/member/index.phtml:219
 msgid "Administrator"
 msgstr "Administrator"
 
-#: module/Decision/view/decision/member/index.phtml:226
+#: module/Decision/view/decision/member/index.phtml:237
 msgid "Bylaws"
 msgstr "Statuten"
 
-#: module/Decision/view/decision/member/index.phtml:238
+#: module/Decision/view/decision/member/index.phtml:249
 msgid "Internal Regulations"
 msgstr "Huishoudelijk reglement"
 
-#: module/Decision/view/decision/member/index.phtml:253
+#: module/Decision/view/decision/member/index.phtml:264
 msgid "Board Policies"
 msgstr "Beleidsnota's"
 
-#: module/Decision/view/decision/member/index.phtml:258
+#: module/Decision/view/decision/member/index.phtml:269
 msgid "Borrel Policy"
 msgstr "Borrelreglement"
 
-#: module/Decision/view/decision/member/index.phtml:263
+#: module/Decision/view/decision/member/index.phtml:274
 msgid "House Rules"
 msgstr "Huisregels"
 
-#: module/Decision/view/decision/member/index.phtml:268
+#: module/Decision/view/decision/member/index.phtml:279
 msgid "ICT Policy"
 msgstr "ICT-reglement"
 
-#: module/Decision/view/decision/member/index.phtml:273
+#: module/Decision/view/decision/member/index.phtml:284
 msgid "Key Policy"
 msgstr "Sleutelreglement"
 
-#: module/Decision/view/decision/member/index.phtml:278
+#: module/Decision/view/decision/member/index.phtml:289
 msgid "Poster Policy"
 msgstr "Posterbeleid"
 
-#: module/Decision/view/decision/member/index.phtml:289
+#: module/Decision/view/decision/member/index.phtml:300
 msgid "Organ Regulations"
 msgstr "Orgaanreglementen"
 
-#: module/Decision/view/decision/member/search.phtml:3
-#: module/Decision/view/decision/member/search.phtml:9
+#: module/Decision/view/decision/member/search.phtml:10
+#: module/Decision/view/decision/member/search.phtml:16
 msgid "Zoeken op lid"
 msgstr "Zoeken op lid"
 
-#: module/Decision/view/decision/member/search.phtml:13
+#: module/Decision/view/decision/member/search.phtml:20
 msgid "Zoek"
 msgstr "Zoek"
 
-#: module/Decision/view/decision/member/search.phtml:23
+#: module/Decision/view/decision/member/search.phtml:30
 msgid "Naam"
 msgstr "Naam"
 
-#: module/Decision/view/decision/member/search.phtml:24
+#: module/Decision/view/decision/member/search.phtml:31
 msgid "Generatie"
 msgstr "Generatie"
 
-#: module/Decision/view/decision/member/search.phtml:31
+#: module/Decision/view/decision/member/search.phtml:38
 msgid ""
 "Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
 "resultaten te zien."
@@ -4100,52 +4130,52 @@ msgstr ""
 "Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
 "resultaten te zien."
 
-#: module/Decision/view/decision/member/self.phtml:10
+#: module/Decision/view/decision/member/self.phtml:20
 msgid "My Information"
 msgstr "Mijn informatie"
 
-#: module/Decision/view/decision/member/self.phtml:19
-#: module/User/src/Form/Register.php:34 module/User/src/Form/UserReset.php:32
+#: module/Decision/view/decision/member/self.phtml:29
+#: module/User/src/Form/Register.php:32 module/User/src/Form/UserReset.php:30
 msgid "Membership number"
 msgstr "Lidmaatschapsnummer"
 
-#: module/Decision/view/decision/member/self.phtml:23
+#: module/Decision/view/decision/member/self.phtml:33
 msgid "Initials"
 msgstr "Initialen"
 
-#: module/Decision/view/decision/member/self.phtml:27
+#: module/Decision/view/decision/member/self.phtml:37
 msgid "First name"
 msgstr "Voornaam"
 
-#: module/Decision/view/decision/member/self.phtml:31
-#: module/User/src/Model/Enums/JWTClaims.php:43
+#: module/Decision/view/decision/member/self.phtml:41
+#: module/User/src/Model/Enums/JWTClaims.php:45
 msgid "Middle name"
 msgstr "Tussenvoegsels"
 
-#: module/Decision/view/decision/member/self.phtml:35
+#: module/Decision/view/decision/member/self.phtml:45
 msgid "Last name"
 msgstr "Achternaam"
 
-#: module/Decision/view/decision/member/self.phtml:50
-#: module/Decision/view/decision/member/view.phtml:46
+#: module/Decision/view/decision/member/self.phtml:60
+#: module/Decision/view/decision/member/view.phtml:45
 msgid "Birth date"
 msgstr "Geboortedatum"
 
-#: module/Decision/view/decision/member/self.phtml:58
-#: module/Decision/view/decision/member/view.phtml:55
-#: module/User/src/Model/Enums/JWTClaims.php:42
+#: module/Decision/view/decision/member/self.phtml:68
+#: module/Decision/view/decision/member/view.phtml:54
+#: module/User/src/Model/Enums/JWTClaims.php:44
 msgid "Membership type"
 msgstr "Type lidmaatschap"
 
-#: module/Decision/view/decision/member/self.phtml:62
+#: module/Decision/view/decision/member/self.phtml:72
 msgid "Last membership change"
 msgstr "Laatste wijziging lidmaatschap"
 
-#: module/Decision/view/decision/member/self.phtml:66
+#: module/Decision/view/decision/member/self.phtml:76
 msgid "End date of membership"
 msgstr "Einddatum van lidmaatschap"
 
-#: module/Decision/view/decision/member/self.phtml:73
+#: module/Decision/view/decision/member/self.phtml:83
 msgid ""
 "If your information is no longer up to date and you would like to change it, "
 "you can contact the secretary of GEWIS."
@@ -4153,148 +4183,148 @@ msgstr ""
 "Als je gegevens niet meer actueel zijn of je ze wilt ze laten wijzigen, neem "
 "dan contact op met de secretaris van GEWIS."
 
-#: module/Decision/view/decision/member/self.phtml:74
+#: module/Decision/view/decision/member/self.phtml:84
 msgid "Also for data removal requests, you can contact"
 msgstr "Ook als je gegevens wilt laten verwijderen, neem dan contact op met"
 
-#: module/Decision/view/decision/member/self.phtml:75
+#: module/Decision/view/decision/member/self.phtml:85
 msgid "Email the secretary of GEWIS"
 msgstr "Email de secretaris van GEWIS"
 
-#: module/Decision/view/decision/member/self.phtml:75
+#: module/Decision/view/decision/member/self.phtml:85
 msgid "the secretary of GEWIS"
 msgstr "de secretaris van GEWIS"
 
-#: module/Decision/view/decision/member/self.phtml:79
-#: module/Decision/view/decision/member/view.phtml:127
+#: module/Decision/view/decision/member/self.phtml:89
+#: module/Decision/view/decision/member/view.phtml:117
 msgid "Memberships of committees and fraternities"
 msgstr "Lidmaatschappen van commissies en disputen"
 
-#: module/Decision/view/decision/member/self.phtml:84
+#: module/Decision/view/decision/member/self.phtml:94
 msgid "You have not been a member of a committee or fraternity."
 msgstr "Je bent geen lid geweest van een commissie of dispuut."
 
-#: module/Decision/view/decision/member/self.phtml:87
+#: module/Decision/view/decision/member/self.phtml:97
 msgid "You are currently a member of:"
 msgstr "Je bent momenteel lid van:"
 
-#: module/Decision/view/decision/member/self.phtml:108
+#: module/Decision/view/decision/member/self.phtml:121
 msgid "You were a member of:"
 msgstr "Je was een lid van:"
 
-#: module/Decision/view/decision/member/self.phtml:129
-#: module/Decision/view/decision/member/view.phtml:192
+#: module/Decision/view/decision/member/self.phtml:145
+#: module/Decision/view/decision/member/view.phtml:188
 msgid "Addresses"
 msgstr "Adressen"
 
-#: module/Decision/view/decision/member/self.phtml:134
-#: module/Decision/view/decision/member/view.phtml:197
+#: module/Decision/view/decision/member/self.phtml:150
+#: module/Decision/view/decision/member/view.phtml:193
 msgid "Country"
 msgstr "Land"
 
-#: module/Decision/view/decision/member/self.phtml:138
-#: module/Decision/view/decision/member/view.phtml:201
+#: module/Decision/view/decision/member/self.phtml:154
+#: module/Decision/view/decision/member/view.phtml:197
 msgid "Street and number"
 msgstr "Straat en huisnummer"
 
-#: module/Decision/view/decision/member/self.phtml:141
-#: module/Decision/view/decision/member/self.phtml:151
-#: module/Decision/view/decision/member/view.phtml:204
-#: module/Decision/view/decision/member/view.phtml:214
+#: module/Decision/view/decision/member/self.phtml:157
+#: module/Decision/view/decision/member/self.phtml:167
+#: module/Decision/view/decision/member/view.phtml:200
+#: module/Decision/view/decision/member/view.phtml:210
 #, php-format
 msgid "%s %s"
 msgstr "%s %s"
 
-#: module/Decision/view/decision/member/self.phtml:148
-#: module/Decision/view/decision/member/view.phtml:211
+#: module/Decision/view/decision/member/self.phtml:164
+#: module/Decision/view/decision/member/view.phtml:207
 msgid "City and postal code"
 msgstr "Woonplaats en postcode"
 
-#: module/Decision/view/decision/member/self.phtml:164
+#: module/Decision/view/decision/member/self.phtml:180
 msgid "External applications"
 msgstr "Externe applicaties"
 
-#: module/Decision/view/decision/member/self.phtml:167
+#: module/Decision/view/decision/member/self.phtml:183
 msgid "App"
 msgstr "App"
 
-#: module/Decision/view/decision/member/self.phtml:168
+#: module/Decision/view/decision/member/self.phtml:184
 msgid "First authentication"
 msgstr "Eerste authenticatie"
 
-#: module/Decision/view/decision/member/self.phtml:169
+#: module/Decision/view/decision/member/self.phtml:185
 msgid "Last authentication"
 msgstr "Laatste authenticatie"
 
-#: module/Decision/view/decision/member/self.phtml:214
+#: module/Decision/view/decision/member/self.phtml:230
 msgid "Remove this picture as your profile picture"
 msgstr "Verwijder deze foto als profielfoto"
 
-#: module/Decision/view/decision/member/self.phtml:216
+#: module/Decision/view/decision/member/self.phtml:232
 msgid "Your profile picture will be chosen automatically instead."
 msgstr "Jouw profiel foto wordt in plaats hiervan automatisch gekozen."
 
-#: module/Decision/view/decision/member/self.phtml:231
+#: module/Decision/view/decision/member/self.phtml:247
 msgid "More of my photo's"
 msgstr "Meer van mijn foto’s"
 
-#: module/Decision/view/decision/member/view.phtml:59
+#: module/Decision/view/decision/member/view.phtml:58
 msgid "Has key code?"
 msgstr "Heeft sleutelcode?"
 
-#: module/Decision/view/decision/member/view.phtml:89
+#: module/Decision/view/decision/member/view.phtml:79
 #, php-format
 msgid "%s is the upcoming <strong>%s</strong>."
 msgstr "%s is de aankomende <strong>%s</strong>."
 
-#: module/Decision/view/decision/member/view.phtml:105
+#: module/Decision/view/decision/member/view.phtml:95
 #, php-format
 msgid "%s is currently the <strong>%s</strong>."
 msgstr "%s is de huidige <strong>%s</strong>."
 
-#: module/Decision/view/decision/member/view.phtml:115
+#: module/Decision/view/decision/member/view.phtml:105
 #, php-format
 msgid "%s was the <strong>%s</strong> during the association year %d/%d."
 msgstr "%s was de <strong>%s</strong> gedurende het verenigingsjaar %d/%d."
 
-#: module/Decision/view/decision/member/view.phtml:134
+#: module/Decision/view/decision/member/view.phtml:124
 #, php-format
 msgid "%s has never been part of a committee or fraternity."
 msgstr "%s is geen lid geweest van een commissie of dispuut."
 
-#: module/Decision/view/decision/member/view.phtml:142
+#: module/Decision/view/decision/member/view.phtml:132
 #, php-format
 msgid "%s is currently a member of:"
 msgstr "%s is momenteel lid van:"
 
-#: module/Decision/view/decision/member/view.phtml:168
+#: module/Decision/view/decision/member/view.phtml:161
 #, php-format
 msgid "%s was a member of:"
 msgstr "%s is lid geweest van:"
 
-#: module/Decision/view/decision/member/view.phtml:266
+#: module/Decision/view/decision/member/view.phtml:262
 #, php-format
 msgid "Photo's of %s"
 msgstr "Foto's van %s"
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:64
+#: module/Decision/view/decision/organ-admin/edit.phtml:75
 msgid "Edit organ information"
 msgstr "Bewerk orgaan informatie"
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:139
+#: module/Decision/view/decision/organ-admin/edit.phtml:150
 msgid ""
 "To optimally display your image on the overview page, please crop it below"
 msgstr ""
 "Om deze afbeelding optimaal weer te kunnen geven op commissies pagina, moet "
 "deze bijgesneden worden"
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:155
+#: module/Decision/view/decision/organ-admin/edit.phtml:166
 msgid "To optimally display your image your page, please crop it below"
 msgstr ""
 "Om deze afbeelding optimaal weer te kunnen geven op je persoonlijke "
 "commissie pagina, moet deze bijgesneden worden"
 
-#: module/Decision/view/decision/organ-admin/index.phtml:6
+#: module/Decision/view/decision/organ-admin/index.phtml:18
 msgid ""
 "Select an organ to edit its information. Changes will not be displayed until "
 "they have been approved."
@@ -4302,110 +4332,110 @@ msgstr ""
 "Selecteer een orgaan om de informatie te wijzigen. Wijzigingen worden niet "
 "getoond totdat deze goedgekeurd zijn."
 
-#: module/Decision/view/decision/organ-admin/index.phtml:13
+#: module/Decision/view/decision/organ-admin/index.phtml:25
 msgid "Approval status"
 msgstr "Goedkeuringsstatus"
 
-#: module/Decision/view/decision/organ/index.phtml:6
+#: module/Decision/view/decision/organ/index.phtml:15
 msgid "Organ list"
 msgstr "Organen"
 
-#: module/Decision/view/decision/organ/show.phtml:32
+#: module/Decision/view/decision/organ/show.phtml:50
 msgid "Inactive members"
 msgstr "Inactieve leden"
 
-#: module/Decision/view/decision/organ/show.phtml:43
+#: module/Decision/view/decision/organ/show.phtml:61
 msgid "Old members"
 msgstr "Oud leden"
 
-#: module/Decision/view/decision/organ/show.phtml:52
+#: module/Decision/view/decision/organ/show.phtml:70
 msgid "Organ mutations"
 msgstr "Mutaties in orgaan"
 
-#: module/Education/src/Controller/AdminController.php:43
+#: module/Education/src/Controller/AdminController.php:41
 msgid "You are not allowed to administer education settings"
 msgstr "Je hebt niet de rechten om onderwijsinstellingen te beheren"
 
-#: module/Education/src/Controller/AdminController.php:53
+#: module/Education/src/Controller/AdminController.php:51
 msgid "You are not allowed to administer courses"
 msgstr "Je hebt niet de rechten om vakken te beheren"
 
-#: module/Education/src/Controller/AdminController.php:62
-#: module/Education/src/Service/Exam.php:482
+#: module/Education/src/Controller/AdminController.php:60
+#: module/Education/src/Service/Exam.php:473
 msgid "You are not allowed to add courses"
 msgstr "Je hebt niet de rechten om vakken toe te voegen"
 
-#: module/Education/src/Controller/AdminController.php:78
+#: module/Education/src/Controller/AdminController.php:76
 msgid "Successfully added course!"
 msgstr "Vak succesvol toegevoegd!"
 
-#: module/Education/src/Controller/AdminController.php:84
-#: module/Education/src/Controller/AdminController.php:127
+#: module/Education/src/Controller/AdminController.php:83
+#: module/Education/src/Controller/AdminController.php:125
 msgid "An error occurred while saving the course!"
 msgstr "Er is een fout opgetreden tijdens het opslaan van het vak!"
 
-#: module/Education/src/Controller/AdminController.php:100
-#: module/Education/src/Controller/AdminController.php:164
+#: module/Education/src/Controller/AdminController.php:98
+#: module/Education/src/Controller/AdminController.php:162
 msgid "You are not allowed to edit courses"
 msgstr "Je hebt niet de rechten om vakken te wijzigen"
 
-#: module/Education/src/Controller/AdminController.php:123
+#: module/Education/src/Controller/AdminController.php:121
 msgid "Successfully updated course information!"
 msgstr "Vakinformatie succesvol aangepast!"
 
-#: module/Education/src/Controller/AdminController.php:142
+#: module/Education/src/Controller/AdminController.php:140
 msgid "You are not allowed to delete courses"
 msgstr "Je hebt niet de rechten om vakken te verwijderen"
 
-#: module/Education/src/Controller/AdminController.php:185
+#: module/Education/src/Controller/AdminController.php:183
 msgid "You are not allowed to delete course documents"
 msgstr "Je hebt niet de rechten om documenten van vakken te verwijderen"
 
-#: module/Education/src/Form/Bulk.php:45
+#: module/Education/src/Form/Bulk.php:43
 msgid "Finalize uploads"
 msgstr "Rond uploaden af"
 
-#: module/Education/src/Form/Bulk.php:66
+#: module/Education/src/Form/Bulk.php:64
 msgid "Course does not exist"
 msgstr "Vak bestaat niet"
 
-#: module/Education/src/Form/Course.php:32
-#: module/Education/src/Form/Fieldset/Exam.php:48
-#: module/Education/src/Form/Fieldset/Summary.php:50
-#: module/Education/view/education/education/index.phtml:65
+#: module/Education/src/Form/Course.php:33
+#: module/Education/src/Form/Fieldset/Exam.php:47
+#: module/Education/src/Form/Fieldset/Summary.php:47
+#: module/Education/view/education/education/index.phtml:91
 msgid "Course code"
 msgstr "Vakcode"
 
-#: module/Education/src/Form/Course.php:52
+#: module/Education/src/Form/Course.php:53
 msgid "Add course"
 msgstr "Vak toevoegen"
 
-#: module/Education/src/Form/Course.php:83
+#: module/Education/src/Form/Course.php:84
 msgid "There already exists a course with this code"
 msgstr "Er bestaat al een vak met deze code"
 
-#: module/Education/src/Form/Fieldset/Exam.php:58
+#: module/Education/src/Form/Fieldset/Exam.php:57
 msgid "Exam date"
 msgstr "Datum tentamen"
 
-#: module/Education/src/Form/Fieldset/Exam.php:85
-#: module/Education/src/Form/Fieldset/Summary.php:81
-#: module/Education/view/education/admin/course-documents.phtml:61
-#: module/Education/view/education/admin/course-documents.phtml:112
+#: module/Education/src/Form/Fieldset/Exam.php:84
+#: module/Education/src/Form/Fieldset/Summary.php:78
+#: module/Education/view/education/admin/course-documents.phtml:71
+#: module/Education/view/education/admin/course-documents.phtml:122
 msgid "Language"
 msgstr "Taal"
 
-#: module/Education/src/Form/Fieldset/Exam.php:99
-#: module/Education/src/Form/Fieldset/Summary.php:95
+#: module/Education/src/Form/Fieldset/Exam.php:98
+#: module/Education/src/Form/Fieldset/Summary.php:92
 msgid "Scanned?"
 msgstr "Gescand?"
 
-#: module/Education/src/Form/Fieldset/Summary.php:60
+#: module/Education/src/Form/Fieldset/Summary.php:57
 msgid "Summary date"
 msgstr "Datum van samenvatting"
 
-#: module/Education/src/Form/Fieldset/Summary.php:71
-#: module/Education/view/education/admin/course-documents.phtml:109
+#: module/Education/src/Form/Fieldset/Summary.php:68
+#: module/Education/view/education/admin/course-documents.phtml:119
 #: module/Frontpage/src/Form/PollComment.php:27
 msgid "Author"
 msgstr "Auteur"
@@ -4414,96 +4444,96 @@ msgstr "Auteur"
 msgid "Exam to upload"
 msgstr "Tentamen"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:20
+#: module/Education/src/Model/Enums/ExamTypes.php:25
 msgid "Final"
 msgstr "Eindexamen"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:21
+#: module/Education/src/Model/Enums/ExamTypes.php:26
 msgid "Interim"
 msgstr "Tussentijdse toets"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:22
+#: module/Education/src/Model/Enums/ExamTypes.php:27
 msgid "Answers"
 msgstr "Antwoorden"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:23
+#: module/Education/src/Model/Enums/ExamTypes.php:28
 msgid "Other"
 msgstr "Anders"
 
-#: module/Education/src/Service/Exam.php:91
+#: module/Education/src/Service/Exam.php:98
 msgid "You are not allowed to download course documents"
 msgstr "Je hebt niet de rechten om documenten van vakken te downloaden"
 
-#: module/Education/src/Service/Exam.php:320
+#: module/Education/src/Service/Exam.php:318
 msgid "You are not allowed to delete exams"
 msgstr "Je hebt niet de rechten om tentamens te verwijderen"
 
-#: module/Education/src/Service/Exam.php:339
-#: module/Education/src/Service/Exam.php:464
+#: module/Education/src/Service/Exam.php:334
+#: module/Education/src/Service/Exam.php:456
 msgid "You are not allowed to upload exams"
 msgstr "Het is niet toegestaan om tentamens te uploaden"
 
-#: module/Education/view/education/admin/add-course.phtml:5
+#: module/Education/view/education/admin/add-course.phtml:17
 msgid "Add"
 msgstr "Voeg toe"
 
-#: module/Education/view/education/admin/add-course.phtml:16
-#: module/Education/view/education/admin/course.phtml:19
+#: module/Education/view/education/admin/add-course.phtml:28
+#: module/Education/view/education/admin/course.phtml:31
 msgid "Add Course"
 msgstr "Vak toevoegen"
 
-#: module/Education/view/education/admin/bulk-exam.phtml:12
+#: module/Education/view/education/admin/bulk-exam.phtml:20
 msgid "Upload Exams"
 msgstr "Upload tentamens"
 
-#: module/Education/view/education/admin/bulk-exam.phtml:27
+#: module/Education/view/education/admin/bulk-exam.phtml:35
 msgid "Finalize exam uploads"
 msgstr "Rond uploaden tentamens af"
 
-#: module/Education/view/education/admin/bulk-summary.phtml:12
+#: module/Education/view/education/admin/bulk-summary.phtml:20
 msgid "Upload Summaries"
 msgstr "Upload samenvattingen"
 
-#: module/Education/view/education/admin/bulk-summary.phtml:27
+#: module/Education/view/education/admin/bulk-summary.phtml:35
 msgid "Finalize summary uploads"
 msgstr "Rond uploaden samenvattingen af"
 
-#: module/Education/view/education/admin/course-documents.phtml:37
+#: module/Education/view/education/admin/course-documents.phtml:47
 #, php-format
 msgid "Course Documents of %s"
 msgstr "Documenten van %s"
 
-#: module/Education/view/education/admin/course-documents.phtml:47
-#: module/Education/view/education/education/index.phtml:22
+#: module/Education/view/education/admin/course-documents.phtml:57
+#: module/Education/view/education/education/index.phtml:36
 msgid "Exams"
 msgstr "Tentamens"
 
-#: module/Education/view/education/admin/course-documents.phtml:90
-#: module/Education/view/education/admin/course-documents.phtml:139
+#: module/Education/view/education/admin/course-documents.phtml:100
+#: module/Education/view/education/admin/course-documents.phtml:149
 msgid "This course does not have any exams."
 msgstr "Deze cursus heeft geen examens."
 
-#: module/Education/view/education/admin/course-documents.phtml:98
+#: module/Education/view/education/admin/course-documents.phtml:108
 msgid "Summaries"
 msgstr "Samenvattingen"
 
-#: module/Education/view/education/admin/course-documents.phtml:157
+#: module/Education/view/education/admin/course-documents.phtml:167
 msgid "Are you sure you want to delete this document?"
 msgstr "Weet je zeker dat u dit document wilt verwijderen?"
 
-#: module/Education/view/education/admin/course.phtml:10
+#: module/Education/view/education/admin/course.phtml:22
 msgid "Course Admin"
 msgstr "Vak administratie"
 
-#: module/Education/view/education/admin/course.phtml:29
+#: module/Education/view/education/admin/course.phtml:41
 msgid "Code"
 msgstr "Code"
 
-#: module/Education/view/education/admin/course.phtml:75
+#: module/Education/view/education/admin/course.phtml:87
 msgid "Delete Course"
 msgstr "Verwijder vak"
 
-#: module/Education/view/education/admin/course.phtml:81
+#: module/Education/view/education/admin/course.phtml:93
 #, php-format
 msgid ""
 "Are you sure you want to delete %s? This will also delete all associated "
@@ -4512,26 +4542,26 @@ msgstr ""
 "Weet je zeker dat je %s wilt verwijderen? Dan worden ook alle bijbehorende "
 "examens en samenvattingen verwijderd."
 
-#: module/Education/view/education/admin/edit-course.phtml:23
+#: module/Education/view/education/admin/edit-course.phtml:37
 msgid "Edit Course"
 msgstr "Bewerk vak"
 
-#: module/Education/view/education/admin/edit-exam.phtml:19
+#: module/Education/view/education/admin/edit-exam.phtml:32
 msgid "Edit Exam"
 msgstr "Bewerk examen"
 
-#: module/Education/view/education/admin/edit-exam.phtml:22
+#: module/Education/view/education/admin/edit-exam.phtml:35
 msgid "Upload of all exams was finished."
 msgstr "Het uploaden van alle tentamens is klaar."
 
-#: module/Education/view/education/admin/edit-exam.phtml:24
+#: module/Education/view/education/admin/edit-exam.phtml:37
 msgid "There are no exams to be edited. Upload exams to edit them."
 msgstr ""
 "Er zijn geen tentamens om te wijzigen. Upload nieuwe tentamens om deze "
 "correct in de Website te zetten."
 
-#: module/Education/view/education/admin/edit-exam.phtml:115
-#: module/Education/view/education/admin/edit-summary.phtml:117
+#: module/Education/view/education/admin/edit-exam.phtml:128
+#: module/Education/view/education/admin/edit-summary.phtml:130
 msgid ""
 "Check this if the document is scanned, as this will enable higher quality "
 "downloads. Please note that enabling setting this for non-scanned documents "
@@ -4542,80 +4572,86 @@ msgstr ""
 "voor niet-gescande documenten de mogelijkheid om het document te downloaden "
 "aanzienlijk zal beïnvloeden."
 
-#: module/Education/view/education/admin/edit-summary.phtml:19
+#: module/Education/view/education/admin/edit-summary.phtml:32
 msgid "Edit Summary"
 msgstr "Bewerk samenvatting"
 
-#: module/Education/view/education/admin/edit-summary.phtml:22
+#: module/Education/view/education/admin/edit-summary.phtml:35
 msgid "Upload of all summaries was finished."
 msgstr "Het uploaden van alle tentamens is klaar."
 
-#: module/Education/view/education/admin/edit-summary.phtml:24
+#: module/Education/view/education/admin/edit-summary.phtml:37
 msgid "There are no summaries to be edited. Upload exams to edit them."
 msgstr ""
 "Er zijn geen samenvattingen om te wijzigen. Upload nieuwe samenvattingen om "
 "deze correct in de Website te zetten."
 
-#: module/Education/view/education/admin/index.phtml:5
+#: module/Education/view/education/admin/index.phtml:13
 msgid "Education admin"
 msgstr "Onderwijs admin"
 
-#: module/Education/view/education/education/course.phtml:23
+#: module/Education/view/education/education/course.phtml:33
 msgid "Exams and summaries"
 msgstr "Tentamens en samenvattingen"
 
-#: module/Education/view/education/education/course.phtml:34
+#: module/Education/view/education/education/course.phtml:44
 #, php-format
 msgid "Summary by %s on %s (%s)"
 msgstr "Samenvatting door %s van %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:43
+#: module/Education/view/education/education/course.phtml:53
 #, php-format
 msgid "Summary on %s (%s)"
 msgstr "Samenvatting van %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:54
+#: module/Education/view/education/education/course.phtml:64
 #, php-format
 msgid "Final test from %s (%s)"
 msgstr "Eindexamen op %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:57
+#: module/Education/view/education/education/course.phtml:67
 #, php-format
 msgid "Interim test from %s (%s)"
 msgstr "Tussentijdse toets op %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:60
+#: module/Education/view/education/education/course.phtml:70
 #, php-format
 msgid "Answers from %s (%s)"
 msgstr "Antwoorden van %s (%s)"
 
-#: module/Education/view/education/education/course.phtml:63
+#: module/Education/view/education/education/course.phtml:73
 #, php-format
 msgid "Other exam material from %s (%s)"
 msgstr "Ander tentamenmateriaal van %s (%s)"
 
-#: module/Education/view/education/education/index.phtml:41
+#: module/Education/view/education/education/index.phtml:54
 msgid "Course code or course description"
 msgstr "Vak code of omschrijving"
 
-#: module/Education/view/education/education/index.phtml:58
+#: module/Education/view/education/education/index.phtml:76
 #, php-format
-msgid "Found %d course(s) matching your description"
-msgstr "%d vak(ken) gevonden welke aan je zoektermen voldoen"
+msgid "Found %d %s matching your description"
+msgstr "%d %s gevonden overeenkomend met je zoektermen"
 
-#: module/Education/view/education/education/index.phtml:66
+#: module/Education/view/education/education/index.phtml:79
+msgid "course"
+msgid_plural "courses"
+msgstr[0] "vak"
+msgstr[1] "vakken"
+
+#: module/Education/view/education/education/index.phtml:92
 msgid "Course name"
 msgstr "Vak naam"
 
-#: module/Education/view/education/education/index.phtml:67
+#: module/Education/view/education/education/index.phtml:93
 msgid "Available documents"
 msgstr "Beschikbare documenten"
 
-#: module/Education/view/education/education/index.phtml:78
+#: module/Education/view/education/education/index.phtml:104
 msgid "View available documents"
 msgstr "Bekijk beschikbare documenten"
 
-#: module/Education/view/education/education/index.phtml:97
+#: module/Education/view/education/education/index.phtml:123
 #, php-format
 msgid ""
 "Do you want to contribute to the collection of old exams and summaries? Send "
@@ -4625,44 +4661,44 @@ msgstr ""
 "samenvatting naar de %sonderwijs commissaris%s zodat je (toekomstige) "
 "studiegenoten er van kunnen profiteren."
 
-#: module/Education/view/education/education/index.phtml:98
-#: module/Education/view/education/education/index.phtml:156
+#: module/Education/view/education/education/index.phtml:124
+#: module/Education/view/education/education/index.phtml:182
 msgid "Mail the education officer"
 msgstr "E-mail de onderwijscommissaris"
 
-#: module/Education/view/education/education/index.phtml:106
+#: module/Education/view/education/education/index.phtml:132
 msgid "For old exams of minor courses, you can also look at:"
 msgstr "Voor oude tentamens of minor vakken kun je ook terecht bij:"
 
-#: module/Education/view/education/education/index.phtml:109
+#: module/Education/view/education/education/index.phtml:135
 msgid "Applied Physics"
 msgstr "Technische Natuurkunde"
 
-#: module/Education/view/education/education/index.phtml:112
+#: module/Education/view/education/education/index.phtml:138
 msgid "Biomedical Engineering"
 msgstr "Biomedische Technologie"
 
-#: module/Education/view/education/education/index.phtml:115
+#: module/Education/view/education/education/index.phtml:141
 msgid "Electrical Engineering"
 msgstr "Electrical Engineering"
 
-#: module/Education/view/education/education/index.phtml:118
+#: module/Education/view/education/education/index.phtml:144
 msgid "Chemical Engineering"
 msgstr "Scheikundige Technologie"
 
-#: module/Education/view/education/education/index.phtml:121
+#: module/Education/view/education/education/index.phtml:147
 msgid "Innovation Sciences"
 msgstr "Innovation Sciences"
 
-#: module/Education/view/education/education/index.phtml:128
+#: module/Education/view/education/education/index.phtml:154
 msgid "Useful links"
 msgstr "Handige links"
 
-#: module/Education/view/education/education/index.phtml:133
+#: module/Education/view/education/education/index.phtml:159
 msgid "Books"
 msgstr "Boeken"
 
-#: module/Education/view/education/education/index.phtml:136
+#: module/Education/view/education/education/index.phtml:162
 msgid ""
 "Order your course books via GEWIS to receive a discount. Specific ordering "
 "deadlines and pickup dates will be timely communicated to you via an email."
@@ -4670,19 +4706,19 @@ msgstr ""
 "Bestel je boeken met korting via GEWIS. Specifieke bestel deadlines en "
 "ophaaltijden worden tijdig naar je gecommuniceerd via de e-mail."
 
-#: module/Education/view/education/education/index.phtml:139
+#: module/Education/view/education/education/index.phtml:165
 msgid "Visit the webshop"
 msgstr "Bezoek de webshop"
 
-#: module/Education/view/education/education/index.phtml:141
+#: module/Education/view/education/education/index.phtml:167
 msgid "Visit webshop"
 msgstr "Bezoek webshop"
 
-#: module/Education/view/education/education/index.phtml:149
+#: module/Education/view/education/education/index.phtml:175
 msgid "Complaint or suggestion about TU/e education?"
 msgstr "Klacht of suggestie over TU/e onderwijs?"
 
-#: module/Education/view/education/education/index.phtml:155
+#: module/Education/view/education/education/index.phtml:181
 #, php-format
 msgid ""
 "Do you have a complaint or suggestion concerning the education at the TU/e? "
@@ -4691,11 +4727,11 @@ msgstr ""
 "Heb je een klacht of een suggestie over het onderwijs aan de TU/e? Neem dan "
 "contact op met de %sonderwijscommissaris%s om je feedback te delen."
 
-#: module/Education/view/education/education/index.phtml:166
+#: module/Education/view/education/education/index.phtml:192
 msgid "Disclaimer on educational content"
 msgstr "Disclaimer over onderwijsinhoud"
 
-#: module/Education/view/education/education/index.phtml:171
+#: module/Education/view/education/education/index.phtml:197
 msgid ""
 "The exams on the website of GEWIS are provided by Education & Student "
 "Affairs of the department of Mathematics and Computer Science of the TU/e."
@@ -4703,7 +4739,7 @@ msgstr ""
 "De tentamens op de site van GEWIS zijn verstrekt door Education & Student "
 "Affairs van de faculteit Wiskunde en Informatica van de TU/e."
 
-#: module/Education/view/education/education/index.phtml:172
+#: module/Education/view/education/education/index.phtml:198
 msgid ""
 "If an exam has been put online without the intention of the author, please "
 "let the board of GEWIS know by sending an"
@@ -4711,15 +4747,15 @@ msgstr ""
 "Mocht er onbedoeld een tentamen online zijn gekomen dat niet gepubliceerd "
 "had mogen worden, laat dit dan weten aan het bestuur van GEWIS door"
 
-#: module/Education/view/education/education/index.phtml:173
+#: module/Education/view/education/education/index.phtml:199
 msgid "Email the board of GEWIS"
 msgstr "Email het bestuur van GEWIS"
 
-#: module/Education/view/education/education/index.phtml:173
+#: module/Education/view/education/education/index.phtml:199
 msgid "email to the board of GEWIS"
 msgstr "een mail te sturen naar het bestuur van GEWIS"
 
-#: module/Education/view/education/education/index.phtml:174
+#: module/Education/view/education/education/index.phtml:200
 msgid ""
 "then this exam will be removed from the website. Using the summaries or "
 "exams on this website for commercial goals without the permission of the "
@@ -4730,102 +4766,102 @@ msgstr ""
 "toestemming van de auteur te gebruiken voor commerciële doeleinden, dit is "
 "strafbaar."
 
-#: module/Frontpage/src/Controller/InfimumController.php:24
+#: module/Frontpage/src/Controller/InfimumController.php:26
 msgid "You are not allowed to view infima"
 msgstr "Je hebt niet de rechten om infima te bekijken"
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:53
+#: module/Frontpage/src/Controller/NewsAdminController.php:51
 msgid "You are not allowed to create news items"
 msgstr "Je hebt niet de rechten om nieuwsberichten toe te voegen"
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:90
+#: module/Frontpage/src/Controller/NewsAdminController.php:88
 msgid "You are not allowed to edit news items"
 msgstr "Je hebt niet de rechten om nieuwsberichten te wijzigen"
 
-#: module/Frontpage/src/Controller/NewsAdminController.php:135
+#: module/Frontpage/src/Controller/NewsAdminController.php:133
 msgid "You are not allowed to delete news items"
 msgstr "Je hebt niet de rechten om nieuwsberichten te verwijderen"
 
-#: module/Frontpage/src/Controller/PageAdminController.php:35
-#: module/Frontpage/src/Service/Page.php:110
+#: module/Frontpage/src/Controller/PageAdminController.php:31
+#: module/Frontpage/src/Service/Page.php:107
 msgid "You are not allowed to view the list of pages."
 msgstr "Je hebt niet de rechten om de lijst met pagina's te bekijken."
 
-#: module/Frontpage/src/Controller/PageAdminController.php:50
-#: module/Frontpage/src/Service/Page.php:270
+#: module/Frontpage/src/Controller/PageAdminController.php:46
+#: module/Frontpage/src/Service/Page.php:260
 msgid "You are not allowed to create new pages."
 msgstr "Je hebt niet de rechten om nieuw pagina's te maken."
 
-#: module/Frontpage/src/Controller/PageAdminController.php:81
-#: module/Frontpage/src/Service/Page.php:201
+#: module/Frontpage/src/Controller/PageAdminController.php:77
+#: module/Frontpage/src/Service/Page.php:193
 msgid "You are not allowed to edit pages."
 msgstr "Je hebt niet de rechten om pagina's te wijzigen."
 
-#: module/Frontpage/src/Controller/PageAdminController.php:108
+#: module/Frontpage/src/Controller/PageAdminController.php:104
 msgid "You are not allowed to delete pages."
 msgstr "Je hebt niet de rechten om pagina's te verwijderen."
 
-#: module/Frontpage/src/Controller/PageAdminController.php:125
+#: module/Frontpage/src/Controller/PageAdminController.php:121
 msgid "You are not allowed to upload images."
 msgstr "Het is niet toegestaan om foto's te uploaden."
 
-#: module/Frontpage/src/Controller/PollAdminController.php:34
+#: module/Frontpage/src/Controller/PollAdminController.php:32
 msgid "You are not allowed to administer polls"
 msgstr "Je hebt niet de rechten om poll-instellingen te beheren"
 
-#: module/Frontpage/src/Controller/PollAdminController.php:66
+#: module/Frontpage/src/Controller/PollAdminController.php:64
 msgid "You are not allowed to approve polls"
 msgstr "Je hebt niet de rechten om polls goed te keuren"
 
-#: module/Frontpage/src/Controller/PollAdminController.php:98
+#: module/Frontpage/src/Controller/PollAdminController.php:96
 msgid "You are not allowed to delete polls"
 msgstr "Je hebt niet de rechten om polls te verwijderen"
 
-#: module/Frontpage/src/Controller/PollController.php:97
+#: module/Frontpage/src/Controller/PollController.php:96
 msgid "You are not allowed to create comments on this poll"
 msgstr "Je hebt niet de rechten om commentaar te geven op de poll"
 
 #: module/Frontpage/src/Form/NewsItem.php:27
-#: module/Frontpage/src/Form/Page.php:51
+#: module/Frontpage/src/Form/Page.php:49
 msgid "Dutch title"
 msgstr "Nederlandse titel"
 
 #: module/Frontpage/src/Form/NewsItem.php:37
-#: module/Frontpage/src/Form/Page.php:61
+#: module/Frontpage/src/Form/Page.php:59
 msgid "English title"
 msgstr "Engelse titel"
 
 #: module/Frontpage/src/Form/NewsItem.php:47
-#: module/Frontpage/src/Form/Page.php:71
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:60
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:92
+#: module/Frontpage/src/Form/Page.php:69
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:73
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:104
 msgid "Dutch content"
 msgstr "Nederlandse inhoud"
 
 #: module/Frontpage/src/Form/NewsItem.php:57
-#: module/Frontpage/src/Form/Page.php:81
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:36
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:68
+#: module/Frontpage/src/Form/Page.php:79
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:49
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:80
 msgid "English content"
 msgstr "Engelse inhoud"
 
-#: module/Frontpage/src/Form/Page.php:91
+#: module/Frontpage/src/Form/Page.php:89
 msgid "Required role"
 msgstr "Verplichte rol"
 
 #: module/Frontpage/src/Form/Poll.php:28
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:24
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:36
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:97
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:109
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:51
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:124
 msgid "Dutch question"
 msgstr "Nederlandse vraag"
 
 #: module/Frontpage/src/Form/Poll.php:38
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:25
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:98
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:40
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:54
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:113
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:127
 msgid "English question"
 msgstr "Engelse vraag"
 
@@ -4834,8 +4870,8 @@ msgid "Expiration date for the poll (YYYY-MM-DD)"
 msgstr "Verloopdatum van de poll (JJJJ-MM-DD)"
 
 #: module/Frontpage/src/Form/PollApproval.php:36
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:213
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:201
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:227
 msgid "Approve poll"
 msgstr "Keur poll goed"
 
@@ -4847,36 +4883,36 @@ msgstr "Inhoud"
 msgid "Comment"
 msgstr "Commentaar"
 
-#: module/Frontpage/src/Service/News.php:47
+#: module/Frontpage/src/Service/News.php:45
 msgid "You are not allowed to list all news items."
 msgstr "Je hebt niet de rechten om alle nieuws items te bekijken."
 
-#: module/Frontpage/src/Service/Page.php:61
+#: module/Frontpage/src/Service/Page.php:56
 msgid "You are not allowed to view this page."
 msgstr "Je hebt niet de rechten om deze pagina te bekijken."
 
-#: module/Frontpage/src/Service/Page.php:250
-#: module/Photo/src/Service/Admin.php:189
+#: module/Frontpage/src/Service/Page.php:244
+#: module/Photo/src/Service/Admin.php:212
 msgid "The uploaded file does not have a valid extension"
 msgstr "Het geuploade bestand heeft geen valide extensie"
 
-#: module/Frontpage/src/Service/Page.php:255
+#: module/Frontpage/src/Service/Page.php:249
 msgid "The uploaded file is not a valid image"
 msgstr "Het geuploade bestand is geen valide plaatje"
 
-#: module/Frontpage/src/Service/Poll.php:72
+#: module/Frontpage/src/Service/Poll.php:71
 msgid "You are not allowed to view unapproved polls"
 msgstr "Je hebt niet de rechten om niet-goedgekeurde polls te bekijken"
 
-#: module/Frontpage/src/Service/Poll.php:192
+#: module/Frontpage/src/Service/Poll.php:183
 msgid "You are not allowed to vote on this poll."
 msgstr "Je hebt niet de rechten om op deze poll te stemmen."
 
-#: module/Frontpage/src/Service/Poll.php:347
+#: module/Frontpage/src/Service/Poll.php:329
 msgid "You are not allowed to request polls"
 msgstr "Je hebt niet de rechten om polls aan te vragen"
 
-#: module/Frontpage/view/frontpage/admin/index.phtml:1
+#: module/Frontpage/view/frontpage/admin/index.phtml:10
 msgid ""
 "Welcome to the admin interface of the GEWIS website. If you are experiencing "
 "any issues or have a question, please contact the ApplicatieBeheerCommissie."
@@ -4885,15 +4921,15 @@ msgstr ""
 "ondervindt of een vraag hebt, neem dan contact op met de "
 "ApplicatieBeheerCommissie."
 
-#: module/Frontpage/view/frontpage/admin/index.phtml:3
+#: module/Frontpage/view/frontpage/admin/index.phtml:12
 msgid "Recent changes"
 msgstr "Recente wijzigingen"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:29
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:47
 msgid "Studievereniging GEWIS"
 msgstr "Studievereniging GEWIS"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:31
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:49
 msgid ""
 "Welcome to the website of Study association GEWIS, the study association of "
 "the department of Mathematics & Computer Science of the Eindhoven University "
@@ -4902,86 +4938,86 @@ msgstr ""
 "Welkom op de website van Studievereniging GEWIS. De studievereniging van de "
 "faculteit Wiskunde & Informatica aan de Technische Universiteit Eindhoven."
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:130
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:148
 msgid "Verjaardagen"
 msgstr "Verjaardagen"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:135
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:153
 #, php-format
 msgid "%s wil be %s years old today!"
 msgstr "%s wordt vandaag %s jaar oud!"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:150
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:168
 msgid "Agenda"
 msgstr "Agenda"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:167
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:185
 #, php-format
 msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
 msgstr "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:176
-#: module/Frontpage/view/frontpage/organ/organ.phtml:120
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:194
+#: module/Frontpage/view/frontpage/organ/organ.phtml:136
 msgid "Complete agenda"
 msgstr "Volledige agenda"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:180
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:198
 msgid "Google Calendar"
 msgstr "Google Calendar"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:264
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
 msgid "Poll"
 msgstr "Poll"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:277
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:296
 msgid "View details"
 msgstr "Bekijk details"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:301
 msgid "There currently is no poll."
 msgstr "Er is op het moment geen poll."
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:286
-#: module/Frontpage/view/frontpage/poll/request.phtml:162
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:305
+#: module/Frontpage/view/frontpage/poll/request.phtml:174
 msgid "Request poll"
 msgstr "Vraag poll aan"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:289
-#: module/Frontpage/view/frontpage/poll/index.phtml:20
+#: module/Frontpage/view/frontpage/frontpage/home.phtml:308
+#: module/Frontpage/view/frontpage/poll/index.phtml:39
 msgid "Old polls"
 msgstr "Oude polls"
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:88
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:101
 msgid "Pin news item"
 msgstr "Nieuws item vastzetten"
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:90
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:103
 msgid "Select this if you want this news item to stay at the top of the page."
 msgstr "Selecteer dit als je wil dat je nieuws item bovenaan de pagina blijft."
 
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:105
+#: module/Frontpage/view/frontpage/news-admin/edit.phtml:118
 msgid "Delete this news item"
 msgstr "Verwijder dit nieuwsitem"
 
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:5
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:16
 msgid "News items"
 msgstr "Nieuws items"
 
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:6
+#: module/Frontpage/view/frontpage/news-admin/list.phtml:17
 msgid "Create news item"
 msgstr "Maak een nieuw nieuwsitem"
 
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:10
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:21
 msgid "GEWIS has many different committees, learn more about them below!"
 msgstr ""
 "GEWIS heeft veel verschillende commissies, zie hieronder voor meer "
 "informatie!"
 
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:16
+#: module/Frontpage/view/frontpage/organ/committee-list.phtml:27
 msgid "Information for committees"
 msgstr "Informatie voor commissies"
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:8
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:20
 msgid ""
 "Study association GEWIS obviously has several fraternities which contribute "
 "to the atmosphere at GEWIS and organize fun activities. Some fraternities "
@@ -4991,48 +5027,48 @@ msgstr ""
 "aan de goede atmosfeer bij GEWIS en leuke activiteiten organiseren. Sommige "
 "disputen zijn in ruste."
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:9
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:21
 msgid "The currently active fraternities of GEWIS (in arbitrary order)"
 msgstr "De huidige disputen van GEWIS zijn (in willekeurige volgorde):"
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:24
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:36
 msgid "Retired fraternities"
 msgstr "Disputen in ruste"
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:25
+#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:37
 msgid "The following fraternities have retired:"
 msgstr "De volgende disputen zijn in ruste:"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:51
+#: module/Frontpage/view/frontpage/organ/organ.phtml:67
 msgid "GMM Committees"
 msgstr "ALV-Commissies"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:53
+#: module/Frontpage/view/frontpage/organ/organ.phtml:69
 msgid "GMM Taskforces"
 msgstr "ALV-Werkgroepen"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:55
+#: module/Frontpage/view/frontpage/organ/organ.phtml:71
 msgid "Financial Audit Committees"
 msgstr "Kas Controle Commissies"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:57
+#: module/Frontpage/view/frontpage/organ/organ.phtml:73
 msgid "Advisory Boards"
 msgstr "Raden van Advies"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:106
+#: module/Frontpage/view/frontpage/organ/organ.phtml:122
 #, php-format
 msgid "%s's activities"
 msgstr "Activiteiten door %s"
 
-#: module/Frontpage/view/frontpage/organ/organ.phtml:152
+#: module/Frontpage/view/frontpage/organ/organ.phtml:168
 msgid "Login to view more information"
 msgstr "Log in om meer informatie te zien"
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:36
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:48
 msgid "URL options"
 msgstr "URL opties"
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:49
 msgid ""
 "Make this page available at the following URL. Providing a category is "
 "required."
@@ -5040,136 +5076,136 @@ msgstr ""
 "Maak deze pagina beschikbaar op de volgende URL. Het is verplicht om een "
 "categorie te specificeren."
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:116
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:128
 msgid "Permissions"
 msgstr "Rechten"
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:139
+#: module/Frontpage/view/frontpage/page-admin/edit.phtml:151
 msgid "Delete this page"
 msgstr "Verwijder deze pagina"
 
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:17
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:29
 msgid "Create a new page"
 msgstr "Maak een nieuwe pagina"
 
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:19
+#: module/Frontpage/view/frontpage/page-admin/index.phtml:31
 msgid "Or select a page to edit below."
 msgstr "Of selecteer hieronder een pagina om te wijzigen."
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:19
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:34
 msgid "Polls awaiting approval"
 msgstr "Niet goedgekeurde polls"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:28
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:101
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:43
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:116
 msgid "Approver"
 msgstr "Goedgekeurd door"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:45
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:118
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:60
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:133
 msgid "Dutch option"
 msgstr "Nederlandse optie"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:46
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:119
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:61
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:134
 msgid "English option"
 msgstr "Engelse optie"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:80
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:95
 msgid "Approved polls"
 msgstr "Goedgekeurde polls"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:163
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:178
 msgid "Are you sure you want to delete this poll?"
 msgstr "Weet je zeker dat je deze poll wilt verwijderen?"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:169
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:184
 msgid "Delete poll"
 msgstr "Verwijder poll"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:189
+#: module/Frontpage/view/frontpage/poll-admin/list.phtml:204
 msgid "Are you sure that you want to approve this poll?"
 msgstr "Weet je zeker dat je deze poll wilt goedkeuren?"
 
-#: module/Frontpage/view/frontpage/poll/history.phtml:3
+#: module/Frontpage/view/frontpage/poll/history.phtml:14
 msgid "Poll history"
 msgstr "Poll historie"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:22
+#: module/Frontpage/view/frontpage/poll/index.phtml:41
 #, php-format
 msgid "%sRequest a poll%s"
 msgstr "%sVraag een poll aan%s"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:37
+#: module/Frontpage/view/frontpage/poll/index.phtml:56
 msgid "Unfortunately there currently is no poll :("
 msgstr "Helaas is er op het moment geen poll :("
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:42
+#: module/Frontpage/view/frontpage/poll/index.phtml:61
 msgid "Comments"
 msgstr "Commentaar"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:44
+#: module/Frontpage/view/frontpage/poll/index.phtml:63
 msgid "This poll has no comments"
 msgstr "Deze poll heeft geen commentaar"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:65
+#: module/Frontpage/view/frontpage/poll/index.phtml:84
 msgid "Comment on this poll"
 msgstr "Commentaar op deze poll"
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:3
-#: module/Frontpage/view/frontpage/poll/request.phtml:7
+#: module/Frontpage/view/frontpage/poll/request.phtml:14
+#: module/Frontpage/view/frontpage/poll/request.phtml:19
 msgid "Request a poll"
 msgstr "Vraag een poll aan"
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:9
+#: module/Frontpage/view/frontpage/poll/request.phtml:21
 msgid "Your poll request has been received and will be reviewed shortly."
 msgstr "Je poll is aangevraagd en zal zo snel mogelijk bekeken worden."
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:146
+#: module/Frontpage/view/frontpage/poll/request.phtml:158
 msgid "Remove option"
 msgstr "Verwijder optie"
 
-#: module/Frontpage/view/frontpage/poll/request.phtml:151
+#: module/Frontpage/view/frontpage/poll/request.phtml:163
 msgid "Add option"
 msgstr "Voeg optie toe"
 
-#: module/Frontpage/view/partial/poll.phtml:40
-#: module/Frontpage/view/partial/poll.phtml:51
+#: module/Frontpage/view/partial/poll.phtml:61
+#: module/Frontpage/view/partial/poll.phtml:72
 #, php-format
 msgid "%d votes"
 msgstr "%d stemmen"
 
-#: module/Frontpage/view/partial/poll.phtml:40
-#: module/Frontpage/view/partial/poll.phtml:51
+#: module/Frontpage/view/partial/poll.phtml:61
+#: module/Frontpage/view/partial/poll.phtml:72
 msgid "1 vote"
 msgstr "1 stem"
 
-#: module/Photo/src/Controller/AlbumController.php:49
-#: module/Photo/src/Service/Album.php:123
+#: module/Photo/src/Controller/AlbumController.php:50
+#: module/Photo/src/Service/Album.php:122
 msgid "Not allowed to view albums without dates"
 msgstr "Het is niet toegestaan om albums te zien zonder data"
 
-#: module/Photo/src/Controller/ApiController.php:48
+#: module/Photo/src/Controller/ApiController.php:50
 msgid "Not allowed to view photo details"
 msgstr "Het is niet toegestaan om details van foto's te zien"
 
-#: module/Photo/src/Controller/PhotoController.php:38
-#: module/Photo/src/Service/Album.php:70 module/Photo/src/Service/Album.php:100
-#: module/Photo/src/Service/Album.php:239
-#: module/Photo/src/Service/Album.php:253
+#: module/Photo/src/Controller/PhotoController.php:44
+#: module/Photo/src/Service/Album.php:67 module/Photo/src/Service/Album.php:99
+#: module/Photo/src/Service/Album.php:234
+#: module/Photo/src/Service/Album.php:248
 msgid "Not allowed to view albums"
 msgstr "Het is niet toegestaan om albums te zien"
 
-#: module/Photo/src/Controller/PhotoController.php:85
-#: module/Photo/src/Service/Photo.php:93
+#: module/Photo/src/Controller/PhotoController.php:91
+#: module/Photo/src/Service/Photo.php:95
 msgid "Not allowed to download photos"
 msgstr "Het is niet toegestaan om foto's te downloaden"
 
-#: module/Photo/src/Controller/PhotoController.php:100
+#: module/Photo/src/Controller/PhotoController.php:106
 msgid "Not allowed to view previous photos of the week"
 msgstr "Not allowed to view previous photos of the week"
 
-#: module/Photo/src/Controller/PhotoController.php:157
+#: module/Photo/src/Controller/PhotoController.php:163
 msgid "Not allowed to vote for a photo of the week"
 msgstr "Het is niet toegestaan om te stemmen voor een foto van de week"
 
@@ -5183,7 +5219,7 @@ msgstr "Het is niet toegestaan om tags te verwijderen."
 
 #: module/Photo/src/Form/CreateAlbum.php:25
 #: module/Photo/src/Form/EditAlbum.php:27
-#: module/Photo/view/photo/album-admin/create.phtml:16
+#: module/Photo/view/photo/album-admin/create.phtml:28
 msgid "Album title"
 msgstr "Album titel"
 
@@ -5195,15 +5231,15 @@ msgstr "Maak"
 msgid "End date"
 msgstr "Einddatum"
 
-#: module/Photo/src/Service/Admin.php:58
+#: module/Photo/src/Service/Admin.php:66
 msgid "Not allowed to add photos."
 msgstr "Het is niet toegestaan om foto's toe te voegen."
 
-#: module/Photo/src/Service/Admin.php:172
+#: module/Photo/src/Service/Admin.php:185
 msgid "An unknown error occurred during uploading ("
 msgstr "Een onbekende error vond plaats tijdens het uploaden van ("
 
-#: module/Photo/src/Service/Admin.php:195
+#: module/Photo/src/Service/Admin.php:201
 #, php-format
 msgid ""
 "The uploaded file is not a valid image \n"
@@ -5212,222 +5248,222 @@ msgstr ""
 "Het geuploade bestand is geen valide plaatje \n"
 "Error: %s"
 
-#: module/Photo/src/Service/Admin.php:211
+#: module/Photo/src/Service/Admin.php:225
 msgid "Not allowed to upload photos."
 msgstr "Het is niet toegestaan om foto's te uploaden."
 
-#: module/Photo/src/Service/Album.php:194
+#: module/Photo/src/Service/Album.php:191
 msgid "Not allowed to create albums"
 msgstr "Het is niet toegestaan om albums te maken"
 
-#: module/Photo/src/Service/Album.php:218
+#: module/Photo/src/Service/Album.php:213
 msgid "Not allowed to create albums."
 msgstr "Het is niet toegestaan om albums te maken."
 
-#: module/Photo/src/Service/Album.php:331
+#: module/Photo/src/Service/Album.php:327
 #, php-format
 msgid "Photos of the Week in %d/%d"
 msgstr "Foto's van de Week in %d/%d"
 
-#: module/Photo/src/Service/Album.php:360
+#: module/Photo/src/Service/Album.php:358
 msgid "Not allowed to edit albums"
 msgstr "Het is niet toegestaan om albums te wijzigen"
 
-#: module/Photo/src/Service/Album.php:379
+#: module/Photo/src/Service/Album.php:376
 msgid "Not allowed to edit albums."
 msgstr "Het is niet toegestaan om albums te wijzigen."
 
-#: module/Photo/src/Service/Album.php:404
+#: module/Photo/src/Service/Album.php:401
 msgid "Not allowed to move albums"
 msgstr "Het is niet toegestaan om albums te verplaatsen"
 
-#: module/Photo/src/Service/Album.php:438
+#: module/Photo/src/Service/Album.php:435
 msgid "Not allowed to delete albums."
 msgstr "Het is niet toegestaan om albums te verwijderen."
 
-#: module/Photo/src/Service/Album.php:459
+#: module/Photo/src/Service/Album.php:456
 msgid "Not allowed to generate album covers."
 msgstr "Het is niet toegestaan om albums-covers opnieuw te genereren."
 
-#: module/Photo/src/Service/Album.php:507
+#: module/Photo/src/Service/Album.php:504
 msgid "Not allowed to move photos"
 msgstr "Het is niet toegestaan om foto's te verplaatsen"
 
-#: module/Photo/src/Service/Photo.php:67 module/Photo/src/Service/Photo.php:112
-#: module/Photo/src/Service/Photo.php:154
-#: module/Photo/src/Service/Photo.php:205
-#: module/Photo/src/Service/Photo.php:221
+#: module/Photo/src/Service/Photo.php:73 module/Photo/src/Service/Photo.php:114
+#: module/Photo/src/Service/Photo.php:159
+#: module/Photo/src/Service/Photo.php:210
+#: module/Photo/src/Service/Photo.php:226
 msgid "Not allowed to view photos"
 msgstr "Het is niet toegestaan om foto's te zien"
 
-#: module/Photo/src/Service/Photo.php:239
+#: module/Photo/src/Service/Photo.php:245
 msgid "Not allowed to delete photos."
 msgstr "Het is niet toegestaan om foto's te verwijderen."
 
-#: module/Photo/src/Service/Photo.php:669
-#: module/Photo/src/Service/Photo.php:731
+#: module/Photo/src/Service/Photo.php:623
+#: module/Photo/src/Service/Photo.php:672
 msgid "Not allowed to view tags."
 msgstr "Het is niet toegestaan om tags te zien."
 
-#: module/Photo/view/partial/metadata.phtml:6
+#: module/Photo/view/partial/metadata.phtml:19
 msgid "Artist"
 msgstr "Artiest"
 
-#: module/Photo/view/partial/metadata.phtml:13
+#: module/Photo/view/partial/metadata.phtml:26
 msgid "Camera"
 msgstr "Camera"
 
-#: module/Photo/view/partial/metadata.phtml:20
+#: module/Photo/view/partial/metadata.phtml:33
 msgid "Date/time"
 msgstr "Datum/tijd"
 
-#: module/Photo/view/partial/metadata.phtml:27
+#: module/Photo/view/partial/metadata.phtml:40
 msgid "Flash"
 msgstr "Flits"
 
-#: module/Photo/view/partial/metadata.phtml:34
+#: module/Photo/view/partial/metadata.phtml:47
 msgid "Focal length"
 msgstr "Brandpuntsafstand"
 
-#: module/Photo/view/partial/metadata.phtml:41
+#: module/Photo/view/partial/metadata.phtml:54
 msgid "Exposure time"
 msgstr "Belichtingstijd"
 
-#: module/Photo/view/partial/metadata.phtml:48
+#: module/Photo/view/partial/metadata.phtml:61
 msgid "Shutter speed"
 msgstr "Sluitertijd"
 
-#: module/Photo/view/partial/metadata.phtml:55
+#: module/Photo/view/partial/metadata.phtml:68
 msgid "Aperture"
 msgstr "Aperture"
 
-#: module/Photo/view/partial/metadata.phtml:62
+#: module/Photo/view/partial/metadata.phtml:75
 msgid "ISO"
 msgstr "ISO"
 
-#: module/Photo/view/partial/metadata.phtml:75
+#: module/Photo/view/partial/metadata.phtml:95
 msgid "View on map"
 msgstr "Toon op kaart"
 
-#: module/Photo/view/partial/tags.phtml:10
-#: module/Photo/view/photo/album/index.phtml:665
+#: module/Photo/view/partial/tags.phtml:22
+#: module/Photo/view/photo/album/index.phtml:674
 msgid "In this photo:"
 msgstr "In deze foto:"
 
-#: module/Photo/view/partial/tags.phtml:11
-#: module/Photo/view/photo/album/index.phtml:666
+#: module/Photo/view/partial/tags.phtml:23
+#: module/Photo/view/photo/album/index.phtml:675
 msgid ""
 "No one has been tagged in this photo yet. Tag someone you recognise now!"
 msgstr "Er is nog niemand getagd in deze foto. Tag nu iemand die je herkent!"
 
-#: module/Photo/view/partial/tags.phtml:49
-#: module/Photo/view/photo/album/index.phtml:694
+#: module/Photo/view/partial/tags.phtml:61
+#: module/Photo/view/photo/album/index.phtml:703
 msgid "Tag someone"
 msgstr "Tag iemand"
 
-#: module/Photo/view/photo/album-admin/add.phtml:29
+#: module/Photo/view/photo/album-admin/add.phtml:41
 msgid "Upload Photos"
 msgstr "Foto's uploaden"
 
-#: module/Photo/view/photo/album-admin/add.phtml:31
+#: module/Photo/view/photo/album-admin/add.phtml:43
 #, php-format
 msgid "Uploading photos to %s"
 msgstr "Foto's aan het uploaden naar %s"
 
-#: module/Photo/view/photo/album-admin/create.phtml:4
+#: module/Photo/view/photo/album-admin/create.phtml:16
 msgid "Create Album"
 msgstr "Album maken"
 
-#: module/Photo/view/photo/album-admin/create.phtml:25
+#: module/Photo/view/photo/album-admin/create.phtml:37
 msgid "Create album"
 msgstr "Nieuw album"
 
-#: module/Photo/view/photo/album-admin/edit.phtml:4
+#: module/Photo/view/photo/album-admin/edit.phtml:16
 msgid "Edit Album"
 msgstr "Wijzig album"
 
-#: module/Photo/view/photo/album-admin/edit.phtml:10
+#: module/Photo/view/photo/album-admin/edit.phtml:22
 msgid "Update Album"
 msgstr "Album Bijwerken"
 
-#: module/Photo/view/photo/album-admin/index.phtml:44
-#: module/Photo/view/photo/photo-admin/index.phtml:44
+#: module/Photo/view/photo/album-admin/index.phtml:55
+#: module/Photo/view/photo/photo-admin/index.phtml:62
 msgid "Photo admin"
 msgstr "Foto admin"
 
-#: module/Photo/view/photo/album-admin/index.phtml:93
+#: module/Photo/view/photo/album-admin/index.phtml:104
 msgid "Other albums"
 msgstr "Andere albums"
 
-#: module/Photo/view/photo/album-admin/index.phtml:106
+#: module/Photo/view/photo/album-admin/index.phtml:117
 msgid "Create new album"
 msgstr "Maak nieuw album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:111
+#: module/Photo/view/photo/album-admin/index.phtml:122
 msgid "Edit album"
 msgstr "Wijzig album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:114
+#: module/Photo/view/photo/album-admin/index.phtml:125
 msgid "Add photos"
 msgstr "Voeg foto's toe"
 
-#: module/Photo/view/photo/album-admin/index.phtml:116
+#: module/Photo/view/photo/album-admin/index.phtml:127
 msgid "Move album"
 msgstr "Verplaats album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:119
+#: module/Photo/view/photo/album-admin/index.phtml:130
 msgid "Move %i photos"
 msgstr "Verplaats %i foto's"
 
-#: module/Photo/view/photo/album-admin/index.phtml:122
+#: module/Photo/view/photo/album-admin/index.phtml:133
 msgid "Regenerate album cover"
 msgstr "Genereer album cover opnieuw"
 
-#: module/Photo/view/photo/album-admin/index.phtml:126
-#: module/Photo/view/photo/album-admin/index.phtml:220
+#: module/Photo/view/photo/album-admin/index.phtml:137
+#: module/Photo/view/photo/album-admin/index.phtml:231
 msgid "Delete album"
 msgstr "Verwijder album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:129
+#: module/Photo/view/photo/album-admin/index.phtml:140
 msgid "Delete %i photos"
 msgstr "Verwijder %i foto's"
 
-#: module/Photo/view/photo/album-admin/index.phtml:147
+#: module/Photo/view/photo/album-admin/index.phtml:158
 msgid "Generate a new cover photo"
 msgstr "Genereer nieuwe cover foto"
 
-#: module/Photo/view/photo/album-admin/index.phtml:153
+#: module/Photo/view/photo/album-admin/index.phtml:164
 msgid "An error occurred while trying to generate an album photo."
 msgstr "Er is een fout opgetreden tijdens het genereren van een albumfoto."
 
-#: module/Photo/view/photo/album-admin/index.phtml:160
+#: module/Photo/view/photo/album-admin/index.phtml:171
 msgid "Regenerate"
 msgstr "Genereer opnieuw"
 
-#: module/Photo/view/photo/album-admin/index.phtml:162
-#: module/Photo/view/photo/album/index.phtml:426
+#: module/Photo/view/photo/album-admin/index.phtml:173
+#: module/Photo/view/photo/album/index.phtml:435
 msgid "Close"
 msgstr "Sluiten"
 
-#: module/Photo/view/photo/album-admin/index.phtml:175
+#: module/Photo/view/photo/album-admin/index.phtml:186
 msgid "Move the album"
 msgstr "Verplaats het album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:180
+#: module/Photo/view/photo/album-admin/index.phtml:191
 msgid "Select a new parent for the album"
 msgstr "Selecteer een nieuwe bovenliggende album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:184
+#: module/Photo/view/photo/album-admin/index.phtml:195
 msgid "The album has been moved"
 msgstr "Het album is verplaatst"
 
-#: module/Photo/view/photo/album-admin/index.phtml:189
-#: module/Photo/view/photo/album-admin/index.phtml:280
-#: module/Photo/view/photo/photo-admin/index.phtml:108
+#: module/Photo/view/photo/album-admin/index.phtml:200
+#: module/Photo/view/photo/album-admin/index.phtml:291
+#: module/Photo/view/photo/photo-admin/index.phtml:126
 msgid "Move"
 msgstr "Verplaats"
 
-#: module/Photo/view/photo/album-admin/index.phtml:206
+#: module/Photo/view/photo/album-admin/index.phtml:217
 msgid ""
 "Are you sure you want to delete this album including all photos inside of "
 "it? <strong>This action can not be reverted.</strong>"
@@ -5435,15 +5471,15 @@ msgstr ""
 "Weet je zeker dat je dit album met alle foto's wilt verwijderen? "
 "<strong>Deze actie kan niet ongedaan gemaakt worden.</strong>"
 
-#: module/Photo/view/photo/album-admin/index.phtml:209
+#: module/Photo/view/photo/album-admin/index.phtml:220
 msgid "Please wait while the album is being deleted."
 msgstr "Wacht terwijl dit album verwijderd wordt."
 
-#: module/Photo/view/photo/album-admin/index.phtml:215
+#: module/Photo/view/photo/album-admin/index.phtml:226
 msgid "The album has been deleted"
 msgstr "Dit album kan verwijderd worden"
 
-#: module/Photo/view/photo/album-admin/index.phtml:238
+#: module/Photo/view/photo/album-admin/index.phtml:249
 msgid ""
 "Are you sure you want to delete the selected items? <strong>This action can "
 "not be reverted.</strong>"
@@ -5451,154 +5487,154 @@ msgstr ""
 "Weet je zeker dat je de geselecteerde items wilt verwijderen? <strong>Deze "
 "actie kan niet ongedaan gemaakt worden.</strong>"
 
-#: module/Photo/view/photo/album-admin/index.phtml:241
+#: module/Photo/view/photo/album-admin/index.phtml:252
 msgid "Please wait while the photos are being deleted."
 msgstr "Wacht a.u.b. terwijl de foto's verwijderd worden."
 
-#: module/Photo/view/photo/album-admin/index.phtml:247
+#: module/Photo/view/photo/album-admin/index.phtml:258
 msgid "The photos have been been deleted"
 msgstr "De foto's zijn verwijderd"
 
-#: module/Photo/view/photo/album-admin/index.phtml:252
+#: module/Photo/view/photo/album-admin/index.phtml:263
 msgid "Delete photos"
 msgstr "Verwijder foto's"
 
-#: module/Photo/view/photo/album-admin/index.phtml:266
+#: module/Photo/view/photo/album-admin/index.phtml:277
 msgid "Move the photos to another album"
 msgstr "Verplaats de foto's naar een ander album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:271
-#: module/Photo/view/photo/photo-admin/index.phtml:99
+#: module/Photo/view/photo/album-admin/index.phtml:282
+#: module/Photo/view/photo/photo-admin/index.phtml:117
 msgid "Select a new parent album"
 msgstr "Selecteer een nieuwe bovenliggende album"
 
-#: module/Photo/view/photo/album-admin/index.phtml:275
+#: module/Photo/view/photo/album-admin/index.phtml:286
 msgid "The photos have been moved"
 msgstr "De foto's zijn verplaatst"
 
-#: module/Photo/view/photo/album/index.phtml:77
-#: module/Photo/view/photo/photo/weekly.phtml:2
-#: module/Photo/view/photo/photo/weekly.phtml:8
+#: module/Photo/view/photo/album/index.phtml:86
+#: module/Photo/view/photo/photo/weekly.phtml:13
+#: module/Photo/view/photo/photo/weekly.phtml:20
 msgid "Photos of the Week"
 msgstr "Foto's van de week"
 
-#: module/Photo/view/photo/album/index.phtml:131
+#: module/Photo/view/photo/album/index.phtml:140
 msgid "View user profile"
 msgstr "Bekijk profiel"
 
-#: module/Photo/view/photo/album/index.phtml:143
+#: module/Photo/view/photo/album/index.phtml:152
 msgid "No date"
 msgstr "Geen datum"
 
-#: module/Photo/view/photo/album/index.phtml:192
-#: module/Photo/view/photo/photo/index.phtml:58
+#: module/Photo/view/photo/album/index.phtml:201
+#: module/Photo/view/photo/photo/index.phtml:71
 msgid "NEW"
 msgstr "NIEUW"
 
-#: module/Photo/view/photo/album/index.phtml:216
+#: module/Photo/view/photo/album/index.phtml:225
 msgid "This album does not contain any photos."
 msgstr "Dit album bevat geen foto's."
 
-#: module/Photo/view/photo/album/index.phtml:389
+#: module/Photo/view/photo/album/index.phtml:398
 msgid "Already voted!"
 msgstr "Je hebt al gestemd!"
 
-#: module/Photo/view/photo/album/index.phtml:392
-#: module/Photo/view/photo/album/index.phtml:563
+#: module/Photo/view/photo/album/index.phtml:401
+#: module/Photo/view/photo/album/index.phtml:572
 msgid "Vote for photo of the week"
 msgstr "Stem voor de foto van de week"
 
-#: module/Photo/view/photo/album/index.phtml:427
+#: module/Photo/view/photo/album/index.phtml:436
 msgid "Zoom (z)"
 msgstr "Zoom (z)"
 
-#: module/Photo/view/photo/album/index.phtml:430
+#: module/Photo/view/photo/album/index.phtml:439
 msgid "The image could not be loaded."
 msgstr "De foto kan niet worden geladen."
 
-#: module/Photo/view/photo/album/index.phtml:443
+#: module/Photo/view/photo/album/index.phtml:452
 msgid "Download"
 msgstr "Downloaden"
 
-#: module/Photo/view/photo/album/index.phtml:467
+#: module/Photo/view/photo/album/index.phtml:476
 msgid "Share"
 msgstr "Delen"
 
-#: module/Photo/view/photo/album/index.phtml:478
+#: module/Photo/view/photo/album/index.phtml:487
 msgid "Copied URL!"
 msgstr "URL gekopieerd!"
 
-#: module/Photo/view/photo/album/index.phtml:489
+#: module/Photo/view/photo/album/index.phtml:498
 msgid "Go to album"
 msgstr "Ga naar album"
 
-#: module/Photo/view/photo/album/index.phtml:532
+#: module/Photo/view/photo/album/index.phtml:541
 msgid "Set as profile picture"
 msgstr "Kies deze foto als jouw profielfoto"
 
-#: module/Photo/view/photo/album/index.phtml:549
+#: module/Photo/view/photo/album/index.phtml:558
 msgid "Set as profile picture!"
 msgstr "Gekozen als profielfoto!"
 
-#: module/Photo/view/photo/album/index.phtml:552
+#: module/Photo/view/photo/album/index.phtml:561
 msgid "Could not set as profile photo, try again"
 msgstr "Profielfoto instellen mislukt, probeer het nog een keer"
 
-#: module/Photo/view/photo/album/index.phtml:585
+#: module/Photo/view/photo/album/index.phtml:594
 msgid "Cannot load vote"
 msgstr "Kan stem niet laden"
 
-#: module/Photo/view/photo/album/index.phtml:605
+#: module/Photo/view/photo/album/index.phtml:614
 msgid "Voted!"
 msgstr "Gestemd!"
 
-#: module/Photo/view/photo/album/index.phtml:617
+#: module/Photo/view/photo/album/index.phtml:626
 msgid "Could not vote, try again"
 msgstr "Stemmen mislukt, probeer het nog een keer"
 
-#: module/Photo/view/photo/album/index.phtml:632
+#: module/Photo/view/photo/album/index.phtml:641
 msgid "Loading tags..."
 msgstr "Tags aan het laden..."
 
-#: module/Photo/view/photo/album/index.phtml:653
+#: module/Photo/view/photo/album/index.phtml:662
 msgid "Cannot load tags"
 msgstr "Kan tags niet laden"
 
-#: module/Photo/view/photo/album/index.phtml:748
+#: module/Photo/view/photo/album/index.phtml:757
 msgid "Cannot load metadata"
 msgstr "Kan metadata niet laden"
 
-#: module/Photo/view/photo/album/index.phtml:774
+#: module/Photo/view/photo/album/index.phtml:783
 msgid "Photo of the Week:<br> Week"
 msgstr "Foto van de week<br> Week"
 
-#: module/Photo/view/photo/album/index.phtml:774
+#: module/Photo/view/photo/album/index.phtml:783
 msgid "of"
 msgstr "van"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:33
+#: module/Photo/view/photo/photo-admin/index.phtml:51
 #, php-format
 msgid "Photo #%d"
 msgstr "Foto #%d"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:71
+#: module/Photo/view/photo/photo-admin/index.phtml:89
 msgid "Move photo"
 msgstr "Verplaats foto"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:73
-#: module/Photo/view/photo/photo-admin/index.phtml:139
+#: module/Photo/view/photo/photo-admin/index.phtml:91
+#: module/Photo/view/photo/photo-admin/index.phtml:157
 msgid "Delete photo"
 msgstr "Verwijder foto"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:94
+#: module/Photo/view/photo/photo-admin/index.phtml:112
 msgid "Move the photo to another album"
 msgstr "Verplaats de foto naar een ander album"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:103
+#: module/Photo/view/photo/photo-admin/index.phtml:121
 msgid "The photo has been moved"
 msgstr "De foto is verplaatst"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:125
+#: module/Photo/view/photo/photo-admin/index.phtml:143
 msgid ""
 "Are you sure you want to delete this photo? <strong>This action can not be "
 "reverted.</strong>"
@@ -5606,27 +5642,27 @@ msgstr ""
 "Weet je zeker dat je deze foto wilt verwijderen? <strong>Deze actie kan niet "
 "ongedaan gemaakt worden.</strong>"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:128
+#: module/Photo/view/photo/photo-admin/index.phtml:146
 msgid "Please wait while your photo is being deleted."
 msgstr "Wacht terwijl de foto verwijderd wordt."
 
-#: module/Photo/view/photo/photo-admin/index.phtml:134
+#: module/Photo/view/photo/photo-admin/index.phtml:152
 msgid "The photo has been deleted"
 msgstr "De foto is verwijderd"
 
-#: module/Photo/view/photo/photo/index.phtml:69
+#: module/Photo/view/photo/photo/index.phtml:82
 msgid "There are no photos in this year."
 msgstr "Er zijn geen foto's in dit jaar."
 
-#: module/Photo/view/photo/photo/weekly.phtml:6
+#: module/Photo/view/photo/photo/weekly.phtml:18
 msgid "Currently, no pictures of the week are available."
 msgstr "Op het moment zijn er geen foto's van de week beschikbaar."
 
-#: module/Photo/view/photo/photo/weekly.phtml:9
+#: module/Photo/view/photo/photo/weekly.phtml:21
 msgid "Current photo of the week"
 msgstr "Huidige foto van de week"
 
-#: module/Photo/view/photo/photo/weekly.phtml:40
+#: module/Photo/view/photo/photo/weekly.phtml:52
 msgid "Old photos of the week"
 msgstr "Oude foto's van de week"
 
@@ -5642,8 +5678,8 @@ msgstr "De combinatie van login en wachtwoord is onjuist."
 msgid "Too many login attempts, try again later."
 msgstr "Te veel login pogingen, probeer het later nog eens."
 
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:77
-#: module/User/src/Authentication/Adapter/UserAdapter.php:91
+#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:78
+#: module/User/src/Authentication/Adapter/UserAdapter.php:92
 msgid ""
 "Your password was found in a public data breach and is therefore considered "
 "insecure. Please request a password reset before continuing. We recommend "
@@ -5659,8 +5695,8 @@ msgstr ""
 msgid "You cannot sign in to this account at this moment."
 msgstr "Je kunt momenteel niet inloggen op dit account."
 
-#: module/User/src/Authorization/GenericAclService.php:98
-#: module/User/src/Authorization/GenericAclService.php:122
+#: module/User/src/Authorization/GenericAclService.php:108
+#: module/User/src/Authorization/GenericAclService.php:135
 msgid ""
 "You are not allowed to perform this action. If you are not logged in please "
 "do so before continuing. If you are already logged in this action may "
@@ -5670,21 +5706,21 @@ msgstr ""
 "ingelogd, doe dat dan eerst voordat je verder gaat. Als je al bent ingelogd "
 "kan het zijn dat je voor deze actie moet inloggen met een ander account."
 
-#: module/User/src/Controller/UserController.php:184
+#: module/User/src/Controller/UserController.php:178
 msgid "You are not allowed to change passwords"
 msgstr "Je hebt niet de rechten om een wachtwoord te wijzigen"
 
-#: module/User/src/Form/Activate.php:31 module/User/src/Form/UserLogin.php:45
+#: module/User/src/Form/Activate.php:29 module/User/src/Form/UserLogin.php:43
 msgid "Your password"
 msgstr "Wachtwoord"
 
-#: module/User/src/Form/Activate.php:41
+#: module/User/src/Form/Activate.php:39
 msgid "Verify your password"
 msgstr "Verifieer je wachtwoord"
 
-#: module/User/src/Form/Activate.php:51
-#: module/User/view/user/user/activate.phtml:2
-#: module/User/view/user/user/activate.phtml:23
+#: module/User/src/Form/Activate.php:49
+#: module/User/view/user/user/activate.phtml:20
+#: module/User/view/user/user/activate.phtml:40
 msgid "Activate"
 msgstr "Activeer"
 
@@ -5693,47 +5729,47 @@ msgid "Authorise"
 msgstr "Sta toe"
 
 #: module/User/src/Form/ApiToken.php:35
-#: module/User/view/user/api-admin/add.phtml:33
+#: module/User/view/user/api-admin/add.phtml:45
 msgid "Create API token"
 msgstr "Maak een API token"
 
-#: module/User/src/Form/CompanyUserLogin.php:36
-#: module/User/src/Form/CompanyUserReset.php:34
+#: module/User/src/Form/CompanyUserLogin.php:34
+#: module/User/src/Form/CompanyUserReset.php:27
 msgid "Email address"
 msgstr "E-mailadres"
 
-#: module/User/src/Form/CompanyUserLogin.php:46
-#: module/User/view/user/user/activate.phtml:41
+#: module/User/src/Form/CompanyUserLogin.php:44
+#: module/User/view/user/user/activate.phtml:58
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: module/User/src/Form/CompanyUserLogin.php:56
+#: module/User/src/Form/CompanyUserLogin.php:54
 msgid "Log in as company"
 msgstr "Inloggen als bedrijf"
 
-#: module/User/src/Form/CompanyUserReset.php:44
+#: module/User/src/Form/CompanyUserReset.php:37
 msgid "Request password reset"
 msgstr "Wachtwoord reset aanvragen"
 
-#: module/User/src/Form/Password.php:31
+#: module/User/src/Form/Password.php:29
 msgid "Old password"
 msgstr "Oud wachtwoord"
 
-#: module/User/src/Form/Password.php:41
+#: module/User/src/Form/Password.php:39
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
-#: module/User/src/Form/Password.php:51
+#: module/User/src/Form/Password.php:49
 msgid "Verify new password"
 msgstr "Verifier nieuw wachtwoord"
 
-#: module/User/src/Form/Register.php:44
-#: module/User/view/user/user/register.phtml:2
-#: module/User/view/user/user/register.phtml:23
+#: module/User/src/Form/Register.php:42
+#: module/User/view/user/user/register.phtml:14
+#: module/User/view/user/user/register.phtml:34
 msgid "Register"
 msgstr "Registreer"
 
-#: module/User/src/Form/Register.php:69
+#: module/User/src/Form/Register.php:65
 msgid ""
 "This member cannot create an account, please contact the secretary for more "
 "information."
@@ -5741,11 +5777,11 @@ msgstr ""
 "Dit lid kan geen account aanmaken, neem contact op met de secretaris voor "
 "meer informatie."
 
-#: module/User/src/Form/Register.php:77
+#: module/User/src/Form/Register.php:73
 msgid "There is no member with this membership number."
 msgstr "Er is geen lid met dit lidmaatschapsnummer."
 
-#: module/User/src/Form/Register.php:85
+#: module/User/src/Form/Register.php:81
 msgid ""
 "You already attempted to register, please check your email or try again "
 "after 20 minutes."
@@ -5753,60 +5789,60 @@ msgstr ""
 "Je hebt al geprobeerd te registreren, controleer je e-mail of probeer het na "
 "20 minuten opnieuw."
 
-#: module/User/src/Form/Register.php:93
+#: module/User/src/Form/Register.php:89
 msgid "This member already has an account."
 msgstr "Dit lid heeft al een account."
 
-#: module/User/src/Form/UserLogin.php:35
+#: module/User/src/Form/UserLogin.php:33
 msgid "Membership number or email address"
 msgstr "Lidnummer of email adres"
 
-#: module/User/src/Form/UserLogin.php:55
+#: module/User/src/Form/UserLogin.php:53
 msgid "Log in as member"
 msgstr "Inloggen als lid"
 
-#: module/User/src/Form/UserLogin.php:65
+#: module/User/src/Form/UserLogin.php:63
 msgid "Remember me"
 msgstr "Onthoud mij"
 
-#: module/User/src/Form/UserReset.php:52
-#: module/User/view/partial/reset/company.phtml:33
-#: module/User/view/partial/reset/member.phtml:47
-#: module/User/view/user/user/reset-password.phtml:2
-#: module/User/view/user/user/reset-password.phtml:13
+#: module/User/src/Form/UserReset.php:50
+#: module/User/view/partial/reset/company.phtml:46
+#: module/User/view/partial/reset/member.phtml:59
+#: module/User/view/user/user/reset-password.phtml:18
+#: module/User/view/user/user/reset-password.phtml:29
 msgid "Reset password"
 msgstr "Reset wachtwoord"
 
-#: module/User/src/Model/Enums/JWTClaims.php:38
+#: module/User/src/Model/Enums/JWTClaims.php:40
 msgid "Family name"
 msgstr "Achternaam"
 
-#: module/User/src/Model/Enums/JWTClaims.php:39
+#: module/User/src/Model/Enums/JWTClaims.php:41
 msgid "Given name"
 msgstr "Voornaam"
 
-#: module/User/src/Model/Enums/JWTClaims.php:40
+#: module/User/src/Model/Enums/JWTClaims.php:42
 msgid "Is 18+?"
 msgstr "Is 18+?"
 
-#: module/User/src/Model/Enums/JWTClaims.php:41
+#: module/User/src/Model/Enums/JWTClaims.php:43
 msgid "Member number"
 msgstr "Lidmaatschapsnummer"
 
-#: module/User/src/Service/ApiUser.php:43
-#: module/User/src/Service/ApiUser.php:75
+#: module/User/src/Service/ApiUser.php:46
+#: module/User/src/Service/ApiUser.php:74
 msgid "You are not allowed to view API tokens"
 msgstr "Je hebt niet de rechten om API tokens in te zien"
 
-#: module/User/src/Service/ApiUser.php:59
+#: module/User/src/Service/ApiUser.php:60
 msgid "You are not allowed to remove API tokens"
 msgstr "Je hebt niet de rechten om API tokens te verwijderen"
 
-#: module/User/src/Service/ApiUser.php:119
+#: module/User/src/Service/ApiUser.php:115
 msgid "You are not allowed to add API tokens"
 msgstr "Je hebt niet de rechten om API tokens toe te voegen"
 
-#: module/User/src/Service/User.php:104 module/User/src/Service/User.php:327
+#: module/User/src/Service/User.php:105 module/User/src/Service/User.php:339
 msgid ""
 "You cannot use this password, it was found in a public data breach and is "
 "therefore considered insecure. We recommend using a password generated by a "
@@ -5817,27 +5853,27 @@ msgstr ""
 "te gebruiken dat is gegenereerd door een goede wachtwoordmanager, zoals "
 "Bitwarden of 1Password."
 
-#: module/User/src/Service/User.php:316
+#: module/User/src/Service/User.php:326
 msgid "Password incorrect"
 msgstr "Wachtwoord incorrect"
 
-#: module/User/src/Service/User.php:476
+#: module/User/src/Service/User.php:481
 msgid "You are not allowed to change your password"
 msgstr "Je hebt niet de rechten om een wachtwoord te wijzigen"
 
-#: module/User/view/partial/login/company.phtml:64
-#: module/User/view/partial/login/member.phtml:74
+#: module/User/view/partial/login/company.phtml:77
+#: module/User/view/partial/login/member.phtml:87
 #, php-format
 msgid "If you forgot your password, go to the %sPassword reset page%s"
 msgstr ""
 "Als je je wachtwoord bent vergeten, ga naar de %sWachtwoord reset pagina %s"
 
-#: module/User/view/partial/login/member.phtml:70
+#: module/User/view/partial/login/member.phtml:83
 #, php-format
 msgid "If you don't have an account yet, go to the %sRegistration page%s"
 msgstr "Als je nog geen account hebt, ga naar de %sRegistratie pagina%s"
 
-#: module/User/view/partial/reset/member.phtml:39
+#: module/User/view/partial/reset/member.phtml:51
 msgid ""
 "Have you forgotten your e-mail address and do you want to change it? Ask the "
 "secretary by going to GEWIS (preferred) or by sending an e-mail."
@@ -5846,44 +5882,44 @@ msgstr ""
 "secretaris door naar GEWIS te komen (aanbevolen) of door een e-mail te "
 "sturen."
 
-#: module/User/view/user/api-admin/add.phtml:3
-#: module/User/view/user/api-admin/index.phtml:3
-#: module/User/view/user/api-admin/index.phtml:5
-#: module/User/view/user/api-admin/remove.phtml:3
+#: module/User/view/user/api-admin/add.phtml:15
+#: module/User/view/user/api-admin/index.phtml:15
+#: module/User/view/user/api-admin/index.phtml:17
+#: module/User/view/user/api-admin/remove.phtml:15
 msgid "API Tokens"
 msgstr "API Tokens"
 
-#: module/User/view/user/api-admin/add.phtml:4
+#: module/User/view/user/api-admin/add.phtml:16
 msgid "Add Token"
 msgstr "Token toevoegen"
 
-#: module/User/view/user/api-admin/add.phtml:6
+#: module/User/view/user/api-admin/add.phtml:18
 msgid "Add a token"
 msgstr "Voeg een token toe"
 
-#: module/User/view/user/api-admin/add.phtml:41
+#: module/User/view/user/api-admin/add.phtml:53
 msgid "Token was successfully generated"
 msgstr "Token is gegenereerd"
 
-#: module/User/view/user/api-admin/add.phtml:49
-#: module/User/view/user/api-admin/index.phtml:11
+#: module/User/view/user/api-admin/add.phtml:61
+#: module/User/view/user/api-admin/index.phtml:23
 msgid "Token"
 msgstr "Token"
 
-#: module/User/view/user/api-admin/index.phtml:30
+#: module/User/view/user/api-admin/index.phtml:42
 msgid "Add new Token"
 msgstr "Voeg een nieuw Token toe"
 
-#: module/User/view/user/api-admin/remove.phtml:4
+#: module/User/view/user/api-admin/remove.phtml:16
 msgid "Remove Token"
 msgstr "Verwijder token"
 
-#: module/User/view/user/api-authentication/redirect.phtml:13
+#: module/User/view/user/api-authentication/redirect.phtml:21
 #, php-format
 msgid "You are being redirected to %s"
 msgstr "Je wordt doorgestuurd naar %s"
 
-#: module/User/view/user/api-authentication/redirect.phtml:22
+#: module/User/view/user/api-authentication/redirect.phtml:30
 #, php-format
 msgid ""
 "If your browser does not redirect you back, please <a href=\"%s\">click "
@@ -5892,12 +5928,12 @@ msgstr ""
 "Als je  browser je niet doorstuurt, <a href=\"%s\">klik dan hier</a> om "
 "verder te gaan."
 
-#: module/User/view/user/api-authentication/token.phtml:16
+#: module/User/view/user/api-authentication/token.phtml:28
 #, php-format
 msgid "Authorize %s to use your account?"
 msgstr "Geef je %s toestemming om je account te gebruiken?"
 
-#: module/User/view/user/api-authentication/token.phtml:25
+#: module/User/view/user/api-authentication/token.phtml:37
 #, php-format
 msgid ""
 "It has been more than 90 days since you last used <strong>%s</strong>. As a "
@@ -5906,38 +5942,38 @@ msgstr ""
 "Het is meer dan 90 dagen geleden dat je <strong>%s</strong> voor het laatst "
 "heeft gebruikt. Ter herinnering, de applicatie heeft toegang tot:"
 
-#: module/User/view/user/api-authentication/token.phtml:30
+#: module/User/view/user/api-authentication/token.phtml:42
 msgid "The application will get the following information:"
 msgstr "De applicatie zal de volgende informatie krijgen:"
 
-#: module/User/view/user/user/activate.phtml:7
+#: module/User/view/user/user/activate.phtml:25
 msgid "Your account has been activated. You are now able to login."
 msgstr "Je account is geactiveerd. Je kunt nu inloggen."
 
-#: module/User/view/user/user/activate.phtml:36
+#: module/User/view/user/user/activate.phtml:53
 #, php-format
 msgid ""
 "Welcome %s. Create your password for the website and activate your account."
 msgstr ""
 "Welkom %s. Maak hier je wachtwoord voor de website en activeer je account."
 
-#: module/User/view/user/user/activate.phtml:54
+#: module/User/view/user/user/activate.phtml:72
 msgid "Verify password"
 msgstr "Verifier wachtwoord"
 
-#: module/User/view/user/user/change-password.phtml:7
+#: module/User/view/user/user/change-password.phtml:20
 msgid "Password changed successfully"
 msgstr "Wachtwoord succesvol gewijzigd"
 
-#: module/User/view/user/user/login.phtml:2
+#: module/User/view/user/user/login.phtml:16
 msgid "Log in"
 msgstr "Inloggen"
 
-#: module/User/view/user/user/logout.phtml:1
+#: module/User/view/user/user/logout.phtml:10
 msgid "You are logged out."
 msgstr "Je bent uitgelogd."
 
-#: module/User/view/user/user/register.phtml:7
+#: module/User/view/user/user/register.phtml:19
 msgid ""
 "Your account for the GEWIS website has been registered, check your inbox for "
 "an activation e-mail."
@@ -5945,7 +5981,7 @@ msgstr ""
 "Je account voor de GEWIS-website is geregistreerd, controleer je inbox voor "
 "een activerings e-mail."
 
-#: module/User/view/user/user/register.phtml:60
+#: module/User/view/user/user/register.phtml:71
 #, php-format
 msgid ""
 "To read more about the benefits of becoming a member and how to become a "
@@ -5954,7 +5990,7 @@ msgstr ""
 "Om meer te lezen over de voordelen van het worden van een lid en hoe je een "
 "lid kunt worden, ga naar deze %sinformatie pagina%s."
 
-#: module/User/view/user/user/reset-password.phtml:7
+#: module/User/view/user/user/reset-password.phtml:23
 msgid ""
 "An e-mail has been sent with instructions for resetting your password. If "
 "you have not received an e-mail, try again in 20 minutes."

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-25 00:26+0200\n"
+"POT-Creation-Date: 2023-06-25 00:47+0200\n"
 "PO-Revision-Date: 2023-06-25 00:28+0200\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -19,111 +19,116 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: module/Activity/src/Controller/ActivityCalendarController.php:82
-msgid "You are not allowed to create activity proposals"
-msgstr "Je hebt niet de rechten om opties voor activiteiten te maken"
+msgid " <strong>has a limited capacity</strong> and "
+msgstr " <strong>heeft een beperkte capaciteit</strong> en "
 
-#: module/Activity/src/Controller/ActivityController.php:228
-#: module/Activity/view/activity/activity/index.phtml:45
-msgid "Create Activity"
-msgstr "Maak nieuwe activiteit"
+msgid "# Decisions"
+msgstr "# Besluiten"
 
-#: module/Activity/src/Controller/ActivityController.php:258
-#: module/Activity/src/Controller/ActivityController.php:351
-#: module/Activity/src/Controller/AdminController.php:294
-#: module/Activity/src/Controller/AdminController.php:381
-msgid "Invalid form"
-msgstr "De ingevulde gegevens zijn niet geldig"
+#, php-format
+msgid "%d votes"
+msgstr "%d stemmen"
 
-#: module/Activity/src/Controller/ActivityController.php:267
-#: module/Activity/src/Controller/ActivityController.php:360
-msgid "You need to log in to subscribe"
-msgstr "Je moet inloggen om in te schrijven"
+#, php-format
+msgid "%s %s"
+msgstr "%s %s"
 
-#: module/Activity/src/Controller/ActivityController.php:277
-#: module/Activity/src/Controller/ActivityController.php:370
-msgid "You cannot subscribe to this activity at this moment in time"
-msgstr "Je kunt je op dit moment niet inschrijven voor deze activiteit"
+#, php-format
+msgid "%s %s on %s"
+msgstr "%s %s op %s"
 
-#: module/Activity/src/Controller/ActivityController.php:286
-msgid "You have already been subscribed for this activity"
-msgstr "Je bent al ingeschreven voor deze activiteit"
+#, php-format
+msgid "%s for company %s will expire on %s"
+msgstr "%s voor bedrijf %s verloopt op %s"
 
-#: module/Activity/src/Controller/ActivityController.php:292
-msgid "Successfully subscribed"
-msgstr "Succesvol geregistreerd"
+#, php-format
+msgid "%s for company %s will start on %s"
+msgstr "%s voor bedrijf %s begint op %s"
 
-#: module/Activity/src/Controller/ActivityController.php:297
-#: module/Activity/src/Controller/ActivityController.php:386
-#: module/Activity/src/Controller/AdminController.php:318
-msgid "Use the form to subscribe"
-msgstr "Gebruik het formulier om in te schrijven"
+#, php-format
+msgid "%s has never been part of a committee or fraternity."
+msgstr "%s is geen lid geweest van een commissie of dispuut."
 
-#: module/Activity/src/Controller/ActivityController.php:381
-msgid "Successfully subscribed as external participant"
-msgstr "Succesvol geregistreerd"
+#, php-format
+msgid "%s is currently a member of:"
+msgstr "%s is momenteel lid van:"
 
-#: module/Activity/src/Controller/ActivityController.php:413
-msgid "Wrong form"
-msgstr "Verkeerd formulier"
+#, php-format
+msgid "%s is currently the <strong>%s</strong>."
+msgstr "%s is de huidige <strong>%s</strong>."
 
-#: module/Activity/src/Controller/ActivityController.php:420
-msgid "You have to be logged in to subscribe for this activity"
-msgstr "Je moet ingelogd zijn om je voor deze activiteit in te schrijven"
+#, php-format
+msgid "%s is the upcoming <strong>%s</strong>."
+msgstr "%s is de aankomende <strong>%s</strong>."
 
-#: module/Activity/src/Controller/ActivityController.php:431
-msgid "You cannot unsubscribe from this activity at this moment in time"
-msgstr "Je kunt je op dit moment niet afmelden voor deze activiteit"
+#, php-format
+msgid "%s was a member of:"
+msgstr "%s is lid geweest van:"
 
-#: module/Activity/src/Controller/ActivityController.php:441
-msgid "You are not subscribed to this activity!"
-msgstr "Je bent niet ingeschreven voor deze activiteit!"
+#, php-format
+msgid "%s was the <strong>%s</strong> during the association year %d/%d."
+msgstr "%s was de <strong>%s</strong> gedurende het verenigingsjaar %d/%d."
 
-#: module/Activity/src/Controller/ActivityController.php:447
-msgid "Successfully unsubscribed"
-msgstr "Succesvol uitgeschreven"
+#, php-format
+msgid "%s wil be %s years old today!"
+msgstr "%s wordt vandaag %s jaar oud!"
 
-#: module/Activity/src/Controller/ActivityController.php:452
-msgid "Use the form to unsubscribe"
-msgstr "Gebruik het formulier om in te schrijven"
+#, php-format
+msgid "%s's activities"
+msgstr "Activiteiten door %s"
 
-#: module/Activity/src/Controller/AdminApprovalController.php:41
-msgid "You are not allowed to view the approval of this activity"
-msgstr ""
-"Je hebt niet de rechten om de goedkeuringsstatus van deze activiteit te "
-"bekijken"
+#, php-format
+msgid "%sRequest a poll%s"
+msgstr "%sVraag een poll aan%s"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:50
-#: module/Activity/src/Service/ActivityCategory.php:76
-msgid "You are not allowed to create an activity category"
-msgstr "Je hebt niet de rechten om een activiteitencategorie te maken"
+msgid "(Update Pending)"
+msgstr "(Update in behandeling)"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:63
-msgid "The activity category was created successfully!"
-msgstr "De activiteitencategorie is succesvol aangemaakt!"
+msgid ".. Move up a folder"
+msgstr ".. Ga map omhoog"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:73
-#: module/Activity/src/Form/ActivityCategory.php:44
-msgid "Create Activity Category"
-msgstr "Activiteitencategorie aanmaken"
+msgid "1 vote"
+msgstr "1 stem"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:122
-msgid "You are not allowed to edit an activity category"
-msgstr "Je hebt niet de rechten om een activiteitencategorie bij te werken"
+msgid "403 Forbidden"
+msgstr "403 Verboden Toegang"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:142
-msgid "The activity category was successfully updated!"
-msgstr "De activiteitencategorie is succesvol bijgewerkt!"
+msgid "A 404 error occurred"
+msgstr "404: De pagina kon niet worden gevonden"
 
-#: module/Activity/src/Controller/AdminCategoryController.php:159
-msgid "Update Activity Category"
-msgstr "Activiteitencategorie bijwerken"
+msgid "A list of helpful resources for active members."
+msgstr "Een lijst met nuttige pagina's voor actieve leden."
 
-#: module/Activity/src/Controller/AdminController.php:62
-msgid "You are not allowed to update this activity"
-msgstr "Je hebt niet de rechten om deze activiteit te wijzigen"
+msgid "API Tokens"
+msgstr "API Tokens"
 
-#: module/Activity/src/Controller/AdminController.php:76
+msgid "API Users"
+msgstr "API gebruikers"
+
+msgid "Abbreviation"
+msgstr "Afkorting"
+
+msgid "Actions"
+msgstr "Acties"
+
+msgid "Activate"
+msgstr "Activeer"
+
+msgid "Active"
+msgstr "Actief"
+
+msgid "Active Option Planning Periods"
+msgstr "Actieve optieplanningsperioden"
+
+msgid "Active jobs"
+msgstr "Actieve vacatures"
+
+msgid "Active members"
+msgstr "Actieve leden"
+
+msgid "Activities"
+msgstr "Activiteiten"
+
 msgid ""
 "Activities that have sign-up lists which are open or approved cannot be "
 "updated."
@@ -131,587 +136,1421 @@ msgstr ""
 "Activiteiten met inschrijflijsten die open of goedgekeurd zijn, kunnen niet "
 "worden bijgewerkt."
 
-#: module/Activity/src/Controller/AdminController.php:87
-msgid "This activity has already started/ended and can no longer be updated."
-msgstr ""
-"Deze activiteit is al gestart/geëindigd en kan niet meer worden bijgewerkt."
+msgid "Activity Archive"
+msgstr "Archief"
 
-#: module/Activity/src/Controller/AdminController.php:106
-msgid ""
-"You have successfully created an update proposal for the activity! If the "
-"activity was already approved, the proposal will be applied after it has "
-"been approved by the board. Otherwise, the update has already been applied "
-"to the activity."
-msgstr ""
-"Je hebt met succes een update voorstel voor de activiteit gemaakt! Als de "
-"activiteit al was goedgekeurd, zal het voorstel worden toegepast nadat het "
-"is goedgekeurd door het bestuur. Anders is de update al toegepast op de "
-"activiteit."
+msgid "Activity Categories"
+msgstr "Activiteitencategorieën"
 
-#: module/Activity/src/Controller/AdminController.php:143
-msgid "Update Activity"
-msgstr "Activiteit bijwerken"
+msgid "Activity Policy"
+msgstr "Activiteitenbeleid"
 
-#: module/Activity/src/Controller/AdminController.php:188
-#: module/Activity/src/Controller/AdminController.php:200
-#: module/Activity/src/Controller/AdminController.php:212
-msgid "You are not allowed to view the participants of this activity"
-msgstr ""
-"Je hebt niet de rechten om de deelnemers van deze activiteit te bekijken"
+msgid "Add"
+msgstr "Voeg toe"
 
-#: module/Activity/src/Controller/AdminController.php:234
-#: module/Activity/src/Controller/AdminController.php:372
-#: module/User/view/user/api-admin/index.phtml:35
-msgid "Remove"
-msgstr "Verwijder"
+msgid "Add Banner Package"
+msgstr "Voeg bannerpakket toe"
 
-#: module/Activity/src/Controller/AdminController.php:273
-#: module/Activity/src/Controller/AdminController.php:364
-msgid "You are not allowed to use this form"
-msgstr "Je hebt niet de rechten om dit formulier te gebruiken"
+msgid "Add Category"
+msgstr "Nieuwe categorie"
 
-#: module/Activity/src/Controller/AdminController.php:310
-msgid "Successfully subscribed external participant"
-msgstr "Succesvol geregistreerd"
+msgid "Add Company"
+msgstr "Voeg bedrijf toe"
 
-#: module/Activity/src/Controller/AdminController.php:391
-msgid "Successfully removed external participant"
-msgstr "Deelnemer succesvol verwijderd"
+msgid "Add Course"
+msgstr "Vak toevoegen"
 
-#: module/Activity/src/Controller/AdminController.php:399
-msgid "Use the form to unsubscribe an external participant"
-msgstr "Gebruik het formulier om iemand uit te schrijven"
+msgid "Add Job"
+msgstr "Voeg vacature toe"
 
-#: module/Activity/src/Controller/AdminController.php:409
-msgid "You are not allowed to administer activities"
-msgstr "Je hebt niet de rechten om activiteiten te beheren"
+msgid "Add Job Package"
+msgstr "Voeg vacaturepakket toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:41
-msgid "You are not allowed to administer option calendar periods"
-msgstr "Je hebt niet de rechten om optieperiodes te beheren"
+msgid "Add Label"
+msgstr "Voeg een label toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:57
-msgid "You are not allowed to create option calendar periods"
-msgstr "Je hebt niet de rechten om optieperiodes toe te voegen"
-
-#: module/Activity/src/Controller/AdminOptionController.php:77
-msgid "Option planning period created successfully."
-msgstr "Optie planningsperiode succesvol aangemaakt."
-
-#: module/Activity/src/Controller/AdminOptionController.php:101
-#: module/Activity/view/activity/admin-option/index.phtml:113
 msgid "Add Option Period"
 msgstr "Voeg optieperiode toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:109
-msgid "You are not allowed to delete option calendar periods"
-msgstr "Je hebt niet de rechten om optieperiodes te verwijderen"
+msgid "Add Package"
+msgstr "Voeg pakket toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:124
-msgid "Past option planning periods cannot be deleted."
-msgstr "Eerdere optieplanningsperioden kunnen niet worden verwijderd."
+msgid "Add Spotlight Package"
+msgstr "Voeg spotlight-pakket toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:132
-msgid "Option planning period deleted."
-msgstr "Optieplanningsperiode geschrapt."
+msgid "Add Token"
+msgstr "Token toevoegen"
 
-#: module/Activity/src/Controller/AdminOptionController.php:145
-msgid "You are not allowed to edit option calendar periods"
-msgstr "Je hebt niet de rechten om optieplanningsperioden te wijzigen"
+msgid "Add a sign-up list"
+msgstr "Voeg een inschrijflijst toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:161
-msgid "This option planning period cannot be edited."
-msgstr "Deze optieplanningsperiode kan niet worden gewijzigd."
+msgid "Add a sign-up list field"
+msgstr "Voeg een inschrijflijst veld toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:185
-msgid "Option planning period has been updated."
-msgstr "De optieplanningsperiode is bijgewerkt."
+msgid "Add a token"
+msgstr "Voeg een token toe"
 
-#: module/Activity/src/Controller/AdminOptionController.php:207
-msgid "Edit Option Period"
-msgstr "Bewerk optieperiode"
-
-#: module/Activity/src/Controller/ApiController.php:30
-msgid "You are not allowed to access the activities through the API"
-msgstr "Je hebt niet de rechten om de activiteiten in te zien via de API"
-
-#: module/Activity/src/Form/Activity.php:35
-msgid "No organ"
-msgstr "Geen orgaan"
-
-#: module/Activity/src/Form/Activity.php:36
-msgid "No Company"
-msgstr "Geen bedrijf"
-
-#: module/Activity/src/Form/Activity.php:282
-#: module/Activity/src/Form/Activity.php:294
-#: module/Activity/src/Form/Activity.php:308
-#: module/Activity/src/Form/Activity.php:320
-#: module/Activity/src/Form/Activity.php:335
-#: module/Activity/src/Form/Activity.php:350
-#: module/Activity/src/Form/ActivityCalendarProposal.php:128
-#: module/Activity/src/Form/ActivityCalendarProposal.php:142
-#: module/Activity/src/Form/ActivityCalendarProposal.php:150
-#: module/Education/src/Form/Bulk.php:57
-msgid "Value is required and can't be empty"
-msgstr "Waarde is vereist en kan niet leeg zijn"
-
-#: module/Activity/src/Form/Activity.php:373
 msgid ""
-"The sign-up list closing date and time must be before the activity starts."
+"Add activity categories to your activity to give potential subscribers a "
+"better understanding of the activity."
 msgstr ""
-"De openingsdatum en -tijd van de inschrijflijst moeten vóór de startdatum en-"
-"tijd van de activiteit vallen."
+"Voeg activiteitencategorieën toe aan deze activiteit om potentiële "
+"deelnemers een beter inzicht te geven in de activiteit."
 
-#: module/Activity/src/Form/Activity.php:409
-msgid "The activity must start before it ends."
-msgstr "De activiteit moet beginnen voordat deze eindigt."
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:26
-msgid "Morning"
-msgstr "Ochtend"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:27
-msgid "Lunch break"
-msgstr "Lunchpauze"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:28
-msgid "Afternoon"
-msgstr "Namiddag"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:29
-msgid "Evening"
-msgstr "Avond"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:30
-#: module/Activity/view/activity/activity-calendar/index.phtml:160
-msgid "Day"
-msgstr "Dag"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:31
-msgid "Multiple days"
-msgstr "Meerdere dagen"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:60
-msgid "Select a type"
-msgstr "Selecteer een type"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:84
-msgid "The activity must start before it ends"
-msgstr "De starttijd van de activiteit moet voor de eindtijd zijn"
-
-#: module/Activity/src/Form/ActivityCalendarOption.php:97
-msgid "The activity must start after today"
-msgstr "De starttijd van de activiteit moet in de toekomst zijn"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:30
-msgid "Start date and time of planning period"
-msgstr "Begindatum en -tijd van de planningsperiode"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:41
-msgid "End date and time of planning period"
-msgstr "Einddatum en -tijd van de planningsperiode"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:52
-msgid "Start date and time of option period"
-msgstr "Begindatum en -tijd van de optieperiode"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:63
-msgid "End date and time of option period"
-msgstr "Einddatum en -tijd van de optieperiode"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:89
-msgid "Create Option Period"
-msgstr "Optieperiode maken"
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:126
-msgid "The planning period must end after it starts."
-msgstr "De planningsperiode moet eindigen nadat deze begonnen is."
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:149
-msgid "The option period must start after the planning period ends."
-msgstr "De optieperiode moet ingaan na afloop van de planningsperiode."
-
-#: module/Activity/src/Form/ActivityCalendarPeriod.php:172
-msgid "The option period must end after it starts."
-msgstr "De optieperiode moet eindigen nadat deze begonnen is."
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:63
-msgid "Select a period"
-msgstr "Selecteer een periode"
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:78
-msgid "Select an option"
-msgstr "Selecteer een optie"
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:165
-msgid "Option should end after it starts."
-msgstr "De optie moet eindigen nadat deze is begonnen."
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:176
-msgid "Option does not fall within option period (also check the end date)."
-msgstr "Optie valt niet binnen optieperiode (controleer ook de einddatum)."
-
-#: module/Activity/src/Form/ActivityCalendarProposal.php:220
-msgid "The activity does now have an acceptable amount of options"
-msgstr "De activiteit heeft geen acceptabel aantal opties"
-
-#: module/Activity/src/Form/ActivityCategory.php:24
-#: module/Activity/src/Form/ActivityCategory.php:34
-#: module/Activity/src/Form/SignupList.php:35
-#: module/Activity/src/Form/SignupList.php:45
-#: module/Activity/src/Form/SignupListField.php:34
-#: module/Activity/src/Form/SignupListField.php:44
-#: module/Activity/view/activity/activity-calendar/create.phtml:90
-#: module/Activity/view/activity/activity-calendar/index.phtml:64
-#: module/Activity/view/activity/activity/view.phtml:268
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:133
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:138
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:150
-#: module/Activity/view/activity/admin-approval/view.phtml:80
-#: module/Activity/view/activity/admin-approval/view.phtml:85
-#: module/Activity/view/activity/admin-approval/view.phtml:92
-#: module/Activity/view/activity/admin-category/add.phtml:69
-#: module/Activity/view/activity/admin-category/add.phtml:106
-#: module/Activity/view/activity/admin/participantsTable.phtml:20
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:18
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:23
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:30
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:102
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:107
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:114
-#: module/Activity/view/partial/create.phtml:44
-#: module/Activity/view/partial/create.phtml:118
-#: module/Activity/view/partial/signuplist.phtml:54
-#: module/Activity/view/partial/signuplist.phtml:70
-#: module/Company/src/Form/Company.php:51
-#: module/Company/src/Form/Company.php:93
-#: module/Company/src/Form/Company.php:113 module/Company/src/Form/Job.php:106
-#: module/Company/src/Form/Job.php:137 module/Company/src/Form/Job.php:147
-#: module/Company/src/Form/JobCategory.php:45
-#: module/Company/src/Form/JobCategory.php:55
-#: module/Company/src/Form/JobLabel.php:31
-#: module/Company/src/Form/JobLabel.php:41
-#: module/Company/view/company/admin-approval/index.phtml:30
-#: module/Company/view/company/admin-approval/job-approval.phtml:66
-#: module/Company/view/company/admin-approval/job-approval.phtml:70
-#: module/Company/view/company/admin-approval/job-approval.phtml:119
-#: module/Company/view/company/admin-approval/job-approval.phtml:124
-#: module/Company/view/company/admin-approval/job-approval.phtml:131
-#: module/Company/view/company/admin-approval/job-proposal.phtml:97
-#: module/Company/view/company/admin-approval/job-proposal.phtml:101
-#: module/Company/view/company/admin-approval/job-proposal.phtml:159
-#: module/Company/view/company/admin-approval/job-proposal.phtml:164
-#: module/Company/view/company/admin-approval/job-proposal.phtml:174
-#: module/Company/view/company/admin/edit-package.phtml:83
-#: module/Company/view/company/admin/index.phtml:126
-#: module/Company/view/company/admin/index.phtml:212
-#: module/Company/view/company/company-account/jobs.phtml:196
-#: module/Decision/view/decision/admin/document.phtml:71
-#: module/Decision/view/decision/member/birthdays.phtml:23
-#: module/Decision/view/decision/organ-admin/index.phtml:24
-#: module/Decision/view/decision/organ/index.phtml:23
-#: module/Education/src/Form/Course.php:43
-#: module/Education/view/education/admin/course.phtml:44
-#: module/Photo/view/photo/album-admin/edit.phtml:35
-#: module/User/src/Form/ApiToken.php:25
-#: module/User/view/user/api-admin/add.phtml:57
-#: module/User/view/user/api-admin/index.phtml:22
-msgid "Name"
-msgstr "Naam"
-
-#: module/Activity/src/Form/SignupList.php:180
-msgid ""
-"The sign-up list opening date and time must be before the sign-up list "
-"closes."
-msgstr ""
-"De openingsdatum en -tijd van de inschrijflijst moeten vóór de "
-"sluitingsdatum en-tijd van de inschrijflijst vallen."
-
-#: module/Activity/src/Form/SignupListField.php:55
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:128
-msgid "Text"
-msgstr "Tekst"
-
-#: module/Activity/src/Form/SignupListField.php:56
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:131
-msgid "Yes/No"
-msgstr "Ja/Nee"
-
-#: module/Activity/src/Form/SignupListField.php:57
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:134
-msgid "Number"
-msgstr "Getal"
-
-#: module/Activity/src/Form/SignupListField.php:58
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:137
-msgid "Choice"
-msgstr "Keuze"
-
-#: module/Activity/src/Form/SignupListField.php:60
-#: module/Activity/view/activity/activity-calendar/index.phtml:65
-#: module/Activity/view/activity/admin/participantsTable.phtml:22
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:121
-#: module/Activity/view/partial/option.phtml:19
-#: module/Decision/view/decision/decision/index.phtml:23
-#: module/Decision/view/decision/organ/index.phtml:24
-#: module/Education/src/Form/Fieldset/Exam.php:68
-#: module/Education/view/education/admin/course-documents.phtml:68
-msgid "Type"
-msgstr "Type"
-
-#: module/Activity/src/Form/SignupListField.php:70
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:147
-msgid "Min. value"
-msgstr "Min. waarde"
-
-#: module/Activity/src/Form/SignupListField.php:80
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:157
-msgid "Max. value"
-msgstr "Max. waarde"
-
-#: module/Activity/src/Form/SignupListField.php:90
-#: module/Activity/src/Form/SignupListField.php:103
-msgid "Option 1, Option 2, ..."
-msgstr "Optie 1, Optie 2, ..."
-
-#: module/Activity/src/Form/SignupListField.php:93
-#: module/Activity/src/Form/SignupListField.php:106
-#: module/Activity/view/activity/activity-calendar/create.phtml:119
-#: module/Activity/view/activity/activity-calendar/index.phtml:193
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:169
-#: module/Activity/view/partial/create.phtml:170
-msgid "Options"
-msgstr "Opties"
-
-#: module/Activity/src/Form/SignupListField.php:160
-msgid "Some of the required fields for this type are empty"
-msgstr "Sommige van de verplichte velden voor dit type zijn leeg"
-
-#: module/Activity/src/Form/SignupListField.php:191
-msgid "The number of English options must equal the number of Dutch options"
-msgstr ""
-"Het aantal Engelse opties moet gelijk zijn aan het aantal Nederlandse opties"
-
-#: module/Activity/src/Service/Activity.php:66
-#: module/Activity/src/Service/Activity.php:105
-msgid "You are not allowed to create an activity"
-msgstr "Je hebt niet de rechten om een activiteit te maken"
-
-#: module/Activity/src/Service/Activity.php:145
-msgid "You are not allowed to create an activity for this organ"
-msgstr "Je hebt niet de rechten om een activiteit aan te maken voor dit orgaan"
-
-#: module/Activity/src/Service/Activity.php:406
-msgid "You are not allowed to create activity option proposals"
-msgstr "Je hebt niet de rechten om opties voor activiteiten te maken"
-
-#: module/Activity/src/Service/Activity.php:754
-#: module/Activity/src/Service/Activity.php:772
-#: module/Activity/src/Service/Activity.php:790
-msgid "You are not allowed to change the status of the activity"
-msgstr "Je hebt niet de rechten om de status van deze activiteit te wijzigen"
-
-#: module/Activity/src/Service/ActivityCalendar.php:169
-msgid "You are not allowed to approve this option"
-msgstr "Je hebt niet de rechten om deze optie goed te keuren"
-
-#: module/Activity/src/Service/ActivityCalendar.php:209
-msgid "You are not allowed to delete this option"
-msgstr "Je hebt niet de rechten om deze optie te verwijderen"
-
-#: module/Activity/src/Service/ActivityCategory.php:31
-#: module/Activity/src/Service/ActivityCategory.php:47
-msgid "You are not allowed to view activity categories"
-msgstr "Je hebt niet de rechten om activiteitencategorieën te bekijken"
-
-#: module/Activity/src/Service/ActivityCategory.php:105
-msgid "You are not allowed to delete an activity category"
-msgstr "Je hebt niet de rechten om een activiteitencategorie te verwijderen"
-
-#: module/Activity/src/Service/ActivityQuery.php:86
-msgid "You are not allowed to view this activity"
-msgstr "Je hebt niet de rechten om deze activiteit te bekijken"
-
-#: module/Activity/src/Service/ActivityQuery.php:102
-#: module/Activity/src/Service/ActivityQuery.php:262
-#: module/Activity/src/Service/Signup.php:128
-msgid "You are not allowed to view the activities"
-msgstr "Je hebt niet de rechten om de activiteiten in te zien"
-
-#: module/Activity/src/Service/ActivityQuery.php:117
-msgid "You are not allowed to view unapproved activities"
-msgstr "Je hebt niet de rechten om niet goedgekeurde activiteiten in te zien"
-
-#: module/Activity/src/Service/ActivityQuery.php:132
-msgid "You are not allowed to view activities"
-msgstr "Je hebt niet de rechten om de activiteiten in te zien"
-
-#: module/Activity/src/Service/ActivityQuery.php:159
-msgid "You are not allowed to view the disapproved activities"
-msgstr "Je hebt niet de rechten om afgekeurde activiteiten in te zien"
-
-#: module/Activity/src/Service/ActivityQuery.php:177
-msgid "You are not allowed to view upcoming the activities"
-msgstr "Je hebt niet de rechten om aankomende activiteiten te zien"
-
-#: module/Activity/src/Service/ActivityQuery.php:185
-msgid ""
-"You are not allowed to view upcoming activities coupled to a member account"
-msgstr ""
-"Je hebt niet de rechten om aankomende activiteiten te zien die gekoppeld "
-"zijn een het account van een lid"
-
-#: module/Activity/src/Service/Signup.php:47
-#: module/Activity/src/Service/Signup.php:147
-msgid "You need to be logged in to sign up for this activity"
-msgstr "Je moet ingelogd zijn om je voor deze activiteit in te schrijven"
-
-#: module/Activity/src/Service/Signup.php:61
-msgid "You are not allowed to use the external admin signup"
-msgstr "Je hebt niet de rechten om een externe admin inschrijving te maken"
-
-#: module/Activity/src/Service/Signup.php:75
-msgid "You are not allowed to use the external signup"
-msgstr "Je hebt niet de rechten om een externe inschrijving te maken"
-
-#: module/Activity/src/Service/Signup.php:96
-msgid "You are not allowed to view the sign up data"
-msgstr "Je hebt niet de rechten om ingeschreven leden te zien"
-
-#: module/Activity/src/Service/Signup.php:229
-msgid "You are not allowed to subscribe an external user to this sign-up list"
-msgstr ""
-"Je hebt niet de rechten om een externe gebruiker op deze inschrijflijst in "
-"te schrijven"
-
-#: module/Activity/src/Service/Signup.php:276
-msgid "You are not allowed to subscribe to this sign-up list"
-msgstr ""
-"Je hebt niet de rechten om jezelf op deze inschrijflijst in te schrijven"
-
-#: module/Activity/src/Service/Signup.php:292
-msgid "You need to be logged in to sign off for this activity"
-msgstr "Je moet ingelogd zijn om je uit te schrijven voor deze activiteit"
-
-#: module/Activity/src/Service/Signup.php:333
-msgid "You are not allowed to remove external signups for this activity"
-msgstr ""
-"Je hebt niet de rechten om externe inschrijvingen te verwijderen voor deze "
-"activiteit"
-
-#: module/Activity/src/Service/SignupListQuery.php:26
-msgid "You are not allowed to view sign-up lists"
-msgstr "Je hebt niet de rechten om inschrijflijsten te bekijken"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:14
-msgid "Create activity proposal"
-msgstr "Creëer activiteitenvoorstel"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:30
-#: module/Activity/view/activity/activity-calendar/index.phtml:38
-#: module/Application/view/partial/main-nav.phtml:417
-#: module/Decision/view/decision/member/index.phtml:207
-msgid "Option calendar"
-msgstr "Optiekalender"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:31
-msgid "Propose options for an activity"
-msgstr "Opties voor een activiteit voorstellen"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:39
-msgid "Organisation"
-msgstr "Organisatie"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:40
-#: module/Activity/view/activity/activity-calendar/create.phtml:78
-msgid ""
-"Select the organ for which the options are and in which option period the "
-"options should be planned."
-msgstr ""
-"Selecteer het orgaan waarvoor de opties zijn en in welke optieperiode de "
-"opties moeten worden gepland."
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:49
-msgid "Period"
-msgstr "Periode"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:64
-#: module/Activity/view/activity/activity/create.phtml:62
-msgid "Committee / fraternity"
-msgstr "Commissee / dispuut"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:77
-#: module/Activity/view/activity/admin/list.phtml:67
-#: module/Company/view/company/admin-approval/job-approval.phtml:100
-#: module/Company/view/company/admin-approval/job-proposal.phtml:140
-#: module/Company/view/company/admin/edit-package.phtml:111
-#: module/Company/view/company/company-account/jobs.phtml:234
-msgid "Details"
-msgstr "Details"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:106
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:220
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:225
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:237
-#: module/Activity/view/activity/admin-approval/view.phtml:137
-#: module/Activity/view/activity/admin-approval/view.phtml:142
-#: module/Activity/view/activity/admin-approval/view.phtml:149
-#: module/Activity/view/partial/create.phtml:87
-#: module/Activity/view/partial/create.phtml:161
-#: module/Company/src/Form/Company.php:198
-#: module/Company/src/Form/Company.php:208 module/Company/src/Form/Job.php:201
-#: module/Company/src/Form/Job.php:211
-#: module/Company/view/company/admin-approval/job-approval.phtml:176
-#: module/Company/view/company/admin-approval/job-approval.phtml:181
-#: module/Company/view/company/admin-approval/job-approval.phtml:188
-#: module/Company/view/company/admin-approval/job-proposal.phtml:234
-#: module/Company/view/company/admin-approval/job-proposal.phtml:239
-#: module/Company/view/company/admin-approval/job-proposal.phtml:249
-#: module/Company/view/company/company/jobs.phtml:140
-#: module/Company/view/partial/company/company/list/company.phtml:99
-msgid "Description"
-msgstr "Beschrijving"
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:120
-msgid "Add options for your activity proposal."
-msgstr "Voeg opties toe voor je activiteitenvoorstel."
-
-#: module/Activity/view/activity/activity-calendar/create.phtml:142
 msgid "Add an option"
 msgstr "Voeg optie toe"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:146
-msgid "Remove the last option"
-msgstr "Verwijder de laatste optie"
+msgid "Add course"
+msgstr "Vak toevoegen"
 
-#: module/Activity/view/activity/activity-calendar/create.phtml:154
-#: module/Decision/src/Form/Minutes.php:55
-#: module/Frontpage/src/Form/Poll.php:63
-msgid "Submit"
-msgstr "Verzend"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:39
 msgid ""
-"Welcome on the page of the digital Option Calendar. In the calendar below "
-"you can place options for GEWIS activities, just like you were used to do in "
-"the paper version of the option calendar before. The red dots indicate "
-"activities that are already fixed in the GEWIS agenda, the blue dots are "
-"options for activities. If you insert an option, please give it a clear "
-"name, so it is clear what the option is for."
+"Add job labels to your job to give viewers a better understanding of the job."
 msgstr ""
-"Welkom bij de digitale optiekalender. In onderstaande kalender kunnen er "
-"opties voor GEWIS-activiteiten geplaatst worden, net zoals dat voorheen in "
-"de papieren optiekalender gebeurde. De rode bolletjes geven goedgekeurde en "
-"vaststaande activiteiten in de GEWIS agenda aan, de blauwe bolletjes zijn "
-"opties voor activiteiten. Als je een optie plaatst, geef deze dan een "
-"duidelijke naam waaruit blijkt waar de optie voor is."
+"Voeg vacature-labels toe aan deze activiteit om kijkers een beter inzicht te "
+"geven in de vacature."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:41
-msgid "There are a few rules:"
-msgstr "Er zijn een paar regels:"
+msgid "Add new Token"
+msgstr "Voeg een nieuw Token toe"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:43
+msgid "Add option"
+msgstr "Voeg optie toe"
+
+msgid "Add options for your activity proposal."
+msgstr "Voeg opties toe voor je activiteitenvoorstel."
+
+msgid "Add photos"
+msgstr "Voeg foto's toe"
+
+msgid ""
+"Add sign-up lists to allow people to sign up for this activity. Each list "
+"can have optional fields to collect specific information from the "
+"participants."
+msgstr ""
+"Voeg inschrijflijsten toe om mensen in staat te stellen zich voor deze "
+"activiteit in te schrijven. Elke lijst kan optionele velden hebben om "
+"specifieke informatie van de deelnemers te verzamelen."
+
+msgid "Additional actions"
+msgstr "Aanvullende acties"
+
+msgid "Additional information"
+msgstr "Meer informatie"
+
+msgid "Address"
+msgstr "Adres"
+
+msgid "Addresses"
+msgstr "Adressen"
+
+msgid "Admin"
+msgstr "Admin"
+
+msgid "Administrator"
+msgstr "Administrator"
+
+msgid "Advisory Board"
+msgstr "Raad van Advies"
+
+msgid "Advisory Boards"
+msgstr "Raden van Advies"
+
+msgid "Afternoon"
+msgstr "Namiddag"
+
+msgid "Age"
+msgstr "Leeftijd"
+
+msgid "Agenda"
+msgstr "Agenda"
+
+msgid "Album title"
+msgstr "Album titel"
+
+msgid "Alcohol Policy"
+msgstr "Alcoholreglement"
+
+msgid "All Activities"
+msgstr "Alle Activiteiten"
+
+msgid "All rights reserved."
+msgstr "Alle rechten voorbehouden."
+
+msgid "Already subscribed"
+msgstr "Je bent al ingeschreven"
+
+msgid "Already voted!"
+msgstr "Je hebt al gestemd!"
+
+msgid "Also for data removal requests, you can contact"
+msgstr "Ook als je gegevens wilt laten verwijderen, neem dan contact op met"
+
+msgid ""
+"An e-mail has been sent with instructions for resetting your password. If "
+"you have not received an e-mail, try again in 20 minutes."
+msgstr ""
+"Er is een e-mail verzonden met instructies om je wachtwoord te resetten. Als "
+"je geen e-mail hebt ontvangen, probeer het dan over 20 minuten opnieuw."
+
+msgid "An error occurred"
+msgstr "Er is een fout opgetreden"
+
+msgid "An error occurred while saving the course!"
+msgstr "Er is een fout opgetreden tijdens het opslaan van het vak!"
+
+msgid "An error occurred while trying to generate an album photo."
+msgstr "Er is een fout opgetreden tijdens het genereren van een albumfoto."
+
+msgid "An unknown error occurred during uploading ("
+msgstr "Een onbekende error vond plaats tijdens het uploaden van ("
+
+msgid "An unknown error occurred during uploading (%i)"
+msgstr "Een onbekende fout vond plaats tijdens het uploaden van (%i)"
+
+msgid ""
+"An unknown error occurred while try to change the status of a job update "
+"proposal. Please try again."
+msgstr ""
+"Er is een onbekende fout opgetreden tijdens het veranderen van de status van "
+"het vacature updatevoorstel. Probeer het opnieuw."
+
+msgid ""
+"An unknown error occurred while trying to transfer jobs, please try again."
+msgstr ""
+"Er is een onbekende fout opgetreden tijdens het verplaatsen van de "
+"vacatures, probeer het opnieuw."
+
+msgid "Answers"
+msgstr "Antwoorden"
+
+#, php-format
+msgid "Answers from %s (%s)"
+msgstr "Antwoorden van %s (%s)"
+
+msgid "Aperture"
+msgstr "Aperture"
+
+msgid "App"
+msgstr "App"
+
+msgid "Applied Physics"
+msgstr "Technische Natuurkunde"
+
+msgid "Apply Update"
+msgstr "Update toepassen"
+
+msgid "Approval"
+msgstr "Goedkeuring"
+
+msgid "Approval status"
+msgstr "Goedkeuringsstatus"
+
+msgid "Approvals"
+msgstr "Goedkeuringen"
+
+msgid "Approve"
+msgstr "Goedkeuren"
+
+msgid "Approve Job"
+msgstr "Keur vacature goed"
+
+msgid "Approve option"
+msgstr "Keur optie goed"
+
+msgid "Approve poll"
+msgstr "Keur poll goed"
+
+msgid "Approved"
+msgstr "Goedgekeurd"
+
+msgid "Approved (Has Updates)"
+msgstr "Goedgekeurd (heeft updates)"
+
+msgid "Approved Activities"
+msgstr "Goedgekeurde activiteiten"
+
+msgid "Approved polls"
+msgstr "Goedgekeurde polls"
+
+msgid "Approver"
+msgstr "Goedgekeurd door"
+
+msgid "Are you sure that you want to approve this poll?"
+msgstr "Weet je zeker dat je deze poll wilt goedkeuren?"
+
+msgid "Are you sure you want to approve this option?"
+msgstr "Weet je zeker dat je deze optie wilt goedkeuren?"
+
+#, php-format
+msgid "Are you sure you want to delete %s?"
+msgstr "Weet je zeker dat je %s wil verwijderen?"
+
+#, php-format
+msgid ""
+"Are you sure you want to delete %s? This will also delete all associated "
+"exams and summaries will be deleted."
+msgstr ""
+"Weet je zeker dat je %s wilt verwijderen? Dan worden ook alle bijbehorende "
+"examens en samenvattingen verwijderd."
+
+msgid ""
+"Are you sure you want to delete the selected items? <strong>This action can "
+"not be reverted.</strong>"
+msgstr ""
+"Weet je zeker dat je de geselecteerde items wilt verwijderen? <strong>Deze "
+"actie kan niet ongedaan gemaakt worden.</strong>"
+
+msgid "Are you sure you want to delete this activity category?"
+msgstr "Weet je zeker dat je deze activiteitencategorie wilt verwijderen?"
+
+msgid ""
+"Are you sure you want to delete this album including all photos inside of "
+"it? <strong>This action can not be reverted.</strong>"
+msgstr ""
+"Weet je zeker dat je dit album met alle foto's wilt verwijderen? "
+"<strong>Deze actie kan niet ongedaan gemaakt worden.</strong>"
+
+msgid "Are you sure you want to delete this document?"
+msgstr "Weet je zeker dat u dit document wilt verwijderen?"
+
+msgid "Are you sure you want to delete this job?"
+msgstr "Weet je zeker dat je deze vacature wilt verwijderen?"
+
+msgid ""
+"Are you sure you want to delete this option planning period? This will "
+"<strong>not</strong> delete proposed options."
+msgstr ""
+"Weet je zeker dat u deze optieplanningsperiode wilt verwijderen? Hiermee "
+"worden voorgestelde opties <strong>niet</strong> verwijderd."
+
+msgid "Are you sure you want to delete this option?"
+msgstr "Weet je zeker dat je deze optie wil verwijderen?"
+
+msgid "Are you sure you want to delete this package?"
+msgstr "Weet je zeker dat je dit pakket wilt verwijderen?"
+
+msgid ""
+"Are you sure you want to delete this photo? <strong>This action can not be "
+"reverted.</strong>"
+msgstr ""
+"Weet je zeker dat je deze foto wilt verwijderen? <strong>Deze actie kan niet "
+"ongedaan gemaakt worden.</strong>"
+
+msgid "Are you sure you want to delete this poll?"
+msgstr "Weet je zeker dat je deze poll wilt verwijderen?"
+
+msgid "Are you sure you would like to authorize"
+msgstr "Weet je zeker dat je wilt machtigen"
+
+#, php-format
+msgid "Are you sure you would like to authorize %s"
+msgstr "Weet je zeker dat je %s wilt machtigen"
+
+msgid "Article"
+msgstr "Artikel"
+
+msgid "Artist"
+msgstr "Artiest"
+
+#, php-format
+msgid ""
+"As per HR article 5 paragraph 4, you have the right to revoke your "
+"authorization for the %s GMM. You can communicate this to the board in "
+"writing (not by email) or by using the form below. Please note that you can "
+"only revoke an authorization that was granted via this website by using the "
+"form below."
+msgstr ""
+"Conform HR artikel 5 lid 4 heb je het recht om jouw machtiging voor de %s "
+"ALV in te trekken. Je kan dit schriftelijk (niet per e-mail) of via "
+"onderstaand formulier aan het bestuur kenbaar maken. Let op: je kan alleen "
+"een machtiging die via deze website is verleend via onderstaand formulier "
+"intrekken."
+
+msgid "Association"
+msgstr "Vereniging"
+
+msgid "Attachment"
+msgstr "Bijlage"
+
+msgid "Author"
+msgstr "Auteur"
+
+msgid "Authorise"
+msgstr "Sta toe"
+
+msgid "Authorizations"
+msgstr "Machtigingen"
+
+msgid "Authorize"
+msgstr "Machtig"
+
+#, php-format
+msgid "Authorize %s to use your account?"
+msgstr "Geef je %s toestemming om je account te gebruiken?"
+
+#, php-format
+msgid "Authorize someone for the %s GMM (%s)"
+msgstr "Machtig iemand voor de %s ALV (%s)"
+
+msgid "Authorizer"
+msgstr "Machtiger"
+
+msgid "Available documents"
+msgstr "Beschikbare documenten"
+
+msgid "BM"
+msgstr "BV"
+
+msgid "Banner"
+msgstr "Banner"
+
+msgid "Banner Package"
+msgstr "Bannerpakket"
+
+msgid "Banner active"
+msgstr "Banner actief"
+
+msgid "Biomedical Engineering"
+msgstr "Biomedische Technologie"
+
+msgid "Birth date"
+msgstr "Geboortedatum"
+
+msgid "Birthdays"
+msgstr "Verjaardagen"
+
+msgid "Board"
+msgstr "Bestuur"
+
+msgid "Board Meeting"
+msgstr "Bestuursvergadering"
+
+msgid "Board Policies"
+msgstr "Beleidsnota's"
+
+msgid "Books"
+msgstr "Boeken"
+
+msgid "Borrel Policy"
+msgstr "Borrelreglement"
+
+msgid "Brand Manager"
+msgstr "Brand Manager"
+
+msgid "Browsing directory: "
+msgstr "Huidige map: "
+
+msgid ""
+"By subscribing an external participant to this activity, they must agree to "
+"the terms outlined in the"
+msgstr ""
+"Door iemand zonder GEWIS lidmaatschap in te schrijven voor deze activiteit "
+"moet deze persoon akkoord gaan met de voorwaarden in het"
+
+msgid "By subscribing to this activity, you agree to the terms outlined in the"
+msgstr ""
+"Door je in te schrijven voor deze activiteit ga je akkoord met de "
+"voorwaarden in het"
+
+msgid "Bylaws"
+msgstr "Statuten"
+
+msgid "CM"
+msgstr "VV"
+
+msgid "Camera"
+msgstr "Camera"
+
+msgid "Cancel"
+msgstr "Annuleer"
+
+msgid "Cannot load metadata"
+msgstr "Kan metadata niet laden"
+
+msgid "Cannot load tags"
+msgstr "Kan tags niet laden"
+
+msgid "Cannot load vote"
+msgstr "Kan stem niet laden"
+
+msgid "Career"
+msgstr "Carrière"
+
+msgid "Career Activities"
+msgstr "Carrière Activiteiten"
+
+msgid "Career related"
+msgstr "Carrière gerelateerd"
+
+msgid "Categories"
+msgstr "Categorieën"
+
+msgid "Category"
+msgstr "Categorie"
+
+msgid "Chair's Meeting"
+msgstr "Voorzittersvergadering"
+
+msgid "Change password"
+msgstr "Wijzig wachtwoord"
+
+#, php-format
+msgid ""
+"Changes in activity attributes are shown like this: %s. If there are no "
+"changes to a certain attribute, you will see the existing data. Sign-up list "
+"differences are <strong>not</strong> shown with colours, both the old sign-"
+"up list(s) and the new sign-up list(s) are shown. There might not be "
+"difference between the two!"
+msgstr ""
+"Veranderingen in activiteitsattributen worden als volgt weergegeven: %s. Als "
+"er geen wijzigingen zijn in een bepaald attribuut, zie je de bestaande "
+"gegevens. Verschillen tussen inschrijflijsten worden <strong>niet</strong> "
+"met kleuren getoond, zowel de oude inschrijflijst(en) als de nieuwe "
+"inschrijflijst(en) worden getoond. Het kan zijn dat er geen verschil is "
+"tussen de twee!"
+
+msgid "Check the spelling of your search term"
+msgstr "Controleer de spelling van je zoekterm"
+
+msgid ""
+"Check this if the document is scanned, as this will enable higher quality "
+"downloads. Please note that enabling setting this for non-scanned documents "
+"will significantly impact the ability to download the document."
+msgstr ""
+"Vink dit aan als het document gescand is, omdat dit downloads van hogere "
+"kwaliteit mogelijk maakt. Let op dat het inschakelen van deze instelling "
+"voor niet-gescande documenten de mogelijkheid om het document te downloaden "
+"aanzienlijk zal beïnvloeden."
+
+msgid "Chemical Engineering"
+msgstr "Scheikundige Technologie"
+
+msgid "Choice"
+msgstr "Keuze"
+
+msgid "Choose a meeting"
+msgstr "Kies een vergadering"
+
+msgid "Choose to which job package you want to transfer the selected jobs."
+msgstr ""
+"Kies naar welk vacaturepakket je de geselecteerde vacatures wilt verplaatsen."
+
+msgid "Choose which options are applicable to this activity."
+msgstr "Kies welke opties van toepassing zijn op deze activiteit."
+
+msgid "City and postal code"
+msgstr "Woonplaats en postcode"
+
+msgid "Close"
+msgstr "Sluiten"
+
+msgid "Close date and time"
+msgstr "Sluitingsdatum en -tijd"
+
+msgid "Code"
+msgstr "Code"
+
+msgid "Comment"
+msgstr "Commentaar"
+
+msgid "Comment on this poll"
+msgstr "Commentaar op deze poll"
+
+msgid "Comments"
+msgstr "Commentaar"
+
+msgid "Commissaris Carrièreontwikkeling en Externe Betrekkingen"
+msgstr "Commissaris Carrièreontwikkeling en Externe Betrekkingen"
+
+msgid "Commissaris Externe Betrekkingen"
+msgstr "Commissaris Externe Betrekkingen"
+
+msgid "Commissaris Innovatie"
+msgstr "Commissaris Innovatie"
+
+msgid "Commissaris Interne Betrekkingen"
+msgstr "Commissaris Interne Betrekkingen"
+
+msgid "Commissaris Kennisbeheer"
+msgstr "Commissaris Kennisbeheer"
+
+msgid "Commissaris Onderwijs"
+msgstr "Commissaris Onderwijs"
+
+msgid "Committee"
+msgstr "Commissie"
+
+msgid "Committee / fraternity"
+msgstr "Commissee / dispuut"
+
+msgid "Committees"
+msgstr "Commissies"
+
+msgid "Companies"
+msgstr "Bedrijven"
+
+msgid "Company"
+msgstr "Bedrijf"
+
+msgid "Company Account"
+msgstr "Bedrijfsprofiel"
+
+msgid "Complaint or suggestion about TU/e education?"
+msgstr "Klacht of suggestie over TU/e onderwijs?"
+
+msgid "Complete agenda"
+msgstr "Volledige agenda"
+
+msgid "Confidential Contact Person (CCP)"
+msgstr "Vertrouwenscontactpersonen (VCP)"
+
+msgid "Confirm authorization"
+msgstr "Bevestig machtiging"
+
+msgid "Confirm subscription"
+msgstr "Bevestig inschrijving"
+
+msgid "Contact"
+msgstr "Contact"
+
+msgid "Contact Information"
+msgstr "Contactgegevens"
+
+msgid "Content"
+msgstr "Inhoud"
+
+msgid "Continue"
+msgstr "Doorgaan"
+
+msgid "Continue reading"
+msgstr "Lees meer"
+
+msgid "Contract Number"
+msgstr "Contractnummer"
+
+msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
+msgstr ""
+"Contractnummers kunnen alleen letters, cijfers, _, -, ., en spaties bevatten"
+
+msgid "Controller"
+msgstr "Controller"
+
+msgid "Copied URL!"
+msgstr "URL gekopieerd!"
+
+msgid "Corporate Identity"
+msgstr "Huisstijl"
+
+msgid "Costs"
+msgstr "Kosten"
+
+msgid "Could not set as profile photo, try again"
+msgstr "Profielfoto instellen mislukt, probeer het nog een keer"
+
+msgid "Could not vote, try again"
+msgstr "Stemmen mislukt, probeer het nog een keer"
+
+msgid "Country"
+msgstr "Land"
+
+msgid "Course Admin"
+msgstr "Vak administratie"
+
+#, php-format
+msgid "Course Documents of %s"
+msgstr "Documenten van %s"
+
+msgid "Course code"
+msgstr "Vakcode"
+
+msgid "Course code or course description"
+msgstr "Vak code of omschrijving"
+
+msgid "Course does not exist"
+msgstr "Vak bestaat niet"
+
+msgid "Course name"
+msgstr "Vak naam"
+
+msgid "Courses"
+msgstr "Vakken"
+
+msgid "Cover photo to upload"
+msgstr "Coverfoto om te uploaden"
+
+msgid "Create"
+msgstr "Maak"
+
+msgid "Create API token"
+msgstr "Maak een API token"
+
+msgid "Create Activity"
+msgstr "Maak nieuwe activiteit"
+
+msgid "Create Activity Category"
+msgstr "Activiteitencategorie aanmaken"
+
+msgid "Create Album"
+msgstr "Album maken"
+
+msgid "Create Company"
+msgstr "Bedrijf aanmaken"
+
+msgid "Create Job Category"
+msgstr "Vacaturecategorie aanmaken"
+
+msgid "Create Job Label"
+msgstr "Vacature-label aanmaken"
+
+msgid "Create Option Period"
+msgstr "Optieperiode maken"
+
+msgid "Create a new page"
+msgstr "Maak een nieuwe pagina"
+
+msgid "Create activity proposal"
+msgstr "Creëer activiteitenvoorstel"
+
+msgid "Create album"
+msgstr "Nieuw album"
+
+msgid "Create an activity"
+msgstr "Maak een activiteit"
+
+msgid "Create new album"
+msgstr "Maak nieuw album"
+
+msgid "Create news item"
+msgstr "Maak een nieuw nieuwsitem"
+
+msgid "Created"
+msgstr "Aangemaakt"
+
+msgid "Creator"
+msgstr "Aangemaakt door"
+
+msgid "Current photo of the week"
+msgstr "Huidige foto van de week"
+
+msgid "Current subscriptions"
+msgstr "Huidige inschrijvingen"
+
+msgid "Currently, no pictures of the week are available."
+msgstr "Op het moment zijn er geen foto's van de week beschikbaar."
+
+msgid "Date"
+msgstr "Datum"
+
+msgid "Date and time"
+msgstr "Datum en tijd"
+
+msgid "Date/time"
+msgstr "Datum/tijd"
+
+msgid "Day"
+msgstr "Dag"
+
+msgid "Decisions"
+msgstr "Besluiten"
+
+msgid "Delete"
+msgstr "Verwijder"
+
+msgid "Delete %i photos"
+msgstr "Verwijder %i foto's"
+
+msgid "Delete Activity Category"
+msgstr "Activiteitencategorie verwijderen"
+
+msgid "Delete Course"
+msgstr "Verwijder vak"
+
+msgid "Delete Document"
+msgstr "Verwijder document"
+
+msgid "Delete album"
+msgstr "Verwijder album"
+
+msgid "Delete company"
+msgstr "Verwijder bedrijf"
+
+msgid "Delete confirmation"
+msgstr "Bevestig verwijderen"
+
+msgid "Delete job"
+msgstr "Verwijder vacature"
+
+msgid "Delete option"
+msgstr "Verwijder optie"
+
+msgid "Delete package"
+msgstr "Verwijder pakket"
+
+msgid "Delete period"
+msgstr "Verwijder periode"
+
+msgid "Delete photo"
+msgstr "Verwijder foto"
+
+msgid "Delete photos"
+msgstr "Verwijder foto's"
+
+msgid "Delete poll"
+msgstr "Verwijder poll"
+
+msgid "Delete this news item"
+msgstr "Verwijder dit nieuwsitem"
+
+msgid "Delete this page"
+msgstr "Verwijder deze pagina"
+
+msgid "Description"
+msgstr "Beschrijving"
+
+msgid "Deselect this to allow people without a GEWIS account to subscribe."
+msgstr ""
+"Deselecteer dit om mensen zonder GEWIS account toe te staan zich in te "
+"schrijven."
+
+msgid "Details"
+msgstr "Details"
+
+msgid "Digital Infrastructure Officer"
+msgstr "Digital Infrastructure Officer"
+
+msgid "Disapprove"
+msgstr "Afkeuren"
+
+msgid "Disapprove Job"
+msgstr "Keur vacature af"
+
+msgid "Disapproved Activities"
+msgstr "Afgekeurde activiteiten"
+
+msgid "Disclaimer on educational content"
+msgstr "Disclaimer over onderwijsinhoud"
+
+msgid "Display GEWIS member count"
+msgstr "Toon aantal GEWIS leden"
+
+msgid "Display number of subscribed members"
+msgstr "Toon aantal deelnemers"
+
+#, php-format
+msgid ""
+"Do you have a complaint or suggestion concerning the education at the TU/e? "
+"Contact the %seducation officer%s to share your ideas."
+msgstr ""
+"Heb je een klacht of een suggestie over het onderwijs aan de TU/e? Neem dan "
+"contact op met de %sonderwijscommissaris%s om je feedback te delen."
+
+#, php-format
+msgid ""
+"Do you want to contribute to the collection of old exams and summaries? Send "
+"them to the %seducation officer%s so that your (future) peers can benefit."
+msgstr ""
+"Wil je bijdragen aan het verzamelen van samenvattingen? Stuur je "
+"samenvatting naar de %sonderwijs commissaris%s zodat je (toekomstige) "
+"studiegenoten er van kunnen profiteren."
+
+msgid "Document name"
+msgstr "Naam document"
+
+msgid "Document to upload"
+msgstr "Te uploaden document"
+
+msgid "Documents"
+msgstr "Documenten"
+
+msgid "Documents for this meeting"
+msgstr "Documenten voor deze vergadering"
+
+#, php-format
+msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
+msgstr "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
+
+msgid "Download"
+msgstr "Downloaden"
+
+msgid "Dutch"
+msgstr "Nederlands"
+
+msgid "Dutch Name"
+msgstr "Nederlandse naam"
+
+msgid "Dutch content"
+msgstr "Nederlandse inhoud"
+
+msgid "Dutch name"
+msgstr "Nederlandse naam"
+
+msgid "Dutch option"
+msgstr "Nederlandse optie"
+
+msgid "Dutch question"
+msgstr "Nederlandse vraag"
+
+msgid "Dutch title"
+msgstr "Nederlandse titel"
+
+msgid "E-mail Address"
+msgstr "E-mailadres"
+
+msgid "E-mail address"
+msgstr "E-mail adres"
+
+msgid "E-mail address format is not valid"
+msgstr "E-mailadres formaat is niet geldig"
+
+msgid "E-mail address format is not valid."
+msgstr "E-mailadres formaat is niet geldig."
+
+msgid "Edit"
+msgstr "Bewerken"
+
+#, php-format
+msgid "Edit %s"
+msgstr "%s bewerken"
+
+msgid "Edit Album"
+msgstr "Wijzig album"
+
+msgid "Edit Company"
+msgstr "Wijzig bedrijf"
+
+msgid "Edit Course"
+msgstr "Bewerk vak"
+
+msgid "Edit Exam"
+msgstr "Bewerk examen"
+
+msgid "Edit Job"
+msgstr "Vacature aanpassen"
+
+msgid "Edit Job Category"
+msgstr "Vacaturecategorie aanpassen"
+
+msgid "Edit Job Label"
+msgstr "Vacature-label aanpassen"
+
+msgid "Edit Option Period"
+msgstr "Bewerk optieperiode"
+
+msgid "Edit Package"
+msgstr "Pakket aanpassen"
+
+msgid "Edit Summary"
+msgstr "Bewerk samenvatting"
+
+msgid "Edit album"
+msgstr "Wijzig album"
+
+msgid "Edit organ information"
+msgstr "Bewerk orgaan informatie"
+
+msgid "Education"
+msgstr "Onderwijs"
+
+msgid "Education admin"
+msgstr "Onderwijs admin"
+
+msgid "Electrical Engineering"
+msgstr "Electrical Engineering"
+
+msgid "Email"
+msgstr "Email"
+
+msgid "Email address"
+msgstr "E-mailadres"
+
+msgid "Email address:"
+msgstr "E-mail adres:"
+
+msgid "Email the board of GEWIS"
+msgstr "Email het bestuur van GEWIS"
+
+msgid "Email the secretary of GEWIS"
+msgstr "Email de secretaris van GEWIS"
+
+msgid "Empty folder"
+msgstr "Lege map"
+
+msgid "Enable Dutch Translations"
+msgstr "Nederlandse vertalingen inschakelen"
+
+msgid "Enable English Translations"
+msgstr "Engelse vertalingen inschakelen"
+
+msgid "End"
+msgstr "Einde"
+
+msgid "End date"
+msgstr "Einddatum"
+
+msgid "End date and time"
+msgstr "Einddatum en -tijd"
+
+msgid "End date and time of option period"
+msgstr "Einddatum en -tijd van de optieperiode"
+
+msgid "End date and time of planning period"
+msgstr "Einddatum en -tijd van de planningsperiode"
+
+msgid "End date of membership"
+msgstr "Einddatum van lidmaatschap"
+
+msgid "English"
+msgstr "Engels"
+
+msgid "English Name"
+msgstr "Engelse naam"
+
+msgid "English content"
+msgstr "Engelse inhoud"
+
+msgid "English name"
+msgstr "Engelse naam"
+
+msgid "English option"
+msgstr "Engelse optie"
+
+msgid "English question"
+msgstr "Engelse vraag"
+
+msgid "English title"
+msgstr "Engelse titel"
+
+msgid "Enter a new name for this document:"
+msgstr "Voor een nieuwe naam in voor dit document:"
+
+msgid "Enter how someone can contact the person responsible for this job."
+msgstr ""
+"Geef aan hoe iemand contact kan opnemen met de persoon die verantwoordelijk "
+"is voor deze vacature."
+
+msgid ""
+"Enter how someone can contact this company and who is responsible for this "
+"company."
+msgstr ""
+"Geef aan hoe iemand contact kan opnemen met dit bedrijf en wie er "
+"verantwoordelijk is voor dit bedrijf."
+
+msgid "Enter information about the representative of this company."
+msgstr "Geef informatie over de vertegenwoordiger van dit bedrijf."
+
+msgid ""
+"Enter the maximum number of activities for which options can be created. You "
+"can either set the number globally or individually for each organ."
+msgstr ""
+"Vul het maximum aantal activiteiten in waarvoor opties kunnen worden "
+"aangemaakt. Dit kan globaal of voor elk orgaan afzonderlijk worden ingesteld."
+
+msgid "Enter the start and end date and time of the option period."
+msgstr "Vul de begin- en einddatum en -tijd van de optieperiode in."
+
+msgid "Enter the start and end date and time of the planning period."
+msgstr "Vul de begin- en einddatum en -tijd van de planningsperiode in."
+
+msgid "Enter the start and end date and time of this activity."
+msgstr "Vul de begin- en einddatum en -tijd van deze activiteit in."
+
+msgid ""
+"Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
+"resultaten te zien."
+msgstr ""
+"Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
+"resultaten te zien."
+
+msgid "Evening"
+msgstr "Avond"
+
+msgid "Exam date"
+msgstr "Datum tentamen"
+
+msgid "Exam to upload"
+msgstr "Tentamen"
+
+msgid "Exams"
+msgstr "Tentamens"
+
+msgid "Exams and summaries"
+msgstr "Tentamens en samenvattingen"
+
+msgid "Exceptional Members"
+msgstr "Uitzonderlijke leden"
+
+msgid "Expiration Date"
+msgstr "Afloopdatum"
+
+msgid "Expiration date"
+msgstr "Verloopdatum"
+
+msgid "Expiration date for the poll (YYYY-MM-DD)"
+msgstr "Verloopdatum van de poll (JJJJ-MM-DD)"
+
+msgid "Expired packages"
+msgstr "Verlopen pakketten"
+
+msgid "Exposure time"
+msgstr "Belichtingstijd"
+
+msgid "External"
+msgstr "Extern"
+
+msgid "External applications"
+msgstr "Externe applicaties"
+
+msgid "FAQ"
+msgstr "FAQ"
+
+msgid "Family name"
+msgstr "Achternaam"
+
+msgid "Featured"
+msgstr "Uitgelicht"
+
+msgid "Featured Package"
+msgstr "Uitgelicht pakket"
+
+msgid "Featured company"
+msgstr "Uitgelicht bedrijf"
+
+msgid "Featured in language"
+msgstr "Uitgelicht in taal"
+
+msgid "File"
+msgstr "Bestand"
+
+msgid "Filename"
+msgstr "Bestandsnaam"
+
+msgid "Filter..."
+msgstr "Filter..."
+
+msgid "Final"
+msgstr "Eindexamen"
+
+#, php-format
+msgid "Final test from %s (%s)"
+msgstr "Eindexamen op %s (%s)"
+
+msgid "Finalize exam uploads"
+msgstr "Rond uploaden tentamens af"
+
+msgid "Finalize summary uploads"
+msgstr "Rond uploaden samenvattingen af"
+
+msgid "Finalize uploads"
+msgstr "Rond uploaden af"
+
+msgid "Financial Audit Committee"
+msgstr "Kas Controle Commissie"
+
+msgid "Financial Audit Committees"
+msgstr "Kas Controle Commissies"
+
+msgid "Find a member"
+msgstr "Vind een lid"
+
+msgid "First authentication"
+msgstr "Eerste authenticatie"
+
+msgid "First name"
+msgstr "Voornaam"
+
+msgid "Flash"
+msgstr "Flits"
+
+msgid "Focal length"
+msgstr "Brandpuntsafstand"
+
+msgid "For old exams of minor courses, you can also look at:"
+msgstr "Voor oude tentamens of minor vakken kun je ook terecht bij:"
+
+#, php-format
+msgid "Found %d %s matching your description"
+msgstr "%d %s gevonden overeenkomend met je zoektermen"
+
+msgid "Fraternities"
+msgstr "Disputen"
+
+msgid "Fraternity"
+msgstr "Dispuut"
+
+msgid "From"
+msgstr "Van"
+
+msgid "Full name:"
+msgstr "Volledige naam:"
+
+msgid "GEWIKI"
+msgstr "GEWIKI"
+
+msgid "GEWIS has many different committees, learn more about them below!"
+msgstr ""
+"GEWIS heeft veel verschillende commissies, zie hieronder voor meer "
+"informatie!"
+
+msgid "GEWIS members only"
+msgstr "Alleen GEWIS leden"
+
+msgid "GEWIS song"
+msgstr "GEWIS-lied"
+
+msgid "GMM"
+msgstr "ALV"
+
+#, php-format
+msgid "GMM %d (%s)"
+msgstr "ALV %d (%s)"
+
+msgid "GMM Committee"
+msgstr "ALV-Commissie"
+
+msgid "GMM Committees"
+msgstr "ALV-Commissies"
+
+msgid "GMM Taskforce"
+msgstr "ALV-Werkgroep"
+
+msgid "GMM Taskforces"
+msgstr "ALV-Werkgroepen"
+
+msgid "General"
+msgstr "Algemeen"
+
+msgid "General Members Meeting"
+msgstr "Algemene Ledenvergadering"
+
+msgid "Generate a new cover photo"
+msgstr "Genereer nieuwe cover foto"
+
+msgid "Generatie"
+msgstr "Generatie"
+
+msgid "Generation"
+msgstr "Generatie"
+
+msgid "Given name"
+msgstr "Voornaam"
+
+msgid "Global Value"
+msgstr "Globale waarde"
+
+msgid "Go to album"
+msgstr "Ga naar album"
+
+msgid "Google Calendar"
+msgstr "Google Calendar"
+
+msgid "Graduate"
+msgstr "Afgestudeerde"
+
+msgid "Has key code?"
+msgstr "Heeft sleutelcode?"
+
+msgid "Has limited capacity"
+msgstr "Heeft beperkte capaciteit"
+
+msgid ""
+"Have you forgotten your e-mail address and do you want to change it? Ask the "
+"secretary by going to GEWIS (preferred) or by sending an e-mail."
+msgstr ""
+"Ben je jouw e-mailadres vergeten en wil je het wijzigen? Vraag het aan de "
+"secretaris door naar GEWIS te komen (aanbevolen) of door een e-mail te "
+"sturen."
+
+msgid ""
+"Here you can add, edit, or remove activity categories. Click on 'Add "
+"Category' to add a new category or click on a category to edit/remove it."
+msgstr ""
+"Hier kan je activiteitencategorieën toevoegen, bewerken of verwijderen. Klik "
+"op 'Nieuwe categorie' om een nieuwe categorie toe te voegen of klik op een "
+"categorie om deze te bewerken/verwijderen."
+
+msgid ""
+"Here you can find everyone who signed up for this activity (may contain "
+"duplicates). Using the tabs above you can navigate to the different sign-up "
+"lists of this activity. From there you can remove external participants and "
+"(when supplied) view additional signup information from each participant."
+msgstr ""
+"Hier vind je iedereen die zich voor deze activiteit heeft aangemeld (kan "
+"duplicaten bevatten). Met de tabs hierboven kun je navigeren naar de "
+"verschillende inschrijflijsten van deze activiteit. Vanaf daar kan je "
+"externe deelnemers verwijderen en (indien aanwezig) extra "
+"inschrijfinformatie van elke deelnemer bekijken."
+
+msgid ""
+"Here you can find everyone who signed up to this sign-up list. Here you can "
+"add or remove external participants and view detailed information regarding "
+"the signup of all participants."
+msgstr ""
+"Hier vind je iedereen die zich op deze inschrijflijst heeft ingeschreven. "
+"Hier kan je externe deelnemers toevoegen of verwijderen en gedetailleerde "
+"informatie bekijken over de inschrijving van alle deelnemers."
+
+msgid "Hidden"
+msgstr "Verborgen"
+
+msgid "Highlighted"
+msgstr "Uitgelicht"
+
+msgid "Highlights"
+msgstr "Highlights"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "Home address (parents)"
+msgstr "Thuisadres (ouders)"
+
+msgid "Honorary"
+msgstr "Erelidmaatschap"
+
+msgid "House Rules"
+msgstr "Huisregels"
+
+msgid "Housing"
+msgstr "Huisvesting"
+
+#, php-format
+msgid ""
+"I, %s I am fully aware that by filling in this form I authorize the person "
+"in this form to represent me at the %s General Members Meeting (%s) of s.v. "
+"GEWIS."
+msgstr ""
+"Ik, %s ben mij er volledig van bewust dat ik door het invullen van dit "
+"formulier de persoon op dit formulier machtig om mij te vertegenwoordigen op "
+"de %s Algemene Ledenvergadering (%s) der s.v. GEWIS."
+
+#, php-format
+msgid ""
+"I, %s am fully aware that by revoking my authorization, %s cannot represent "
+"me at the %s General Members Meeting (%s) of s.v. GEWIS."
+msgstr ""
+"Ik, %s ben mij er volledig van bewust dat door het intrekken van mijn "
+"machtiging, %s mij niet kan vertegenwoordigen op de %s Algemene "
+"Ledenvergadering (%s) der s.v. GEWIS."
+
+msgid "ICT Policy"
+msgstr "ICT-reglement"
+
+msgid "ISO"
+msgstr "ISO"
+
+msgid ""
+"If an exam has been put online without the intention of the author, please "
+"let the board of GEWIS know by sending an"
+msgstr ""
+"Mocht er onbedoeld een tentamen online zijn gekomen dat niet gepubliceerd "
+"had mogen worden, laat dit dan weten aan het bestuur van GEWIS door"
+
+msgid "If approved, this job will be <strong>hidden</strong>."
+msgstr "Bij goedkeuring wordt deze vacature <strong>verborgen</strong>."
+
+msgid ""
+"If approved, this job will be <strong>published</strong>, however, its "
+"actual visiblity depends on the company and associated job package."
+msgstr ""
+"Bij goedkeuring wordt deze vacature <strong>gepubliceerd</strong>, maar de "
+"daadwerkelijke zichtbaarheid hangt af van het bedrijf en het bijbehorende "
+"vacaturepakket."
+
+msgid ""
+"If this is checked the My Future logo will be displayed on the activity page "
+"and the activity will be included on the career activities page."
+msgstr ""
+"Als dit geselecteerd is dan wordt het My Future logo weergegeven op de "
+"pagina van de activiteit en zal de activiteit op de carrière activiteiten "
+"pagina weergegeven worden."
+
+msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
+msgstr ""
+"Blijft dit gebeuren, neem dan contact op met de ApplicatieBeheerCommissie."
+
+#, php-format
+msgid ""
+"If you aren't able to attend a GMM in person but you want your voice to be "
+"heard, consider %sauthorizing another member%s to act on your behalf."
+msgstr ""
+"Als je niet in staat bent een ALV persoonlijk bij te wonen, maar je wilt "
+"toch dat je stem wordt gehoord, overweeg dan %seen ander lid%s te machtigen "
+"om jou te vertegenwoordingen."
+
+#, php-format
+msgid "If you don't have an account yet, go to the %sRegistration page%s"
+msgstr "Als je nog geen account hebt, ga naar de %sRegistratie pagina%s"
+
+#, php-format
+msgid "If you forgot your password, go to the %sPassword reset page%s"
+msgstr ""
+"Als je je wachtwoord bent vergeten, ga naar de %sWachtwoord reset pagina %s"
+
+#, php-format
+msgid ""
+"If your browser does not redirect you back, please <a href=\"%s\">click "
+"here</a> to continue."
+msgstr ""
+"Als je  browser je niet doorstuurt, <a href=\"%s\">klik dan hier</a> om "
+"verder te gaan."
+
+msgid ""
+"If your information is no longer up to date and you would like to change it, "
+"you can contact the secretary of GEWIS."
+msgstr ""
+"Als je gegevens niet meer actueel zijn of je ze wilt ze laten wijzigen, neem "
+"dan contact op met de secretaris van GEWIS."
+
+msgid "In this photo:"
+msgstr "In deze foto:"
+
+msgid "Inactief Lid"
+msgstr "Inactief Lid"
+
+msgid "Inactive members"
+msgstr "Inactieve leden"
+
+msgid "Infimum"
+msgstr "Infimum"
+
+msgid "Information"
+msgstr "Informatie"
+
+msgid "Information for committees"
+msgstr "Informatie voor commissies"
+
+msgid "Initials"
+msgstr "Initialen"
+
+msgid "Inkoper"
+msgstr "Inkoper"
+
+msgid "Innovation Sciences"
+msgstr "Innovation Sciences"
+
+msgid "Interim"
+msgstr "Tussentijdse toets"
+
+#, php-format
+msgid "Interim test from %s (%s)"
+msgstr "Tussentijdse toets op %s (%s)"
+
+msgid "Internal Regulations"
+msgstr "Huishoudelijk reglement"
+
+msgid "Invalid form"
+msgstr "De ingevulde gegevens zijn niet geldig"
+
+msgid "Is 18+?"
+msgstr "Is 18+?"
+
+#, php-format
+msgid ""
+"It has been more than 90 days since you last used <strong>%s</strong>. As a "
+"reminder, the application has access to:"
+msgstr ""
+"Het is meer dan 90 dagen geleden dat je <strong>%s</strong> voor het laatst "
+"heeft gebruikt. Ter herinnering, de applicatie heeft toegang tot:"
+
 msgid ""
 "It is not allowed to put more than 3 options for the same activity in the "
 "calendar."
@@ -719,7 +1558,1148 @@ msgstr ""
 "Er mogen niet meer dan 3 opties voor dezelfde activiteit in de optiekalender "
 "geplaatst worden."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:44
+msgid "It will become visible after it has been approved by the board."
+msgstr ""
+"Het zal zichtbaar worden als de activiteit goedgekeurd is door het bestuur."
+
+msgid "Job Labels"
+msgstr "Vacature-labels"
+
+#, php-format
+msgid "Job Package (%s active)"
+msgstr "Vacaturepakket (%s actief)"
+
+msgid "Job Packages"
+msgstr "Vacaturepakketten"
+
+msgid "Job approval status reset!"
+msgstr "Goedkeuringsstatus van de vacature is ingetrokken!"
+
+msgid "Job approved!"
+msgstr "Vacature goedgekeurd!"
+
+msgid "Job category successfully created!"
+msgstr "Vacaturecategorie succesvol aangemaakt!"
+
+msgid "Job disapproved!"
+msgstr "Vacature afgekeurd!"
+
+msgid "Job has been updated!"
+msgstr "Vacature is bijgewerkt!"
+
+msgid "Job label successfully created!"
+msgstr "Vacature-label succesvol aangemaakt!"
+
+msgid ""
+"Job proposal successfully created! It will become active after it has been "
+"approved."
+msgstr ""
+"Voorstel voor vacature succesvol aangemaakt! Deze zal actief worden zodra "
+"deze is goedgekeurd."
+
+msgid "Job successfully created!"
+msgstr "Vacature succesvol aangemaakt!"
+
+msgid "Job successfully deleted."
+msgstr "Vacature succesvol verwijderd."
+
+msgid "Job successfully edited!"
+msgstr "Vacature succesvol aangepast!"
+
+msgid "Job update has been rejected!"
+msgstr "Vacature update is afgewezen!"
+
+msgid "Jobs"
+msgstr "Vacatures"
+
+msgid "Jobs (Active)"
+msgstr "Vacatures (actief)"
+
+msgid "Jobs (Active) / Type"
+msgstr "Vacatures (Actief) / Type"
+
+msgid "Jobs successfully transferred"
+msgstr "Vacature succesvol verplaatst"
+
+msgid "Key Policy"
+msgstr "Sleutelreglement"
+
+msgid "Labels"
+msgstr "Labels"
+
+msgid "Language"
+msgstr "Taal"
+
+msgid "Language settings"
+msgstr "Taalinstellingen"
+
+msgid "Last authentication"
+msgstr "Laatste authenticatie"
+
+msgid "Last membership change"
+msgstr "Laatste wijziging lidmaatschap"
+
+msgid "Last name"
+msgstr "Achternaam"
+
+msgid "Lid"
+msgstr "Lid"
+
+msgid "Links"
+msgstr "Links"
+
+msgid "Loading an infimum..."
+msgstr "Een infimum aan het laden..."
+
+msgid "Loading tags..."
+msgstr "Tags aan het laden..."
+
+msgid "Location"
+msgstr "Locatie"
+
+msgid "Log in"
+msgstr "Inloggen"
+
+msgid "Log in as company"
+msgstr "Inloggen als bedrijf"
+
+msgid "Log in as member"
+msgstr "Inloggen als lid"
+
+msgid "Login"
+msgstr "Login"
+
+msgid "Login to subscribe"
+msgstr "Login om in te schrijven"
+
+msgid "Login to view more information"
+msgstr "Log in om meer informatie te zien"
+
+msgid "Login to view the subscribed members."
+msgstr "Login om de lijst met deelnemers te bekijken."
+
+msgid "Logo"
+msgstr "Logo"
+
+msgid "Logo of"
+msgstr "Logo van"
+
+msgid "Logout"
+msgstr "Uitloggen"
+
+msgid "Long dutch description"
+msgstr "Volledige Nederlandse omschrijving"
+
+msgid "Long english description"
+msgstr "Volledige Engelse omschrijving"
+
+msgid ""
+"Looking for a specific decision but forgot the numbers? Try dropping the "
+"decision point and/or number"
+msgstr ""
+"Op zoek naar een specifiek besluit maar de nummers vergeten? Probeer het "
+"zonder besluitspunt en/of -nummer"
+
+msgid "Lunch break"
+msgstr "Lunchpauze"
+
+msgid "MMM d"
+msgstr "MMM d"
+
+msgid ""
+"Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
+"2022)."
+msgstr ""
+"Met <3 gemaakt door de ApplicatieBeheerCommissie en Web Commissie (2013 - "
+"2022)."
+
+msgid "Mail address"
+msgstr "Post adres"
+
+msgid "Mail everybody"
+msgstr "E-mail iedereen"
+
+msgid "Mail the education officer"
+msgstr "E-mail de onderwijscommissaris"
+
+msgid ""
+"Make this page available at the following URL. Providing a category is "
+"required."
+msgstr ""
+"Maak deze pagina beschikbaar op de volgende URL. Het is verplicht om een "
+"categorie te specificeren."
+
+msgid "Max Activities"
+msgstr "Max. activiteiten"
+
+msgid "Max. value"
+msgstr "Max. waarde"
+
+msgid "Meeting"
+msgstr "Vergadering"
+
+msgid "Meeting document uploaded"
+msgstr "Vergaderstuk geupload"
+
+msgid "Meeting minutes uploaded"
+msgstr "Notulen geupload"
+
+msgid "Meeting number"
+msgstr "Vergadernummer"
+
+msgid "Meetings"
+msgstr "Vergaderingen"
+
+msgid "Member"
+msgstr "Lid"
+
+msgid "Member number"
+msgstr "Lidmaatschapsnummer"
+
+msgid "Members"
+msgstr "Leden"
+
+msgid "Membership number"
+msgstr "Lidmaatschapsnummer"
+
+msgid "Membership number or email address"
+msgstr "Lidnummer of email adres"
+
+msgid "Membership type"
+msgstr "Type lidmaatschap"
+
+msgid "Memberships of committees and fraternities"
+msgstr "Lidmaatschappen van commissies en disputen"
+
+msgid "Message"
+msgstr "Bericht"
+
+msgid "Middle name"
+msgstr "Tussenvoegsels"
+
+msgid "Min. value"
+msgstr "Min. waarde"
+
+msgid "Minutes"
+msgstr "Notulen"
+
+msgid "Minutes to upload"
+msgstr "Te uploaden notulen"
+
+msgid "Modified by"
+msgstr "Aangepast door"
+
+msgid "More information about this activity is available below."
+msgstr "Meer informatie over deze activiteit is hieronder beschikbaar."
+
+msgid "More of my photo's"
+msgstr "Meer van mijn foto’s"
+
+msgid "Morning"
+msgstr "Ochtend"
+
+msgid "Most recent"
+msgstr "Recentst"
+
+msgid "Move"
+msgstr "Verplaats"
+
+msgid "Move %i photos"
+msgstr "Verplaats %i foto's"
+
+msgid "Move Jobs"
+msgstr "Verplaats vacatures"
+
+msgid "Move album"
+msgstr "Verplaats album"
+
+msgid "Move down"
+msgstr "Verplaats omlaag"
+
+msgid "Move photo"
+msgstr "Verplaats foto"
+
+msgid "Move the album"
+msgstr "Verplaats het album"
+
+msgid "Move the photo to another album"
+msgstr "Verplaats de foto naar een ander album"
+
+msgid "Move the photos to another album"
+msgstr "Verplaats de foto's naar een ander album"
+
+msgid "Move up"
+msgstr "Verplaats omhoog"
+
+msgid "Multiple days"
+msgstr "Meerdere dagen"
+
+msgid "My Activities"
+msgstr "Mijn Activiteiten"
+
+msgid "My Company"
+msgstr "Mijn Bedrijf"
+
+msgid "My Information"
+msgstr "Mijn informatie"
+
+msgid "My activities"
+msgstr "Mijn activiteiten"
+
+msgid "My information"
+msgstr "Mijn informatie"
+
+msgid "My options"
+msgstr "Mijn opties"
+
+msgid "My photo's"
+msgstr "Mijn foto’s"
+
+msgid "N/A"
+msgstr "N.V.T."
+
+msgid "NEW"
+msgstr "NIEUW"
+
+msgid "Naam"
+msgstr "Naam"
+
+msgid "Name"
+msgstr "Naam"
+
+msgid "Name (Plural)"
+msgstr "Naam (meervoud)"
+
+msgid "New password"
+msgstr "Nieuw wachtwoord"
+
+msgid "News"
+msgstr "Nieuws"
+
+msgid "News items"
+msgstr "Nieuws items"
+
+msgid "Next"
+msgstr "Volgende"
+
+msgid "No"
+msgstr "Nee"
+
+msgid "No Company"
+msgstr "Geen bedrijf"
+
+msgid "No Exception available"
+msgstr "Geen exceptie beschikbaar"
+
+msgid "No GMM available."
+msgstr "Geen ALV beschikbaar."
+
+msgid "No date"
+msgstr "Geen datum"
+
+msgid "No decisions were found."
+msgstr "Er zijn geen besluiten gevonden."
+
+msgid "No documents have been added."
+msgstr "Er zijn geen documenten toegevoegd."
+
+msgid "No meeting available."
+msgstr "Geen vergaderingen beschikbaar."
+
+msgid "No notifications"
+msgstr "Geen meldingen"
+
+msgid ""
+"No one has been tagged in this photo yet. Tag someone you recognise now!"
+msgstr "Er is nog niemand getagd in deze foto. Tag nu iemand die je herkent!"
+
+msgid "No organ"
+msgstr "Geen orgaan"
+
+msgid "None"
+msgstr "Geen"
+
+msgid "Not allowed to add photos."
+msgstr "Het is niet toegestaan om foto's toe te voegen."
+
+msgid "Not allowed to add tags."
+msgstr "Het is niet toegestaan om tags toe te voegen."
+
+msgid "Not allowed to create albums"
+msgstr "Het is niet toegestaan om albums te maken"
+
+msgid "Not allowed to create albums."
+msgstr "Het is niet toegestaan om albums te maken."
+
+msgid "Not allowed to delete albums."
+msgstr "Het is niet toegestaan om albums te verwijderen."
+
+msgid "Not allowed to delete photos."
+msgstr "Het is niet toegestaan om foto's te verwijderen."
+
+msgid "Not allowed to download photos"
+msgstr "Het is niet toegestaan om foto's te downloaden"
+
+msgid "Not allowed to edit albums"
+msgstr "Het is niet toegestaan om albums te wijzigen"
+
+msgid "Not allowed to edit albums."
+msgstr "Het is niet toegestaan om albums te wijzigen."
+
+msgid "Not allowed to generate album covers."
+msgstr "Het is niet toegestaan om albums-covers opnieuw te genereren."
+
+msgid "Not allowed to move albums"
+msgstr "Het is niet toegestaan om albums te verplaatsen"
+
+msgid "Not allowed to move photos"
+msgstr "Het is niet toegestaan om foto's te verplaatsen"
+
+msgid "Not allowed to remove tags."
+msgstr "Het is niet toegestaan om tags te verwijderen."
+
+msgid "Not allowed to search for members."
+msgstr "Het is niet toegestaan om te zoeken op leden."
+
+msgid "Not allowed to upload photos."
+msgstr "Het is niet toegestaan om foto's te uploaden."
+
+msgid "Not allowed to view albums"
+msgstr "Het is niet toegestaan om albums te zien"
+
+msgid "Not allowed to view albums without dates"
+msgstr "Het is niet toegestaan om albums te zien zonder data"
+
+msgid "Not allowed to view organ information"
+msgstr "Het is niet toegestaan om informatie over organen in te zien"
+
+msgid "Not allowed to view photo details"
+msgstr "Het is niet toegestaan om details van foto's te zien"
+
+msgid "Not allowed to view photos"
+msgstr "Het is niet toegestaan om foto's te zien"
+
+msgid "Not allowed to view previous photos of the week"
+msgstr "Not allowed to view previous photos of the week"
+
+msgid "Not allowed to view tags."
+msgstr "Het is niet toegestaan om tags te zien."
+
+msgid "Not allowed to view the list of organs"
+msgstr "Niet toegestaan om de lijst van organen te bekijken"
+
+msgid "Not allowed to vote for a photo of the week"
+msgstr "Het is niet toegestaan om te stemmen voor een foto van de week"
+
+msgid "Notifications"
+msgstr "Meldingen"
+
+msgid "Number"
+msgstr "Getal"
+
+msgid "Old activities"
+msgstr "Oude activiteiten"
+
+msgid "Old members"
+msgstr "Oud leden"
+
+msgid "Old password"
+msgstr "Oud wachtwoord"
+
+msgid "Old photos of the week"
+msgstr "Oude foto's van de week"
+
+msgid "Old polls"
+msgstr "Oude polls"
+
+msgid "Older"
+msgstr "Ouder"
+
+msgid "Onderwijscommissaris"
+msgstr "Onderwijscommissaris"
+
+msgid "Only allow GEWIS members"
+msgstr "Sta alleen GEWIS leden toe"
+
+msgid "Open date and time"
+msgstr "Openingsdatum en -tijd"
+
+msgid "Option 1, Option 2, ..."
+msgstr "Optie 1, Optie 2, ..."
+
+msgid "Option Calendar"
+msgstr "Optiekalender"
+
+msgid "Option Period"
+msgstr "Optieperiode"
+
+msgid "Option calendar"
+msgstr "Optiekalender"
+
+msgid "Option does not fall within option period (also check the end date)."
+msgstr "Optie valt niet binnen optieperiode (controleer ook de einddatum)."
+
+msgid "Option planning period created successfully."
+msgstr "Optie planningsperiode succesvol aangemaakt."
+
+msgid "Option planning period deleted."
+msgstr "Optieplanningsperiode geschrapt."
+
+msgid "Option planning period has been updated."
+msgstr "De optieplanningsperiode is bijgewerkt."
+
+msgid "Option should end after it starts."
+msgstr "De optie moet eindigen nadat deze is begonnen."
+
+msgid "Optional message..."
+msgstr "Optioneel bericht..."
+
+msgid "Options"
+msgstr "Opties"
+
+msgid "Or select a page to edit below."
+msgstr "Of selecteer hieronder een pagina om te wijzigen."
+
+msgid "Or subscribe without a GEWIS membership: "
+msgstr "Of schrijf je in zonder een GEWIS lidmaatschap: "
+
+msgid ""
+"Order your course books via GEWIS to receive a discount. Specific ordering "
+"deadlines and pickup dates will be timely communicated to you via an email."
+msgstr ""
+"Bestel je boeken met korting via GEWIS. Specifieke bestel deadlines en "
+"ophaaltijden worden tijdig naar je gecommuniceerd via de e-mail."
+
+msgid "Ordinary"
+msgstr "Gewoon"
+
+msgid "Organ"
+msgstr "Orgaan"
+
+msgid "Organ Regulations"
+msgstr "Orgaanreglementen"
+
+msgid "Organ list"
+msgstr "Organen"
+
+msgid "Organ mutations"
+msgstr "Mutaties in orgaan"
+
+msgid "Organisation"
+msgstr "Organisatie"
+
+msgid "Organizer"
+msgstr "Organisator"
+
+msgid "Organs"
+msgstr "Organen"
+
+msgid ""
+"Original job and proposed update do not have any job labels applied to them."
+msgstr ""
+"De originele vacature en het updatevoorstel hebben geen vacature-labels."
+
+msgid "Other"
+msgstr "Anders"
+
+msgid "Other albums"
+msgstr "Andere albums"
+
+#, php-format
+msgid "Other exam material from %s (%s)"
+msgstr "Ander tentamenmateriaal van %s (%s)"
+
+msgid "Overview"
+msgstr "Overzicht"
+
+msgid "PR-Functionaris"
+msgstr "PR-Functionaris"
+
+msgid "Packages"
+msgstr "Pakketten"
+
+msgid "Pages"
+msgstr "Pagina's"
+
+msgid "Participants"
+msgstr "Deelnemers"
+
+msgid "Password"
+msgstr "Wachtwoord"
+
+msgid "Password changed successfully"
+msgstr "Wachtwoord succesvol gewijzigd"
+
+msgid "Password incorrect"
+msgstr "Wachtwoord incorrect"
+
+msgid "Past option planning periods cannot be deleted."
+msgstr "Eerdere optieplanningsperioden kunnen niet worden verwijderd."
+
+msgid "Penningmeester"
+msgstr "Penningmeester"
+
+msgid "Period"
+msgstr "Periode"
+
+msgid "Permissions"
+msgstr "Rechten"
+
+msgid "Personal"
+msgstr "Persoonlijk"
+
+msgid "Phone Number"
+msgstr "Telefoonnummer"
+
+msgid "Phone number"
+msgstr "Telefoonnummer"
+
+#, php-format
+msgid "Photo #%d"
+msgstr "Foto #%d"
+
+msgid "Photo admin"
+msgstr "Foto admin"
+
+msgid "Photo of the Week:<br> Week"
+msgstr "Foto van de week<br> Week"
+
+msgid "Photo of the week"
+msgstr "Foto van de week"
+
+#, php-format
+msgid "Photo's of %s"
+msgstr "Foto's van %s"
+
+msgid "Photos"
+msgstr "Foto's"
+
+msgid "Photos of the Week"
+msgstr "Foto's van de week"
+
+#, php-format
+msgid "Photos of the Week in %d/%d"
+msgstr "Foto's van de Week in %d/%d"
+
+msgid "Pin news item"
+msgstr "Nieuws item vastzetten"
+
+msgid "Plan activity"
+msgstr "Plan activiteit"
+
+msgid "Planned Activities"
+msgstr "Geplande activiteiten"
+
+msgid "Planned Option Planning Periods"
+msgstr "Geplande optieplanningsperioden"
+
+msgid "Planning Period"
+msgstr "Planningsperiode"
+
+#, php-format
+msgid ""
+"Please contact %s or the board (%s) with any questions or concerns. Have fun!"
+msgstr ""
+"Neem contact op met %s of het bestuur (%s) als je vragen of opmerkingen "
+"hebt. Veel plezier!"
+
+#, php-format
+msgid ""
+"Please contact %s or the board (%s) with any questions, concerns or if you "
+"are unable to attend after the deadline for unsubscribing has passed. Have "
+"fun!"
+msgstr ""
+"Neem contact op met %s of het bestuur (%s) als je vragen of opmerkingen hebt "
+"of als je na het verstrijken van de afmeldtermijn niet aanwezig kunt zijn. "
+"Veel plezier!"
+
+msgid "Please fill in this CAPTCHA:"
+msgstr "CAPTCHA:"
+
+msgid "Please note that numbers are not dependant on the selected language(s)."
+msgstr "De nummers zijn niet afhankelijk van de geselecteerde taal of talen."
+
+msgid "Please select a GMM to view authorizations."
+msgstr "Selecteer een ALV om machtigingen te bekijken."
+
+msgid "Please wait while the album is being deleted."
+msgstr "Wacht terwijl dit album verwijderd wordt."
+
+msgid "Please wait while the photos are being deleted."
+msgstr "Wacht a.u.b. terwijl de foto's verwijderd worden."
+
+msgid "Please wait while your photo is being deleted."
+msgstr "Wacht terwijl de foto verwijderd wordt."
+
+msgid "Poll"
+msgstr "Poll"
+
+msgid "Poll history"
+msgstr "Poll historie"
+
+msgid "Polls"
+msgstr "Polls"
+
+msgid "Polls awaiting approval"
+msgstr "Niet goedgekeurde polls"
+
+msgid "Poster Policy"
+msgstr "Posterbeleid"
+
+msgid "Previous"
+msgstr "Vorige"
+
+msgid "Previous exceptions"
+msgstr "Vorige excepties"
+
+msgid "Privacy Policy"
+msgstr "Privacybeleid"
+
+msgid "Profile"
+msgstr "Profiel"
+
+msgid "Proposals"
+msgstr "Voorstellen"
+
+msgid "Propose options for an activity"
+msgstr "Opties voor een activiteit voorstellen"
+
+msgid "Public Archive"
+msgstr "Openbaar Archief"
+
+msgid "Public archive"
+msgstr "Openbaar Archief"
+
+msgid "Published"
+msgstr "Gepubliceerd"
+
+msgid "Random"
+msgstr "Willekeurig"
+
+msgid "Recent changes"
+msgstr "Recente wijzigingen"
+
+msgid "Recently Approved Jobs"
+msgstr "Onlangs goedgekeurde vacatures"
+
+msgid "Recently Rejected Jobs"
+msgstr "Onlangs afgekeurde vacatures"
+
+msgid "Recently Unapproved Jobs"
+msgstr "Nog niet goedgekeurde vacatures"
+
+msgid "Recipient"
+msgstr "Ontvanger"
+
+msgid "Regenerate"
+msgstr "Genereer opnieuw"
+
+msgid "Regenerate album cover"
+msgstr "Genereer album cover opnieuw"
+
+msgid "Register"
+msgstr "Registreer"
+
+msgid "Regulations"
+msgstr "Reguleringen"
+
+msgid "Reject Update"
+msgstr "Update afwijzen"
+
+msgid "Remember me"
+msgstr "Onthoud mij"
+
+msgid "Remove"
+msgstr "Verwijder"
+
+msgid "Remove Token"
+msgstr "Verwijder token"
+
+msgid "Remove option"
+msgstr "Verwijder optie"
+
+msgid "Remove the last option"
+msgstr "Verwijder de laatste optie"
+
+msgid "Remove the last sign-up list"
+msgstr "Verwijder de laatste inschrijflijst"
+
+msgid "Remove the last sign-up list field"
+msgstr "Verwijder het laatste inschrijflijst veld"
+
+msgid "Remove this picture as your profile picture"
+msgstr "Verwijder deze foto als profielfoto"
+
+msgid "Rename"
+msgstr "Hernoem"
+
+msgid "Rename Meeting Document"
+msgstr "Hernoem vergaderstuk"
+
+msgid "Representative Information"
+msgstr "Informatie van vertegenwoordiger"
+
+msgid "Request a poll"
+msgstr "Vraag een poll aan"
+
+msgid "Request password reset"
+msgstr "Wachtwoord reset aanvragen"
+
+msgid "Request poll"
+msgstr "Vraag poll aan"
+
+msgid "Required role"
+msgstr "Verplichte rol"
+
+msgid "Reset Approval Status"
+msgstr "Goedkeuringsstatus intrekken"
+
+msgid "Reset password"
+msgstr "Reset wachtwoord"
+
+msgid "Retired fraternities"
+msgstr "Disputen in ruste"
+
+msgid "Revoke authorization"
+msgstr "Machtiging intrekken"
+
+msgid "Revoked"
+msgstr "Ingetrokken"
+
+#, php-format
+msgid "Revoked authorizations for GMM %d"
+msgstr "Ingetrokken machtigingen voor ALV %d"
+
+msgid "Root"
+msgstr "Root"
+
+msgid ""
+"S.v. GEWIS uses cookies on this website, these are required for the website "
+"to function. Additionally, we may collection information about how you use "
+"our website in order to improve your experience. If you do not want your "
+"behaviour to be tracked please opt out below."
+msgstr ""
+"S.v. GEWIS maakt gebruik van cookies op deze website, deze zijn nodig om de "
+"website te laten functioneren. Daarnaast kunnen wij informatie verzamelen "
+"over hoe je onze website gebruikt om je ervaring te verbeteren. Als je niet "
+"wilt dat je gedrag wordt bijgehouden, kan je je hieronder afmelden."
+
+msgid "Save"
+msgstr "Opslaan"
+
+msgid "Scanned?"
+msgstr "Gescand?"
+
+msgid "Search"
+msgstr "Zoek"
+
+msgid "Search by keyword or meeting number"
+msgstr "Zoek met trefwoord of vergaderingsnummer"
+
+msgid "Search for decision"
+msgstr "Zoek besluit"
+
+msgid "Search query"
+msgstr "Zoek query"
+
+msgid "Search through the list of decisions accumulated from past meetings:"
+msgstr "Doorzoek de lijst van alle beslissingen van eerdere vergaderingen:"
+
+msgid "Secretaris"
+msgstr "Secretaris"
+
+msgid "Select a job category"
+msgstr "Selecteer een vacaturecategorie"
+
+msgid "Select a new parent album"
+msgstr "Selecteer een nieuwe bovenliggende album"
+
+msgid "Select a new parent for the album"
+msgstr "Selecteer een nieuwe bovenliggende album"
+
+msgid "Select a period"
+msgstr "Selecteer een periode"
+
+msgid "Select a target job package"
+msgstr "Selecteer een vacaturepakket als bestemming"
+
+msgid "Select a type"
+msgstr "Selecteer een type"
+
+msgid "Select an option"
+msgstr "Selecteer een optie"
+
+msgid ""
+"Select an organ to edit its information. Changes will not be displayed until "
+"they have been approved."
+msgstr ""
+"Selecteer een orgaan om de informatie te wijzigen. Wijzigingen worden niet "
+"getoond totdat deze goedgekeurd zijn."
+
+msgid "Select the jobs that you want to transfer to another job package."
+msgstr ""
+"Selecteer de vacatures die je wilt verplaatsen naar een ander vacaturepakket."
+
+msgid ""
+"Select the organ for which the options are and in which option period the "
+"options should be planned."
+msgstr ""
+"Selecteer het orgaan waarvoor de opties zijn en in welke optieperiode de "
+"opties moeten worden gepland."
+
+msgid ""
+"Select this if this sign-up list has limited capacity or is expected to have "
+"limited capacity. Please ensure that you also write this in the description "
+"of the activity."
+msgstr ""
+"Selecteer dit als deze inschrijflijst een beperkte capaciteit heeft of als "
+"dit wordt verwacht. Vergeet niet om dit ook in de beschrijving van de "
+"activiteit."
+
+msgid "Select this if you want this news item to stay at the top of the page."
+msgstr "Selecteer dit als je wil dat je nieuws item bovenaan de pagina blijft."
+
+msgid ""
+"Select this to display the number of subscribed GEWIS members to external "
+"visitors."
+msgstr ""
+"Selecteer dit om het aantal ingeschreven GEWIS-leden aan externe bezoekers "
+"te tonen."
+
+msgid ""
+"Select whether an organ (committee, fraternity, etc.) or a company is "
+"responsible for this activity, or both."
+msgstr ""
+"Selecteer of een orgaan (commissie, dispuut, enz.) of een bedrijf "
+"verantwoordelijk is voor deze activiteit, of beide."
+
+msgid "Set as profile picture"
+msgstr "Kies deze foto als jouw profielfoto"
+
+msgid "Set as profile picture!"
+msgstr "Gekozen als profielfoto!"
+
+msgid "Settings"
+msgstr "Instellingen"
+
+msgid "Share"
+msgstr "Delen"
+
+msgid "Short dutch description"
+msgstr "Korte Nederlandse omschrijving"
+
+msgid "Short english description"
+msgstr "Korte Engelse omschrijving"
+
+msgid "Shutter speed"
+msgstr "Sluitertijd"
+
+msgid "Sign-up List"
+msgstr "Inschrijflijst"
+
+msgid "Sign-up Lists"
+msgstr "Inschrijflijsten"
+
+msgid "Slogan"
+msgstr "Slogan"
+
+msgid "Slug"
+msgstr "Permalink"
+
+msgid "Some of the required fields for this type are empty"
+msgstr "Sommige van de verplichte velden voor dit type zijn leeg"
+
+msgid "Sort on"
+msgstr "Sorteer op"
+
+msgid ""
+"Specify the permanent link for this company, it should be unique across all "
+"companies."
+msgstr ""
+"Geef de permalink voor dit bedrijf, deze moet uniek zijn voor alle bedrijven."
+
+msgid ""
+"Specify the permanent link for this job, it should be unique for this "
+"company."
+msgstr ""
+"Geef de permalink voor deze vacature, deze moet uniek zijn voor dit bedrijf."
+
+msgid "Stack trace"
+msgstr "Stack trace"
+
+msgid "Start"
+msgstr "Start"
+
+msgid "Start Date"
+msgstr "Startdatum"
+
+msgid "Start date"
+msgstr "Startdatum"
+
+msgid "Start date and time"
+msgstr "Begindatum en -tijd"
+
+msgid "Start date and time of option period"
+msgstr "Begindatum en -tijd van de optieperiode"
+
+msgid "Start date and time of planning period"
+msgstr "Begindatum en -tijd van de planningsperiode"
+
+#, php-format
+msgid "Still haven't found what you're looking for? Take a look at %s."
+msgstr "Niet gevonden wat je zoekt? Bekijk ook %s."
+
+msgid "Street and number"
+msgstr "Straat en huisnummer"
+
+msgid "Student address"
+msgstr "Studentadres"
+
+msgid "Studievereniging GEWIS"
+msgstr "Studievereniging GEWIS"
+
+msgid "Study Association GEWIS"
+msgstr "Studievereniging GEWIS"
+
+msgid ""
+"Study association GEWIS obviously has several fraternities which contribute "
+"to the atmosphere at GEWIS and organize fun activities. Some fraternities "
+"have retired, but luckily new fraternities continue to be founded."
+msgstr ""
+"Studievereniging GEWIS heeft natuurlijk verschillende disputen die bijdragen "
+"aan de goede atmosfeer bij GEWIS en leuke activiteiten organiseren. Sommige "
+"disputen zijn in ruste."
+
+msgid "Submit"
+msgstr "Verzend"
+
+msgid "Submitter"
+msgstr "Verzender"
+
+msgid "Subscribe"
+msgstr "Inschrijven"
+
+msgid "Subscribe an external participant"
+msgstr "Inschrijven zonder GEWIS lidmaatschap"
+
+msgid "Subscribe as external participant"
+msgstr "Inschrijven zonder GEWIS lidmaatschap"
+
+msgid "Subscribe now"
+msgstr "Schrijf je in"
+
+msgid "Subscribe yourself"
+msgstr "Inschrijven"
+
+msgid "Subscription closed"
+msgstr "Inschrijving gesloten"
+
+msgid "Successfully added course!"
+msgstr "Vak succesvol toegevoegd!"
+
+msgid "Successfully removed external participant"
+msgstr "Deelnemer succesvol verwijderd"
+
+msgid "Successfully subscribed"
+msgstr "Succesvol geregistreerd"
+
+msgid "Successfully subscribed as external participant"
+msgstr "Succesvol geregistreerd"
+
+msgid "Successfully subscribed external participant"
+msgstr "Succesvol geregistreerd"
+
+msgid "Successfully unsubscribed"
+msgstr "Succesvol uitgeschreven"
+
+msgid "Successfully updated course information!"
+msgstr "Vakinformatie succesvol aangepast!"
+
+msgid "SudoSOS"
+msgstr "SudoSOS"
+
+msgid "Summaries"
+msgstr "Samenvattingen"
+
+#, php-format
+msgid "Summary by %s on %s (%s)"
+msgstr "Samenvatting door %s van %s (%s)"
+
+msgid "Summary date"
+msgstr "Datum van samenvatting"
+
+#, php-format
+msgid "Summary on %s (%s)"
+msgstr "Samenvatting van %s (%s)"
+
+msgid "Tafelvoetbalcoordinator"
+msgstr "Tafelvoetbalcoordinator"
+
+msgid "Tag someone"
+msgstr "Tag iemand"
+
+msgid "Terms"
+msgstr "Voorwaarden"
+
+msgid "Text"
+msgstr "Tekst"
+
+#, php-format
+msgid "The %s%s %s%s will be held on %s."
+msgstr "De %s%s %s%s zal plaatsvinden op %s."
+
+msgid "The activity category was created successfully!"
+msgstr "De activiteitencategorie is succesvol aangemaakt!"
+
+msgid "The activity category was successfully updated!"
+msgstr "De activiteitencategorie is succesvol bijgewerkt!"
+
+msgid "The activity does now have an acceptable amount of options"
+msgstr "De activiteit heeft geen acceptabel aantal opties"
+
+msgid "The activity has been successfully created."
+msgstr "De activiteit is gemaakt."
+
+msgid "The activity must start after today"
+msgstr "De starttijd van de activiteit moet in de toekomst zijn"
+
+msgid "The activity must start before it ends"
+msgstr "De starttijd van de activiteit moet voor de eindtijd zijn"
+
+msgid "The activity must start before it ends."
+msgstr "De activiteit moet beginnen voordat deze eindigt."
+
+msgid "The album has been deleted"
+msgstr "Dit album kan verwijderd worden"
+
+msgid "The album has been moved"
+msgstr "Het album is verplaatst"
+
+msgid "The application will get the following information:"
+msgstr "De applicatie zal de volgende informatie krijgen:"
+
+msgid ""
+"The board can always decide to make an exception to the rules written above, "
+"for example in case of dependence on a third party, or when it concerns very "
+"big activities or weekends."
+msgstr ""
+"Het bestuur kan altijd beslissen om een uitzondering op bovenstaande regels "
+"te maken, bijvoorbeeld in het geval van afhankelijkheid van een derde "
+"partij, of als het gaat om grote activiteiten en weekenden."
+
+msgid "The currently active fraternities of GEWIS (in arbitrary order)"
+msgstr "De huidige disputen van GEWIS zijn (in willekeurige volgorde):"
+
+msgid "The e-mail address must be unique across companies."
+msgstr "Het e-mailadres moet uniek zijn onder alle bedrijven."
+
+msgid ""
+"The exams on the website of GEWIS are provided by Education & Student "
+"Affairs of the department of Mathematics and Computer Science of the TU/e."
+msgstr ""
+"De tentamens op de site van GEWIS zijn verstrekt door Education & Student "
+"Affairs van de faculteit Wiskunde en Informatica van de TU/e."
+
 msgid ""
 "The first to put an option for an activity on a particular date, has the "
 "first dibs to let the activity take place on this date. Five weeks before "
@@ -738,478 +2718,197 @@ msgstr ""
 "ingediend, dan vervalt de optie, en krijgt de volgende in de rij de kans om "
 "deze dag te gebruiken."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:45
-msgid ""
-"The board can always decide to make an exception to the rules written above, "
-"for example in case of dependence on a third party, or when it concerns very "
-"big activities or weekends."
-msgstr ""
-"Het bestuur kan altijd beslissen om een uitzondering op bovenstaande regels "
-"te maken, bijvoorbeeld in het geval van afhankelijkheid van een derde "
-"partij, of als het gaat om grote activiteiten en weekenden."
+msgid "The following fraternities have retired:"
+msgstr "De volgende disputen zijn in ruste:"
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:51
-msgid "Your option has been added successfully"
-msgstr "De optie is succesvol toegevoegd"
+msgid "The image could not be loaded."
+msgstr "De foto kan niet worden geladen."
 
-#: module/Activity/view/activity/activity-calendar/index.phtml:59
-msgid "My options"
-msgstr "Mijn opties"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:63
-msgid "Creator"
-msgstr "Aangemaakt door"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:66
-#: module/Activity/view/activity/activity/list.phtml:50
-#: module/Activity/view/activity/activity/view.phtml:90
-msgid "Start"
-msgstr "Start"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:67
-#: module/Activity/view/activity/activity/list.phtml:52
-#: module/Activity/view/activity/activity/view.phtml:93
-msgid "End"
-msgstr "Einde"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:88
-#: module/Activity/view/activity/activity-calendar/index.phtml:121
-#: module/Activity/view/activity/admin-option/index.phtml:48
-#: module/Activity/view/activity/admin-option/index.phtml:98
-#: module/Activity/view/activity/admin-option/index.phtml:138
-#: module/Company/view/company/admin/edit-company.phtml:162
-#: module/Company/view/company/admin/edit-package.phtml:126
-#: module/Company/view/company/admin/index.phtml:204
-#: module/Company/view/company/company-account/jobs.phtml:254
-#: module/Decision/view/decision/admin/document.phtml:150
-#: module/Decision/view/decision/admin/document.phtml:181
-#: module/Education/view/education/admin/course-documents.phtml:92
-#: module/Education/view/education/admin/course-documents.phtml:141
-#: module/Education/view/education/admin/course-documents.phtml:176
-#: module/Education/view/education/admin/course.phtml:70
-#: module/Education/view/education/admin/course.phtml:105
-#: module/Education/view/education/admin/edit-exam.phtml:62
-#: module/Education/view/education/admin/edit-summary.phtml:62
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:88
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:158
-msgid "Delete"
-msgstr "Verwijder"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:92
-#: module/Activity/view/activity/activity-calendar/index.phtml:145
-#: module/Activity/view/activity/admin-approval/view.phtml:208
-#: module/Decision/view/decision/organ-admin/edit.phtml:181
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:84
-msgid "Approve"
-msgstr "Goedkeuren"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:96
-msgid "Modified by"
-msgstr "Aangepast door"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:110
-msgid "Delete option"
-msgstr "Verwijder optie"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:113
-msgid "Are you sure you want to delete this option?"
-msgstr "Weet je zeker dat je deze optie wil verwijderen?"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:119
-#: module/Activity/view/activity/activity-calendar/index.phtml:143
-#: module/Activity/view/activity/admin-category/index.phtml:64
-#: module/Activity/view/activity/admin-option/index.phtml:135
-#: module/Company/view/company/admin/edit-company.phtml:214
-#: module/Company/view/company/admin/edit-package.phtml:160
-#: module/Company/view/company/admin/index.phtml:244
-#: module/Company/view/company/company-account/jobs.phtml:304
-#: module/Decision/view/decision/admin/document.phtml:178
-#: module/Decision/view/decision/admin/document.phtml:205
-#: module/Decision/view/decision/decision/authorizations.phtml:185
-#: module/Education/view/education/admin/course-documents.phtml:173
-#: module/Education/view/education/admin/course.phtml:102
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:186
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:231
-#: module/Photo/view/photo/album-admin/index.phtml:232
-#: module/Photo/view/photo/album-admin/index.phtml:264
-#: module/Photo/view/photo/photo-admin/index.phtml:158
-#: module/User/src/Form/ApiAppAuthorisation.php:26
-msgid "Cancel"
-msgstr "Annuleer"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:134
-msgid "Approve option"
-msgstr "Keur optie goed"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:137
-msgid "Are you sure you want to approve this option?"
-msgstr "Weet je zeker dat je deze optie wilt goedkeuren?"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:180
-msgid "Planned Activities"
-msgstr "Geplande activiteiten"
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:181
-#: module/Activity/view/activity/activity/list.phtml:68
-msgid "There are no activities."
-msgstr "Er zijn geen activiteiten."
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:194
-msgid "There are no options."
-msgstr "Er zijn geen opties."
-
-#: module/Activity/view/activity/activity-calendar/index.phtml:236
-msgid "Plan activity"
-msgstr "Plan activiteit"
-
-#: module/Activity/view/activity/activity/archive.phtml:34
-#: module/Photo/view/photo/photo/index.phtml:36
-msgid "Older"
-msgstr "Ouder"
-
-#: module/Activity/view/activity/activity/archive.phtml:54
-msgid "There are no activities in the archive."
-msgstr "Er zijn geen activiteiten in het archief."
-
-#: module/Activity/view/activity/activity/create.phtml:51
-msgid "Organizer"
-msgstr "Organisator"
-
-#: module/Activity/view/activity/activity/create.phtml:52
-msgid ""
-"Select whether an organ (committee, fraternity, etc.) or a company is "
-"responsible for this activity, or both."
-msgstr ""
-"Selecteer of een orgaan (commissie, dispuut, enz.) of een bedrijf "
-"verantwoordelijk is voor deze activiteit, of beide."
-
-#: module/Activity/view/activity/activity/create.phtml:76
-#: module/Activity/view/activity/admin/list.phtml:25
-#: module/Activity/view/activity/admin/view.phtml:74
-#: module/Company/view/company/admin-approval/index.phtml:58
-#: module/Company/view/company/company/job-list.phtml:85
-#: module/User/view/user/user/login.phtml:34
-msgid "Company"
-msgstr "Bedrijf"
-
-#: module/Activity/view/activity/activity/create.phtml:87
-#: module/Activity/view/activity/admin/participantsTable.phtml:25
-msgid "Date and time"
-msgstr "Datum en tijd"
-
-#: module/Activity/view/activity/activity/create.phtml:88
-msgid "Enter the start and end date and time of this activity."
-msgstr "Vul de begin- en einddatum en -tijd van deze activiteit in."
-
-#: module/Activity/view/activity/activity/create.phtml:101
-msgid "Start date and time"
-msgstr "Begindatum en -tijd"
-
-#: module/Activity/view/activity/activity/create.phtml:116
-msgid "End date and time"
-msgstr "Einddatum en -tijd"
-
-#: module/Activity/view/activity/activity/create.phtml:130
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:263
-#: module/Activity/view/activity/admin-approval/view.phtml:165
-#: module/Activity/view/activity/admin-category/add.phtml:17
-#: module/Activity/view/activity/admin-category/index.phtml:10
-#: module/Activity/view/activity/admin-category/index.phtml:14
-#: module/Activity/view/activity/admin-category/index.phtml:19
-msgid "Activity Categories"
-msgstr "Activiteitencategorieën"
-
-#: module/Activity/view/activity/activity/create.phtml:131
-msgid ""
-"Add activity categories to your activity to give potential subscribers a "
-"better understanding of the activity."
-msgstr ""
-"Voeg activiteitencategorieën toe aan deze activiteit om potentiële "
-"deelnemers een beter inzicht te geven in de activiteit."
-
-#: module/Activity/view/activity/activity/create.phtml:151
-#: module/Activity/view/activity/admin-category/index.phtml:24
-msgid "There are currently no activity categories..."
-msgstr "Er zijn momenteel geen activiteitencategorieën..."
-
-#: module/Activity/view/activity/activity/create.phtml:177
-#: module/Activity/view/activity/activity/view.phtml:134
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:290
-#: module/Activity/view/activity/admin-approval/view.phtml:179
-msgid "Sign-up Lists"
-msgstr "Inschrijflijsten"
-
-#: module/Activity/view/activity/activity/create.phtml:178
-msgid ""
-"Add sign-up lists to allow people to sign up for this activity. Each list "
-"can have optional fields to collect specific information from the "
-"participants."
-msgstr ""
-"Voeg inschrijflijsten toe om mensen in staat te stellen zich voor deze "
-"activiteit in te schrijven. Elke lijst kan optionele velden hebben om "
-"specifieke informatie van de deelnemers te verzamelen."
-
-#: module/Activity/view/activity/activity/create.phtml:184
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:120
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:300
-#: module/Activity/view/activity/admin-approval/view.phtml:67
-#: module/Activity/view/activity/admin-approval/view.phtml:185
-#: module/Activity/view/activity/admin-category/add.phtml:53
-#: module/Activity/view/partial/create.phtml:30
-#: module/Application/src/Model/Enums/Languages.php:24
-#: module/Company/view/company/admin-approval/job-approval.phtml:106
-#: module/Company/view/company/admin-approval/job-proposal.phtml:146
-#: module/Company/view/partial/company/admin/editors/category.phtml:20
-#: module/Company/view/partial/company/admin/editors/company.phtml:218
-#: module/Company/view/partial/company/admin/editors/job.phtml:146
-#: module/Company/view/partial/company/admin/editors/label.phtml:29
-#: module/Company/view/partial/company/admin/editors/package.phtml:96
-msgid "Dutch"
-msgstr "Nederlands"
-
-#: module/Activity/view/activity/activity/create.phtml:189
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:125
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:305
-#: module/Activity/view/activity/admin-approval/view.phtml:72
-#: module/Activity/view/activity/admin-approval/view.phtml:190
-#: module/Activity/view/activity/admin-category/add.phtml:90
-#: module/Activity/view/partial/create.phtml:104
-#: module/Application/src/Model/Enums/Languages.php:23
-#: module/Company/view/company/admin-approval/job-approval.phtml:111
-#: module/Company/view/company/admin-approval/job-proposal.phtml:151
-#: module/Company/view/partial/company/admin/editors/category.phtml:65
-#: module/Company/view/partial/company/admin/editors/company.phtml:279
-#: module/Company/view/partial/company/admin/editors/job.phtml:240
-#: module/Company/view/partial/company/admin/editors/label.phtml:74
-#: module/Company/view/partial/company/admin/editors/package.phtml:128
-msgid "English"
-msgstr "Engels"
-
-#: module/Activity/view/activity/activity/create.phtml:217
-msgid "Remove the last sign-up list"
-msgstr "Verwijder de laatste inschrijflijst"
-
-#: module/Activity/view/activity/activity/create.phtml:221
-msgid "Add a sign-up list"
-msgstr "Voeg een inschrijflijst toe"
-
-#: module/Activity/view/activity/activity/createSuccess.phtml:15
-msgid "The activity has been successfully created."
-msgstr "De activiteit is gemaakt."
-
-#: module/Activity/view/activity/activity/createSuccess.phtml:16
-msgid "It will become visible after it has been approved by the board."
-msgstr ""
-"Het zal zichtbaar worden als de activiteit goedgekeurd is door het bestuur."
-
-#: module/Activity/view/activity/activity/index.phtml:15
-#: module/Activity/view/activity/activity/index.phtml:21
-#: module/Activity/view/activity/activity/view.phtml:30
-#: module/Activity/view/activity/activity/view.phtml:38
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:24
-#: module/Activity/view/activity/admin-approval/view.phtml:22
-#: module/Activity/view/activity/admin/participants.phtml:22
-#: module/Activity/view/activity/admin/view.phtml:19
-#: module/Application/view/partial/admin.phtml:38
-#: module/Application/view/partial/main-nav.phtml:374
-#: module/Application/view/partial/main-nav.phtml:378
-#: module/Application/view/partial/main-nav.phtml:383
-#: module/Decision/view/decision/member/index.phtml:203
-msgid "Activities"
-msgstr "Activiteiten"
-
-#: module/Activity/view/activity/activity/index.phtml:27
-msgid "All Activities"
-msgstr "Alle Activiteiten"
-
-#: module/Activity/view/activity/activity/index.phtml:30
-msgid "Career Activities"
-msgstr "Carrière Activiteiten"
-
-#: module/Activity/view/activity/activity/index.phtml:34
-msgid "My Activities"
-msgstr "Mijn Activiteiten"
-
-#: module/Activity/view/activity/activity/list.phtml:22
-msgid "MMM d"
-msgstr "MMM d"
-
-#: module/Activity/view/activity/activity/list.phtml:46
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:79
-msgid "Continue reading"
-msgstr "Lees meer"
-
-#: module/Activity/view/activity/activity/list.phtml:55
-#: module/Activity/view/activity/activity/view.phtml:96
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:162
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:167
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:179
-#: module/Activity/view/activity/admin-approval/view.phtml:99
-#: module/Activity/view/activity/admin-approval/view.phtml:104
-#: module/Activity/view/activity/admin-approval/view.phtml:111
-#: module/Activity/view/partial/create.phtml:58
-#: module/Activity/view/partial/create.phtml:132
-#: module/Company/src/Form/Job.php:181 module/Company/src/Form/Job.php:191
-#: module/Company/view/company/admin-approval/job-approval.phtml:157
-#: module/Company/view/company/admin-approval/job-approval.phtml:162
-#: module/Company/view/company/admin-approval/job-approval.phtml:169
-#: module/Company/view/company/admin-approval/job-proposal.phtml:209
-#: module/Company/view/company/admin-approval/job-proposal.phtml:214
-#: module/Company/view/company/admin-approval/job-proposal.phtml:224
-#: module/Photo/view/partial/metadata.phtml:82
-msgid "Location"
-msgstr "Locatie"
-
-#: module/Activity/view/activity/activity/list.phtml:58
-#: module/Activity/view/activity/activity/view.phtml:99
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:191
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:196
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:208
-#: module/Activity/view/activity/admin-approval/view.phtml:118
-#: module/Activity/view/activity/admin-approval/view.phtml:123
-#: module/Activity/view/activity/admin-approval/view.phtml:130
-#: module/Activity/view/partial/create.phtml:72
-#: module/Activity/view/partial/create.phtml:146
-msgid "Costs"
-msgstr "Kosten"
-
-#: module/Activity/view/activity/activity/view.phtml:150
-msgid "the organizing party"
-msgstr "de organiserende partij"
-
-#: module/Activity/view/activity/activity/view.phtml:162
 #, php-format
-msgid ""
-"Please contact %s or the board (%s) with any questions, concerns or if you "
-"are unable to attend after the deadline for unsubscribing has passed. Have "
-"fun!"
+msgid "The latest %s that took place:"
+msgstr "De laatste %s die plaatsvond:"
+
+msgid "The login and password combination is incorrect."
+msgstr "De combinatie van login en wachtwoord is onjuist."
+
+msgid "The number of English options must equal the number of Dutch options"
 msgstr ""
-"Neem contact op met %s of het bestuur (%s) als je vragen of opmerkingen hebt "
-"of als je na het verstrijken van de afmeldtermijn niet aanwezig kunt zijn. "
-"Veel plezier!"
+"Het aantal Engelse opties moet gelijk zijn aan het aantal Nederlandse opties"
 
-#: module/Activity/view/activity/activity/view.phtml:165
-#, php-format
-msgid ""
-"Please contact %s or the board (%s) with any questions or concerns. Have fun!"
-msgstr ""
-"Neem contact op met %s of het bestuur (%s) als je vragen of opmerkingen "
-"hebt. Veel plezier!"
-
-#: module/Activity/view/activity/activity/view.phtml:180
-#, php-format
-msgid ""
-"This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
-msgstr ""
-"Deze inschrijflijst%sis open van <strong>%s</strong> tot <strong>%s</strong>."
-
-#: module/Activity/view/activity/activity/view.phtml:181
-msgid " <strong>has a limited capacity</strong> and "
-msgstr " <strong>heeft een beperkte capaciteit</strong> en "
-
-#: module/Activity/view/activity/activity/view.phtml:193
-msgid "Already subscribed"
-msgstr "Je bent al ingeschreven"
-
-#: module/Activity/view/activity/activity/view.phtml:200
-msgid "Subscription closed"
-msgstr "Inschrijving gesloten"
-
-#: module/Activity/view/activity/activity/view.phtml:206
-msgid "Subscribe now"
-msgstr "Schrijf je in"
-
-#: module/Activity/view/activity/activity/view.phtml:213
-msgid "Unsubscribe yourself"
-msgstr "Uitschrijven"
-
-#: module/Activity/view/activity/activity/view.phtml:216
-msgid "You are not allowed to unsubscribe after the deadline!"
-msgstr "Uitschrijven na de uitschrijfdeadline is niet toegestaan!"
-
-#: module/Activity/view/activity/activity/view.phtml:235
-#: module/Activity/view/activity/activity/view.phtml:252
-msgid "Subscribe yourself"
-msgstr "Inschrijven"
-
-#: module/Activity/view/activity/activity/view.phtml:238
-msgid "Login to subscribe"
-msgstr "Login om in te schrijven"
-
-#: module/Activity/view/activity/activity/view.phtml:242
-msgid "Or subscribe without a GEWIS membership: "
-msgstr "Of schrijf je in zonder een GEWIS lidmaatschap: "
-
-#: module/Activity/view/activity/activity/view.phtml:263
-msgid "Current subscriptions"
-msgstr "Huidige inschrijvingen"
-
-#: module/Activity/view/activity/activity/view.phtml:281
 #, php-format
 msgid "The number of subscribed members is currently %d."
 msgstr "Het aantal ingeschreven leden is momenteel %d."
 
-#: module/Activity/view/activity/activity/view.phtml:285
-msgid "Login to view the subscribed members."
-msgstr "Login om de lijst met deelnemers te bekijken."
+msgid "The option period must end after it starts."
+msgstr "De optieperiode moet eindigen nadat deze begonnen is."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:21
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:31
-msgid "Update Proposal"
-msgstr "Update voorstel"
+msgid "The option period must start after the planning period ends."
+msgstr "De optieperiode moet ingaan na afloop van de planningsperiode."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:56
-#: module/Activity/view/activity/admin-approval/view.phtml:33
-#: module/Activity/view/partial/create.phtml:16
-#: module/Company/view/company/admin-approval/job-approval.phtml:30
-#: module/Company/view/company/admin-approval/job-proposal.phtml:54
-#: module/Company/view/partial/company/admin/editors/category.phtml:16
-#: module/Company/view/partial/company/admin/editors/company.phtml:204
-#: module/Company/view/partial/company/admin/editors/job.phtml:132
-#: module/Company/view/partial/company/admin/editors/label.phtml:16
-#: module/Company/view/partial/company/admin/editors/package.phtml:18
-#: module/Photo/view/photo/album/index.phtml:519
-msgid "Information"
-msgstr "Informatie"
+msgid "The photo has been deleted"
+msgstr "De foto is verwijderd"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:60
+msgid "The photo has been moved"
+msgstr "De foto is verplaatst"
+
+msgid "The photos have been been deleted"
+msgstr "De foto's zijn verwijderd"
+
+msgid "The photos have been moved"
+msgstr "De foto's zijn verplaatst"
+
+msgid "The planning period must end after it starts."
+msgstr "De planningsperiode moet eindigen nadat deze begonnen is."
+
+msgid "The requested URL could not be matched by routing."
+msgstr "Er is geen route gevonden die overeenkomt met de opgevraagde URL."
+
+msgid ""
+"The requested controller could not be mapped to an existing controller class."
+msgstr "Er is geen mapping beschikbaar voor de opgevraagde controller."
+
+msgid "The requested controller was not dispatchable."
+msgstr "De opgevraagde controller is niet bruikbaar."
+
+msgid "The requested controller was unable to dispatch the request."
+msgstr "De opgevraagde controller kon deze aanvraag niet verwerken."
+
+msgid ""
+"The sign-up list closing date and time must be before the activity starts."
+msgstr ""
+"De openingsdatum en -tijd van de inschrijflijst moeten vóór de startdatum en-"
+"tijd van de activiteit vallen."
+
+msgid ""
+"The sign-up list opening date and time must be before the sign-up list "
+"closes."
+msgstr ""
+"De openingsdatum en -tijd van de inschrijflijst moeten vóór de "
+"sluitingsdatum en-tijd van de inschrijflijst vallen."
+
+msgid "The uploaded file does not have a valid extension"
+msgstr "Het geuploade bestand heeft geen valide extensie"
+
+msgid "The uploaded file is not a valid image"
+msgstr "Het geuploade bestand is geen valide plaatje"
+
 #, php-format
 msgid ""
-"Changes in activity attributes are shown like this: %s. If there are no "
-"changes to a certain attribute, you will see the existing data. Sign-up list "
-"differences are <strong>not</strong> shown with colours, both the old sign-"
-"up list(s) and the new sign-up list(s) are shown. There might not be "
-"difference between the two!"
+"The uploaded file is not a valid image \n"
+"Error: %s"
 msgstr ""
-"Veranderingen in activiteitsattributen worden als volgt weergegeven: %s. Als "
-"er geen wijzigingen zijn in een bepaald attribuut, zie je de bestaande "
-"gegevens. Verschillen tussen inschrijflijsten worden <strong>niet</strong> "
-"met kleuren getoond, zowel de oude inschrijflijst(en) als de nieuwe "
-"inschrijflijst(en) worden getoond. Het kan zijn dat er geen verschil is "
-"tussen de twee!"
+"Het geuploade bestand is geen valide plaatje \n"
+"Error: %s"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
-#: module/Company/view/company/admin-approval/job-proposal.phtml:62
-msgid "new"
-msgstr "nieuw"
+msgid "There already are minutes for this meeting"
+msgstr "Er zijn al notulen voor deze vergadering"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:61
-#: module/Company/view/company/admin-approval/job-proposal.phtml:62
-msgid "old"
-msgstr "oud"
+msgid "There already exists a course with this code"
+msgstr "Er bestaat al een vak met deze code"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:73
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:89
-#: module/Activity/view/activity/admin-approval/view.phtml:42
-#: module/Activity/view/partial/signupForm.phtml:86
-#: module/Photo/view/partial/tags.phtml:52
-#: module/Photo/view/photo/album/index.phtml:342
-#: module/Photo/view/photo/album/index.phtml:687
-msgid "and"
-msgstr "en"
+msgid "There are a few rules:"
+msgstr "Er zijn een paar regels:"
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:100
-#: module/Activity/view/activity/admin-approval/view.phtml:53
+msgid "There are currently no activity categories..."
+msgstr "Er zijn momenteel geen activiteitencategorieën..."
+
+msgid "There are currently no job labels..."
+msgstr "Er zijn momenteel geen vacature-labels..."
+
+msgid "There are no activities in the archive."
+msgstr "Er zijn geen activiteiten in het archief."
+
+msgid "There are no activities."
+msgstr "Er zijn geen activiteiten."
+
+msgid "There are no exams to be edited. Upload exams to edit them."
+msgstr ""
+"Er zijn geen tentamens om te wijzigen. Upload nieuwe tentamens om deze "
+"correct in de Website te zetten."
+
+msgid "There are no jobs that you can transfer..."
+msgstr "Er zijn geen vacatures die je kunt verplaatsen..."
+
+msgid "There are no meetings for which you can upload documents."
+msgstr "Er zijn geen vergaderingen waarvoor je documenten kunt uploaden."
+
+msgid "There are no options."
+msgstr "Er zijn geen opties."
+
+msgid "There are no photos in this year."
+msgstr "Er zijn geen foto's in dit jaar."
+
+msgid "There are no planned option creation periods in the future."
+msgstr ""
+"Er zijn geen geplande perioden voor het creëren van opties in de toekomst."
+
+msgid "There are no revoked authorizations for this GMM."
+msgstr "Er zijn geen ingetrokken machtigingen voor deze ALV."
+
+msgid "There are no summaries to be edited. Upload exams to edit them."
+msgstr ""
+"Er zijn geen samenvattingen om te wijzigen. Upload nieuwe samenvattingen om "
+"deze correct in de Website te zetten."
+
+msgid ""
+"There are no upcoming meetings for which you can authorize someone.\n"
+"You may still be able to authorize someone or revoke an authorization by "
+"contacting the board."
+msgstr ""
+"Er zijn geen vergaderingen waar je machtigingen voor af kunt geven of kan "
+"wijzigen.\n"
+"Mogelijk kun je nog wel iemand machtigen of een machtiging intrekken door "
+"contact op te nemen met het bestuur."
+
+msgid "There are no valid authorizations for this GMM."
+msgstr "Er zijn geen geldige machtigingen voor deze ALV."
+
+msgid "There currently is no poll."
+msgstr "Er is op het moment geen poll."
+
+msgid "There is currently no option creation period planned."
+msgstr "Er is momenteel geen optieperiode gepland."
+
+msgid "There is no company or update proposal that requires your approval."
+msgstr "Er is geen bedrijfs- of updatevoorstel die jouw goedkeuring vereist."
+
+msgid "There is no job or update proposal that requires your approval."
+msgstr "Er is geen vacature- of updatevoorstel die jouw goedkeuring vereist."
+
+msgid "There is no member with this membership number."
+msgstr "Er is geen lid met dit lidmaatschapsnummer."
+
+msgid "This activity has already started/ended and can no longer be updated."
+msgstr ""
+"Deze activiteit is al gestart/geëindigd en kan niet meer worden bijgewerkt."
+
+msgid "This activity needs a GEFLITST member to take photos"
+msgstr "Ik wil foto’s door GEFLITST van deze activiteit"
+
+#, php-format
+msgid "This activity was approved by <strong>%s</strong>."
+msgstr "Deze activiteit is goedgekeurd door <strong>%s</strong>."
+
+#, php-format
+msgid "This activity was disapproved by <strong>%s</strong>."
+msgstr "Deze activiteit is afgekeurd door <strong>%s</strong>."
+
+msgid "This album does not contain any photos."
+msgstr "Dit album bevat geen foto's."
+
+msgid "This course does not have any exams."
+msgstr "Deze cursus heeft geen examens."
+
+msgid ""
+"This functionality is currently unavailable. Our apologies for the "
+"inconvenience."
+msgstr ""
+"Deze functionaliteit is momenteel niet beschikbaar. Onze excuses voor het "
+"ongemak."
+
+msgid "This is a career related activity"
+msgstr "Dit is een carrière gerelateerde activiteit"
+
 #, php-format
 msgid ""
 "This is activity <strong>#%d</strong>, organised by <strong>%s</strong>, and "
@@ -1219,1703 +2918,15 @@ msgstr ""
 "strong>, en deze zal beginnen op <strong>%s</strong> en eindigen op "
 "<strong>%s</strong>."
 
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:113
-#: module/Activity/view/activity/admin-approval/view.phtml:60
-msgid "More information about this activity is available below."
-msgstr "Meer informatie over deze activiteit is hieronder beschikbaar."
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:250
-msgid "View details of the old activity"
-msgstr "Bekijk de details van de oude activiteit"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:255
-msgid "View details of the new activity"
-msgstr "Bekijk de details van de nieuwe activiteit"
-
-#: module/Activity/view/activity/admin-approval/view-proposal.phtml:314
-#: module/Activity/view/activity/admin-approval/view.phtml:19
-#: module/Activity/view/activity/admin-approval/view.phtml:29
-#: module/Activity/view/activity/admin-approval/view.phtml:198
-#: module/Company/view/company/admin-approval/job-approval.phtml:21
-#: module/Company/view/company/admin-approval/job-approval.phtml:238
-#: module/Company/view/company/admin-approval/job-proposal.phtml:23
-#: module/Company/view/company/admin-approval/job-proposal.phtml:333
-msgid "Approval"
-msgstr "Goedkeuring"
-
-#: module/Activity/view/activity/admin-approval/view.phtml:157
-msgid "View details / subscriptions"
-msgstr "Bekijk details / inschrijvingen"
-
-#: module/Activity/view/activity/admin-approval/view.phtml:220
-msgid "Disapprove"
-msgstr "Afkeuren"
-
-#: module/Activity/view/activity/admin-approval/view.phtml:230
-#, php-format
-msgid "This activity was approved by <strong>%s</strong>."
-msgstr "Deze activiteit is goedgekeurd door <strong>%s</strong>."
-
-#: module/Activity/view/activity/admin-approval/view.phtml:252
-#, php-format
-msgid "This activity was disapproved by <strong>%s</strong>."
-msgstr "Deze activiteit is afgekeurd door <strong>%s</strong>."
-
-#: module/Activity/view/activity/admin-category/add.phtml:50
-#: module/Activity/view/partial/create.phtml:27
-#: module/Application/src/Form/Localisable.php:32
-msgid "Enable Dutch Translations"
-msgstr "Nederlandse vertalingen inschakelen"
-
-#: module/Activity/view/activity/admin-category/add.phtml:87
-#: module/Activity/view/partial/create.phtml:101
-#: module/Application/src/Form/Localisable.php:44
-msgid "Enable English Translations"
-msgstr "Engelse vertalingen inschakelen"
-
-#: module/Activity/view/activity/admin-category/index.phtml:20
-msgid ""
-"Here you can add, edit, or remove activity categories. Click on 'Add "
-"Category' to add a new category or click on a category to edit/remove it."
-msgstr ""
-"Hier kan je activiteitencategorieën toevoegen, bewerken of verwijderen. Klik "
-"op 'Nieuwe categorie' om een nieuwe categorie toe te voegen of klik op een "
-"categorie om deze te bewerken/verwijderen."
-
-#: module/Activity/view/activity/admin-category/index.phtml:42
-#: module/Company/view/company/admin/categories.phtml:17
-msgid "Add Category"
-msgstr "Nieuwe categorie"
-
-#: module/Activity/view/activity/admin-category/index.phtml:53
-#: module/Company/view/company/admin/edit-company.phtml:203
-#: module/Company/view/company/admin/edit-package.phtml:151
-#: module/Company/view/company/admin/index.phtml:231
-#: module/Company/view/company/company-account/jobs.phtml:294
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:175
-#: module/Photo/view/photo/album-admin/index.phtml:213
-#: module/Photo/view/photo/album-admin/index.phtml:245
-#: module/Photo/view/photo/photo-admin/index.phtml:139
-msgid "Delete confirmation"
-msgstr "Bevestig verwijderen"
-
-#: module/Activity/view/activity/admin-category/index.phtml:56
-msgid "Are you sure you want to delete this activity category?"
-msgstr "Weet je zeker dat je deze activiteitencategorie wilt verwijderen?"
-
-#: module/Activity/view/activity/admin-category/index.phtml:62
-msgid "Delete Activity Category"
-msgstr "Activiteitencategorie verwijderen"
-
-#: module/Activity/view/activity/admin-option/add.phtml:16
-#: module/Activity/view/activity/admin-option/index.phtml:13
-#: module/Application/view/partial/admin.phtml:62
-msgid "Option Calendar"
-msgstr "Optiekalender"
-
-#: module/Activity/view/activity/admin-option/add.phtml:25
-#: module/Activity/view/activity/admin-option/index.phtml:23
-#: module/Activity/view/activity/admin-option/index.phtml:65
-msgid "Planning Period"
-msgstr "Planningsperiode"
-
-#: module/Activity/view/activity/admin-option/add.phtml:26
-msgid "Enter the start and end date and time of the planning period."
-msgstr "Vul de begin- en einddatum en -tijd van de planningsperiode in."
-
-#: module/Activity/view/activity/admin-option/add.phtml:65
-#: module/Activity/view/activity/admin-option/index.phtml:24
-#: module/Activity/view/activity/admin-option/index.phtml:66
-msgid "Option Period"
-msgstr "Optieperiode"
-
-#: module/Activity/view/activity/admin-option/add.phtml:66
-msgid "Enter the start and end date and time of the option period."
-msgstr "Vul de begin- en einddatum en -tijd van de optieperiode in."
-
-#: module/Activity/view/activity/admin-option/add.phtml:105
-msgid "Max Activities"
-msgstr "Max. activiteiten"
-
-#: module/Activity/view/activity/admin-option/add.phtml:106
-msgid ""
-"Enter the maximum number of activities for which options can be created. You "
-"can either set the number globally or individually for each organ."
-msgstr ""
-"Vul het maximum aantal activiteiten in waarvoor opties kunnen worden "
-"aangemaakt. Dit kan globaal of voor elk orgaan afzonderlijk worden ingesteld."
-
-#: module/Activity/view/activity/admin-option/add.phtml:113
-msgid "Global Value"
-msgstr "Globale waarde"
-
-#: module/Activity/view/activity/admin-option/index.phtml:14
-#: module/Activity/view/activity/admin/view.phtml:20
-#: module/Application/view/partial/admin.phtml:43
-msgid "Overview"
-msgstr "Overzicht"
-
-#: module/Activity/view/activity/admin-option/index.phtml:18
-msgid "Active Option Planning Periods"
-msgstr "Actieve optieplanningsperioden"
-
-#: module/Activity/view/activity/admin-option/index.phtml:25
-#: module/Activity/view/activity/admin-option/index.phtml:67
-#: module/Company/view/company/admin-approval/index.phtml:31
-#: module/Company/view/company/admin-approval/index.phtml:59
-#: module/Company/view/company/admin/edit-company.phtml:116
-#: module/Company/view/company/admin/edit-package.phtml:86
-#: module/Company/view/company/admin/index.phtml:177
-#: module/Company/view/company/admin/index.phtml:218
-#: module/Company/view/company/company-account/jobs.phtml:66
-#: module/Company/view/company/company-account/jobs.phtml:199
-#: module/Education/view/education/admin/course-documents.phtml:74
-#: module/Education/view/education/admin/course-documents.phtml:125
-#: module/Education/view/education/admin/course.phtml:47
-msgid "Actions"
-msgstr "Acties"
-
-#: module/Activity/view/activity/admin-option/index.phtml:56
-msgid "There is currently no option creation period planned."
-msgstr "Er is momenteel geen optieperiode gepland."
-
-#: module/Activity/view/activity/admin-option/index.phtml:60
-msgid "Planned Option Planning Periods"
-msgstr "Geplande optieplanningsperioden"
-
-#: module/Activity/view/activity/admin-option/index.phtml:94
-#: module/Activity/view/activity/admin/list.phtml:63
-#: module/Company/view/company/admin/edit-company.phtml:157
-#: module/Company/view/company/admin/edit-package.phtml:122
-#: module/Company/view/company/company-account/jobs.phtml:245
-#: module/Decision/view/decision/organ-admin/edit.phtml:49
-#: module/Education/view/education/admin/course-documents.phtml:34
-#: module/Education/view/education/admin/course.phtml:65
-#: module/Education/view/education/admin/edit-course.phtml:24
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:40
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:38
-msgid "Edit"
-msgstr "Bewerken"
-
-#: module/Activity/view/activity/admin-option/index.phtml:106
-msgid "There are no planned option creation periods in the future."
-msgstr ""
-"Er zijn geen geplande perioden voor het creëren van opties in de toekomst."
-
-#: module/Activity/view/activity/admin-option/index.phtml:125
-msgid "Delete period"
-msgstr "Verwijder periode"
-
-#: module/Activity/view/activity/admin-option/index.phtml:129
-msgid ""
-"Are you sure you want to delete this option planning period? This will "
-"<strong>not</strong> delete proposed options."
-msgstr ""
-"Weet je zeker dat u deze optieplanningsperiode wilt verwijderen? Hiermee "
-"worden voorgestelde opties <strong>niet</strong> verwijderd."
-
-#: module/Activity/view/activity/admin/list.phtml:21
-#: module/Activity/view/activity/admin/view.phtml:70
-msgid "Dutch name"
-msgstr "Nederlandse naam"
-
-#: module/Activity/view/activity/admin/list.phtml:22
-#: module/Activity/view/activity/admin/view.phtml:71
-msgid "English name"
-msgstr "Engelse naam"
-
-#: module/Activity/view/activity/admin/list.phtml:23
-#: module/Activity/view/activity/admin/view.phtml:72
-#: module/Company/view/company/admin/edit-company.phtml:107
-#: module/Company/view/company/company-account/jobs.phtml:57
-#: module/Photo/src/Form/EditAlbum.php:37
-msgid "Start date"
-msgstr "Startdatum"
-
-#: module/Activity/view/activity/admin/list.phtml:24
-#: module/Activity/view/activity/admin/view.phtml:73
-msgid "Organ"
-msgstr "Orgaan"
-
-#: module/Activity/view/activity/admin/list.phtml:26
-#: module/Activity/view/activity/admin/view.phtml:75
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:42
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:115
-msgid "Submitter"
-msgstr "Verzender"
-
-#: module/Activity/view/activity/admin/list.phtml:27
-msgid "Update status"
-msgstr "Bewerkings status"
-
-#: module/Activity/view/activity/admin/list.phtml:29
-#: module/Company/view/company/admin/edit-package.phtml:85
-msgid "Approved"
-msgstr "Goedgekeurd"
-
-#: module/Activity/view/activity/admin/list.phtml:45
-#: module/Activity/view/activity/admin/list.phtml:46
-#: module/Activity/view/activity/admin/view.phtml:91
-#: module/Activity/view/activity/admin/view.phtml:92
-#: module/Education/view/education/education/index.phtml:112
-msgid "None"
-msgstr "Geen"
-
-#: module/Activity/view/activity/admin/list.phtml:50
-#: module/Activity/view/activity/admin/list.phtml:52
-msgid "Update pending"
-msgstr "Update pending"
-
-#: module/Activity/view/activity/admin/list.phtml:71
-#: module/Activity/view/activity/admin/participants.phtml:19
-#: module/Activity/view/activity/admin/participants.phtml:29
-#: module/Activity/view/activity/admin/participants.phtml:61
-#: module/Activity/view/activity/admin/view.phtml:97
-msgid "Participants"
-msgstr "Deelnemers"
-
-#: module/Activity/view/activity/admin/participants.phtml:41
-msgid "General"
-msgstr "Algemeen"
-
-#: module/Activity/view/activity/admin/participants.phtml:55
-msgid ""
-"Here you can find everyone who signed up for this activity (may contain "
-"duplicates). Using the tabs above you can navigate to the different sign-up "
-"lists of this activity. From there you can remove external participants and "
-"(when supplied) view additional signup information from each participant."
-msgstr ""
-"Hier vind je iedereen die zich voor deze activiteit heeft aangemeld (kan "
-"duplicaten bevatten). Met de tabs hierboven kun je navigeren naar de "
-"verschillende inschrijflijsten van deze activiteit. Vanaf daar kan je "
-"externe deelnemers verwijderen en (indien aanwezig) extra "
-"inschrijfinformatie van elke deelnemer bekijken."
-
-#: module/Activity/view/activity/admin/participants.phtml:57
-msgid ""
-"Here you can find everyone who signed up to this sign-up list. Here you can "
-"add or remove external participants and view detailed information regarding "
-"the signup of all participants."
-msgstr ""
-"Hier vind je iedereen die zich op deze inschrijflijst heeft ingeschreven. "
-"Hier kan je externe deelnemers toevoegen of verwijderen en gedetailleerde "
-"informatie bekijken over de inschrijving van alle deelnemers."
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:21
-#: module/Decision/src/Form/OrganInformation.php:32
-#: module/Decision/view/decision/member/self.phtml:49
-#: module/Decision/view/decision/member/view.phtml:33
-#: module/Frontpage/view/frontpage/organ/organ.phtml:99
-msgid "Email"
-msgstr "Email"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:23
-#: module/Decision/view/decision/member/self.phtml:64
-#: module/Decision/view/decision/member/view.phtml:49
-msgid "Generation"
-msgstr "Generatie"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:28
-msgid "Sign-up List"
-msgstr "Inschrijflijst"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:70
-#: module/Decision/view/decision/member/self.phtml:55
-#: module/Decision/view/decision/member/view.phtml:39
-#: module/Photo/view/partial/metadata.phtml:21
-#: module/Photo/view/partial/metadata.phtml:28
-#: module/Photo/view/partial/metadata.phtml:49
-#: module/Photo/view/partial/metadata.phtml:56
-#: module/Photo/view/partial/metadata.phtml:63
-#: module/Photo/view/partial/metadata.phtml:70
-#: module/Photo/view/partial/metadata.phtml:77
-#: module/Photo/view/partial/metadata.phtml:86
-msgid "Unknown"
-msgstr "Onbekend"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:76
-#, php-format
-msgid "User (%s)"
-msgstr "Gebruiker (%s)"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:83
-#: module/Decision/src/Model/Enums/MembershipTypes.php:23
-msgid "External"
-msgstr "Extern"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:96
-#: module/Education/view/education/admin/course-documents.phtml:133
-msgid "N/A"
-msgstr "N.V.T."
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:116
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
-#: module/Application/language/additional-strings:20
-#: module/Company/view/company/admin/edit-company.phtml:126
-#: module/Company/view/company/admin/edit-package.phtml:92
-#: module/Company/view/company/admin/index.phtml:197
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:214
-#: module/Company/view/company/company-account/jobs.phtml:222
-#: module/Decision/view/decision/member/view.phtml:59
-#: module/Photo/view/partial/metadata.phtml:42
-msgid "Yes"
-msgstr "Ja"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:118
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:62
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:65
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:73
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:76
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:84
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:87
-#: module/Application/language/additional-strings:21
-#: module/Company/view/company/admin/edit-company.phtml:126
-#: module/Company/view/company/admin/edit-package.phtml:92
-#: module/Company/view/company/admin/index.phtml:197
-#: module/Company/view/company/admin/index.phtml:198
-#: module/Company/view/company/company-account/jobs.phtml:214
-#: module/Decision/view/decision/member/view.phtml:59
-#: module/Photo/view/partial/metadata.phtml:42
-msgid "No"
-msgstr "Nee"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:141
-msgid "Additional actions"
-msgstr "Aanvullende acties"
-
-#: module/Activity/view/activity/admin/participantsTable.phtml:145
-msgid "Mail everybody"
-msgstr "E-mail iedereen"
-
-#: module/Activity/view/activity/admin/view.phtml:24
-msgid "Unapproved Activities"
-msgstr "Niet goedgekeurde activiteiten"
-
-#: module/Activity/view/activity/admin/view.phtml:31
-msgid "Approved Activities"
-msgstr "Goedgekeurde activiteiten"
-
-#: module/Activity/view/activity/admin/view.phtml:38
-msgid "Disapproved Activities"
-msgstr "Afgekeurde activiteiten"
-
-#: module/Activity/view/activity/admin/view.phtml:46
-msgid "Upcoming Activities"
-msgstr "Aankomende activiteiten"
-
-#: module/Activity/view/activity/admin/view.phtml:53
-msgid "Old activities"
-msgstr "Oude activiteiten"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:37
-#: module/Activity/view/partial/signuplist.phtml:25
-msgid "Open date and time"
-msgstr "Openingsdatum en -tijd"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:48
-#: module/Activity/view/partial/signuplist.phtml:39
-msgid "Close date and time"
-msgstr "Sluitingsdatum en -tijd"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:59
-msgid "GEWIS members only"
-msgstr "Alleen GEWIS leden"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:70
-msgid "Display GEWIS member count"
-msgstr "Toon aantal GEWIS leden"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:81
-#: module/Activity/view/partial/signuplist.phtml:120
-msgid "Has limited capacity"
-msgstr "Heeft beperkte capaciteit"
-
-#: module/Activity/view/partial/admin-approval/signuplists.phtml:93
-msgid ""
-"This sign-up list contains additional fields which require input from "
-"subscribers, they are shown below."
-msgstr ""
-"Deze inschrijflijst bevat extra velden die door de deelnemers moeten worden "
-"ingevuld, deze worden hieronder getoond."
-
-#: module/Activity/view/partial/create.phtml:17
-msgid ""
-"What is this activity about? Fill in the blanks below, please note that at "
-"least one language must be used."
-msgstr ""
-"Waar gaat deze activiteit over? Vul de lege plekken hieronder in, let op dat "
-"er ten minste één taal gebruikt moet worden."
-
-#: module/Activity/view/partial/create.phtml:171
-msgid "Choose which options are applicable to this activity."
-msgstr "Kies welke opties van toepassing zijn op deze activiteit."
-
-#: module/Activity/view/partial/create.phtml:181
-msgid "This is a career related activity"
-msgstr "Dit is een carrière gerelateerde activiteit"
-
-#: module/Activity/view/partial/create.phtml:183
-msgid ""
-"If this is checked the My Future logo will be displayed on the activity page "
-"and the activity will be included on the career activities page."
-msgstr ""
-"Als dit geselecteerd is dan wordt het My Future logo weergegeven op de "
-"pagina van de activiteit en zal de activiteit op de carrière activiteiten "
-"pagina weergegeven worden."
-
-#: module/Activity/view/partial/create.phtml:195
-msgid "This activity needs a GEFLITST member to take photos"
-msgstr "Ik wil foto’s door GEFLITST van deze activiteit"
-
-#: module/Activity/view/partial/create.phtml:197
-msgid ""
-"When this is checked, GEFLITST will be notified that this activity needs a "
-"photographer."
-msgstr ""
-"Door dit te selecteren zal GEFLITST van deze activiteit op de hoogte "
-"gebracht worden."
-
-#: module/Activity/view/partial/option.phtml:33
-msgid "From"
-msgstr "Van"
-
-#: module/Activity/view/partial/option.phtml:47
-msgid "Until"
-msgstr "Tot"
-
-#: module/Activity/view/partial/signupForm.phtml:21
-#: module/Activity/view/partial/signupForm.phtml:26
-msgid "By subscribing to this activity, you agree to the terms outlined in the"
-msgstr ""
-"Door je in te schrijven voor deze activiteit ga je akkoord met de "
-"voorwaarden in het"
-
-#: module/Activity/view/partial/signupForm.phtml:23
-msgid "Confirm subscription"
-msgstr "Bevestig inschrijving"
-
-#: module/Activity/view/partial/signupForm.phtml:28
-msgid "Subscribe as external participant"
-msgstr "Inschrijven zonder GEWIS lidmaatschap"
-
-#: module/Activity/view/partial/signupForm.phtml:33
-msgid ""
-"By subscribing an external participant to this activity, they must agree to "
-"the terms outlined in the"
-msgstr ""
-"Door iemand zonder GEWIS lidmaatschap in te schrijven voor deze activiteit "
-"moet deze persoon akkoord gaan met de voorwaarden in het"
-
-#: module/Activity/view/partial/signupForm.phtml:35
-msgid "Subscribe an external participant"
-msgstr "Inschrijven zonder GEWIS lidmaatschap"
-
-#: module/Activity/view/partial/signupForm.phtml:67
-msgid "Full name:"
-msgstr "Volledige naam:"
-
-#: module/Activity/view/partial/signupForm.phtml:68
-msgid "Email address:"
-msgstr "E-mail adres:"
-
-#: module/Activity/view/partial/signupForm.phtml:72
-msgid "Please fill in this CAPTCHA:"
-msgstr "CAPTCHA:"
-
-#: module/Activity/view/partial/signupForm.phtml:86
-#: module/Decision/view/decision/member/index.phtml:254
-msgid "Activity Policy"
-msgstr "Activiteitenbeleid"
-
-#: module/Activity/view/partial/signupForm.phtml:88
-#: module/Decision/view/decision/member/index.phtml:259
-msgid "Alcohol Policy"
-msgstr "Alcoholreglement"
-
-#: module/Activity/view/partial/signuplist-fields.phtml:95
-msgid "Please note that numbers are not dependant on the selected language(s)."
-msgstr "De nummers zijn niet afhankelijk van de geselecteerde taal of talen."
-
-#: module/Activity/view/partial/signuplist.phtml:88
-msgid "Only allow GEWIS members"
-msgstr "Sta alleen GEWIS leden toe"
-
-#: module/Activity/view/partial/signuplist.phtml:90
-msgid "Deselect this to allow people without a GEWIS account to subscribe."
-msgstr ""
-"Deselecteer dit om mensen zonder GEWIS account toe te staan zich in te "
-"schrijven."
-
-#: module/Activity/view/partial/signuplist.phtml:103
-msgid "Display number of subscribed members"
-msgstr "Toon aantal deelnemers"
-
-#: module/Activity/view/partial/signuplist.phtml:105
-msgid ""
-"Select this to display the number of subscribed GEWIS members to external "
-"visitors."
-msgstr ""
-"Selecteer dit om het aantal ingeschreven GEWIS-leden aan externe bezoekers "
-"te tonen."
-
-#: module/Activity/view/partial/signuplist.phtml:122
-msgid ""
-"Select this if this sign-up list has limited capacity or is expected to have "
-"limited capacity. Please ensure that you also write this in the description "
-"of the activity."
-msgstr ""
-"Selecteer dit als deze inschrijflijst een beperkte capaciteit heeft of als "
-"dit wordt verwacht. Vergeet niet om dit ook in de beschrijving van de "
-"activiteit."
-
-#: module/Activity/view/partial/signuplist.phtml:153
-msgid "Remove the last sign-up list field"
-msgstr "Verwijder het laatste inschrijflijst veld"
-
-#: module/Activity/view/partial/signuplist.phtml:158
-msgid "Add a sign-up list field"
-msgstr "Voeg een inschrijflijst veld toe"
-
-#: module/Application/language/additional-strings:1
-msgid "Lid"
-msgstr "Lid"
-
-#: module/Application/language/additional-strings:2
-msgid "Brand Manager"
-msgstr "Brand Manager"
-
-#: module/Application/language/additional-strings:3
-msgid "Commissaris Carrièreontwikkeling en Externe Betrekkingen"
-msgstr "Commissaris Carrièreontwikkeling en Externe Betrekkingen"
-
-#: module/Application/language/additional-strings:4
-msgid "Commissaris Externe Betrekkingen"
-msgstr "Commissaris Externe Betrekkingen"
-
-#: module/Application/language/additional-strings:5
-msgid "Commissaris Innovatie"
-msgstr "Commissaris Innovatie"
-
-#: module/Application/language/additional-strings:6
-msgid "Commissaris Interne Betrekkingen"
-msgstr "Commissaris Interne Betrekkingen"
-
-#: module/Application/language/additional-strings:7
-msgid "Commissaris Kennisbeheer"
-msgstr "Commissaris Kennisbeheer"
-
-#: module/Application/language/additional-strings:8
-msgid "Commissaris Onderwijs"
-msgstr "Commissaris Onderwijs"
-
-#: module/Application/language/additional-strings:9
-msgid "Digital Infrastructure Officer"
-msgstr "Digital Infrastructure Officer"
-
-#: module/Application/language/additional-strings:10
-msgid "Onderwijscommissaris"
-msgstr "Onderwijscommissaris"
-
-#: module/Application/language/additional-strings:11
-msgid "Penningmeester"
-msgstr "Penningmeester"
-
-#: module/Application/language/additional-strings:12
-msgid "PR-Functionaris"
-msgstr "PR-Functionaris"
-
-#: module/Application/language/additional-strings:13
-msgid "Secretaris"
-msgstr "Secretaris"
-
-#: module/Application/language/additional-strings:14
-msgid "Vicevoorzitter"
-msgstr "Vicevoorzitter"
-
-#: module/Application/language/additional-strings:15
-msgid "Vice-Voorzitter"
-msgstr "Vice-Voorzitter"
-
-#: module/Application/language/additional-strings:16
-msgid "Voorzitter"
-msgstr "Voorzitter"
-
-#: module/Application/language/additional-strings:17
-msgid "Tafelvoetbalcoordinator"
-msgstr "Tafelvoetbalcoordinator"
-
-#: module/Application/language/additional-strings:18
-msgid "Inkoper"
-msgstr "Inkoper"
-
-#: module/Application/language/additional-strings:19
-msgid "Inactief Lid"
-msgstr "Inactief Lid"
-
-#: module/Application/src/Service/FileStorage.php:91
-msgid "An unknown error occurred during uploading (%i)"
-msgstr "Een onbekende fout vond plaats tijdens het uploaden van (%i)"
-
-#: module/Application/src/Service/Infimum.php:66
-#: module/Application/view/partial/footer.phtml:36
-#: module/Application/view/partial/footer.phtml:41
-msgid "Unable to retrieve infimum."
-msgstr "Kan infimum niet ophalen."
-
-#: module/Application/view/error/403.phtml:17
-msgid "You do not have the required privileges to view this page"
-msgstr "Je beschikt niet over de juiste rechten om deze pagina te bekijken"
-
-#: module/Application/view/error/403.phtml:22
-msgid "You might be able to view this page by logging in"
-msgstr "Mogelijk kun je deze pagina wel bekijken door in te loggen"
-
-#: module/Application/view/error/403.phtml:28
-#: module/Application/view/partial/admin.phtml:28
-#: module/Application/view/partial/main-nav.phtml:87
-#: module/User/view/user/user/login.phtml:39
-msgid "Login"
-msgstr "Login"
-
-#: module/Application/view/error/404.phtml:12
-#: module/Application/view/error/debug/404.phtml:12
-msgid "A 404 error occurred"
-msgstr "404: De pagina kon niet worden gevonden"
-
-#: module/Application/view/error/500.phtml:12
-#: module/Application/view/error/debug/500.phtml:13
-msgid "An error occurred"
-msgstr "Er is een fout opgetreden"
-
-#: module/Application/view/error/500.phtml:13
-msgid "If this keeps occurring, please contact the ApplicatieBeheerCommissie."
-msgstr ""
-"Blijft dit gebeuren, neem dan contact op met de ApplicatieBeheerCommissie."
-
-#: module/Application/view/error/debug/403.phtml:12
-msgid "403 Forbidden"
-msgstr "403 Verboden Toegang"
-
-#: module/Application/view/error/debug/404.phtml:22
-msgid "The requested controller was unable to dispatch the request."
-msgstr "De opgevraagde controller kon deze aanvraag niet verwerken."
-
-#: module/Application/view/error/debug/404.phtml:26
-msgid ""
-"The requested controller could not be mapped to an existing controller class."
-msgstr "Er is geen mapping beschikbaar voor de opgevraagde controller."
-
-#: module/Application/view/error/debug/404.phtml:30
-msgid "The requested controller was not dispatchable."
-msgstr "De opgevraagde controller is niet bruikbaar."
-
-#: module/Application/view/error/debug/404.phtml:33
-msgid "The requested URL could not be matched by routing."
-msgstr "Er is geen route gevonden die overeenkomt met de opgevraagde URL."
-
-#: module/Application/view/error/debug/404.phtml:36
-msgid "We cannot determine at this time why a 404 was generated."
-msgstr ""
-"We kunnen op dit moment niet achterhalen waarom de pagina niet kon worden "
-"gevonden."
-
-#: module/Application/view/error/debug/404.phtml:50
-msgid "Controller"
-msgstr "Controller"
-
-#: module/Application/view/error/debug/404.phtml:58
-#, php-format
-msgid "resolves to %s"
-msgstr "verwijst naar %s"
-
-#: module/Application/view/error/debug/404.phtml:75
-#: module/Application/view/error/debug/500.phtml:24
-msgid "Additional information"
-msgstr "Meer informatie"
-
-#: module/Application/view/error/debug/404.phtml:78
-#: module/Application/view/error/debug/404.phtml:104
-#: module/Application/view/error/debug/500.phtml:29
-#: module/Application/view/error/debug/500.phtml:69
-msgid "File"
-msgstr "Bestand"
-
-#: module/Application/view/error/debug/404.phtml:83
-#: module/Application/view/error/debug/404.phtml:109
-#: module/Application/view/error/debug/500.phtml:38
-#: module/Application/view/error/debug/500.phtml:78
-msgid "Message"
-msgstr "Bericht"
-
-#: module/Application/view/error/debug/404.phtml:87
-#: module/Application/view/error/debug/404.phtml:113
-#: module/Application/view/error/debug/500.phtml:46
-#: module/Application/view/error/debug/500.phtml:86
-msgid "Stack trace"
-msgstr "Stack trace"
-
-#: module/Application/view/error/debug/404.phtml:97
-#: module/Application/view/error/debug/500.phtml:60
-msgid "Previous exceptions"
-msgstr "Vorige excepties"
-
-#: module/Application/view/error/debug/404.phtml:130
-#: module/Application/view/error/debug/500.phtml:107
-msgid "No Exception available"
-msgstr "Geen exceptie beschikbaar"
-
-#: module/Application/view/layout/layout.phtml:15
-msgid "Study Association GEWIS"
-msgstr "Studievereniging GEWIS"
-
-#: module/Application/view/partial/admin.phtml:50
-#: module/Application/view/partial/admin.phtml:105
-#: module/Company/view/company/admin/categories.phtml:23
-#: module/Company/view/company/admin/categories.phtml:43
-msgid "Categories"
-msgstr "Categorieën"
-
-#: module/Application/view/partial/admin.phtml:76
-#: module/Application/view/partial/main-nav.phtml:326
-#: module/Application/view/partial/main-nav.phtml:330
-#: module/Application/view/partial/main-nav.phtml:335
-#: module/Company/view/company/admin-approval/index.phtml:19
-#: module/Company/view/company/admin-approval/job-approval.phtml:24
-#: module/Company/view/company/admin-approval/job-proposal.phtml:26
-#: module/Company/view/company/admin/edit-company.phtml:19
-#: module/Company/view/company/admin/index.phtml:20
-msgid "Career"
-msgstr "Carrière"
-
-#: module/Application/view/partial/admin.phtml:83
-#: module/Company/view/company/admin/index.phtml:21
-#: module/Company/view/company/company/job-list.phtml:36
-#: module/Company/view/company/company/jobs.phtml:34
-#: module/Company/view/company/company/list.phtml:21
-#: module/Company/view/company/company/show.phtml:17
-#: module/Company/view/company/company/show.phtml:24
-#: module/Company/view/company/company/spotlight.phtml:33
-msgid "Companies"
-msgstr "Bedrijven"
-
-#: module/Application/view/partial/admin.phtml:96
-#: module/Company/view/company/admin-approval/index.phtml:20
-#: module/Company/view/company/admin-approval/job-approval.phtml:25
-msgid "Approvals"
-msgstr "Goedkeuringen"
-
-#: module/Application/view/partial/admin.phtml:114
-#: module/Company/src/Form/Job.php:241
-#: module/Company/view/company/admin-approval/job-approval.phtml:224
-#: module/Company/view/company/admin/labels.phtml:23
-#: module/Company/view/company/admin/labels.phtml:42
-msgid "Labels"
-msgstr "Labels"
-
-#: module/Application/view/partial/admin.phtml:128
-#: module/Application/view/partial/main-nav.phtml:368
-#: module/Education/view/education/admin/add-course.phtml:15
-#: module/Education/view/education/admin/bulk-exam.phtml:19
-#: module/Education/view/education/admin/bulk-summary.phtml:19
-#: module/Education/view/education/admin/course-documents.phtml:27
-#: module/Education/view/education/admin/course.phtml:17
-#: module/Education/view/education/admin/edit-course.phtml:17
-#: module/Education/view/education/admin/edit-exam.phtml:31
-#: module/Education/view/education/admin/edit-summary.phtml:31
-#: module/Education/view/education/admin/index.phtml:11
-#: module/Education/view/education/education/course.phtml:21
-#: module/Education/view/education/education/index.phtml:16
-#: module/Education/view/education/education/index.phtml:31
-msgid "Education"
-msgstr "Onderwijs"
-
-#: module/Application/view/partial/admin.phtml:133
-#: module/Education/view/education/admin/add-course.phtml:16
-#: module/Education/view/education/admin/course-documents.phtml:28
-#: module/Education/view/education/admin/course.phtml:18
-#: module/Education/view/education/admin/edit-course.phtml:18
-msgid "Courses"
-msgstr "Vakken"
-
-#: module/Application/view/partial/admin.phtml:138
-#: module/Education/view/education/admin/bulk-exam.phtml:24
-msgid "Upload exams"
-msgstr "Upload tentamens"
-
-#: module/Application/view/partial/admin.phtml:143
-#: module/Education/view/education/admin/bulk-summary.phtml:24
-msgid "Upload summaries"
-msgstr "Upload samenvattingen"
-
-#: module/Application/view/partial/admin.phtml:155
-#: module/Decision/view/decision/admin/authorizations.phtml:14
-#: module/Decision/view/decision/admin/document.phtml:29
-#: module/Decision/view/decision/admin/minutes.phtml:15
-#: module/Decision/view/decision/decision/index.phtml:17
-#: module/Decision/view/decision/member/index.phtml:100
-msgid "Meetings"
-msgstr "Vergaderingen"
-
-#: module/Application/view/partial/admin.phtml:160
-#: module/Decision/view/decision/admin/minutes.phtml:16
-#: module/Decision/view/decision/decision/view.phtml:53
-msgid "Minutes"
-msgstr "Notulen"
-
-#: module/Application/view/partial/admin.phtml:165
-#: module/Decision/view/decision/admin/document.phtml:30
-#: module/Decision/view/decision/decision/view.phtml:31
-#: module/Education/view/education/admin/course.phtml:60
-msgid "Documents"
-msgstr "Documenten"
-
-#: module/Application/view/partial/admin.phtml:170
-#: module/Decision/view/decision/admin/authorizations.phtml:15
-#: module/Decision/view/decision/decision/authorizations.phtml:27
-#: module/Decision/view/decision/decision/authorizations.phtml:34
-#: module/Decision/view/decision/member/index.phtml:61
-msgid "Authorizations"
-msgstr "Machtigingen"
-
-#: module/Application/view/partial/admin.phtml:181
-#: module/Decision/view/decision/member/index.phtml:73
-#: module/Decision/view/decision/organ-admin/edit.phtml:48
-#: module/Decision/view/decision/organ-admin/index.phtml:15
-msgid "Organs"
-msgstr "Organen"
-
-#: module/Application/view/partial/admin.phtml:189
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:54
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:39
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:14
-msgid "News"
-msgstr "Nieuws"
-
-#: module/Application/view/partial/admin.phtml:196
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:37
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:23
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:25
-msgid "Pages"
-msgstr "Pagina's"
-
-#: module/Application/view/partial/admin.phtml:203
-#: module/Application/view/partial/main-nav.phtml:434
-#: module/Application/view/partial/main-nav.phtml:438
-#: module/Application/view/partial/main-nav.phtml:443
-#: module/Application/view/partial/main-nav.phtml:452
-#: module/Photo/view/photo/album-admin/add.phtml:33
-#: module/Photo/view/photo/album-admin/create.phtml:15
-#: module/Photo/view/photo/album-admin/edit.phtml:15
-#: module/Photo/view/photo/album-admin/index.phtml:33
-#: module/Photo/view/photo/album/index.phtml:29
-#: module/Photo/view/photo/album/index.phtml:69
-#: module/Photo/view/photo/photo-admin/index.phtml:38
-#: module/Photo/view/photo/photo/index.phtml:15
-msgid "Photos"
-msgstr "Foto's"
-
-#: module/Application/view/partial/admin.phtml:210
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:32
-#: module/Frontpage/view/frontpage/poll/index.phtml:22
-#: module/Frontpage/view/frontpage/poll/index.phtml:30
-msgid "Polls"
-msgstr "Polls"
-
-#: module/Application/view/partial/admin.phtml:219
-msgid "Users"
-msgstr "Gebruikers"
-
-#: module/Application/view/partial/admin.phtml:224
-msgid "API Users"
-msgstr "API gebruikers"
-
-#: module/Application/view/partial/admin.phtml:245
-#: module/Application/view/partial/main-nav.phtml:161
-msgid "Admin"
-msgstr "Admin"
-
-#: module/Application/view/partial/company.phtml:26
-#: module/Frontpage/view/frontpage/page/page.phtml:20
-msgid "Home"
-msgstr "Home"
-
-#: module/Application/view/partial/company.phtml:31
-#: module/Company/src/Form/JobsTransfer.php:27
-#: module/Company/view/company/admin/edit-package.phtml:79
-#: module/Company/view/company/admin/index.phtml:135
-#: module/Company/view/company/admin/index.phtml:213
-#: module/Company/view/company/company-account/jobs.phtml:26
-#: module/Company/view/company/company-account/jobs.phtml:30
-#: module/Company/view/company/company-account/jobs.phtml:33
-#: module/Company/view/company/company-account/jobs.phtml:188
-#: module/Company/view/company/company-account/transfer-jobs.phtml:17
-msgid "Jobs"
-msgstr "Vacatures"
-
-#: module/Application/view/partial/company.phtml:36
-#: module/Company/view/company/company-account/highlights.phtml:10
-#: module/Company/view/company/company-account/highlights.phtml:13
-msgid "Highlights"
-msgstr "Highlights"
-
-#: module/Application/view/partial/company.phtml:41
-#: module/Company/src/Form/Package.php:112
-#: module/Company/view/company/admin/edit-package.phtml:70
-#: module/Company/view/company/company-account/banner.phtml:10
-#: module/Company/view/company/company-account/banner.phtml:13
-msgid "Banner"
-msgstr "Banner"
-
-#: module/Application/view/partial/company.phtml:46
-msgid "Settings"
-msgstr "Instellingen"
-
-#: module/Application/view/partial/company.phtml:58
-#: module/Application/view/partial/main-nav.phtml:116
-msgid "My Company"
-msgstr "Mijn Bedrijf"
-
-#: module/Application/view/partial/footer.phtml:21
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:273
-msgid "Infimum"
-msgstr "Infimum"
-
-#: module/Application/view/partial/footer.phtml:22
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:276
-msgid "Loading an infimum..."
-msgstr "Een infimum aan het laden..."
-
-#: module/Application/view/partial/footer.phtml:50
-msgid "All rights reserved."
-msgstr "Alle rechten voorbehouden."
-
-#: module/Application/view/partial/footer.phtml:52
-msgid ""
-"Made with <3 by the ApplicatieBeheerCommissie and Web Commissie (2013 - "
-"2022)."
-msgstr ""
-"Met <3 gemaakt door de ApplicatieBeheerCommissie en Web Commissie (2013 - "
-"2022)."
-
-#: module/Application/view/partial/footer.phtml:58
-#: module/Application/view/partial/main-nav.phtml:318
-#: module/Company/view/company/company/companyStory.phtml:37
-#: module/Company/view/company/company/jobs.phtml:105
-#: module/Company/view/partial/company/company/list/company.phtml:41
-msgid "Contact"
-msgstr "Contact"
-
-#: module/Application/view/partial/main-nav.phtml:53
-msgid "Language settings"
-msgstr "Taalinstellingen"
-
-#: module/Application/view/partial/main-nav.phtml:81
-#: module/Application/view/partial/main-nav.phtml:485
-#: module/Decision/view/decision/member/birthdays.phtml:15
-#: module/Decision/view/decision/member/index.phtml:22
-#: module/Decision/view/decision/member/index.phtml:28
-#: module/Decision/view/decision/member/search.phtml:11
-#: module/Decision/view/decision/member/view.phtml:23
-msgid "Members"
-msgstr "Leden"
-
-#: module/Application/view/partial/main-nav.phtml:98
-msgid "Subscribe"
-msgstr "Inschrijven"
-
-#: module/Application/view/partial/main-nav.phtml:121
-#: module/Application/view/partial/main-nav.phtml:154
-#: module/Decision/view/decision/member/index.phtml:42
-#: module/User/src/Form/Password.php:59
-#: module/User/view/user/user/change-password.phtml:15
-#: module/User/view/user/user/change-password.phtml:36
-msgid "Change password"
-msgstr "Wijzig wachtwoord"
-
-#: module/Application/view/partial/main-nav.phtml:126
-#: module/Application/view/partial/main-nav.phtml:168
-msgid "Logout"
-msgstr "Uitloggen"
-
-#: module/Application/view/partial/main-nav.phtml:144
-msgid "My information"
-msgstr "Mijn informatie"
-
-#: module/Application/view/partial/main-nav.phtml:149
-#: module/Decision/view/decision/member/index.phtml:56
-msgid "SudoSOS"
-msgstr "SudoSOS"
-
-#: module/Application/view/partial/main-nav.phtml:177
-msgid "Toggle navigation"
-msgstr "Klap navigatie in/uit"
-
-#: module/Application/view/partial/main-nav.phtml:191
-#: module/Application/view/partial/main-nav.phtml:196
-#: module/Application/view/partial/main-nav.phtml:201
-#: module/Decision/view/decision/member/index.phtml:69
-msgid "Association"
-msgstr "Vereniging"
-
-#: module/Application/view/partial/main-nav.phtml:212
-#: module/Decision/view/decision/member/view.phtml:72
-msgid "Board"
-msgstr "Bestuur"
-
-#: module/Application/view/partial/main-nav.phtml:217
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:14
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:20
-#: module/Frontpage/view/frontpage/organ/organ.phtml:64
-msgid "Committees"
-msgstr "Commissies"
-
-#: module/Application/view/partial/main-nav.phtml:222
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:15
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:19
-#: module/Frontpage/view/frontpage/organ/organ.phtml:60
-msgid "Fraternities"
-msgstr "Disputen"
-
-#: module/Application/view/partial/main-nav.phtml:233
-msgid "Exceptional Members"
-msgstr "Uitzonderlijke leden"
-
-#: module/Application/view/partial/main-nav.phtml:244
-msgid "GEWIS song"
-msgstr "GEWIS-lied"
-
-#: module/Application/view/partial/main-nav.phtml:255
-#: module/Decision/view/decision/member/index.phtml:226
-msgid "Regulations"
-msgstr "Reguleringen"
-
-#: module/Application/view/partial/main-nav.phtml:262
-#: module/Application/view/partial/main-nav.phtml:267
-msgid "Useful Information"
-msgstr "Praktische informatie"
-
-#: module/Application/view/partial/main-nav.phtml:273
-#: module/Decision/view/decision/member/index.phtml:93
-msgid "Links"
-msgstr "Links"
-
-#: module/Application/view/partial/main-nav.phtml:278
-msgid "Well-being"
-msgstr "Welzijn"
-
-#: module/Application/view/partial/main-nav.phtml:289
-msgid "Confidential Contact Person (CCP)"
-msgstr "Vertrouwenscontactpersonen (VCP)"
-
-#: module/Application/view/partial/main-nav.phtml:294
-msgid "FAQ"
-msgstr "FAQ"
-
-#: module/Application/view/partial/main-nav.phtml:305
-msgid "Housing"
-msgstr "Huisvesting"
-
-#: module/Application/view/partial/main-nav.phtml:343
-#: module/Company/view/company/admin/index.phtml:161
-msgid "Featured"
-msgstr "Uitgelicht"
-
-#: module/Application/view/partial/main-nav.phtml:390
-msgid "My activities"
-msgstr "Mijn activiteiten"
-
-#: module/Application/view/partial/main-nav.phtml:399
-msgid "Activity Archive"
-msgstr "Archief"
-
-#: module/Application/view/partial/main-nav.phtml:408
-msgid "Create an activity"
-msgstr "Maak een activiteit"
-
-#: module/Application/view/partial/main-nav.phtml:424
-msgid "Career related"
-msgstr "Carrière gerelateerd"
-
-#: module/Application/view/partial/main-nav.phtml:457
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:218
-msgid "Photo of the week"
-msgstr "Foto van de week"
-
-#: module/Application/view/partial/main-nav.phtml:470
-#: module/Decision/view/decision/member/index.phtml:52
-msgid "My photo's"
-msgstr "Mijn foto’s"
-
-#: module/Application/view/partial/main-nav.phtml:499
-msgid "You are currently using administrator privileges to use the website!"
-msgstr "Je gebruikt momenteel beheerdersprivileges om de website te gebruiken!"
-
-#: module/Application/view/partial/paginator.phtml:19
-#: module/Photo/view/photo/album/index.phtml:437
-msgid "Previous"
-msgstr "Vorige"
-
-#: module/Application/view/partial/paginator.phtml:37
-#: module/Photo/view/photo/album/index.phtml:438
-msgid "Next"
-msgstr "Volgende"
-
-#: module/Application/view/partial/privacy-widget.phtml:13
-msgid ""
-"S.v. GEWIS uses cookies on this website, these are required for the website "
-"to function. Additionally, we may collection information about how you use "
-"our website in order to improve your experience. If you do not want your "
-"behaviour to be tracked please opt out below."
-msgstr ""
-"S.v. GEWIS maakt gebruik van cookies op deze website, deze zijn nodig om de "
-"website te laten functioneren. Daarnaast kunnen wij informatie verzamelen "
-"over hoe je onze website gebruikt om je ervaring te verbeteren. Als je niet "
-"wilt dat je gedrag wordt bijgehouden, kan je je hieronder afmelden."
-
-#: module/Application/view/partial/privacy-widget.phtml:19
-msgid "Tracking is currently"
-msgstr "Volgen is momenteel"
-
-#: module/Application/view/partial/privacy-widget.phtml:20
-msgid "enabled"
-msgstr "ingeschakeld"
-
-#: module/Application/view/partial/privacy-widget.phtml:21
-msgid "disabled"
-msgstr "uitgeschakeld"
-
-#: module/Application/view/partial/privacy-widget.phtml:23
-msgid "disabled (Do Not Track)"
-msgstr "uitgeschakeld (volg-me-niet)"
-
-#: module/Application/view/partial/privacy-widget.phtml:25
-msgid "unavailable"
-msgstr "niet beschikbaar"
-
-#: module/Application/view/partial/privacy-widget.phtml:31
-#: module/Decision/view/decision/member/index.phtml:294
-msgid "Privacy Policy"
-msgstr "Privacybeleid"
-
-#: module/Application/view/partial/privacy-widget.phtml:33
-#: module/User/src/Form/ApiAppAuthorisation.php:48
-msgid "Continue"
-msgstr "Doorgaan"
-
-#: module/Company/src/Controller/AdminApprovalController.php:45
-#: module/Company/src/Controller/AdminApprovalController.php:71
-msgid "You are not allowed to view the approval status of jobs"
-msgstr ""
-"Je hebt niet de rechten om de goedkeuringsstatus van deze vacature te "
-"bekijken"
-
-#: module/Company/src/Controller/AdminApprovalController.php:89
-msgid "Approve Job"
-msgstr "Keur vacature goed"
-
-#: module/Company/src/Controller/AdminApprovalController.php:93
-msgid "Disapprove Job"
-msgstr "Keur vacature af"
-
-#: module/Company/src/Controller/AdminApprovalController.php:97
-msgid "Reset Approval Status"
-msgstr "Goedkeuringsstatus intrekken"
-
-#: module/Company/src/Controller/AdminApprovalController.php:107
-msgid "You are not allowed to change the approval status of jobs"
-msgstr ""
-"Je hebt niet de rechten om de goedkeuringsstatus van deze vacatures te "
-"wijzigen"
-
-#: module/Company/src/Controller/AdminApprovalController.php:141
-msgid "Job approved!"
-msgstr "Vacature goedgekeurd!"
-
-#: module/Company/src/Controller/AdminApprovalController.php:149
-msgid "Job disapproved!"
-msgstr "Vacature afgekeurd!"
-
-#: module/Company/src/Controller/AdminApprovalController.php:153
-msgid "Job approval status reset!"
-msgstr "Goedkeuringsstatus van de vacature is ingetrokken!"
-
-#: module/Company/src/Controller/AdminApprovalController.php:164
-#: module/Company/src/Controller/AdminApprovalController.php:194
-msgid "You are not allowed to approve update proposals of jobs"
-msgstr ""
-"Je hebt niet de rechten om updatevoorstellen van vacatures goed te keuren"
-
-#: module/Company/src/Controller/AdminApprovalController.php:180
-msgid "Apply Update"
-msgstr "Update toepassen"
-
-#: module/Company/src/Controller/AdminApprovalController.php:184
-msgid "Reject Update"
-msgstr "Update afwijzen"
-
-#: module/Company/src/Controller/AdminApprovalController.php:218
-msgid ""
-"An unknown error occurred while try to change the status of a job update "
-"proposal. Please try again."
-msgstr ""
-"Er is een onbekende fout opgetreden tijdens het veranderen van de status van "
-"het vacature updatevoorstel. Probeer het opnieuw."
-
-#: module/Company/src/Controller/AdminApprovalController.php:230
-msgid "Job has been updated!"
-msgstr "Vacature is bijgewerkt!"
-
-#: module/Company/src/Controller/AdminApprovalController.php:238
-msgid "Job update has been rejected!"
-msgstr "Vacature update is afgewezen!"
-
-#: module/Company/src/Controller/AdminController.php:47
-msgid "You are not allowed to administer career settings"
-msgstr "Je hebt niet de rechten om carrière-instellingen te beheren"
-
-#: module/Company/src/Controller/AdminController.php:80
-msgid "You are not allowed to create companies"
-msgstr "Je hebt niet de rechten om bedrijven toe te voegen"
-
-#: module/Company/src/Controller/AdminController.php:123
-msgid "You are not allowed to edit companies"
-msgstr "Je hebt niet de rechten om bedrijven te wijzigen"
-
-#: module/Company/src/Controller/AdminController.php:190
-#: module/Company/src/Service/Company.php:856
-msgid "You are not allowed to delete companies"
-msgstr "Je hebt niet de rechten om bedrijven te verwijderen"
-
-#: module/Company/src/Controller/AdminController.php:215
-msgid "You are not allowed to create packages"
-msgstr "Je hebt niet de rechten om pakketten toe te voegen"
-
-#: module/Company/src/Controller/AdminController.php:284
-#: module/Company/src/Service/Company.php:905
-msgid "You are not allowed to edit packages"
-msgstr "Je hebt niet de rechten om pakketten te wijzigen"
-
-#: module/Company/src/Controller/AdminController.php:372
-#: module/Company/src/Service/Company.php:741
-msgid "You are not allowed to delete packages"
-msgstr "Je hebt niet de rechten om pakketten te verwijderen"
-
-#: module/Company/src/Controller/AdminController.php:414
-#: module/Company/src/Controller/CompanyAccountController.php:120
-msgid "You are not allowed to create jobs"
-msgstr "Je hebt niet de rechten om vacatures toe te voegen"
-
-#: module/Company/src/Controller/AdminController.php:453
-msgid "Job successfully created!"
-msgstr "Vacature succesvol aangemaakt!"
-
-#: module/Company/src/Controller/AdminController.php:493
-#: module/Company/src/Controller/CompanyAccountController.php:203
-#: module/Company/src/Service/Company.php:931
-#: module/Company/src/Service/Company.php:1002
-msgid "You are not allowed to edit jobs"
-msgstr "Je hebt niet de rechten om vacatures te wijzigen"
-
-#: module/Company/src/Controller/AdminController.php:532
-msgid "Job successfully edited!"
-msgstr "Vacature succesvol aangepast!"
-
-#: module/Company/src/Controller/AdminController.php:568
-#: module/Company/src/Controller/CompanyAccountController.php:310
-msgid "You are not allowed to delete jobs"
-msgstr "Je hebt niet de rechten om vacatures te verwijderen"
-
-#: module/Company/src/Controller/AdminController.php:610
-msgid "You are not allowed to create job categories"
-msgstr "Je hebt niet de rechten om vacaturecategorieën te wijzigen"
-
-#: module/Company/src/Controller/AdminController.php:629
-msgid "Job category successfully created!"
-msgstr "Vacaturecategorie succesvol aangemaakt!"
-
-#: module/Company/src/Controller/AdminController.php:665
-#: module/Company/src/Service/Company.php:881
-msgid "You are not allowed to edit job categories"
-msgstr "Je hebt niet de rechten om vacature categorieën te wijzigen"
-
-#: module/Company/src/Controller/AdminController.php:705
-msgid "You are not allowed to create job labels"
-msgstr "Je hebt niet de rechten om vacature-labels te wijzigen"
-
-#: module/Company/src/Controller/AdminController.php:724
-msgid "Job label successfully created!"
-msgstr "Vacature-label succesvol aangemaakt!"
-
-#: module/Company/src/Controller/AdminController.php:758
-#: module/Company/src/Service/Company.php:893
-msgid "You are not allowed to edit job labels"
-msgstr "Je hebt niet de rechten om vacature-labels te wijzigen"
-
-#: module/Company/src/Controller/CompanyAccountController.php:47
-#: module/Company/src/Controller/CompanyAccountController.php:58
-#: module/Company/src/Controller/CompanyAccountController.php:69
-msgid "You are not allowed to view the company accounts"
-msgstr "Je hebt niet de rechten om bedrijfsprofielen te bekijken"
-
-#: module/Company/src/Controller/CompanyAccountController.php:143
-msgid "You cannot create new jobs in expired job packages."
-msgstr "Je kan geen nieuwe vacatures maken in verlopen vacaturepakketen."
-
-#: module/Company/src/Controller/CompanyAccountController.php:166
-msgid ""
-"Job proposal successfully created! It will become active after it has been "
-"approved."
-msgstr ""
-"Voorstel voor vacature succesvol aangemaakt! Deze zal actief worden zodra "
-"deze is goedgekeurd."
-
-#: module/Company/src/Controller/CompanyAccountController.php:223
-msgid "You cannot update jobs in expired job packages."
-msgstr "Je kan vacatures in verlopen vacaturepakketten niet bijwerken."
-
-#: module/Company/src/Controller/CompanyAccountController.php:249
-msgid ""
-"Update proposal for job successfully created! It will become active after it "
-"has been approved."
-msgstr ""
-"Updatevoorstel voor vacature succesvol aangemaakt! Deze zal actief worden "
-"zodra deze is goedgekeurd."
-
-#: module/Company/src/Controller/CompanyAccountController.php:335
-msgid "Job successfully deleted."
-msgstr "Vacature succesvol verwijderd."
-
-#: module/Company/src/Controller/CompanyAccountController.php:344
-msgid "You are not allowed to view the status of a job"
-msgstr ""
-"Je hebt niet de rechten om de goedkeuringsstatus van vacatures te bekijken"
-
-#: module/Company/src/Controller/CompanyAccountController.php:369
-msgid "You are not allowed to transfer jobs"
-msgstr "Je hebt niet de rechten om vacatures te verplaatsen"
-
-#: module/Company/src/Controller/CompanyAccountController.php:406
-msgid "Jobs successfully transferred"
-msgstr "Vacature succesvol verplaatst"
-
-#: module/Company/src/Controller/CompanyAccountController.php:417
-msgid ""
-"An unknown error occurred while trying to transfer jobs, please try again."
-msgstr ""
-"Er is een onbekende fout opgetreden tijdens het verplaatsen van de "
-"vacatures, probeer het opnieuw."
-
-#: module/Company/src/Form/Company.php:61 module/Company/src/Form/Job.php:69
-#: module/Company/src/Form/JobCategory.php:85
-#: module/Company/src/Form/JobCategory.php:95
-#: module/Company/view/company/admin-approval/job-approval.phtml:44
-#: module/Company/view/company/admin-approval/job-approval.phtml:48
-#: module/Company/view/company/admin-approval/job-proposal.phtml:69
-#: module/Company/view/company/admin-approval/job-proposal.phtml:73
-#: module/Company/view/partial/company/admin/editors/company.phtml:18
-#: module/Company/view/partial/company/admin/editors/job.phtml:18
-msgid "Slug"
-msgstr "Permalink"
-
-#: module/Company/src/Form/Company.php:71
-msgid "Logo"
-msgstr "Logo"
-
-#: module/Company/src/Form/Company.php:81 module/Company/src/Form/Job.php:91
-#: module/Company/src/Form/Package.php:66
-msgid "Published"
-msgstr "Gepubliceerd"
-
-#: module/Company/src/Form/Company.php:103
-#: module/Company/src/Form/Company.php:133 module/Company/src/Form/Job.php:116
-msgid "E-mail Address"
-msgstr "E-mailadres"
-
-#: module/Company/src/Form/Company.php:123
-msgid "Address"
-msgstr "Adres"
-
-#: module/Company/src/Form/Company.php:143 module/Company/src/Form/Job.php:126
-msgid "Phone Number"
-msgstr "Telefoonnummer"
-
-#: module/Company/src/Form/Company.php:154
-#: module/Company/src/Form/Company.php:164
-msgid "Slogan"
-msgstr "Slogan"
-
-#: module/Company/src/Form/Company.php:178
-#: module/Company/src/Form/Company.php:188 module/Company/src/Form/Job.php:161
-#: module/Company/src/Form/Job.php:171
-#: module/Company/view/company/admin-approval/job-approval.phtml:138
-#: module/Company/view/company/admin-approval/job-approval.phtml:143
-#: module/Company/view/company/admin-approval/job-approval.phtml:150
-#: module/Company/view/company/admin-approval/job-proposal.phtml:184
-#: module/Company/view/company/admin-approval/job-proposal.phtml:189
-#: module/Company/view/company/admin-approval/job-proposal.phtml:199
-#: module/Decision/src/Form/OrganInformation.php:42
-#: module/Frontpage/view/frontpage/organ/organ.phtml:110
-msgid "Website"
-msgstr "Website"
-
-#: module/Company/src/Form/Company.php:261 module/Company/src/Form/Job.php:282
-#: module/Company/src/Form/JobCategory.php:194
-msgid "This slug is already taken"
-msgstr "Deze permalink is al in gebruik"
-
-#: module/Company/src/Form/Company.php:272 module/Company/src/Form/Job.php:293
-#: module/Company/src/Form/JobCategory.php:204
-msgid "This slug contains invalid characters"
-msgstr "Deze permalink bevat ongeldige tekens"
-
-#: module/Company/src/Form/Company.php:346
-msgid "E-mail address format is not valid."
-msgstr "E-mailadres formaat is niet geldig."
-
-#: module/Company/src/Form/Company.php:356
-msgid "The e-mail address must be unique across companies."
-msgstr "Het e-mailadres moet uniek zijn onder alle bedrijven."
-
-#: module/Company/src/Form/Company.php:400 module/Company/src/Form/Job.php:341
-#: module/User/src/Form/CompanyUserLogin.php:125
-#: module/User/src/Form/CompanyUserReset.php:64
-#: module/User/src/Form/UserReset.php:93
-msgid "E-mail address format is not valid"
-msgstr "E-mailadres formaat is niet geldig"
-
-#: module/Company/src/Form/Job.php:79
-#: module/Company/view/company/admin-approval/job-approval.phtml:55
-#: module/Company/view/company/admin-approval/job-approval.phtml:59
-#: module/Company/view/company/admin-approval/job-proposal.phtml:83
-#: module/Company/view/company/admin-approval/job-proposal.phtml:87
-msgid "Category"
-msgstr "Categorie"
-
-#: module/Company/src/Form/Job.php:80
-msgid "Select a job category"
-msgstr "Selecteer een vacaturecategorie"
-
-#: module/Company/src/Form/Job.php:221 module/Company/src/Form/Job.php:231
-#: module/Company/view/company/admin-approval/job-approval.phtml:195
-#: module/Company/view/company/admin-approval/job-approval.phtml:200
-#: module/Company/view/company/admin-approval/job-approval.phtml:211
-#: module/Company/view/company/admin-approval/job-proposal.phtml:259
-#: module/Company/view/company/admin-approval/job-proposal.phtml:264
-#: module/Company/view/company/admin-approval/job-proposal.phtml:280
-msgid "Attachment"
-msgstr "Bijlage"
-
-#: module/Company/src/Form/JobCategory.php:65
-#: module/Company/src/Form/JobCategory.php:75
-msgid "Name (Plural)"
-msgstr "Naam (meervoud)"
-
-#: module/Company/src/Form/JobCategory.php:105
-msgid "Hidden"
-msgstr "Verborgen"
-
-#: module/Company/src/Form/JobLabel.php:51
-#: module/Company/src/Form/JobLabel.php:61
-#: module/Decision/view/decision/organ-admin/index.phtml:23
-#: module/Decision/view/decision/organ/index.phtml:22
-msgid "Abbreviation"
-msgstr "Afkorting"
-
-#: module/Company/src/Form/JobsTransfer.php:38
-msgid "Select a target job package"
-msgstr "Selecteer een vacaturepakket als bestemming"
-
-#: module/Company/src/Form/JobsTransfer.php:39
-#: module/Company/view/company/admin/edit-company.phtml:59
-msgid "Packages"
-msgstr "Pakketten"
-
-#: module/Company/src/Form/JobsTransfer.php:50
-#: module/Company/view/company/company-account/jobs.phtml:272
-#: module/Company/view/company/company-account/transfer-jobs.phtml:14
-#: module/Company/view/company/company-account/transfer-jobs.phtml:24
-msgid "Transfer Jobs"
-msgstr "Verplaats vacatures"
-
-#: module/Company/src/Form/Package.php:38
-msgid "Start Date"
-msgstr "Startdatum"
-
-#: module/Company/src/Form/Package.php:52
-msgid "Expiration Date"
-msgstr "Afloopdatum"
-
-#: module/Company/src/Form/Package.php:79
-#: module/Company/view/company/admin/edit-company.phtml:101
-#: module/Company/view/company/company-account/jobs.phtml:54
-msgid "Contract Number"
-msgstr "Contractnummer"
-
-#: module/Company/src/Form/Package.php:90
-#: module/Company/src/Form/Package.php:100
-msgid "Article"
-msgstr "Artikel"
-
-#: module/Company/src/Form/Package.php:179
-msgid "Contract numbers can only contain letters, numbers, _, -, ., and spaces"
-msgstr ""
-"Contractnummers kunnen alleen letters, cijfers, _, -, ., en spaties bevatten"
-
-#: module/Company/src/Service/Company.php:92
-msgid "You are not allowed to view the banner"
-msgstr "Je hebt niet de rechten om de banner te zien"
-
-#: module/Company/src/Service/Company.php:102
-msgid "You are not allowed to view the featured company"
-msgstr "Je hebt niet de rechten om het uitgelichte bedrijf te zien"
-
-#: module/Company/src/Service/Company.php:170
-#: module/Company/src/Service/Company.php:190
-#: module/Company/src/Service/Company.php:218
-msgid "You are not allowed to list the companies"
-msgstr "Je hebt niet de rechten om de lijst met bedrijven te zien"
-
-#: module/Company/src/Service/Company.php:205
-msgid "You are not allowed to access the admin interface"
-msgstr "Je hebt niet de rechten om de admin interface te zien"
-
-#: module/Company/src/Service/Company.php:948
-msgid "You are not allowed to edit categories"
-msgstr "Je hebt niet de rechten om alle categorieën te wijzigen"
-
-#: module/Company/src/Service/Company.php:965
-msgid "You are not allowed to edit labels"
-msgstr "Je hebt niet de rechten om labels te wijzigen"
-
-#: module/Company/src/Service/Company.php:1015
-msgid "You are not allowed to create a company"
-msgstr "Je hebt niet de rechten om een bedrijf toe te voegen"
-
-#: module/Company/src/Service/CompanyQuery.php:98
-msgid "You are not allowed to list all job categories"
-msgstr "Je hebt niet de rechten om alle vacaturecategorieën te bekijken"
-
-#: module/Company/src/Service/CompanyQuery.php:106
-msgid "You are not allowed to list job categories"
-msgstr "Je hebt niet de rechten om vacaturecategorieën te bekijken"
-
-#: module/Company/src/Service/CompanyQuery.php:146
-msgid "You are not allowed to list all job labels"
-msgstr "Je hebt niet de rechten om alle vacature-labels te bekijken"
-
-#: module/Company/src/Service/CompanyQuery.php:154
-msgid "You are not allowed to list job labels"
-msgstr "Je hebt niet de rechten om vacature-labels te bekijken"
-
-#: module/Company/view/company/admin-approval/index.phtml:24
-msgid "Unapproved Companies"
-msgstr "Niet goedgekeurde bedrijven"
-
-#: module/Company/view/company/admin-approval/index.phtml:38
-msgid "There is no company or update proposal that requires your approval."
-msgstr "Er is geen bedrijfs- of updatevoorstel die jouw goedkeuring vereist."
-
-#: module/Company/view/company/admin-approval/index.phtml:50
-msgid "Unapproved Jobs"
-msgstr "Niet goedgekeurde vacatures"
-
-#: module/Company/view/company/admin-approval/index.phtml:56
-msgid "Dutch Name"
-msgstr "Nederlandse naam"
-
-#: module/Company/view/company/admin-approval/index.phtml:57
-msgid "English Name"
-msgstr "Engelse naam"
-
-#: module/Company/view/company/admin-approval/index.phtml:66
-msgid "There is no job or update proposal that requires your approval."
-msgstr "Er is geen vacature- of updatevoorstel die jouw goedkeuring vereist."
-
-#: module/Company/view/company/admin-approval/index.phtml:82
-msgid "View Update"
-msgstr "Bekijk updatevoorstel"
-
-#: module/Company/view/company/admin-approval/index.phtml:90
-msgid "View Proposal"
-msgstr "Bekijk voorstel"
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:35
 #, php-format
 msgid "This job is proposed by <strong>%s</strong> as part of job package %s."
 msgstr ""
 "Deze vacature is voorgesteld door <strong>%s</strong> als onderdeel van "
 "vacaturepakket %s."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:77
-#: module/Company/view/company/admin-approval/job-approval.phtml:81
-#: module/Company/view/company/admin-approval/job-proposal.phtml:111
-#: module/Company/view/company/admin-approval/job-proposal.phtml:115
-#: module/Decision/view/decision/member/self.phtml:174
-msgid "Phone number"
-msgstr "Telefoonnummer"
+msgid "This job package does not contain any jobs."
+msgstr "Dit vacaturepakket bevat geen vacatures."
 
-#: module/Company/view/company/admin-approval/job-approval.phtml:88
-#: module/Company/view/company/admin-approval/job-approval.phtml:92
-#: module/Company/view/company/admin-approval/job-proposal.phtml:125
-#: module/Company/view/company/admin-approval/job-proposal.phtml:129
-#: module/User/src/Form/UserReset.php:40
-#: module/User/src/Model/Enums/JWTClaims.php:39
-msgid "E-mail address"
-msgstr "E-mail adres"
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:204
-#: module/Company/view/company/admin-approval/job-approval.phtml:215
-#: module/Company/view/company/admin-approval/job-proposal.phtml:284
-#: module/Company/view/company/company/jobs.phtml:133
-msgid "View Attachment"
-msgstr "Bijlage bekijken"
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:244
-msgid ""
-"If approved, this job will be <strong>published</strong>, however, its "
-"actual visiblity depends on the company and associated job package."
-msgstr ""
-"Bij goedkeuring wordt deze vacature <strong>gepubliceerd</strong>, maar de "
-"daadwerkelijke zichtbaarheid hangt af van het bedrijf en het bijbehorende "
-"vacaturepakket."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:246
-msgid "If approved, this job will be <strong>hidden</strong>."
-msgstr "Bij goedkeuring wordt deze vacature <strong>verborgen</strong>."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:291
-#: module/Company/view/company/admin-approval/job-proposal.phtml:397
-msgid "Optional message..."
-msgstr "Optioneel bericht..."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:312
-#, php-format
-msgid "This job was approved by <strong>%s</strong>."
-msgstr "Deze vacature is goedgekeurd door <strong>%s</strong>."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:341
-#, php-format
-msgid ""
-"This job was disapproved by <strong>%s</strong> with the message \"%s\"."
-msgstr ""
-"Deze vacature is afgekeurd door <strong>%s</strong> met het bericht \"%s\"."
-
-#: module/Company/view/company/admin-approval/job-approval.phtml:347
-#, php-format
-msgid "This job was disapproved by <strong>%s</strong>."
-msgstr "Deze vacature is afgekeurd door <strong>%s</strong>."
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:27
-msgid "Proposals"
-msgstr "Voorstellen"
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:59
 #, php-format
 msgid ""
 "This job update is proposed by <strong>%s</strong> as part of job package "
@@ -2927,938 +2938,33 @@ msgstr ""
 "worden als volgt weergegeven: %s. Als er geen wijzigingen zijn in een "
 "bepaald kenmerk, zie je de bestaande gegevens."
 
-#: module/Company/view/company/admin-approval/job-proposal.phtml:268
-msgid "View Original Attachment"
-msgstr "Bekijk originele bijlage"
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:273
-#: module/Company/view/company/admin-approval/job-proposal.phtml:289
-msgid "View New Attachment"
-msgstr "Bekijk nieuwe bijlage"
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:297
-#: module/Company/view/partial/company/admin/editors/job.phtml:328
-msgid "Job Labels"
-msgstr "Vacature-labels"
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:328
-msgid ""
-"Original job and proposed update do not have any job labels applied to them."
-msgstr ""
-"De originele vacature en het updatevoorstel hebben geen vacature-labels."
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:340
-msgid ""
-"Warning! This is an update to an unapproved job. Applying this update will "
-"approve the job."
-msgstr ""
-"Waarschuwing! Dit is een update van een nog niet goedgekeurde vacature. Het "
-"toepassen van deze update zal de vacature goedkeuren."
-
-#: module/Company/view/company/admin-approval/job-proposal.phtml:350
-msgid ""
-"Warning! This is an update to rejected job. Applying this update will "
-"approve the job."
-msgstr ""
-"Waarschuwing! Dit is een update voor een afgewezen vacature. Het toepassen "
-"van deze update zal de vacature goedkeuren."
-
-#: module/Company/view/company/admin/add-category.phtml:14
-#: module/Company/view/company/admin/add-category.phtml:22
-#: module/Company/view/company/admin/add-category.phtml:37
-msgid "Create Job Category"
-msgstr "Vacaturecategorie aanmaken"
-
-#: module/Company/view/company/admin/add-company.phtml:14
-#: module/Company/view/company/admin/add-company.phtml:28
-#: module/Company/view/company/admin/add-company.phtml:43
-msgid "Create Company"
-msgstr "Bedrijf aanmaken"
-
-#: module/Company/view/company/admin/add-job.phtml:14
-#: module/Company/view/company/admin/add-job.phtml:33
-#: module/Company/view/company/admin/add-job.phtml:48
-#: module/Company/view/company/admin/edit-package.phtml:140
-#: module/Company/view/company/company-account/jobs.phtml:97
-#: module/Company/view/company/company-account/jobs.phtml:282
-msgid "Add Job"
-msgstr "Voeg vacature toe"
-
-#: module/Company/view/company/admin/add-label.phtml:14
-#: module/Company/view/company/admin/add-label.phtml:28
-#: module/Company/view/company/admin/add-label.phtml:43
-msgid "Create Job Label"
-msgstr "Vacature-label aanmaken"
-
-#: module/Company/view/company/admin/add-package.phtml:15
-#: module/Company/view/company/admin/add-package.phtml:29
-#: module/Company/view/company/admin/add-package.phtml:45
-msgid "Add Package"
-msgstr "Voeg pakket toe"
-
-#: module/Company/view/company/admin/categories.phtml:36
-#: module/Company/view/company/admin/labels.phtml:35
-msgid "edit"
-msgstr "wijzig"
-
-#: module/Company/view/company/admin/edit-category.phtml:14
-#: module/Company/view/company/admin/edit-category.phtml:21
-msgid "Edit Job Category"
-msgstr "Vacaturecategorie aanpassen"
-
-#: module/Company/view/company/admin/edit-category.phtml:36
-msgid "Update Job Category"
-msgstr "Vacaturecategorie bijwerken"
-
-#: module/Company/view/company/admin/edit-company.phtml:17
-msgid "Edit Company"
-msgstr "Wijzig bedrijf"
-
-#: module/Company/view/company/admin/edit-company.phtml:53
 #, php-format
-msgid "Edit %s"
-msgstr "%s bewerken"
+msgid "This job was approved by <strong>%s</strong>."
+msgstr "Deze vacature is goedgekeurd door <strong>%s</strong>."
 
-#: module/Company/view/company/admin/edit-company.phtml:70
-msgid "Add Job Package"
-msgstr "Voeg vacaturepakket toe"
-
-#: module/Company/view/company/admin/edit-company.phtml:80
-msgid "Add Spotlight Package"
-msgstr "Voeg spotlight-pakket toe"
-
-#: module/Company/view/company/admin/edit-company.phtml:90
-msgid "Add Banner Package"
-msgstr "Voeg bannerpakket toe"
-
-#: module/Company/view/company/admin/edit-company.phtml:104
-#: module/Company/view/company/admin/edit-package.phtml:84
-#: module/Company/view/company/company-account/jobs.phtml:197
-msgid "Active"
-msgstr "Actief"
-
-#: module/Company/view/company/admin/edit-company.phtml:110
-#: module/Company/view/company/company-account/jobs.phtml:60
-msgid "Expiration date"
-msgstr "Verloopdatum"
-
-#: module/Company/view/company/admin/edit-company.phtml:113
-msgid "Jobs (Active) / Type"
-msgstr "Vacatures (Actief) / Type"
-
-#: module/Company/view/company/admin/edit-company.phtml:136
-#: module/Company/view/company/admin/index.phtml:50
-#: module/Company/view/company/admin/index.phtml:82
-msgid "Banner Package"
-msgstr "Bannerpakket"
-
-#: module/Company/view/company/admin/edit-company.phtml:139
-#: module/Company/view/company/admin/index.phtml:53
-#: module/Company/view/company/admin/index.phtml:85
-msgid "Featured Package"
-msgstr "Uitgelicht pakket"
-
-#: module/Company/view/company/admin/edit-company.phtml:187
-msgid "Update Company"
-msgstr "Bedrijf bijwerken"
-
-#: module/Company/view/company/admin/edit-company.phtml:206
-msgid "Are you sure you want to delete this package?"
-msgstr "Weet je zeker dat je dit pakket wilt verwijderen?"
-
-#: module/Company/view/company/admin/edit-company.phtml:212
-msgid "Delete package"
-msgstr "Verwijder pakket"
-
-#: module/Company/view/company/admin/edit-job.phtml:19
-#: module/Company/view/company/admin/edit-job.phtml:38
-msgid "Edit Job"
-msgstr "Vacature aanpassen"
-
-#: module/Company/view/company/admin/edit-job.phtml:47
 #, php-format
 msgid ""
-"You are currently updating an update proposal that was previously rejected "
-"for the following reason: %s"
+"This job was disapproved by <strong>%s</strong> with the message \"%s\"."
 msgstr ""
-"Je werkt momenteel een updatevoorstel bij dat eerder is afgewezen met de "
-"volgende reden: %s"
+"Deze vacature is afgekeurd door <strong>%s</strong> met het bericht \"%s\"."
 
-#: module/Company/view/company/admin/edit-job.phtml:53
-msgid ""
-"You are currently updating an update proposal that was previously rejected, "
-"however, no reason was provided."
-msgstr ""
-"Je werkt momenteel een updatevoorstel bij dat eerder is afgewezen, maar er "
-"is hiervoor geen reden opgegeven."
-
-#: module/Company/view/company/admin/edit-job.phtml:58
 #, php-format
-msgid ""
-"You are currently updating a job that was previously rejected for the "
-"following reason: %s"
-msgstr ""
-"Je werkt momenteel een vacature bij die eerder is afgewezen met de volgende "
-"reden: %s"
+msgid "This job was disapproved by <strong>%s</strong>."
+msgstr "Deze vacature is afgekeurd door <strong>%s</strong>."
 
-#: module/Company/view/company/admin/edit-job.phtml:64
-msgid ""
-"You are currently updating a job that was previously rejected, however, no "
-"reason was provided."
-msgstr ""
-"Je werkt momenteel een vacature bij die eerder is afgewezen, maar er is "
-"hiervoor geen reden opgegeven."
-
-#: module/Company/view/company/admin/edit-job.phtml:85
-msgid "Update Job"
-msgstr "Vacature bijwerken"
-
-#: module/Company/view/company/admin/edit-label.phtml:14
-#: module/Company/view/company/admin/edit-label.phtml:28
-msgid "Edit Job Label"
-msgstr "Vacature-label aanpassen"
-
-#: module/Company/view/company/admin/edit-label.phtml:43
-msgid "Update Job Label"
-msgstr "Vacature-label bijwerken"
-
-#: module/Company/view/company/admin/edit-package.phtml:19
-#: module/Company/view/company/admin/edit-package.phtml:40
-msgid "Edit Package"
-msgstr "Pakket aanpassen"
-
-#: module/Company/view/company/admin/edit-package.phtml:56
-msgid "Update Package"
-msgstr "Pakket bijwerken"
-
-#: module/Company/view/company/admin/edit-package.phtml:101
-msgid "(Update Pending)"
-msgstr "(Update in behandeling)"
-
-#: module/Company/view/company/admin/edit-package.phtml:154
-#: module/Company/view/company/company-account/jobs.phtml:297
-msgid "Are you sure you want to delete this job?"
-msgstr "Weet je zeker dat je deze vacature wilt verwijderen?"
-
-#: module/Company/view/company/admin/edit-package.phtml:159
-#: module/Company/view/company/company-account/jobs.phtml:302
-msgid "Delete job"
-msgstr "Verwijder vacature"
-
-#: module/Company/view/company/admin/index.phtml:36
-#: module/Company/view/company/company-account/jobs.phtml:39
-msgid "Notifications"
-msgstr "Meldingen"
-
-#: module/Company/view/company/admin/index.phtml:38
-msgid "No notifications"
-msgstr "Geen meldingen"
-
-#: module/Company/view/company/admin/index.phtml:56
-#: module/Company/view/company/admin/index.phtml:88
-#, php-format
-msgid "Job Package (%s active)"
-msgstr "Vacaturepakket (%s actief)"
-
-#: module/Company/view/company/admin/index.phtml:63
-#, php-format
-msgid "%s for company %s will start on %s"
-msgstr "%s voor bedrijf %s begint op %s"
-
-#: module/Company/view/company/admin/index.phtml:95
-#, php-format
-msgid "%s for company %s will expire on %s"
-msgstr "%s voor bedrijf %s verloopt op %s"
-
-#: module/Company/view/company/admin/index.phtml:110
-#: module/Education/view/education/admin/course.phtml:27
-msgid "Filter..."
-msgstr "Filter..."
-
-#: module/Company/view/company/admin/index.phtml:115
-msgid "Add Company"
-msgstr "Voeg bedrijf toe"
-
-#: module/Company/view/company/admin/index.phtml:144
-#: module/Company/view/company/admin/index.phtml:214
-msgid "Active jobs"
-msgstr "Actieve vacatures"
-
-#: module/Company/view/company/admin/index.phtml:152
-#: module/Company/view/company/admin/index.phtml:215
-msgid "Banner active"
-msgstr "Banner actief"
-
-#: module/Company/view/company/admin/index.phtml:169
-#: module/Company/view/company/admin/index.phtml:217
-msgid "Expired packages"
-msgstr "Verlopen pakketten"
-
-#: module/Company/view/company/admin/index.phtml:216
-msgid "Featured in language"
-msgstr "Uitgelicht in taal"
-
-#: module/Company/view/company/admin/index.phtml:234
-#: module/Decision/view/decision/admin/document.phtml:169
-#, php-format
-msgid "Are you sure you want to delete %s?"
-msgstr "Weet je zeker dat je %s wil verwijderen?"
-
-#: module/Company/view/company/admin/index.phtml:241
-msgid "Delete company"
-msgstr "Verwijder bedrijf"
-
-#: module/Company/view/company/admin/labels.phtml:17
-msgid "Add Label"
-msgstr "Voeg een label toe"
-
-#: module/Company/view/company/company-account/banner.phtml:20
-#: module/Company/view/company/company-account/highlights.phtml:20
-msgid ""
-"This functionality is currently unavailable. Our apologies for the "
-"inconvenience."
-msgstr ""
-"Deze functionaliteit is momenteel niet beschikbaar. Onze excuses voor het "
-"ongemak."
-
-#: module/Company/view/company/company-account/jobs.phtml:45
-msgid "Job Packages"
-msgstr "Vacaturepakketten"
-
-#: module/Company/view/company/company-account/jobs.phtml:63
-msgid "Jobs (Active)"
-msgstr "Vacatures (actief)"
-
-#: module/Company/view/company/company-account/jobs.phtml:106
-#: module/Company/view/company/company/job-list.phtml:152
-msgid "View"
-msgstr "Toon"
-
-#: module/Company/view/company/company-account/jobs.phtml:118
-msgid "Recently Approved Jobs"
-msgstr "Onlangs goedgekeurde vacatures"
-
-#: module/Company/view/company/company-account/jobs.phtml:120
-msgid "You do not have recently approved jobs."
-msgstr "Je hebt geen vacatures die recentelijk zijn goedgekeurd."
-
-#: module/Company/view/company/company-account/jobs.phtml:140
-msgid "Recently Rejected Jobs"
-msgstr "Onlangs afgekeurde vacatures"
-
-#: module/Company/view/company/company-account/jobs.phtml:142
-msgid "You do not have recently rejected jobs."
-msgstr "Je hebt geen vacatures die recentelijk zijn afgekeurd."
-
-#: module/Company/view/company/company-account/jobs.phtml:162
-msgid "Recently Unapproved Jobs"
-msgstr "Nog niet goedgekeurde vacatures"
-
-#: module/Company/view/company/company-account/jobs.phtml:164
-msgid "You do not have any recent jobs pending approval."
-msgstr "Je hebt geen vacatures die nog niet zijn goedgekeurd."
-
-#: module/Company/view/company/company-account/jobs.phtml:198
-msgid "Approved (Has Updates)"
-msgstr "Goedgekeurd (heeft updates)"
-
-#: module/Company/view/company/company-account/jobs.phtml:206
-msgid "This job package does not contain any jobs."
-msgstr "Dit vacaturepakket bevat geen vacatures."
-
-#: module/Company/view/company/company-account/self.phtml:10
-msgid "Company Account"
-msgstr "Bedrijfsprofiel"
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:30
-msgid "Select the jobs that you want to transfer to another job package."
-msgstr ""
-"Selecteer de vacatures die je wilt verplaatsen naar een ander vacaturepakket."
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:48
-msgid "There are no jobs that you can transfer..."
-msgstr "Er zijn geen vacatures die je kunt verplaatsen..."
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:64
-msgid "Choose to which job package you want to transfer the selected jobs."
-msgstr ""
-"Kies naar welk vacaturepakket je de geselecteerde vacatures wilt verplaatsen."
-
-#: module/Company/view/company/company-account/transfer-jobs.phtml:81
-msgid "Move Jobs"
-msgstr "Verplaats vacatures"
-
-#: module/Company/view/company/company/companyStory.phtml:34
-#: module/Company/view/company/company/jobs.phtml:95
-#: module/Company/view/partial/company/company/grid/company.phtml:32
-#: module/Company/view/partial/company/company/list/company.phtml:36
-msgid "Logo of"
-msgstr "Logo van"
-
-#: module/Company/view/company/company/companyStory.phtml:63
-#: module/Company/view/partial/company/company/list/company.phtml:62
-msgid "Visit Website"
-msgstr "Website bezoeken"
-
-#: module/Company/view/company/company/companyStory.phtml:68
-msgid "Highlighted"
-msgstr "Uitgelicht"
-
-#: module/Company/view/company/company/job-list.phtml:74
-msgid "What are you looking for?"
-msgstr "Waar ben je naar op zoek?"
-
-#: module/Company/view/company/company/job-list.phtml:77
-msgid "Sort on"
-msgstr "Sorteer op"
-
-#: module/Company/view/company/company/job-list.phtml:79
-msgid "Random"
-msgstr "Willekeurig"
-
-#: module/Company/view/company/company/job-list.phtml:80
-msgid "Most recent"
-msgstr "Recentst"
-
-#: module/Company/view/company/company/job-list.phtml:108
-#, php-format
-msgid "Unfortunately, there aren't any %s at the moment."
-msgstr "Helaas zijn er momenteel geen %s."
-
-#: module/Company/view/company/company/job-list.phtml:183
-#, php-format
-msgid "Still haven't found what you're looking for? Take a look at %s."
-msgstr "Niet gevonden wat je zoekt? Bekijk ook %s."
-
-#: module/Company/view/company/company/jobs.phtml:76
-msgid "at"
-msgstr "bij"
-
-#: module/Company/view/company/company/jobs.phtml:126
-msgid "View Website"
-msgstr "Website bezoeken"
-
-#: module/Company/view/company/company/list.phtml:40
-#: module/Company/view/company/company/spotlight.phtml:49
-msgid "in the spotlight"
-msgstr "uitgelicht"
-
-#: module/Company/view/company/company/spotlight.phtml:37
-msgid "Featured company"
-msgstr "Uitgelicht bedrijf"
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:21
-msgid ""
-"Specify the permanent link for this company, it should be unique across all "
-"companies."
-msgstr ""
-"Geef de permalink voor dit bedrijf, deze moet uniek zijn voor alle bedrijven."
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:70
-msgid "View current logo"
-msgstr "Huidige logo weergeven"
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:94
-msgid "Representative Information"
-msgstr "Informatie van vertegenwoordiger"
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:95
-msgid "Enter information about the representative of this company."
-msgstr "Geef informatie over de vertegenwoordiger van dit bedrijf."
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:136
-#: module/Company/view/partial/company/admin/editors/job.phtml:78
-msgid "Contact Information"
-msgstr "Contactgegevens"
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:137
-msgid ""
-"Enter how someone can contact this company and who is responsible for this "
-"company."
-msgstr ""
-"Geef aan hoe iemand contact kan opnemen met dit bedrijf en wie er "
-"verantwoordelijk is voor dit bedrijf."
-
-#: module/Company/view/partial/company/admin/editors/company.phtml:205
-#: module/Company/view/partial/company/admin/editors/job.phtml:133
-msgid ""
-"What is this company about? Fill in the blanks below, please note that at "
-"least one language must be used."
-msgstr ""
-"Waar gaat dit bedrijf over? Vul de lege plekken hieronder in, let op dat er "
-"ten minste één taal gebruikt moet worden."
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:21
-msgid ""
-"Specify the permanent link for this job, it should be unique for this "
-"company."
-msgstr ""
-"Geef de permalink voor deze vacature, deze moet uniek zijn voor dit bedrijf."
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:79
-msgid "Enter how someone can contact the person responsible for this job."
-msgstr ""
-"Geef aan hoe iemand contact kan opnemen met de persoon die verantwoordelijk "
-"is voor deze vacature."
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:224
-#: module/Company/view/partial/company/admin/editors/job.phtml:320
-msgid "View current attachment"
-msgstr "Huidige bijlage weergeven"
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:329
-msgid ""
-"Add job labels to your job to give viewers a better understanding of the job."
-msgstr ""
-"Voeg vacature-labels toe aan deze activiteit om kijkers een beter inzicht te "
-"geven in de vacature."
-
-#: module/Company/view/partial/company/admin/editors/job.phtml:349
-msgid "There are currently no job labels..."
-msgstr "Er zijn momenteel geen vacature-labels..."
-
-#: module/Decision/src/Controller/AdminController.php:55
-msgid "Meeting minutes uploaded"
-msgstr "Notulen geupload"
-
-#: module/Decision/src/Controller/AdminController.php:137
-msgid "You are not allowed to rename meeting documents"
-msgstr "Je hebt niet de rechten om vergaderstukken te hernoemen"
-
-#: module/Decision/src/Controller/AdminController.php:177
-#: module/Decision/src/Service/Decision.php:279
-msgid "You are not allowed to delete meeting documents."
-msgstr "Je hebt niet de rechten om vergaderstukken te verwijderen."
-
-#: module/Decision/src/Controller/DecisionController.php:109
-msgid "You are not allowed to search decisions."
-msgstr "Je hebt niet de rechten om besluiten te doorzoeken."
-
-#: module/Decision/src/Controller/DecisionController.php:142
-msgid "You are not allowed to authorize someone"
-msgstr "Je hebt niet de rechten om iemand te machtigen"
-
-#: module/Decision/src/Controller/DecisionController.php:190
-#: module/Decision/src/Service/Decision.php:571
-msgid "You are not allowed to revoke authorizations."
-msgstr "Je hebt niet de rechten om machtigingen in te trekken."
-
-#: module/Decision/src/Controller/DecisionController.php:219
-msgid "You are not allowed to browse files."
-msgstr "Je hebt niet de rechten om door bestanden te bladeren."
-
-#: module/Decision/src/Controller/MemberController.php:40
-#: module/Decision/src/Service/Decision.php:137
-msgid "You are not allowed to view meetings."
-msgstr "Het is niet toegestaan om vergaderingen te zien."
-
-#: module/Decision/src/Controller/MemberController.php:98
-msgid "Not allowed to search for members."
-msgstr "Het is niet toegestaan om te zoeken op leden."
-
-#: module/Decision/src/Controller/MemberController.php:151
-msgid "You are not allowed to view the list of birthdays."
-msgstr "Het is niet toegestaan om de lijst met verjaardagen te zien."
-
-#: module/Decision/src/Form/Authorization.php:50
-#: module/Decision/view/decision/decision/authorizations.phtml:133
-#: module/Decision/view/decision/decision/authorizations.phtml:139
-msgid "Authorize"
-msgstr "Machtig"
-
-#: module/Decision/src/Form/AuthorizationRevocation.php:42
-msgid "Revoke authorization"
-msgstr "Machtiging intrekken"
-
-#: module/Decision/src/Form/Document.php:29
-#: module/Decision/src/Form/Minutes.php:33
-#: module/Decision/view/decision/admin/minutes.phtml:31
-msgid "Meeting"
-msgstr "Vergadering"
-
-#: module/Decision/src/Form/Document.php:39
-msgid "Document name"
-msgstr "Naam document"
-
-#: module/Decision/src/Form/Document.php:49
-msgid "Document to upload"
-msgstr "Te uploaden document"
-
-#: module/Decision/src/Form/Document.php:59
-msgid "Upload document"
-msgstr "Upload document"
-
-#: module/Decision/src/Form/Minutes.php:34
-msgid "Choose a meeting"
-msgstr "Kies een vergadering"
-
-#: module/Decision/src/Form/Minutes.php:45
-msgid "Minutes to upload"
-msgstr "Te uploaden notulen"
-
-#: module/Decision/src/Form/Minutes.php:94
-msgid "There already are minutes for this meeting"
-msgstr "Er zijn al notulen voor deze vergadering"
-
-#: module/Decision/src/Form/OrganInformation.php:52
-msgid "Short dutch description"
-msgstr "Korte Nederlandse omschrijving"
-
-#: module/Decision/src/Form/OrganInformation.php:62
-msgid "Short english description"
-msgstr "Korte Engelse omschrijving"
-
-#: module/Decision/src/Form/OrganInformation.php:72
-msgid "Long dutch description"
-msgstr "Volledige Nederlandse omschrijving"
-
-#: module/Decision/src/Form/OrganInformation.php:82
-msgid "Long english description"
-msgstr "Volledige Engelse omschrijving"
-
-#: module/Decision/src/Form/OrganInformation.php:92
-msgid "Thumbnail photo to upload"
-msgstr "Profiel foto"
-
-#: module/Decision/src/Form/OrganInformation.php:102
-msgid "Cover photo to upload"
-msgstr "Coverfoto om te uploaden"
-
-#: module/Decision/src/Form/OrganInformation.php:123
-#: module/Decision/view/decision/organ-admin/edit.phtml:182
-#: module/Frontpage/src/Form/NewsItem.php:78
-#: module/Frontpage/src/Form/Page.php:100
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:110
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:143
-#: module/Photo/src/Form/EditAlbum.php:59
-msgid "Save"
-msgstr "Opslaan"
-
-#: module/Decision/src/Form/ReorderDocument.php:46
-msgid "Move up"
-msgstr "Verplaats omhoog"
-
-#: module/Decision/src/Form/ReorderDocument.php:50
-msgid "Move down"
-msgstr "Verplaats omlaag"
-
-#: module/Decision/src/Form/SearchDecision.php:25
-#: module/Decision/view/decision/decision/search.phtml:32
-#: module/Education/src/Form/SearchCourse.php:23
-msgid "Search query"
-msgstr "Zoek query"
-
-#: module/Decision/src/Form/SearchDecision.php:35
-#: module/Decision/src/Form/SearchDecision.php:36
-#: module/Decision/view/decision/decision/search.phtml:41
-#: module/Decision/view/decision/member/index.phtml:157
-#: module/Education/view/education/education/index.phtml:59
-msgid "Search"
-msgstr "Zoek"
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:21
-msgid "Home address (parents)"
-msgstr "Thuisadres (ouders)"
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:22
-msgid "Student address"
-msgstr "Studentadres"
-
-#: module/Decision/src/Model/Enums/AddressTypes.php:23
-msgid "Mail address"
-msgstr "Post adres"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:22
-msgid "Board Meeting"
-msgstr "Bestuursvergadering"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:23
-msgid "General Members Meeting"
-msgstr "Algemene Ledenvergadering"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:24
-msgid "Chair's Meeting"
-msgstr "Voorzittersvergadering"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:25
-msgid "Virtual Meeting"
-msgstr "Virtuele Vergadering"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:32
-msgid "BM"
-msgstr "BV"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:33
-msgid "GMM"
-msgstr "ALV"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:34
-msgid "CM"
-msgstr "VV"
-
-#: module/Decision/src/Model/Enums/MeetingTypes.php:35
-msgid "VIRT"
-msgstr "VIRT"
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:22
-msgid "Ordinary"
-msgstr "Gewoon"
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:24
-msgid "Graduate"
-msgstr "Afgestudeerde"
-
-#: module/Decision/src/Model/Enums/MembershipTypes.php:25
-msgid "Honorary"
-msgstr "Erelidmaatschap"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:24
-msgid "Committee"
-msgstr "Commissie"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:25
-msgid "GMM Committee"
-msgstr "ALV-Commissie"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:26
-msgid "Fraternity"
-msgstr "Dispuut"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:27
-msgid "Financial Audit Committee"
-msgstr "Kas Controle Commissie"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:28
-msgid "GMM Taskforce"
-msgstr "ALV-Werkgroep"
-
-#: module/Decision/src/Model/Enums/OrganTypes.php:29
-msgid "Advisory Board"
-msgstr "Raad van Advies"
-
-#: module/Decision/src/Service/Decision.php:90
-#: module/Decision/src/Service/Decision.php:109
-#: module/Decision/src/Service/Decision.php:121
-msgid "You are not allowed to list meetings."
-msgstr "Het is niet toegestaan om de lijst van vergaderingen te zien."
-
-#: module/Decision/src/Service/Decision.php:178
-msgid "You are not allowed to view meeting documents."
-msgstr "Het is niet toegestaan om vergaderstukken te zien."
-
-#: module/Decision/src/Service/Decision.php:195
-msgid "You are not allowed to view meeting minutes."
-msgstr "Het is niet toegestaan om notulen te zien."
-
-#: module/Decision/src/Service/Decision.php:388
-msgid "You are not allowed to view all authorizations."
-msgstr "Je hebt niet de rechten om alle machtigingen te bekijken."
-
-#: module/Decision/src/Service/Decision.php:404
-msgid "You are not allowed to view authorizations."
-msgstr "Je hebt niet de rechten om all machtigingen te bekijken."
-
-#: module/Decision/src/Service/Decision.php:514
-msgid "You are not allowed to upload meeting minutes."
-msgstr "Het is niet toegestaan om notulen te uploaden."
-
-#: module/Decision/src/Service/Decision.php:528
-msgid "You are not allowed to upload meeting documents."
-msgstr "Het is niet toegestaan om vergaderstukken te uploaden."
-
-#: module/Decision/src/Service/Decision.php:558
-msgid "You are not allowed authorize people."
-msgstr "Je hebt niet de rechten om iemand te machtigen."
-
-#: module/Decision/src/Service/Member.php:50
-#: module/Decision/src/Service/MemberInfo.php:69
-msgid "You are not allowed to view members."
-msgstr "Het is niet toegestaan om lidinformatie in te zien."
-
-#: module/Decision/src/Service/MemberInfo.php:65
-msgid "You are not allowed to view membership info."
-msgstr "Het is niet toegestaan om lidinformatie in te zien."
-
-#: module/Decision/src/Service/Organ.php:66
-msgid "Not allowed to view the list of organs"
-msgstr "Niet toegestaan om de lijst van organen te bekijken"
-
-#: module/Decision/src/Service/Organ.php:78
-msgid "Not allowed to view organ information"
-msgstr "Het is niet toegestaan om informatie over organen in te zien"
-
-#: module/Decision/src/Service/Organ.php:93
-msgid "You are not allowed to edit organ information"
-msgstr "Je hebt niet de rechten om organen te wijzigen"
-
-#: module/Decision/src/Service/Organ.php:305
-msgid "You are not allowed to edit this organ's information"
-msgstr "Je hebt niet de rechten om de informatie van dit orgaan te wijzigen"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:31
-#, php-format
-msgid "GMM %d (%s)"
-msgstr "ALV %d (%s)"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:38
-msgid "No GMM available."
-msgstr "Geen ALV beschikbaar."
-
-#: module/Decision/view/decision/admin/authorizations.phtml:43
-#, php-format
-msgid "Valid authorizations for GMM %d"
-msgstr "Geldige machtigingen voor ALV %d"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:48
-#: module/Decision/view/decision/admin/authorizations.phtml:72
-msgid "Authorizer"
-msgstr "Machtiger"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:49
-#: module/Decision/view/decision/admin/authorizations.phtml:73
-msgid "Recipient"
-msgstr "Ontvanger"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:50
-#: module/Decision/view/decision/admin/authorizations.phtml:74
-msgid "Created"
-msgstr "Aangemaakt"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:64
-msgid "There are no valid authorizations for this GMM."
-msgstr "Er zijn geen geldige machtigingen voor deze ALV."
-
-#: module/Decision/view/decision/admin/authorizations.phtml:67
-#, php-format
-msgid "Revoked authorizations for GMM %d"
-msgstr "Ingetrokken machtigingen voor ALV %d"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:75
-msgid "Revoked"
-msgstr "Ingetrokken"
-
-#: module/Decision/view/decision/admin/authorizations.phtml:90
-msgid "There are no revoked authorizations for this GMM."
-msgstr "Er zijn geen ingetrokken machtigingen voor deze ALV."
-
-#: module/Decision/view/decision/admin/authorizations.phtml:93
-msgid "Please select a GMM to view authorizations."
-msgstr "Selecteer een ALV om machtigingen te bekijken."
-
-#: module/Decision/view/decision/admin/document.phtml:33
-msgid "There are no meetings for which you can upload documents."
-msgstr "Er zijn geen vergaderingen waarvoor je documenten kunt uploaden."
-
-#: module/Decision/view/decision/admin/document.phtml:37
-msgid "Meeting document uploaded"
-msgstr "Vergaderstuk geupload"
-
-#: module/Decision/view/decision/admin/document.phtml:62
-msgid "No meeting available."
-msgstr "Geen vergaderingen beschikbaar."
-
-#: module/Decision/view/decision/admin/document.phtml:103
-msgid "Documents for this meeting"
-msgstr "Documenten voor deze vergadering"
-
-#: module/Decision/view/decision/admin/document.phtml:106
 msgid "This meeting does not have any associated documents."
 msgstr "Voor deze vergadering zijn geen documenten beschikbaar."
 
-#: module/Decision/view/decision/admin/document.phtml:145
-#: module/Decision/view/decision/admin/document.phtml:208
-msgid "Rename"
-msgstr "Hernoem"
+msgid "This member already has an account."
+msgstr "Dit lid heeft al een account."
 
-#: module/Decision/view/decision/admin/document.phtml:163
-#: module/Education/view/education/admin/course-documents.phtml:163
-msgid "Delete Document"
-msgstr "Verwijder document"
-
-#: module/Decision/view/decision/admin/document.phtml:195
-msgid "Rename Meeting Document"
-msgstr "Hernoem vergaderstuk"
-
-#: module/Decision/view/decision/admin/document.phtml:198
-msgid "Enter a new name for this document:"
-msgstr "Voor een nieuwe naam in voor dit document:"
-
-#: module/Decision/view/decision/admin/minutes.phtml:55
-msgid "Upload"
-msgstr "Upload"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:36
 msgid ""
-"There are no upcoming meetings for which you can authorize someone.\n"
-"You may still be able to authorize someone or revoke an authorization by "
-"contacting the board."
+"This member cannot create an account, please contact the secretary for more "
+"information."
 msgstr ""
-"Er zijn geen vergaderingen waar je machtigingen voor af kunt geven of kan "
-"wijzigen.\n"
-"Mogelijk kun je nog wel iemand machtigen of een machtiging intrekken door "
-"contact op te nemen met het bestuur."
+"Dit lid kan geen account aanmaken, neem contact op met de secretaris voor "
+"meer informatie."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:40
-#, php-format
-msgid "You have authorized %s for the %s GMM (%s)."
-msgstr "Je hebt %s gemachtigd voor de %s ALV (%s)."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:47
-#, php-format
-msgid ""
-"As per HR article 5 paragraph 4, you have the right to revoke your "
-"authorization for the %s GMM. You can communicate this to the board in "
-"writing (not by email) or by using the form below. Please note that you can "
-"only revoke an authorization that was granted via this website by using the "
-"form below."
-msgstr ""
-"Conform HR artikel 5 lid 4 heb je het recht om jouw machtiging voor de %s "
-"ALV in te trekken. Je kan dit schriftelijk (niet per e-mail) of via "
-"onderstaand formulier aan het bestuur kenbaar maken. Let op: je kan alleen "
-"een machtiging die via deze website is verleend via onderstaand formulier "
-"intrekken."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:63
-#: module/Decision/view/decision/decision/authorizations.phtml:118
-msgid "Terms"
-msgstr "Voorwaarden"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:68
-#, php-format
-msgid ""
-"I, %s am fully aware that by revoking my authorization, %s cannot represent "
-"me at the %s General Members Meeting (%s) of s.v. GEWIS."
-msgstr ""
-"Ik, %s ben mij er volledig van bewust dat door het intrekken van mijn "
-"machtiging, %s mij niet kan vertegenwoordigen op de %s Algemene "
-"Ledenvergadering (%s) der s.v. GEWIS."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:89
-#, php-format
-msgid "Authorize someone for the %s GMM (%s)"
-msgstr "Machtig iemand voor de %s ALV (%s)"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:105
-#: module/User/view/user/user/login.phtml:29
-msgid "Member"
-msgstr "Lid"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:123
-#, php-format
-msgid ""
-"I, %s I am fully aware that by filling in this form I authorize the person "
-"in this form to represent me at the %s General Members Meeting (%s) of s.v. "
-"GEWIS."
-msgstr ""
-"Ik, %s ben mij er volledig van bewust dat ik door het invullen van dit "
-"formulier de persoon op dit formulier machtig om mij te vertegenwoordigen op "
-"de %s Algemene Ledenvergadering (%s) der s.v. GEWIS."
-
-#: module/Decision/view/decision/decision/authorizations.phtml:175
-msgid "Are you sure you would like to authorize"
-msgstr "Weet je zeker dat je wilt machtigen"
-
-#: module/Decision/view/decision/decision/authorizations.phtml:181
 msgid ""
 "This member has already received 2 or more authorizations through the "
 "website. Since you can only use two authorizations at the same time, this "
@@ -3874,1045 +2980,365 @@ msgstr ""
 "wordt. Als je iemand anders wilt machtigen, klik dan op \"annuleer\"; als je "
 "deze person toch wilt machtigen, klik dan op \"bevestig machtiging\"."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:187
-msgid "Confirm authorization"
-msgstr "Bevestig machtiging"
+msgid "This option planning period cannot be edited."
+msgstr "Deze optieplanningsperiode kan niet worden gewijzigd."
 
-#: module/Decision/view/decision/decision/authorizations.phtml:211
-#, php-format
-msgid "Are you sure you would like to authorize %s"
-msgstr "Weet je zeker dat je %s wilt machtigen"
+msgid "This poll has no comments"
+msgstr "Deze poll heeft geen commentaar"
 
-#: module/Decision/view/decision/decision/files.phtml:26
-#: module/Decision/view/decision/decision/files.phtml:28
-#: module/Decision/view/decision/decision/files.phtml:47
-#: module/Decision/view/decision/decision/files.phtml:51
-msgid "Root"
-msgstr "Root"
-
-#: module/Decision/view/decision/decision/files.phtml:47
-msgid "Public Archive"
-msgstr "Openbaar Archief"
-
-#: module/Decision/view/decision/decision/files.phtml:51
-msgid "Browsing directory: "
-msgstr "Huidige map: "
-
-#: module/Decision/view/decision/decision/files.phtml:78
-msgid "Filename"
-msgstr "Bestandsnaam"
-
-#: module/Decision/view/decision/decision/files.phtml:92
-msgid ".. Move up a folder"
-msgstr ".. Ga map omhoog"
-
-#: module/Decision/view/decision/decision/files.phtml:101
-msgid "Empty folder"
-msgstr "Lege map"
-
-#: module/Decision/view/decision/decision/index.phtml:24
-msgid "Meeting number"
-msgstr "Vergadernummer"
-
-#: module/Decision/view/decision/decision/index.phtml:25
-#: module/Decision/view/decision/member/birthdays.phtml:22
-#: module/Education/view/education/admin/course-documents.phtml:65
-#: module/Education/view/education/admin/course-documents.phtml:116
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:41
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:114
-msgid "Date"
-msgstr "Datum"
-
-#: module/Decision/view/decision/decision/index.phtml:26
-msgid "# Decisions"
-msgstr "# Besluiten"
-
-#: module/Decision/view/decision/decision/search.phtml:14
-msgid "Search for decision"
-msgstr "Zoek besluit"
-
-#: module/Decision/view/decision/decision/search.phtml:50
-msgid "No decisions were found."
-msgstr "Er zijn geen besluiten gevonden."
-
-#: module/Decision/view/decision/decision/search.phtml:52
-msgid "Check the spelling of your search term"
-msgstr "Controleer de spelling van je zoekterm"
-
-#: module/Decision/view/decision/decision/search.phtml:53
-msgid "Try alternate words or selections"
-msgstr "Probeer alternatieve woorden of selecties"
-
-#: module/Decision/view/decision/decision/search.phtml:54
-msgid "Try using a more generic search term"
-msgstr "Probeer een meer algemene zoekterm te gebruiken"
-
-#: module/Decision/view/decision/decision/search.phtml:55
-msgid "Try entering fewer keywords"
-msgstr "Probeer minder trefwoorden in te voeren"
-
-#: module/Decision/view/decision/decision/search.phtml:56
 msgid ""
-"Looking for a specific decision but forgot the numbers? Try dropping the "
-"decision point and/or number"
+"This sign-up list contains additional fields which require input from "
+"subscribers, they are shown below."
 msgstr ""
-"Op zoek naar een specifiek besluit maar de nummers vergeten? Probeer het "
-"zonder besluitspunt en/of -nummer"
+"Deze inschrijflijst bevat extra velden die door de deelnemers moeten worden "
+"ingevuld, deze worden hieronder getoond."
 
-#: module/Decision/view/decision/decision/view.phtml:47
-msgid "No documents have been added."
-msgstr "Er zijn geen documenten toegevoegd."
-
-#: module/Decision/view/decision/decision/view.phtml:62
-#, php-format
-msgid "View the minutes of the %s"
-msgstr "Geef de notulen van de %s weer"
-
-#: module/Decision/view/decision/decision/view.phtml:71
-msgid "Decisions"
-msgstr "Besluiten"
-
-#: module/Decision/view/decision/member/birthdays.phtml:14
-msgid "Birthdays"
-msgstr "Verjaardagen"
-
-#: module/Decision/view/decision/member/birthdays.phtml:24
-msgid "Age"
-msgstr "Leeftijd"
-
-#: module/Decision/view/decision/member/birthdays.phtml:44
-msgid "years"
-msgstr "jaren"
-
-#: module/Decision/view/decision/member/index.phtml:33
-msgid "Personal"
-msgstr "Persoonlijk"
-
-#: module/Decision/view/decision/member/index.phtml:37
-msgid "Profile"
-msgstr "Profiel"
-
-#: module/Decision/view/decision/member/index.phtml:78
-msgid "Public archive"
-msgstr "Openbaar Archief"
-
-#: module/Decision/view/decision/member/index.phtml:83
-msgid "Find a member"
-msgstr "Vind een lid"
-
-#: module/Decision/view/decision/member/index.phtml:106
-msgid "Upcoming meeting"
-msgid_plural "Upcoming meetings"
-msgstr[0] "Aankomende vergadering"
-msgstr[1] "Aankomende vergaderingen"
-
-#: module/Decision/view/decision/member/index.phtml:118
-#, php-format
-msgid "The %s%s %s%s will be held on %s."
-msgstr "De %s%s %s%s zal plaatsvinden op %s."
-
-#: module/Decision/view/decision/member/index.phtml:144
 #, php-format
 msgid ""
-"If you aren't able to attend a GMM in person but you want your voice to be "
-"heard, consider %sauthorizing another member%s to act on your behalf."
+"This sign-up list%sis open from <strong>%s</strong> till <strong>%s</strong>."
 msgstr ""
-"Als je niet in staat bent een ALV persoonlijk bij te wonen, maar je wilt "
-"toch dat je stem wordt gehoord, overweeg dan %seen ander lid%s te machtigen "
-"om jou te vertegenwoordingen."
+"Deze inschrijflijst%sis open van <strong>%s</strong> tot <strong>%s</strong>."
 
-#: module/Decision/view/decision/member/index.phtml:152
-msgid "Search through the list of decisions accumulated from past meetings:"
-msgstr "Doorzoek de lijst van alle beslissingen van eerdere vergaderingen:"
+msgid "This slug contains invalid characters"
+msgstr "Deze permalink bevat ongeldige tekens"
 
-#: module/Decision/view/decision/member/index.phtml:155
-msgid "Search by keyword or meeting number"
-msgstr "Zoek met trefwoord of vergaderingsnummer"
+msgid "This slug is already taken"
+msgstr "Deze permalink is al in gebruik"
 
-#: module/Decision/view/decision/member/index.phtml:162
-#, php-format
-msgid "The latest %s that took place:"
-msgstr "De laatste %s die plaatsvond:"
+msgid "Thumbnail photo to upload"
+msgstr "Profiel foto"
 
-#: module/Decision/view/decision/member/index.phtml:174
-#, php-format
-msgid "%s %s on %s"
-msgstr "%s %s op %s"
-
-#: module/Decision/view/decision/member/index.phtml:189
-msgid "View all meetings"
-msgstr "Toon alle vergaderingen"
-
-#: module/Decision/view/decision/member/index.phtml:194
-#: module/Decision/view/decision/organ/show.phtml:25
-#: module/Frontpage/view/frontpage/organ/organ.phtml:145
-msgid "Active members"
-msgstr "Actieve leden"
-
-#: module/Decision/view/decision/member/index.phtml:195
-msgid "A list of helpful resources for active members."
-msgstr "Een lijst met nuttige pagina's voor actieve leden."
-
-#: module/Decision/view/decision/member/index.phtml:199
-msgid "Webmail"
-msgstr "Webmail"
-
-#: module/Decision/view/decision/member/index.phtml:211
-msgid "GEWIKI"
-msgstr "GEWIKI"
-
-#: module/Decision/view/decision/member/index.phtml:215
-msgid "Corporate Identity"
-msgstr "Huisstijl"
-
-#: module/Decision/view/decision/member/index.phtml:219
-msgid "Administrator"
-msgstr "Administrator"
-
-#: module/Decision/view/decision/member/index.phtml:237
-msgid "Bylaws"
-msgstr "Statuten"
-
-#: module/Decision/view/decision/member/index.phtml:249
-msgid "Internal Regulations"
-msgstr "Huishoudelijk reglement"
-
-#: module/Decision/view/decision/member/index.phtml:264
-msgid "Board Policies"
-msgstr "Beleidsnota's"
-
-#: module/Decision/view/decision/member/index.phtml:269
-msgid "Borrel Policy"
-msgstr "Borrelreglement"
-
-#: module/Decision/view/decision/member/index.phtml:274
-msgid "House Rules"
-msgstr "Huisregels"
-
-#: module/Decision/view/decision/member/index.phtml:279
-msgid "ICT Policy"
-msgstr "ICT-reglement"
-
-#: module/Decision/view/decision/member/index.phtml:284
-msgid "Key Policy"
-msgstr "Sleutelreglement"
-
-#: module/Decision/view/decision/member/index.phtml:289
-msgid "Poster Policy"
-msgstr "Posterbeleid"
-
-#: module/Decision/view/decision/member/index.phtml:300
-msgid "Organ Regulations"
-msgstr "Orgaanreglementen"
-
-#: module/Decision/view/decision/member/search.phtml:10
-#: module/Decision/view/decision/member/search.phtml:16
-msgid "Zoeken op lid"
-msgstr "Zoeken op lid"
-
-#: module/Decision/view/decision/member/search.phtml:20
-msgid "Zoek"
-msgstr "Zoek"
-
-#: module/Decision/view/decision/member/search.phtml:30
-msgid "Naam"
-msgstr "Naam"
-
-#: module/Decision/view/decision/member/search.phtml:31
-msgid "Generatie"
-msgstr "Generatie"
-
-#: module/Decision/view/decision/member/search.phtml:38
-msgid ""
-"Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
-"resultaten te zien."
-msgstr ""
-"Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere "
-"resultaten te zien."
-
-#: module/Decision/view/decision/member/self.phtml:20
-msgid "My Information"
-msgstr "Mijn informatie"
-
-#: module/Decision/view/decision/member/self.phtml:29
-#: module/User/src/Form/Register.php:32 module/User/src/Form/UserReset.php:30
-msgid "Membership number"
-msgstr "Lidmaatschapsnummer"
-
-#: module/Decision/view/decision/member/self.phtml:33
-msgid "Initials"
-msgstr "Initialen"
-
-#: module/Decision/view/decision/member/self.phtml:37
-msgid "First name"
-msgstr "Voornaam"
-
-#: module/Decision/view/decision/member/self.phtml:41
-#: module/User/src/Model/Enums/JWTClaims.php:45
-msgid "Middle name"
-msgstr "Tussenvoegsels"
-
-#: module/Decision/view/decision/member/self.phtml:45
-msgid "Last name"
-msgstr "Achternaam"
-
-#: module/Decision/view/decision/member/self.phtml:60
-#: module/Decision/view/decision/member/view.phtml:45
-msgid "Birth date"
-msgstr "Geboortedatum"
-
-#: module/Decision/view/decision/member/self.phtml:68
-#: module/Decision/view/decision/member/view.phtml:54
-#: module/User/src/Model/Enums/JWTClaims.php:44
-msgid "Membership type"
-msgstr "Type lidmaatschap"
-
-#: module/Decision/view/decision/member/self.phtml:72
-msgid "Last membership change"
-msgstr "Laatste wijziging lidmaatschap"
-
-#: module/Decision/view/decision/member/self.phtml:76
-msgid "End date of membership"
-msgstr "Einddatum van lidmaatschap"
-
-#: module/Decision/view/decision/member/self.phtml:83
-msgid ""
-"If your information is no longer up to date and you would like to change it, "
-"you can contact the secretary of GEWIS."
-msgstr ""
-"Als je gegevens niet meer actueel zijn of je ze wilt ze laten wijzigen, neem "
-"dan contact op met de secretaris van GEWIS."
-
-#: module/Decision/view/decision/member/self.phtml:84
-msgid "Also for data removal requests, you can contact"
-msgstr "Ook als je gegevens wilt laten verwijderen, neem dan contact op met"
-
-#: module/Decision/view/decision/member/self.phtml:85
-msgid "Email the secretary of GEWIS"
-msgstr "Email de secretaris van GEWIS"
-
-#: module/Decision/view/decision/member/self.phtml:85
-msgid "the secretary of GEWIS"
-msgstr "de secretaris van GEWIS"
-
-#: module/Decision/view/decision/member/self.phtml:89
-#: module/Decision/view/decision/member/view.phtml:117
-msgid "Memberships of committees and fraternities"
-msgstr "Lidmaatschappen van commissies en disputen"
-
-#: module/Decision/view/decision/member/self.phtml:94
-msgid "You have not been a member of a committee or fraternity."
-msgstr "Je bent geen lid geweest van een commissie of dispuut."
-
-#: module/Decision/view/decision/member/self.phtml:97
-msgid "You are currently a member of:"
-msgstr "Je bent momenteel lid van:"
-
-#: module/Decision/view/decision/member/self.phtml:121
-msgid "You were a member of:"
-msgstr "Je was een lid van:"
-
-#: module/Decision/view/decision/member/self.phtml:145
-#: module/Decision/view/decision/member/view.phtml:188
-msgid "Addresses"
-msgstr "Adressen"
-
-#: module/Decision/view/decision/member/self.phtml:150
-#: module/Decision/view/decision/member/view.phtml:193
-msgid "Country"
-msgstr "Land"
-
-#: module/Decision/view/decision/member/self.phtml:154
-#: module/Decision/view/decision/member/view.phtml:197
-msgid "Street and number"
-msgstr "Straat en huisnummer"
-
-#: module/Decision/view/decision/member/self.phtml:157
-#: module/Decision/view/decision/member/self.phtml:167
-#: module/Decision/view/decision/member/view.phtml:200
-#: module/Decision/view/decision/member/view.phtml:210
-#, php-format
-msgid "%s %s"
-msgstr "%s %s"
-
-#: module/Decision/view/decision/member/self.phtml:164
-#: module/Decision/view/decision/member/view.phtml:207
-msgid "City and postal code"
-msgstr "Woonplaats en postcode"
-
-#: module/Decision/view/decision/member/self.phtml:180
-msgid "External applications"
-msgstr "Externe applicaties"
-
-#: module/Decision/view/decision/member/self.phtml:183
-msgid "App"
-msgstr "App"
-
-#: module/Decision/view/decision/member/self.phtml:184
-msgid "First authentication"
-msgstr "Eerste authenticatie"
-
-#: module/Decision/view/decision/member/self.phtml:185
-msgid "Last authentication"
-msgstr "Laatste authenticatie"
-
-#: module/Decision/view/decision/member/self.phtml:230
-msgid "Remove this picture as your profile picture"
-msgstr "Verwijder deze foto als profielfoto"
-
-#: module/Decision/view/decision/member/self.phtml:232
-msgid "Your profile picture will be chosen automatically instead."
-msgstr "Jouw profiel foto wordt in plaats hiervan automatisch gekozen."
-
-#: module/Decision/view/decision/member/self.phtml:247
-msgid "More of my photo's"
-msgstr "Meer van mijn foto’s"
-
-#: module/Decision/view/decision/member/view.phtml:58
-msgid "Has key code?"
-msgstr "Heeft sleutelcode?"
-
-#: module/Decision/view/decision/member/view.phtml:79
-#, php-format
-msgid "%s is the upcoming <strong>%s</strong>."
-msgstr "%s is de aankomende <strong>%s</strong>."
-
-#: module/Decision/view/decision/member/view.phtml:95
-#, php-format
-msgid "%s is currently the <strong>%s</strong>."
-msgstr "%s is de huidige <strong>%s</strong>."
-
-#: module/Decision/view/decision/member/view.phtml:105
-#, php-format
-msgid "%s was the <strong>%s</strong> during the association year %d/%d."
-msgstr "%s was de <strong>%s</strong> gedurende het verenigingsjaar %d/%d."
-
-#: module/Decision/view/decision/member/view.phtml:124
-#, php-format
-msgid "%s has never been part of a committee or fraternity."
-msgstr "%s is geen lid geweest van een commissie of dispuut."
-
-#: module/Decision/view/decision/member/view.phtml:132
-#, php-format
-msgid "%s is currently a member of:"
-msgstr "%s is momenteel lid van:"
-
-#: module/Decision/view/decision/member/view.phtml:161
-#, php-format
-msgid "%s was a member of:"
-msgstr "%s is lid geweest van:"
-
-#: module/Decision/view/decision/member/view.phtml:262
-#, php-format
-msgid "Photo's of %s"
-msgstr "Foto's van %s"
-
-#: module/Decision/view/decision/organ-admin/edit.phtml:75
-msgid "Edit organ information"
-msgstr "Bewerk orgaan informatie"
-
-#: module/Decision/view/decision/organ-admin/edit.phtml:150
 msgid ""
 "To optimally display your image on the overview page, please crop it below"
 msgstr ""
 "Om deze afbeelding optimaal weer te kunnen geven op commissies pagina, moet "
 "deze bijgesneden worden"
 
-#: module/Decision/view/decision/organ-admin/edit.phtml:166
 msgid "To optimally display your image your page, please crop it below"
 msgstr ""
 "Om deze afbeelding optimaal weer te kunnen geven op je persoonlijke "
 "commissie pagina, moet deze bijgesneden worden"
 
-#: module/Decision/view/decision/organ-admin/index.phtml:18
+#, php-format
 msgid ""
-"Select an organ to edit its information. Changes will not be displayed until "
-"they have been approved."
+"To read more about the benefits of becoming a member and how to become a "
+"member, go to this %sinformation page%s."
 msgstr ""
-"Selecteer een orgaan om de informatie te wijzigen. Wijzigingen worden niet "
-"getoond totdat deze goedgekeurd zijn."
+"Om meer te lezen over de voordelen van het worden van een lid en hoe je een "
+"lid kunt worden, ga naar deze %sinformatie pagina%s."
 
-#: module/Decision/view/decision/organ-admin/index.phtml:25
-msgid "Approval status"
-msgstr "Goedkeuringsstatus"
+msgid "Toggle navigation"
+msgstr "Klap navigatie in/uit"
 
-#: module/Decision/view/decision/organ/index.phtml:15
-msgid "Organ list"
-msgstr "Organen"
+msgid "Token"
+msgstr "Token"
 
-#: module/Decision/view/decision/organ/show.phtml:50
-msgid "Inactive members"
-msgstr "Inactieve leden"
+msgid "Token was successfully generated"
+msgstr "Token is gegenereerd"
 
-#: module/Decision/view/decision/organ/show.phtml:61
-msgid "Old members"
-msgstr "Oud leden"
+msgid "Too many login attempts, try again later."
+msgstr "Te veel login pogingen, probeer het later nog eens."
 
-#: module/Decision/view/decision/organ/show.phtml:70
-msgid "Organ mutations"
-msgstr "Mutaties in orgaan"
+msgid "Tracking is currently"
+msgstr "Volgen is momenteel"
 
-#: module/Education/src/Controller/AdminController.php:41
-msgid "You are not allowed to administer education settings"
-msgstr "Je hebt niet de rechten om onderwijsinstellingen te beheren"
+msgid "Transfer Jobs"
+msgstr "Verplaats vacatures"
 
-#: module/Education/src/Controller/AdminController.php:51
-msgid "You are not allowed to administer courses"
-msgstr "Je hebt niet de rechten om vakken te beheren"
+msgid "Try alternate words or selections"
+msgstr "Probeer alternatieve woorden of selecties"
 
-#: module/Education/src/Controller/AdminController.php:60
-#: module/Education/src/Service/Exam.php:473
-msgid "You are not allowed to add courses"
-msgstr "Je hebt niet de rechten om vakken toe te voegen"
+msgid "Try entering fewer keywords"
+msgstr "Probeer minder trefwoorden in te voeren"
 
-#: module/Education/src/Controller/AdminController.php:76
-msgid "Successfully added course!"
-msgstr "Vak succesvol toegevoegd!"
+msgid "Try using a more generic search term"
+msgstr "Probeer een meer algemene zoekterm te gebruiken"
 
-#: module/Education/src/Controller/AdminController.php:83
-#: module/Education/src/Controller/AdminController.php:125
-msgid "An error occurred while saving the course!"
-msgstr "Er is een fout opgetreden tijdens het opslaan van het vak!"
+msgid "Type"
+msgstr "Type"
 
-#: module/Education/src/Controller/AdminController.php:98
-#: module/Education/src/Controller/AdminController.php:162
-msgid "You are not allowed to edit courses"
-msgstr "Je hebt niet de rechten om vakken te wijzigen"
+msgid "URL options"
+msgstr "URL opties"
 
-#: module/Education/src/Controller/AdminController.php:121
-msgid "Successfully updated course information!"
-msgstr "Vakinformatie succesvol aangepast!"
+msgid "Unable to retrieve infimum."
+msgstr "Kan infimum niet ophalen."
 
-#: module/Education/src/Controller/AdminController.php:140
-msgid "You are not allowed to delete courses"
-msgstr "Je hebt niet de rechten om vakken te verwijderen"
+msgid "Unapproved Activities"
+msgstr "Niet goedgekeurde activiteiten"
 
-#: module/Education/src/Controller/AdminController.php:183
-msgid "You are not allowed to delete course documents"
-msgstr "Je hebt niet de rechten om documenten van vakken te verwijderen"
+msgid "Unapproved Companies"
+msgstr "Niet goedgekeurde bedrijven"
 
-#: module/Education/src/Form/Bulk.php:43
-msgid "Finalize uploads"
-msgstr "Rond uploaden af"
+msgid "Unapproved Jobs"
+msgstr "Niet goedgekeurde vacatures"
 
-#: module/Education/src/Form/Bulk.php:64
-msgid "Course does not exist"
-msgstr "Vak bestaat niet"
+msgid "Unfortunately there currently is no poll :("
+msgstr "Helaas is er op het moment geen poll :("
 
-#: module/Education/src/Form/Course.php:33
-#: module/Education/src/Form/Fieldset/Exam.php:47
-#: module/Education/src/Form/Fieldset/Summary.php:47
-#: module/Education/view/education/education/index.phtml:91
-msgid "Course code"
-msgstr "Vakcode"
+#, php-format
+msgid "Unfortunately, there aren't any %s at the moment."
+msgstr "Helaas zijn er momenteel geen %s."
 
-#: module/Education/src/Form/Course.php:53
-msgid "Add course"
-msgstr "Vak toevoegen"
+msgid "Unknown"
+msgstr "Onbekend"
 
-#: module/Education/src/Form/Course.php:84
-msgid "There already exists a course with this code"
-msgstr "Er bestaat al een vak met deze code"
+msgid "Unsubscribe yourself"
+msgstr "Uitschrijven"
 
-#: module/Education/src/Form/Fieldset/Exam.php:57
-msgid "Exam date"
-msgstr "Datum tentamen"
+msgid "Until"
+msgstr "Tot"
 
-#: module/Education/src/Form/Fieldset/Exam.php:84
-#: module/Education/src/Form/Fieldset/Summary.php:78
-#: module/Education/view/education/admin/course-documents.phtml:71
-#: module/Education/view/education/admin/course-documents.phtml:122
-msgid "Language"
-msgstr "Taal"
+msgid "Upcoming Activities"
+msgstr "Aankomende activiteiten"
 
-#: module/Education/src/Form/Fieldset/Exam.php:98
-#: module/Education/src/Form/Fieldset/Summary.php:92
-msgid "Scanned?"
-msgstr "Gescand?"
+msgid "Upcoming meeting"
+msgid_plural "Upcoming meetings"
+msgstr[0] "Aankomende vergadering"
+msgstr[1] "Aankomende vergaderingen"
 
-#: module/Education/src/Form/Fieldset/Summary.php:57
-msgid "Summary date"
-msgstr "Datum van samenvatting"
+msgid "Update Activity"
+msgstr "Activiteit bijwerken"
 
-#: module/Education/src/Form/Fieldset/Summary.php:68
-#: module/Education/view/education/admin/course-documents.phtml:119
-#: module/Frontpage/src/Form/PollComment.php:27
-msgid "Author"
-msgstr "Auteur"
+msgid "Update Activity Category"
+msgstr "Activiteitencategorie bijwerken"
 
-#: module/Education/src/Form/TempUpload.php:25
-msgid "Exam to upload"
-msgstr "Tentamen"
+msgid "Update Album"
+msgstr "Album Bijwerken"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:25
-msgid "Final"
-msgstr "Eindexamen"
+msgid "Update Company"
+msgstr "Bedrijf bijwerken"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:26
-msgid "Interim"
-msgstr "Tussentijdse toets"
+msgid "Update Job"
+msgstr "Vacature bijwerken"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:27
-msgid "Answers"
-msgstr "Antwoorden"
+msgid "Update Job Category"
+msgstr "Vacaturecategorie bijwerken"
 
-#: module/Education/src/Model/Enums/ExamTypes.php:28
-msgid "Other"
-msgstr "Anders"
+msgid "Update Job Label"
+msgstr "Vacature-label bijwerken"
 
-#: module/Education/src/Service/Exam.php:98
-msgid "You are not allowed to download course documents"
-msgstr "Je hebt niet de rechten om documenten van vakken te downloaden"
+msgid "Update Package"
+msgstr "Pakket bijwerken"
 
-#: module/Education/src/Service/Exam.php:318
-msgid "You are not allowed to delete exams"
-msgstr "Je hebt niet de rechten om tentamens te verwijderen"
+msgid "Update Proposal"
+msgstr "Update voorstel"
 
-#: module/Education/src/Service/Exam.php:334
-#: module/Education/src/Service/Exam.php:456
-msgid "You are not allowed to upload exams"
-msgstr "Het is niet toegestaan om tentamens te uploaden"
+msgid "Update pending"
+msgstr "Update pending"
 
-#: module/Education/view/education/admin/add-course.phtml:17
-msgid "Add"
-msgstr "Voeg toe"
+msgid ""
+"Update proposal for job successfully created! It will become active after it "
+"has been approved."
+msgstr ""
+"Updatevoorstel voor vacature succesvol aangemaakt! Deze zal actief worden "
+"zodra deze is goedgekeurd."
 
-#: module/Education/view/education/admin/add-course.phtml:28
-#: module/Education/view/education/admin/course.phtml:31
-msgid "Add Course"
-msgstr "Vak toevoegen"
+msgid "Update status"
+msgstr "Bewerkings status"
 
-#: module/Education/view/education/admin/bulk-exam.phtml:20
+msgid "Upload"
+msgstr "Upload"
+
 msgid "Upload Exams"
 msgstr "Upload tentamens"
 
-#: module/Education/view/education/admin/bulk-exam.phtml:35
-msgid "Finalize exam uploads"
-msgstr "Rond uploaden tentamens af"
+msgid "Upload Photos"
+msgstr "Foto's uploaden"
 
-#: module/Education/view/education/admin/bulk-summary.phtml:20
 msgid "Upload Summaries"
 msgstr "Upload samenvattingen"
 
-#: module/Education/view/education/admin/bulk-summary.phtml:35
-msgid "Finalize summary uploads"
-msgstr "Rond uploaden samenvattingen af"
+msgid "Upload document"
+msgstr "Upload document"
 
-#: module/Education/view/education/admin/course-documents.phtml:47
-#, php-format
-msgid "Course Documents of %s"
-msgstr "Documenten van %s"
+msgid "Upload exams"
+msgstr "Upload tentamens"
 
-#: module/Education/view/education/admin/course-documents.phtml:57
-#: module/Education/view/education/education/index.phtml:36
-msgid "Exams"
-msgstr "Tentamens"
-
-#: module/Education/view/education/admin/course-documents.phtml:100
-#: module/Education/view/education/admin/course-documents.phtml:149
-msgid "This course does not have any exams."
-msgstr "Deze cursus heeft geen examens."
-
-#: module/Education/view/education/admin/course-documents.phtml:108
-msgid "Summaries"
-msgstr "Samenvattingen"
-
-#: module/Education/view/education/admin/course-documents.phtml:167
-msgid "Are you sure you want to delete this document?"
-msgstr "Weet je zeker dat u dit document wilt verwijderen?"
-
-#: module/Education/view/education/admin/course.phtml:22
-msgid "Course Admin"
-msgstr "Vak administratie"
-
-#: module/Education/view/education/admin/course.phtml:41
-msgid "Code"
-msgstr "Code"
-
-#: module/Education/view/education/admin/course.phtml:87
-msgid "Delete Course"
-msgstr "Verwijder vak"
-
-#: module/Education/view/education/admin/course.phtml:93
-#, php-format
-msgid ""
-"Are you sure you want to delete %s? This will also delete all associated "
-"exams and summaries will be deleted."
-msgstr ""
-"Weet je zeker dat je %s wilt verwijderen? Dan worden ook alle bijbehorende "
-"examens en samenvattingen verwijderd."
-
-#: module/Education/view/education/admin/edit-course.phtml:37
-msgid "Edit Course"
-msgstr "Bewerk vak"
-
-#: module/Education/view/education/admin/edit-exam.phtml:32
-msgid "Edit Exam"
-msgstr "Bewerk examen"
-
-#: module/Education/view/education/admin/edit-exam.phtml:35
 msgid "Upload of all exams was finished."
 msgstr "Het uploaden van alle tentamens is klaar."
 
-#: module/Education/view/education/admin/edit-exam.phtml:37
-msgid "There are no exams to be edited. Upload exams to edit them."
-msgstr ""
-"Er zijn geen tentamens om te wijzigen. Upload nieuwe tentamens om deze "
-"correct in de Website te zetten."
-
-#: module/Education/view/education/admin/edit-exam.phtml:128
-#: module/Education/view/education/admin/edit-summary.phtml:130
-msgid ""
-"Check this if the document is scanned, as this will enable higher quality "
-"downloads. Please note that enabling setting this for non-scanned documents "
-"will significantly impact the ability to download the document."
-msgstr ""
-"Vink dit aan als het document gescand is, omdat dit downloads van hogere "
-"kwaliteit mogelijk maakt. Let op dat het inschakelen van deze instelling "
-"voor niet-gescande documenten de mogelijkheid om het document te downloaden "
-"aanzienlijk zal beïnvloeden."
-
-#: module/Education/view/education/admin/edit-summary.phtml:32
-msgid "Edit Summary"
-msgstr "Bewerk samenvatting"
-
-#: module/Education/view/education/admin/edit-summary.phtml:35
 msgid "Upload of all summaries was finished."
 msgstr "Het uploaden van alle tentamens is klaar."
 
-#: module/Education/view/education/admin/edit-summary.phtml:37
-msgid "There are no summaries to be edited. Upload exams to edit them."
-msgstr ""
-"Er zijn geen samenvattingen om te wijzigen. Upload nieuwe samenvattingen om "
-"deze correct in de Website te zetten."
+msgid "Upload summaries"
+msgstr "Upload samenvattingen"
 
-#: module/Education/view/education/admin/index.phtml:13
-msgid "Education admin"
-msgstr "Onderwijs admin"
-
-#: module/Education/view/education/education/course.phtml:33
-msgid "Exams and summaries"
-msgstr "Tentamens en samenvattingen"
-
-#: module/Education/view/education/education/course.phtml:44
 #, php-format
-msgid "Summary by %s on %s (%s)"
-msgstr "Samenvatting door %s van %s (%s)"
+msgid "Uploading photos to %s"
+msgstr "Foto's aan het uploaden naar %s"
 
-#: module/Education/view/education/education/course.phtml:53
-#, php-format
-msgid "Summary on %s (%s)"
-msgstr "Samenvatting van %s (%s)"
+msgid "Use the form to subscribe"
+msgstr "Gebruik het formulier om in te schrijven"
 
-#: module/Education/view/education/education/course.phtml:64
-#, php-format
-msgid "Final test from %s (%s)"
-msgstr "Eindexamen op %s (%s)"
+msgid "Use the form to unsubscribe"
+msgstr "Gebruik het formulier om in te schrijven"
 
-#: module/Education/view/education/education/course.phtml:67
-#, php-format
-msgid "Interim test from %s (%s)"
-msgstr "Tussentijdse toets op %s (%s)"
+msgid "Use the form to unsubscribe an external participant"
+msgstr "Gebruik het formulier om iemand uit te schrijven"
 
-#: module/Education/view/education/education/course.phtml:70
-#, php-format
-msgid "Answers from %s (%s)"
-msgstr "Antwoorden van %s (%s)"
+msgid "Useful Information"
+msgstr "Praktische informatie"
 
-#: module/Education/view/education/education/course.phtml:73
-#, php-format
-msgid "Other exam material from %s (%s)"
-msgstr "Ander tentamenmateriaal van %s (%s)"
-
-#: module/Education/view/education/education/index.phtml:54
-msgid "Course code or course description"
-msgstr "Vak code of omschrijving"
-
-#: module/Education/view/education/education/index.phtml:76
-#, php-format
-msgid "Found %d %s matching your description"
-msgstr "%d %s gevonden overeenkomend met je zoektermen"
-
-#: module/Education/view/education/education/index.phtml:79
-msgid "course"
-msgid_plural "courses"
-msgstr[0] "vak"
-msgstr[1] "vakken"
-
-#: module/Education/view/education/education/index.phtml:92
-msgid "Course name"
-msgstr "Vak naam"
-
-#: module/Education/view/education/education/index.phtml:93
-msgid "Available documents"
-msgstr "Beschikbare documenten"
-
-#: module/Education/view/education/education/index.phtml:104
-msgid "View available documents"
-msgstr "Bekijk beschikbare documenten"
-
-#: module/Education/view/education/education/index.phtml:123
-#, php-format
-msgid ""
-"Do you want to contribute to the collection of old exams and summaries? Send "
-"them to the %seducation officer%s so that your (future) peers can benefit."
-msgstr ""
-"Wil je bijdragen aan het verzamelen van samenvattingen? Stuur je "
-"samenvatting naar de %sonderwijs commissaris%s zodat je (toekomstige) "
-"studiegenoten er van kunnen profiteren."
-
-#: module/Education/view/education/education/index.phtml:124
-#: module/Education/view/education/education/index.phtml:182
-msgid "Mail the education officer"
-msgstr "E-mail de onderwijscommissaris"
-
-#: module/Education/view/education/education/index.phtml:132
-msgid "For old exams of minor courses, you can also look at:"
-msgstr "Voor oude tentamens of minor vakken kun je ook terecht bij:"
-
-#: module/Education/view/education/education/index.phtml:135
-msgid "Applied Physics"
-msgstr "Technische Natuurkunde"
-
-#: module/Education/view/education/education/index.phtml:138
-msgid "Biomedical Engineering"
-msgstr "Biomedische Technologie"
-
-#: module/Education/view/education/education/index.phtml:141
-msgid "Electrical Engineering"
-msgstr "Electrical Engineering"
-
-#: module/Education/view/education/education/index.phtml:144
-msgid "Chemical Engineering"
-msgstr "Scheikundige Technologie"
-
-#: module/Education/view/education/education/index.phtml:147
-msgid "Innovation Sciences"
-msgstr "Innovation Sciences"
-
-#: module/Education/view/education/education/index.phtml:154
 msgid "Useful links"
 msgstr "Handige links"
 
-#: module/Education/view/education/education/index.phtml:159
-msgid "Books"
-msgstr "Boeken"
+#, php-format
+msgid "User (%s)"
+msgstr "Gebruiker (%s)"
 
-#: module/Education/view/education/education/index.phtml:162
-msgid ""
-"Order your course books via GEWIS to receive a discount. Specific ordering "
-"deadlines and pickup dates will be timely communicated to you via an email."
-msgstr ""
-"Bestel je boeken met korting via GEWIS. Specifieke bestel deadlines en "
-"ophaaltijden worden tijdig naar je gecommuniceerd via de e-mail."
+msgid "Users"
+msgstr "Gebruikers"
 
-#: module/Education/view/education/education/index.phtml:165
+msgid "VIRT"
+msgstr "VIRT"
+
+#, php-format
+msgid "Valid authorizations for GMM %d"
+msgstr "Geldige machtigingen voor ALV %d"
+
+msgid "Value is required and can't be empty"
+msgstr "Waarde is vereist en kan niet leeg zijn"
+
+msgid "Verify new password"
+msgstr "Verifier nieuw wachtwoord"
+
+msgid "Verify password"
+msgstr "Verifier wachtwoord"
+
+msgid "Verify your password"
+msgstr "Verifieer je wachtwoord"
+
+msgid "Verjaardagen"
+msgstr "Verjaardagen"
+
+msgid "Vice-Voorzitter"
+msgstr "Vice-Voorzitter"
+
+msgid "Vicevoorzitter"
+msgstr "Vicevoorzitter"
+
+msgid "View"
+msgstr "Toon"
+
+msgid "View Attachment"
+msgstr "Bijlage bekijken"
+
+msgid "View New Attachment"
+msgstr "Bekijk nieuwe bijlage"
+
+msgid "View Original Attachment"
+msgstr "Bekijk originele bijlage"
+
+msgid "View Proposal"
+msgstr "Bekijk voorstel"
+
+msgid "View Update"
+msgstr "Bekijk updatevoorstel"
+
+msgid "View Website"
+msgstr "Website bezoeken"
+
+msgid "View all meetings"
+msgstr "Toon alle vergaderingen"
+
+msgid "View available documents"
+msgstr "Bekijk beschikbare documenten"
+
+msgid "View current attachment"
+msgstr "Huidige bijlage weergeven"
+
+msgid "View current logo"
+msgstr "Huidige logo weergeven"
+
+msgid "View details"
+msgstr "Bekijk details"
+
+msgid "View details / subscriptions"
+msgstr "Bekijk details / inschrijvingen"
+
+msgid "View details of the new activity"
+msgstr "Bekijk de details van de nieuwe activiteit"
+
+msgid "View details of the old activity"
+msgstr "Bekijk de details van de oude activiteit"
+
+msgid "View on map"
+msgstr "Toon op kaart"
+
+#, php-format
+msgid "View the minutes of the %s"
+msgstr "Geef de notulen van de %s weer"
+
+msgid "View user profile"
+msgstr "Bekijk profiel"
+
+msgid "Virtual Meeting"
+msgstr "Virtuele Vergadering"
+
+msgid "Visit Website"
+msgstr "Website bezoeken"
+
 msgid "Visit the webshop"
 msgstr "Bezoek de webshop"
 
-#: module/Education/view/education/education/index.phtml:167
 msgid "Visit webshop"
 msgstr "Bezoek webshop"
 
-#: module/Education/view/education/education/index.phtml:175
-msgid "Complaint or suggestion about TU/e education?"
-msgstr "Klacht of suggestie over TU/e onderwijs?"
+msgid "Voorzitter"
+msgstr "Voorzitter"
 
-#: module/Education/view/education/education/index.phtml:181
+msgid "Vote for photo of the week"
+msgstr "Stem voor de foto van de week"
+
+msgid "Voted!"
+msgstr "Gestemd!"
+
+msgid ""
+"Warning! This is an update to an unapproved job. Applying this update will "
+"approve the job."
+msgstr ""
+"Waarschuwing! Dit is een update van een nog niet goedgekeurde vacature. Het "
+"toepassen van deze update zal de vacature goedkeuren."
+
+msgid ""
+"Warning! This is an update to rejected job. Applying this update will "
+"approve the job."
+msgstr ""
+"Waarschuwing! Dit is een update voor een afgewezen vacature. Het toepassen "
+"van deze update zal de vacature goedkeuren."
+
+msgid "We cannot determine at this time why a 404 was generated."
+msgstr ""
+"We kunnen op dit moment niet achterhalen waarom de pagina niet kon worden "
+"gevonden."
+
+msgid "Webmail"
+msgstr "Webmail"
+
+msgid "Website"
+msgstr "Website"
+
 #, php-format
 msgid ""
-"Do you have a complaint or suggestion concerning the education at the TU/e? "
-"Contact the %seducation officer%s to share your ideas."
+"Welcome %s. Create your password for the website and activate your account."
 msgstr ""
-"Heb je een klacht of een suggestie over het onderwijs aan de TU/e? Neem dan "
-"contact op met de %sonderwijscommissaris%s om je feedback te delen."
+"Welkom %s. Maak hier je wachtwoord voor de website en activeer je account."
 
-#: module/Education/view/education/education/index.phtml:192
-msgid "Disclaimer on educational content"
-msgstr "Disclaimer over onderwijsinhoud"
-
-#: module/Education/view/education/education/index.phtml:197
 msgid ""
-"The exams on the website of GEWIS are provided by Education & Student "
-"Affairs of the department of Mathematics and Computer Science of the TU/e."
+"Welcome on the page of the digital Option Calendar. In the calendar below "
+"you can place options for GEWIS activities, just like you were used to do in "
+"the paper version of the option calendar before. The red dots indicate "
+"activities that are already fixed in the GEWIS agenda, the blue dots are "
+"options for activities. If you insert an option, please give it a clear "
+"name, so it is clear what the option is for."
 msgstr ""
-"De tentamens op de site van GEWIS zijn verstrekt door Education & Student "
-"Affairs van de faculteit Wiskunde en Informatica van de TU/e."
+"Welkom bij de digitale optiekalender. In onderstaande kalender kunnen er "
+"opties voor GEWIS-activiteiten geplaatst worden, net zoals dat voorheen in "
+"de papieren optiekalender gebeurde. De rode bolletjes geven goedgekeurde en "
+"vaststaande activiteiten in de GEWIS agenda aan, de blauwe bolletjes zijn "
+"opties voor activiteiten. Als je een optie plaatst, geef deze dan een "
+"duidelijke naam waaruit blijkt waar de optie voor is."
 
-#: module/Education/view/education/education/index.phtml:198
-msgid ""
-"If an exam has been put online without the intention of the author, please "
-"let the board of GEWIS know by sending an"
-msgstr ""
-"Mocht er onbedoeld een tentamen online zijn gekomen dat niet gepubliceerd "
-"had mogen worden, laat dit dan weten aan het bestuur van GEWIS door"
-
-#: module/Education/view/education/education/index.phtml:199
-msgid "Email the board of GEWIS"
-msgstr "Email het bestuur van GEWIS"
-
-#: module/Education/view/education/education/index.phtml:199
-msgid "email to the board of GEWIS"
-msgstr "een mail te sturen naar het bestuur van GEWIS"
-
-#: module/Education/view/education/education/index.phtml:200
-msgid ""
-"then this exam will be removed from the website. Using the summaries or "
-"exams on this website for commercial goals without the permission of the "
-"author is illegal."
-msgstr ""
-"dan zal dit tentamen worden verwijderd van de website. Het is niet "
-"toegestaan om de samenvattingen of tentamens op deze website zonder "
-"toestemming van de auteur te gebruiken voor commerciële doeleinden, dit is "
-"strafbaar."
-
-#: module/Frontpage/src/Controller/InfimumController.php:26
-msgid "You are not allowed to view infima"
-msgstr "Je hebt niet de rechten om infima te bekijken"
-
-#: module/Frontpage/src/Controller/NewsAdminController.php:51
-msgid "You are not allowed to create news items"
-msgstr "Je hebt niet de rechten om nieuwsberichten toe te voegen"
-
-#: module/Frontpage/src/Controller/NewsAdminController.php:88
-msgid "You are not allowed to edit news items"
-msgstr "Je hebt niet de rechten om nieuwsberichten te wijzigen"
-
-#: module/Frontpage/src/Controller/NewsAdminController.php:133
-msgid "You are not allowed to delete news items"
-msgstr "Je hebt niet de rechten om nieuwsberichten te verwijderen"
-
-#: module/Frontpage/src/Controller/PageAdminController.php:31
-#: module/Frontpage/src/Service/Page.php:107
-msgid "You are not allowed to view the list of pages."
-msgstr "Je hebt niet de rechten om de lijst met pagina's te bekijken."
-
-#: module/Frontpage/src/Controller/PageAdminController.php:46
-#: module/Frontpage/src/Service/Page.php:260
-msgid "You are not allowed to create new pages."
-msgstr "Je hebt niet de rechten om nieuw pagina's te maken."
-
-#: module/Frontpage/src/Controller/PageAdminController.php:77
-#: module/Frontpage/src/Service/Page.php:193
-msgid "You are not allowed to edit pages."
-msgstr "Je hebt niet de rechten om pagina's te wijzigen."
-
-#: module/Frontpage/src/Controller/PageAdminController.php:104
-msgid "You are not allowed to delete pages."
-msgstr "Je hebt niet de rechten om pagina's te verwijderen."
-
-#: module/Frontpage/src/Controller/PageAdminController.php:121
-msgid "You are not allowed to upload images."
-msgstr "Het is niet toegestaan om foto's te uploaden."
-
-#: module/Frontpage/src/Controller/PollAdminController.php:32
-msgid "You are not allowed to administer polls"
-msgstr "Je hebt niet de rechten om poll-instellingen te beheren"
-
-#: module/Frontpage/src/Controller/PollAdminController.php:64
-msgid "You are not allowed to approve polls"
-msgstr "Je hebt niet de rechten om polls goed te keuren"
-
-#: module/Frontpage/src/Controller/PollAdminController.php:96
-msgid "You are not allowed to delete polls"
-msgstr "Je hebt niet de rechten om polls te verwijderen"
-
-#: module/Frontpage/src/Controller/PollController.php:96
-msgid "You are not allowed to create comments on this poll"
-msgstr "Je hebt niet de rechten om commentaar te geven op de poll"
-
-#: module/Frontpage/src/Form/NewsItem.php:27
-#: module/Frontpage/src/Form/Page.php:49
-msgid "Dutch title"
-msgstr "Nederlandse titel"
-
-#: module/Frontpage/src/Form/NewsItem.php:37
-#: module/Frontpage/src/Form/Page.php:59
-msgid "English title"
-msgstr "Engelse titel"
-
-#: module/Frontpage/src/Form/NewsItem.php:47
-#: module/Frontpage/src/Form/Page.php:69
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:73
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:104
-msgid "Dutch content"
-msgstr "Nederlandse inhoud"
-
-#: module/Frontpage/src/Form/NewsItem.php:57
-#: module/Frontpage/src/Form/Page.php:79
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:49
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:80
-msgid "English content"
-msgstr "Engelse inhoud"
-
-#: module/Frontpage/src/Form/Page.php:89
-msgid "Required role"
-msgstr "Verplichte rol"
-
-#: module/Frontpage/src/Form/Poll.php:28
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:39
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:51
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:112
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:124
-msgid "Dutch question"
-msgstr "Nederlandse vraag"
-
-#: module/Frontpage/src/Form/Poll.php:38
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:40
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:54
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:113
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:127
-msgid "English question"
-msgstr "Engelse vraag"
-
-#: module/Frontpage/src/Form/PollApproval.php:25
-msgid "Expiration date for the poll (YYYY-MM-DD)"
-msgstr "Verloopdatum van de poll (JJJJ-MM-DD)"
-
-#: module/Frontpage/src/Form/PollApproval.php:36
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:201
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:227
-msgid "Approve poll"
-msgstr "Keur poll goed"
-
-#: module/Frontpage/src/Form/PollComment.php:37
-msgid "Content"
-msgstr "Inhoud"
-
-#: module/Frontpage/src/Form/PollComment.php:47
-msgid "Comment"
-msgstr "Commentaar"
-
-#: module/Frontpage/src/Service/News.php:45
-msgid "You are not allowed to list all news items."
-msgstr "Je hebt niet de rechten om alle nieuws items te bekijken."
-
-#: module/Frontpage/src/Service/Page.php:56
-msgid "You are not allowed to view this page."
-msgstr "Je hebt niet de rechten om deze pagina te bekijken."
-
-#: module/Frontpage/src/Service/Page.php:244
-#: module/Photo/src/Service/Admin.php:212
-msgid "The uploaded file does not have a valid extension"
-msgstr "Het geuploade bestand heeft geen valide extensie"
-
-#: module/Frontpage/src/Service/Page.php:249
-msgid "The uploaded file is not a valid image"
-msgstr "Het geuploade bestand is geen valide plaatje"
-
-#: module/Frontpage/src/Service/Poll.php:71
-msgid "You are not allowed to view unapproved polls"
-msgstr "Je hebt niet de rechten om niet-goedgekeurde polls te bekijken"
-
-#: module/Frontpage/src/Service/Poll.php:183
-msgid "You are not allowed to vote on this poll."
-msgstr "Je hebt niet de rechten om op deze poll te stemmen."
-
-#: module/Frontpage/src/Service/Poll.php:329
-msgid "You are not allowed to request polls"
-msgstr "Je hebt niet de rechten om polls aan te vragen"
-
-#: module/Frontpage/view/frontpage/admin/index.phtml:10
 msgid ""
 "Welcome to the admin interface of the GEWIS website. If you are experiencing "
 "any issues or have a question, please contact the ApplicatieBeheerCommissie."
@@ -4921,15 +3347,6 @@ msgstr ""
 "ondervindt of een vraag hebt, neem dan contact op met de "
 "ApplicatieBeheerCommissie."
 
-#: module/Frontpage/view/frontpage/admin/index.phtml:12
-msgid "Recent changes"
-msgstr "Recente wijzigingen"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:47
-msgid "Studievereniging GEWIS"
-msgstr "Studievereniging GEWIS"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:49
 msgid ""
 "Welcome to the website of Study association GEWIS, the study association of "
 "the department of Mathematics & Computer Science of the Eindhoven University "
@@ -4938,748 +3355,570 @@ msgstr ""
 "Welkom op de website van Studievereniging GEWIS. De studievereniging van de "
 "faculteit Wiskunde & Informatica aan de Technische Universiteit Eindhoven."
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:148
-msgid "Verjaardagen"
-msgstr "Verjaardagen"
+msgid "Well-being"
+msgstr "Welzijn"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:153
-#, php-format
-msgid "%s wil be %s years old today!"
-msgstr "%s wordt vandaag %s jaar oud!"
+msgid "What are you looking for?"
+msgstr "Waar ben je naar op zoek?"
 
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:168
-msgid "Agenda"
-msgstr "Agenda"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:185
-#, php-format
-msgid "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
-msgstr "Donderdags is er %sborrel%s van 16.30 tot 19.00 uur."
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:194
-#: module/Frontpage/view/frontpage/organ/organ.phtml:136
-msgid "Complete agenda"
-msgstr "Volledige agenda"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:198
-msgid "Google Calendar"
-msgstr "Google Calendar"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:282
-msgid "Poll"
-msgstr "Poll"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:296
-msgid "View details"
-msgstr "Bekijk details"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:301
-msgid "There currently is no poll."
-msgstr "Er is op het moment geen poll."
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:305
-#: module/Frontpage/view/frontpage/poll/request.phtml:174
-msgid "Request poll"
-msgstr "Vraag poll aan"
-
-#: module/Frontpage/view/frontpage/frontpage/home.phtml:308
-#: module/Frontpage/view/frontpage/poll/index.phtml:39
-msgid "Old polls"
-msgstr "Oude polls"
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:101
-msgid "Pin news item"
-msgstr "Nieuws item vastzetten"
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:103
-msgid "Select this if you want this news item to stay at the top of the page."
-msgstr "Selecteer dit als je wil dat je nieuws item bovenaan de pagina blijft."
-
-#: module/Frontpage/view/frontpage/news-admin/edit.phtml:118
-msgid "Delete this news item"
-msgstr "Verwijder dit nieuwsitem"
-
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:16
-msgid "News items"
-msgstr "Nieuws items"
-
-#: module/Frontpage/view/frontpage/news-admin/list.phtml:17
-msgid "Create news item"
-msgstr "Maak een nieuw nieuwsitem"
-
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:21
-msgid "GEWIS has many different committees, learn more about them below!"
-msgstr ""
-"GEWIS heeft veel verschillende commissies, zie hieronder voor meer "
-"informatie!"
-
-#: module/Frontpage/view/frontpage/organ/committee-list.phtml:27
-msgid "Information for committees"
-msgstr "Informatie voor commissies"
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:20
 msgid ""
-"Study association GEWIS obviously has several fraternities which contribute "
-"to the atmosphere at GEWIS and organize fun activities. Some fraternities "
-"have retired, but luckily new fraternities continue to be founded."
+"What is this activity about? Fill in the blanks below, please note that at "
+"least one language must be used."
 msgstr ""
-"Studievereniging GEWIS heeft natuurlijk verschillende disputen die bijdragen "
-"aan de goede atmosfeer bij GEWIS en leuke activiteiten organiseren. Sommige "
-"disputen zijn in ruste."
+"Waar gaat deze activiteit over? Vul de lege plekken hieronder in, let op dat "
+"er ten minste één taal gebruikt moet worden."
 
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:21
-msgid "The currently active fraternities of GEWIS (in arbitrary order)"
-msgstr "De huidige disputen van GEWIS zijn (in willekeurige volgorde):"
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:36
-msgid "Retired fraternities"
-msgstr "Disputen in ruste"
-
-#: module/Frontpage/view/frontpage/organ/fraternity-list.phtml:37
-msgid "The following fraternities have retired:"
-msgstr "De volgende disputen zijn in ruste:"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:67
-msgid "GMM Committees"
-msgstr "ALV-Commissies"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:69
-msgid "GMM Taskforces"
-msgstr "ALV-Werkgroepen"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:71
-msgid "Financial Audit Committees"
-msgstr "Kas Controle Commissies"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:73
-msgid "Advisory Boards"
-msgstr "Raden van Advies"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:122
-#, php-format
-msgid "%s's activities"
-msgstr "Activiteiten door %s"
-
-#: module/Frontpage/view/frontpage/organ/organ.phtml:168
-msgid "Login to view more information"
-msgstr "Log in om meer informatie te zien"
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:48
-msgid "URL options"
-msgstr "URL opties"
-
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:49
 msgid ""
-"Make this page available at the following URL. Providing a category is "
-"required."
+"What is this company about? Fill in the blanks below, please note that at "
+"least one language must be used."
 msgstr ""
-"Maak deze pagina beschikbaar op de volgende URL. Het is verplicht om een "
-"categorie te specificeren."
+"Waar gaat dit bedrijf over? Vul de lege plekken hieronder in, let op dat er "
+"ten minste één taal gebruikt moet worden."
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:128
-msgid "Permissions"
-msgstr "Rechten"
+msgid ""
+"When this is checked, GEFLITST will be notified that this activity needs a "
+"photographer."
+msgstr ""
+"Door dit te selecteren zal GEFLITST van deze activiteit op de hoogte "
+"gebracht worden."
 
-#: module/Frontpage/view/frontpage/page-admin/edit.phtml:151
-msgid "Delete this page"
-msgstr "Verwijder deze pagina"
+msgid "Wrong form"
+msgstr "Verkeerd formulier"
 
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:29
-msgid "Create a new page"
-msgstr "Maak een nieuwe pagina"
+msgid "Yes"
+msgstr "Ja"
 
-#: module/Frontpage/view/frontpage/page-admin/index.phtml:31
-msgid "Or select a page to edit below."
-msgstr "Of selecteer hieronder een pagina om te wijzigen."
+msgid "Yes/No"
+msgstr "Ja/Nee"
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:34
-msgid "Polls awaiting approval"
-msgstr "Niet goedgekeurde polls"
+msgid ""
+"You already attempted to register, please check your email or try again "
+"after 20 minutes."
+msgstr ""
+"Je hebt al geprobeerd te registreren, controleer je e-mail of probeer het na "
+"20 minuten opnieuw."
 
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:43
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:116
-msgid "Approver"
-msgstr "Goedgekeurd door"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:60
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:133
-msgid "Dutch option"
-msgstr "Nederlandse optie"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:61
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:134
-msgid "English option"
-msgstr "Engelse optie"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:95
-msgid "Approved polls"
-msgstr "Goedgekeurde polls"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:178
-msgid "Are you sure you want to delete this poll?"
-msgstr "Weet je zeker dat je deze poll wilt verwijderen?"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:184
-msgid "Delete poll"
-msgstr "Verwijder poll"
-
-#: module/Frontpage/view/frontpage/poll-admin/list.phtml:204
-msgid "Are you sure that you want to approve this poll?"
-msgstr "Weet je zeker dat je deze poll wilt goedkeuren?"
-
-#: module/Frontpage/view/frontpage/poll/history.phtml:14
-msgid "Poll history"
-msgstr "Poll historie"
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:41
 #, php-format
-msgid "%sRequest a poll%s"
-msgstr "%sVraag een poll aan%s"
+msgid "You are being redirected to %s"
+msgstr "Je wordt doorgestuurd naar %s"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:56
-msgid "Unfortunately there currently is no poll :("
-msgstr "Helaas is er op het moment geen poll :("
+msgid "You are currently a member of:"
+msgstr "Je bent momenteel lid van:"
 
-#: module/Frontpage/view/frontpage/poll/index.phtml:61
-msgid "Comments"
-msgstr "Commentaar"
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:63
-msgid "This poll has no comments"
-msgstr "Deze poll heeft geen commentaar"
-
-#: module/Frontpage/view/frontpage/poll/index.phtml:84
-msgid "Comment on this poll"
-msgstr "Commentaar op deze poll"
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:14
-#: module/Frontpage/view/frontpage/poll/request.phtml:19
-msgid "Request a poll"
-msgstr "Vraag een poll aan"
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:21
-msgid "Your poll request has been received and will be reviewed shortly."
-msgstr "Je poll is aangevraagd en zal zo snel mogelijk bekeken worden."
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:158
-msgid "Remove option"
-msgstr "Verwijder optie"
-
-#: module/Frontpage/view/frontpage/poll/request.phtml:163
-msgid "Add option"
-msgstr "Voeg optie toe"
-
-#: module/Frontpage/view/partial/poll.phtml:61
-#: module/Frontpage/view/partial/poll.phtml:72
-#, php-format
-msgid "%d votes"
-msgstr "%d stemmen"
-
-#: module/Frontpage/view/partial/poll.phtml:61
-#: module/Frontpage/view/partial/poll.phtml:72
-msgid "1 vote"
-msgstr "1 stem"
-
-#: module/Photo/src/Controller/AlbumController.php:50
-#: module/Photo/src/Service/Album.php:122
-msgid "Not allowed to view albums without dates"
-msgstr "Het is niet toegestaan om albums te zien zonder data"
-
-#: module/Photo/src/Controller/ApiController.php:50
-msgid "Not allowed to view photo details"
-msgstr "Het is niet toegestaan om details van foto's te zien"
-
-#: module/Photo/src/Controller/PhotoController.php:44
-#: module/Photo/src/Service/Album.php:67 module/Photo/src/Service/Album.php:99
-#: module/Photo/src/Service/Album.php:234
-#: module/Photo/src/Service/Album.php:248
-msgid "Not allowed to view albums"
-msgstr "Het is niet toegestaan om albums te zien"
-
-#: module/Photo/src/Controller/PhotoController.php:91
-#: module/Photo/src/Service/Photo.php:95
-msgid "Not allowed to download photos"
-msgstr "Het is niet toegestaan om foto's te downloaden"
-
-#: module/Photo/src/Controller/PhotoController.php:106
-msgid "Not allowed to view previous photos of the week"
-msgstr "Not allowed to view previous photos of the week"
-
-#: module/Photo/src/Controller/PhotoController.php:163
-msgid "Not allowed to vote for a photo of the week"
-msgstr "Het is niet toegestaan om te stemmen voor een foto van de week"
-
-#: module/Photo/src/Controller/TagController.php:27
-msgid "Not allowed to add tags."
-msgstr "Het is niet toegestaan om tags toe te voegen."
-
-#: module/Photo/src/Controller/TagController.php:53
-msgid "Not allowed to remove tags."
-msgstr "Het is niet toegestaan om tags te verwijderen."
-
-#: module/Photo/src/Form/CreateAlbum.php:25
-#: module/Photo/src/Form/EditAlbum.php:27
-#: module/Photo/view/photo/album-admin/create.phtml:28
-msgid "Album title"
-msgstr "Album titel"
-
-#: module/Photo/src/Form/CreateAlbum.php:35
-msgid "Create"
-msgstr "Maak"
-
-#: module/Photo/src/Form/EditAlbum.php:48
-msgid "End date"
-msgstr "Einddatum"
-
-#: module/Photo/src/Service/Admin.php:66
-msgid "Not allowed to add photos."
-msgstr "Het is niet toegestaan om foto's toe te voegen."
-
-#: module/Photo/src/Service/Admin.php:185
-msgid "An unknown error occurred during uploading ("
-msgstr "Een onbekende error vond plaats tijdens het uploaden van ("
-
-#: module/Photo/src/Service/Admin.php:201
 #, php-format
 msgid ""
-"The uploaded file is not a valid image \n"
-"Error: %s"
+"You are currently updating a job that was previously rejected for the "
+"following reason: %s"
 msgstr ""
-"Het geuploade bestand is geen valide plaatje \n"
-"Error: %s"
+"Je werkt momenteel een vacature bij die eerder is afgewezen met de volgende "
+"reden: %s"
 
-#: module/Photo/src/Service/Admin.php:225
-msgid "Not allowed to upload photos."
+msgid ""
+"You are currently updating a job that was previously rejected, however, no "
+"reason was provided."
+msgstr ""
+"Je werkt momenteel een vacature bij die eerder is afgewezen, maar er is "
+"hiervoor geen reden opgegeven."
+
+#, php-format
+msgid ""
+"You are currently updating an update proposal that was previously rejected "
+"for the following reason: %s"
+msgstr ""
+"Je werkt momenteel een updatevoorstel bij dat eerder is afgewezen met de "
+"volgende reden: %s"
+
+msgid ""
+"You are currently updating an update proposal that was previously rejected, "
+"however, no reason was provided."
+msgstr ""
+"Je werkt momenteel een updatevoorstel bij dat eerder is afgewezen, maar er "
+"is hiervoor geen reden opgegeven."
+
+msgid "You are currently using administrator privileges to use the website!"
+msgstr "Je gebruikt momenteel beheerdersprivileges om de website te gebruiken!"
+
+msgid "You are logged out."
+msgstr "Je bent uitgelogd."
+
+msgid "You are not allowed authorize people."
+msgstr "Je hebt niet de rechten om iemand te machtigen."
+
+msgid "You are not allowed to access the activities through the API"
+msgstr "Je hebt niet de rechten om de activiteiten in te zien via de API"
+
+msgid "You are not allowed to access the admin interface"
+msgstr "Je hebt niet de rechten om de admin interface te zien"
+
+msgid "You are not allowed to add API tokens"
+msgstr "Je hebt niet de rechten om API tokens toe te voegen"
+
+msgid "You are not allowed to add courses"
+msgstr "Je hebt niet de rechten om vakken toe te voegen"
+
+msgid "You are not allowed to administer activities"
+msgstr "Je hebt niet de rechten om activiteiten te beheren"
+
+msgid "You are not allowed to administer career settings"
+msgstr "Je hebt niet de rechten om carrière-instellingen te beheren"
+
+msgid "You are not allowed to administer courses"
+msgstr "Je hebt niet de rechten om vakken te beheren"
+
+msgid "You are not allowed to administer education settings"
+msgstr "Je hebt niet de rechten om onderwijsinstellingen te beheren"
+
+msgid "You are not allowed to administer option calendar periods"
+msgstr "Je hebt niet de rechten om optieperiodes te beheren"
+
+msgid "You are not allowed to administer polls"
+msgstr "Je hebt niet de rechten om poll-instellingen te beheren"
+
+msgid "You are not allowed to approve polls"
+msgstr "Je hebt niet de rechten om polls goed te keuren"
+
+msgid "You are not allowed to approve this option"
+msgstr "Je hebt niet de rechten om deze optie goed te keuren"
+
+msgid "You are not allowed to approve update proposals of jobs"
+msgstr ""
+"Je hebt niet de rechten om updatevoorstellen van vacatures goed te keuren"
+
+msgid "You are not allowed to authorize someone"
+msgstr "Je hebt niet de rechten om iemand te machtigen"
+
+msgid "You are not allowed to browse files."
+msgstr "Je hebt niet de rechten om door bestanden te bladeren."
+
+msgid "You are not allowed to change passwords"
+msgstr "Je hebt niet de rechten om een wachtwoord te wijzigen"
+
+msgid "You are not allowed to change the approval status of jobs"
+msgstr ""
+"Je hebt niet de rechten om de goedkeuringsstatus van deze vacatures te "
+"wijzigen"
+
+msgid "You are not allowed to change the status of the activity"
+msgstr "Je hebt niet de rechten om de status van deze activiteit te wijzigen"
+
+msgid "You are not allowed to change your password"
+msgstr "Je hebt niet de rechten om een wachtwoord te wijzigen"
+
+msgid "You are not allowed to create a company"
+msgstr "Je hebt niet de rechten om een bedrijf toe te voegen"
+
+msgid "You are not allowed to create activity option proposals"
+msgstr "Je hebt niet de rechten om opties voor activiteiten te maken"
+
+msgid "You are not allowed to create activity proposals"
+msgstr "Je hebt niet de rechten om opties voor activiteiten te maken"
+
+msgid "You are not allowed to create an activity"
+msgstr "Je hebt niet de rechten om een activiteit te maken"
+
+msgid "You are not allowed to create an activity category"
+msgstr "Je hebt niet de rechten om een activiteitencategorie te maken"
+
+msgid "You are not allowed to create an activity for this organ"
+msgstr "Je hebt niet de rechten om een activiteit aan te maken voor dit orgaan"
+
+msgid "You are not allowed to create comments on this poll"
+msgstr "Je hebt niet de rechten om commentaar te geven op de poll"
+
+msgid "You are not allowed to create companies"
+msgstr "Je hebt niet de rechten om bedrijven toe te voegen"
+
+msgid "You are not allowed to create job categories"
+msgstr "Je hebt niet de rechten om vacaturecategorieën te wijzigen"
+
+msgid "You are not allowed to create job labels"
+msgstr "Je hebt niet de rechten om vacature-labels te wijzigen"
+
+msgid "You are not allowed to create jobs"
+msgstr "Je hebt niet de rechten om vacatures toe te voegen"
+
+msgid "You are not allowed to create new pages."
+msgstr "Je hebt niet de rechten om nieuw pagina's te maken."
+
+msgid "You are not allowed to create news items"
+msgstr "Je hebt niet de rechten om nieuwsberichten toe te voegen"
+
+msgid "You are not allowed to create option calendar periods"
+msgstr "Je hebt niet de rechten om optieperiodes toe te voegen"
+
+msgid "You are not allowed to create packages"
+msgstr "Je hebt niet de rechten om pakketten toe te voegen"
+
+msgid "You are not allowed to delete an activity category"
+msgstr "Je hebt niet de rechten om een activiteitencategorie te verwijderen"
+
+msgid "You are not allowed to delete companies"
+msgstr "Je hebt niet de rechten om bedrijven te verwijderen"
+
+msgid "You are not allowed to delete course documents"
+msgstr "Je hebt niet de rechten om documenten van vakken te verwijderen"
+
+msgid "You are not allowed to delete courses"
+msgstr "Je hebt niet de rechten om vakken te verwijderen"
+
+msgid "You are not allowed to delete exams"
+msgstr "Je hebt niet de rechten om tentamens te verwijderen"
+
+msgid "You are not allowed to delete jobs"
+msgstr "Je hebt niet de rechten om vacatures te verwijderen"
+
+msgid "You are not allowed to delete meeting documents."
+msgstr "Je hebt niet de rechten om vergaderstukken te verwijderen."
+
+msgid "You are not allowed to delete news items"
+msgstr "Je hebt niet de rechten om nieuwsberichten te verwijderen"
+
+msgid "You are not allowed to delete option calendar periods"
+msgstr "Je hebt niet de rechten om optieperiodes te verwijderen"
+
+msgid "You are not allowed to delete packages"
+msgstr "Je hebt niet de rechten om pakketten te verwijderen"
+
+msgid "You are not allowed to delete pages."
+msgstr "Je hebt niet de rechten om pagina's te verwijderen."
+
+msgid "You are not allowed to delete polls"
+msgstr "Je hebt niet de rechten om polls te verwijderen"
+
+msgid "You are not allowed to delete this option"
+msgstr "Je hebt niet de rechten om deze optie te verwijderen"
+
+msgid "You are not allowed to download course documents"
+msgstr "Je hebt niet de rechten om documenten van vakken te downloaden"
+
+msgid "You are not allowed to edit an activity category"
+msgstr "Je hebt niet de rechten om een activiteitencategorie bij te werken"
+
+msgid "You are not allowed to edit categories"
+msgstr "Je hebt niet de rechten om alle categorieën te wijzigen"
+
+msgid "You are not allowed to edit companies"
+msgstr "Je hebt niet de rechten om bedrijven te wijzigen"
+
+msgid "You are not allowed to edit courses"
+msgstr "Je hebt niet de rechten om vakken te wijzigen"
+
+msgid "You are not allowed to edit job categories"
+msgstr "Je hebt niet de rechten om vacature categorieën te wijzigen"
+
+msgid "You are not allowed to edit job labels"
+msgstr "Je hebt niet de rechten om vacature-labels te wijzigen"
+
+msgid "You are not allowed to edit jobs"
+msgstr "Je hebt niet de rechten om vacatures te wijzigen"
+
+msgid "You are not allowed to edit labels"
+msgstr "Je hebt niet de rechten om labels te wijzigen"
+
+msgid "You are not allowed to edit news items"
+msgstr "Je hebt niet de rechten om nieuwsberichten te wijzigen"
+
+msgid "You are not allowed to edit option calendar periods"
+msgstr "Je hebt niet de rechten om optieplanningsperioden te wijzigen"
+
+msgid "You are not allowed to edit organ information"
+msgstr "Je hebt niet de rechten om organen te wijzigen"
+
+msgid "You are not allowed to edit packages"
+msgstr "Je hebt niet de rechten om pakketten te wijzigen"
+
+msgid "You are not allowed to edit pages."
+msgstr "Je hebt niet de rechten om pagina's te wijzigen."
+
+msgid "You are not allowed to edit this organ's information"
+msgstr "Je hebt niet de rechten om de informatie van dit orgaan te wijzigen"
+
+msgid "You are not allowed to list all job categories"
+msgstr "Je hebt niet de rechten om alle vacaturecategorieën te bekijken"
+
+msgid "You are not allowed to list all job labels"
+msgstr "Je hebt niet de rechten om alle vacature-labels te bekijken"
+
+msgid "You are not allowed to list all news items."
+msgstr "Je hebt niet de rechten om alle nieuws items te bekijken."
+
+msgid "You are not allowed to list job categories"
+msgstr "Je hebt niet de rechten om vacaturecategorieën te bekijken"
+
+msgid "You are not allowed to list job labels"
+msgstr "Je hebt niet de rechten om vacature-labels te bekijken"
+
+msgid "You are not allowed to list meetings."
+msgstr "Het is niet toegestaan om de lijst van vergaderingen te zien."
+
+msgid "You are not allowed to list the companies"
+msgstr "Je hebt niet de rechten om de lijst met bedrijven te zien"
+
+msgid ""
+"You are not allowed to perform this action. If you are not logged in please "
+"do so before continuing. If you are already logged in this action may "
+"require you to login in with a different account."
+msgstr ""
+"Je hebt niet de rechten om deze actie uit te voeren. Als je niet bent "
+"ingelogd, doe dat dan eerst voordat je verder gaat. Als je al bent ingelogd "
+"kan het zijn dat je voor deze actie moet inloggen met een ander account."
+
+msgid "You are not allowed to remove API tokens"
+msgstr "Je hebt niet de rechten om API tokens te verwijderen"
+
+msgid "You are not allowed to remove external signups for this activity"
+msgstr ""
+"Je hebt niet de rechten om externe inschrijvingen te verwijderen voor deze "
+"activiteit"
+
+msgid "You are not allowed to rename meeting documents"
+msgstr "Je hebt niet de rechten om vergaderstukken te hernoemen"
+
+msgid "You are not allowed to request polls"
+msgstr "Je hebt niet de rechten om polls aan te vragen"
+
+msgid "You are not allowed to revoke authorizations."
+msgstr "Je hebt niet de rechten om machtigingen in te trekken."
+
+msgid "You are not allowed to search decisions."
+msgstr "Je hebt niet de rechten om besluiten te doorzoeken."
+
+msgid "You are not allowed to subscribe an external user to this sign-up list"
+msgstr ""
+"Je hebt niet de rechten om een externe gebruiker op deze inschrijflijst in "
+"te schrijven"
+
+msgid "You are not allowed to subscribe to this sign-up list"
+msgstr ""
+"Je hebt niet de rechten om jezelf op deze inschrijflijst in te schrijven"
+
+msgid "You are not allowed to transfer jobs"
+msgstr "Je hebt niet de rechten om vacatures te verplaatsen"
+
+msgid "You are not allowed to unsubscribe after the deadline!"
+msgstr "Uitschrijven na de uitschrijfdeadline is niet toegestaan!"
+
+msgid "You are not allowed to update this activity"
+msgstr "Je hebt niet de rechten om deze activiteit te wijzigen"
+
+msgid "You are not allowed to upload exams"
+msgstr "Het is niet toegestaan om tentamens te uploaden"
+
+msgid "You are not allowed to upload images."
 msgstr "Het is niet toegestaan om foto's te uploaden."
 
-#: module/Photo/src/Service/Album.php:191
-msgid "Not allowed to create albums"
-msgstr "Het is niet toegestaan om albums te maken"
+msgid "You are not allowed to upload meeting documents."
+msgstr "Het is niet toegestaan om vergaderstukken te uploaden."
 
-#: module/Photo/src/Service/Album.php:213
-msgid "Not allowed to create albums."
-msgstr "Het is niet toegestaan om albums te maken."
+msgid "You are not allowed to upload meeting minutes."
+msgstr "Het is niet toegestaan om notulen te uploaden."
 
-#: module/Photo/src/Service/Album.php:327
-#, php-format
-msgid "Photos of the Week in %d/%d"
-msgstr "Foto's van de Week in %d/%d"
+msgid "You are not allowed to use the external admin signup"
+msgstr "Je hebt niet de rechten om een externe admin inschrijving te maken"
 
-#: module/Photo/src/Service/Album.php:358
-msgid "Not allowed to edit albums"
-msgstr "Het is niet toegestaan om albums te wijzigen"
+msgid "You are not allowed to use the external signup"
+msgstr "Je hebt niet de rechten om een externe inschrijving te maken"
 
-#: module/Photo/src/Service/Album.php:376
-msgid "Not allowed to edit albums."
-msgstr "Het is niet toegestaan om albums te wijzigen."
+msgid "You are not allowed to use this form"
+msgstr "Je hebt niet de rechten om dit formulier te gebruiken"
 
-#: module/Photo/src/Service/Album.php:401
-msgid "Not allowed to move albums"
-msgstr "Het is niet toegestaan om albums te verplaatsen"
+msgid "You are not allowed to view API tokens"
+msgstr "Je hebt niet de rechten om API tokens in te zien"
 
-#: module/Photo/src/Service/Album.php:435
-msgid "Not allowed to delete albums."
-msgstr "Het is niet toegestaan om albums te verwijderen."
+msgid "You are not allowed to view activities"
+msgstr "Je hebt niet de rechten om de activiteiten in te zien"
 
-#: module/Photo/src/Service/Album.php:456
-msgid "Not allowed to generate album covers."
-msgstr "Het is niet toegestaan om albums-covers opnieuw te genereren."
+msgid "You are not allowed to view activity categories"
+msgstr "Je hebt niet de rechten om activiteitencategorieën te bekijken"
 
-#: module/Photo/src/Service/Album.php:504
-msgid "Not allowed to move photos"
-msgstr "Het is niet toegestaan om foto's te verplaatsen"
+msgid "You are not allowed to view all authorizations."
+msgstr "Je hebt niet de rechten om alle machtigingen te bekijken."
 
-#: module/Photo/src/Service/Photo.php:73 module/Photo/src/Service/Photo.php:114
-#: module/Photo/src/Service/Photo.php:159
-#: module/Photo/src/Service/Photo.php:210
-#: module/Photo/src/Service/Photo.php:226
-msgid "Not allowed to view photos"
-msgstr "Het is niet toegestaan om foto's te zien"
+msgid "You are not allowed to view authorizations."
+msgstr "Je hebt niet de rechten om all machtigingen te bekijken."
 
-#: module/Photo/src/Service/Photo.php:245
-msgid "Not allowed to delete photos."
-msgstr "Het is niet toegestaan om foto's te verwijderen."
+msgid "You are not allowed to view infima"
+msgstr "Je hebt niet de rechten om infima te bekijken"
 
-#: module/Photo/src/Service/Photo.php:623
-#: module/Photo/src/Service/Photo.php:672
-msgid "Not allowed to view tags."
-msgstr "Het is niet toegestaan om tags te zien."
+msgid "You are not allowed to view meeting documents."
+msgstr "Het is niet toegestaan om vergaderstukken te zien."
 
-#: module/Photo/view/partial/metadata.phtml:19
-msgid "Artist"
-msgstr "Artiest"
+msgid "You are not allowed to view meeting minutes."
+msgstr "Het is niet toegestaan om notulen te zien."
 
-#: module/Photo/view/partial/metadata.phtml:26
-msgid "Camera"
-msgstr "Camera"
+msgid "You are not allowed to view meetings."
+msgstr "Het is niet toegestaan om vergaderingen te zien."
 
-#: module/Photo/view/partial/metadata.phtml:33
-msgid "Date/time"
-msgstr "Datum/tijd"
+msgid "You are not allowed to view members."
+msgstr "Het is niet toegestaan om lidinformatie in te zien."
 
-#: module/Photo/view/partial/metadata.phtml:40
-msgid "Flash"
-msgstr "Flits"
+msgid "You are not allowed to view membership info."
+msgstr "Het is niet toegestaan om lidinformatie in te zien."
 
-#: module/Photo/view/partial/metadata.phtml:47
-msgid "Focal length"
-msgstr "Brandpuntsafstand"
+msgid "You are not allowed to view sign-up lists"
+msgstr "Je hebt niet de rechten om inschrijflijsten te bekijken"
 
-#: module/Photo/view/partial/metadata.phtml:54
-msgid "Exposure time"
-msgstr "Belichtingstijd"
+msgid "You are not allowed to view the activities"
+msgstr "Je hebt niet de rechten om de activiteiten in te zien"
 
-#: module/Photo/view/partial/metadata.phtml:61
-msgid "Shutter speed"
-msgstr "Sluitertijd"
-
-#: module/Photo/view/partial/metadata.phtml:68
-msgid "Aperture"
-msgstr "Aperture"
-
-#: module/Photo/view/partial/metadata.phtml:75
-msgid "ISO"
-msgstr "ISO"
-
-#: module/Photo/view/partial/metadata.phtml:95
-msgid "View on map"
-msgstr "Toon op kaart"
-
-#: module/Photo/view/partial/tags.phtml:22
-#: module/Photo/view/photo/album/index.phtml:674
-msgid "In this photo:"
-msgstr "In deze foto:"
-
-#: module/Photo/view/partial/tags.phtml:23
-#: module/Photo/view/photo/album/index.phtml:675
-msgid ""
-"No one has been tagged in this photo yet. Tag someone you recognise now!"
-msgstr "Er is nog niemand getagd in deze foto. Tag nu iemand die je herkent!"
-
-#: module/Photo/view/partial/tags.phtml:61
-#: module/Photo/view/photo/album/index.phtml:703
-msgid "Tag someone"
-msgstr "Tag iemand"
-
-#: module/Photo/view/photo/album-admin/add.phtml:41
-msgid "Upload Photos"
-msgstr "Foto's uploaden"
-
-#: module/Photo/view/photo/album-admin/add.phtml:43
-#, php-format
-msgid "Uploading photos to %s"
-msgstr "Foto's aan het uploaden naar %s"
-
-#: module/Photo/view/photo/album-admin/create.phtml:16
-msgid "Create Album"
-msgstr "Album maken"
-
-#: module/Photo/view/photo/album-admin/create.phtml:37
-msgid "Create album"
-msgstr "Nieuw album"
-
-#: module/Photo/view/photo/album-admin/edit.phtml:16
-msgid "Edit Album"
-msgstr "Wijzig album"
-
-#: module/Photo/view/photo/album-admin/edit.phtml:22
-msgid "Update Album"
-msgstr "Album Bijwerken"
-
-#: module/Photo/view/photo/album-admin/index.phtml:55
-#: module/Photo/view/photo/photo-admin/index.phtml:62
-msgid "Photo admin"
-msgstr "Foto admin"
-
-#: module/Photo/view/photo/album-admin/index.phtml:104
-msgid "Other albums"
-msgstr "Andere albums"
-
-#: module/Photo/view/photo/album-admin/index.phtml:117
-msgid "Create new album"
-msgstr "Maak nieuw album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:122
-msgid "Edit album"
-msgstr "Wijzig album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:125
-msgid "Add photos"
-msgstr "Voeg foto's toe"
-
-#: module/Photo/view/photo/album-admin/index.phtml:127
-msgid "Move album"
-msgstr "Verplaats album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:130
-msgid "Move %i photos"
-msgstr "Verplaats %i foto's"
-
-#: module/Photo/view/photo/album-admin/index.phtml:133
-msgid "Regenerate album cover"
-msgstr "Genereer album cover opnieuw"
-
-#: module/Photo/view/photo/album-admin/index.phtml:137
-#: module/Photo/view/photo/album-admin/index.phtml:231
-msgid "Delete album"
-msgstr "Verwijder album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:140
-msgid "Delete %i photos"
-msgstr "Verwijder %i foto's"
-
-#: module/Photo/view/photo/album-admin/index.phtml:158
-msgid "Generate a new cover photo"
-msgstr "Genereer nieuwe cover foto"
-
-#: module/Photo/view/photo/album-admin/index.phtml:164
-msgid "An error occurred while trying to generate an album photo."
-msgstr "Er is een fout opgetreden tijdens het genereren van een albumfoto."
-
-#: module/Photo/view/photo/album-admin/index.phtml:171
-msgid "Regenerate"
-msgstr "Genereer opnieuw"
-
-#: module/Photo/view/photo/album-admin/index.phtml:173
-#: module/Photo/view/photo/album/index.phtml:435
-msgid "Close"
-msgstr "Sluiten"
-
-#: module/Photo/view/photo/album-admin/index.phtml:186
-msgid "Move the album"
-msgstr "Verplaats het album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:191
-msgid "Select a new parent for the album"
-msgstr "Selecteer een nieuwe bovenliggende album"
-
-#: module/Photo/view/photo/album-admin/index.phtml:195
-msgid "The album has been moved"
-msgstr "Het album is verplaatst"
-
-#: module/Photo/view/photo/album-admin/index.phtml:200
-#: module/Photo/view/photo/album-admin/index.phtml:291
-#: module/Photo/view/photo/photo-admin/index.phtml:126
-msgid "Move"
-msgstr "Verplaats"
-
-#: module/Photo/view/photo/album-admin/index.phtml:217
-msgid ""
-"Are you sure you want to delete this album including all photos inside of "
-"it? <strong>This action can not be reverted.</strong>"
+msgid "You are not allowed to view the approval of this activity"
 msgstr ""
-"Weet je zeker dat je dit album met alle foto's wilt verwijderen? "
-"<strong>Deze actie kan niet ongedaan gemaakt worden.</strong>"
+"Je hebt niet de rechten om de goedkeuringsstatus van deze activiteit te "
+"bekijken"
 
-#: module/Photo/view/photo/album-admin/index.phtml:220
-msgid "Please wait while the album is being deleted."
-msgstr "Wacht terwijl dit album verwijderd wordt."
-
-#: module/Photo/view/photo/album-admin/index.phtml:226
-msgid "The album has been deleted"
-msgstr "Dit album kan verwijderd worden"
-
-#: module/Photo/view/photo/album-admin/index.phtml:249
-msgid ""
-"Are you sure you want to delete the selected items? <strong>This action can "
-"not be reverted.</strong>"
+msgid "You are not allowed to view the approval status of jobs"
 msgstr ""
-"Weet je zeker dat je de geselecteerde items wilt verwijderen? <strong>Deze "
-"actie kan niet ongedaan gemaakt worden.</strong>"
+"Je hebt niet de rechten om de goedkeuringsstatus van deze vacature te "
+"bekijken"
 
-#: module/Photo/view/photo/album-admin/index.phtml:252
-msgid "Please wait while the photos are being deleted."
-msgstr "Wacht a.u.b. terwijl de foto's verwijderd worden."
+msgid "You are not allowed to view the banner"
+msgstr "Je hebt niet de rechten om de banner te zien"
 
-#: module/Photo/view/photo/album-admin/index.phtml:258
-msgid "The photos have been been deleted"
-msgstr "De foto's zijn verwijderd"
+msgid "You are not allowed to view the company accounts"
+msgstr "Je hebt niet de rechten om bedrijfsprofielen te bekijken"
 
-#: module/Photo/view/photo/album-admin/index.phtml:263
-msgid "Delete photos"
-msgstr "Verwijder foto's"
+msgid "You are not allowed to view the disapproved activities"
+msgstr "Je hebt niet de rechten om afgekeurde activiteiten in te zien"
 
-#: module/Photo/view/photo/album-admin/index.phtml:277
-msgid "Move the photos to another album"
-msgstr "Verplaats de foto's naar een ander album"
+msgid "You are not allowed to view the featured company"
+msgstr "Je hebt niet de rechten om het uitgelichte bedrijf te zien"
 
-#: module/Photo/view/photo/album-admin/index.phtml:282
-#: module/Photo/view/photo/photo-admin/index.phtml:117
-msgid "Select a new parent album"
-msgstr "Selecteer een nieuwe bovenliggende album"
+msgid "You are not allowed to view the list of birthdays."
+msgstr "Het is niet toegestaan om de lijst met verjaardagen te zien."
 
-#: module/Photo/view/photo/album-admin/index.phtml:286
-msgid "The photos have been moved"
-msgstr "De foto's zijn verplaatst"
+msgid "You are not allowed to view the list of pages."
+msgstr "Je hebt niet de rechten om de lijst met pagina's te bekijken."
 
-#: module/Photo/view/photo/album/index.phtml:86
-#: module/Photo/view/photo/photo/weekly.phtml:13
-#: module/Photo/view/photo/photo/weekly.phtml:20
-msgid "Photos of the Week"
-msgstr "Foto's van de week"
+msgid "You are not allowed to view the participants of this activity"
+msgstr ""
+"Je hebt niet de rechten om de deelnemers van deze activiteit te bekijken"
 
-#: module/Photo/view/photo/album/index.phtml:140
-msgid "View user profile"
-msgstr "Bekijk profiel"
+msgid "You are not allowed to view the sign up data"
+msgstr "Je hebt niet de rechten om ingeschreven leden te zien"
 
-#: module/Photo/view/photo/album/index.phtml:152
-msgid "No date"
-msgstr "Geen datum"
+msgid "You are not allowed to view the status of a job"
+msgstr ""
+"Je hebt niet de rechten om de goedkeuringsstatus van vacatures te bekijken"
 
-#: module/Photo/view/photo/album/index.phtml:201
-#: module/Photo/view/photo/photo/index.phtml:71
-msgid "NEW"
-msgstr "NIEUW"
+msgid "You are not allowed to view this activity"
+msgstr "Je hebt niet de rechten om deze activiteit te bekijken"
 
-#: module/Photo/view/photo/album/index.phtml:225
-msgid "This album does not contain any photos."
-msgstr "Dit album bevat geen foto's."
+msgid "You are not allowed to view this page."
+msgstr "Je hebt niet de rechten om deze pagina te bekijken."
 
-#: module/Photo/view/photo/album/index.phtml:398
-msgid "Already voted!"
-msgstr "Je hebt al gestemd!"
+msgid "You are not allowed to view unapproved activities"
+msgstr "Je hebt niet de rechten om niet goedgekeurde activiteiten in te zien"
 
-#: module/Photo/view/photo/album/index.phtml:401
-#: module/Photo/view/photo/album/index.phtml:572
-msgid "Vote for photo of the week"
-msgstr "Stem voor de foto van de week"
+msgid "You are not allowed to view unapproved polls"
+msgstr "Je hebt niet de rechten om niet-goedgekeurde polls te bekijken"
 
-#: module/Photo/view/photo/album/index.phtml:436
-msgid "Zoom (z)"
-msgstr "Zoom (z)"
+msgid ""
+"You are not allowed to view upcoming activities coupled to a member account"
+msgstr ""
+"Je hebt niet de rechten om aankomende activiteiten te zien die gekoppeld "
+"zijn een het account van een lid"
 
-#: module/Photo/view/photo/album/index.phtml:439
-msgid "The image could not be loaded."
-msgstr "De foto kan niet worden geladen."
+msgid "You are not allowed to view upcoming the activities"
+msgstr "Je hebt niet de rechten om aankomende activiteiten te zien"
 
-#: module/Photo/view/photo/album/index.phtml:452
-msgid "Download"
-msgstr "Downloaden"
+msgid "You are not allowed to vote on this poll."
+msgstr "Je hebt niet de rechten om op deze poll te stemmen."
 
-#: module/Photo/view/photo/album/index.phtml:476
-msgid "Share"
-msgstr "Delen"
+msgid "You are not subscribed to this activity!"
+msgstr "Je bent niet ingeschreven voor deze activiteit!"
 
-#: module/Photo/view/photo/album/index.phtml:487
-msgid "Copied URL!"
-msgstr "URL gekopieerd!"
+msgid "You cannot create new jobs in expired job packages."
+msgstr "Je kan geen nieuwe vacatures maken in verlopen vacaturepakketen."
 
-#: module/Photo/view/photo/album/index.phtml:498
-msgid "Go to album"
-msgstr "Ga naar album"
+msgid "You cannot sign in to this account at this moment."
+msgstr "Je kunt momenteel niet inloggen op dit account."
 
-#: module/Photo/view/photo/album/index.phtml:541
-msgid "Set as profile picture"
-msgstr "Kies deze foto als jouw profielfoto"
+msgid "You cannot subscribe to this activity at this moment in time"
+msgstr "Je kunt je op dit moment niet inschrijven voor deze activiteit"
 
-#: module/Photo/view/photo/album/index.phtml:558
-msgid "Set as profile picture!"
-msgstr "Gekozen als profielfoto!"
+msgid "You cannot unsubscribe from this activity at this moment in time"
+msgstr "Je kunt je op dit moment niet afmelden voor deze activiteit"
 
-#: module/Photo/view/photo/album/index.phtml:561
-msgid "Could not set as profile photo, try again"
-msgstr "Profielfoto instellen mislukt, probeer het nog een keer"
+msgid "You cannot update jobs in expired job packages."
+msgstr "Je kan vacatures in verlopen vacaturepakketten niet bijwerken."
 
-#: module/Photo/view/photo/album/index.phtml:594
-msgid "Cannot load vote"
-msgstr "Kan stem niet laden"
+msgid ""
+"You cannot use this password, it was found in a public data breach and is "
+"therefore considered insecure. We recommend using a password generated by a "
+"good password manager, such as Bitwarden or 1Password."
+msgstr ""
+"Je kunt dit wachtwoord niet gebruiken, het is gevonden in een openbaar "
+"datalek en wordt daarom als onveilig beschouwd. Wij raden aan een wachtwoord "
+"te gebruiken dat is gegenereerd door een goede wachtwoordmanager, zoals "
+"Bitwarden of 1Password."
 
-#: module/Photo/view/photo/album/index.phtml:614
-msgid "Voted!"
-msgstr "Gestemd!"
+msgid "You do not have any recent jobs pending approval."
+msgstr "Je hebt geen vacatures die nog niet zijn goedgekeurd."
 
-#: module/Photo/view/photo/album/index.phtml:626
-msgid "Could not vote, try again"
-msgstr "Stemmen mislukt, probeer het nog een keer"
+msgid "You do not have recently approved jobs."
+msgstr "Je hebt geen vacatures die recentelijk zijn goedgekeurd."
 
-#: module/Photo/view/photo/album/index.phtml:641
-msgid "Loading tags..."
-msgstr "Tags aan het laden..."
+msgid "You do not have recently rejected jobs."
+msgstr "Je hebt geen vacatures die recentelijk zijn afgekeurd."
 
-#: module/Photo/view/photo/album/index.phtml:662
-msgid "Cannot load tags"
-msgstr "Kan tags niet laden"
+msgid "You do not have the required privileges to view this page"
+msgstr "Je beschikt niet over de juiste rechten om deze pagina te bekijken"
 
-#: module/Photo/view/photo/album/index.phtml:757
-msgid "Cannot load metadata"
-msgstr "Kan metadata niet laden"
+msgid "You have already been subscribed for this activity"
+msgstr "Je bent al ingeschreven voor deze activiteit"
 
-#: module/Photo/view/photo/album/index.phtml:783
-msgid "Photo of the Week:<br> Week"
-msgstr "Foto van de week<br> Week"
-
-#: module/Photo/view/photo/album/index.phtml:783
-msgid "of"
-msgstr "van"
-
-#: module/Photo/view/photo/photo-admin/index.phtml:51
 #, php-format
-msgid "Photo #%d"
-msgstr "Foto #%d"
+msgid "You have authorized %s for the %s GMM (%s)."
+msgstr "Je hebt %s gemachtigd voor de %s ALV (%s)."
 
-#: module/Photo/view/photo/photo-admin/index.phtml:89
-msgid "Move photo"
-msgstr "Verplaats foto"
+msgid "You have not been a member of a committee or fraternity."
+msgstr "Je bent geen lid geweest van een commissie of dispuut."
 
-#: module/Photo/view/photo/photo-admin/index.phtml:91
-#: module/Photo/view/photo/photo-admin/index.phtml:157
-msgid "Delete photo"
-msgstr "Verwijder foto"
-
-#: module/Photo/view/photo/photo-admin/index.phtml:112
-msgid "Move the photo to another album"
-msgstr "Verplaats de foto naar een ander album"
-
-#: module/Photo/view/photo/photo-admin/index.phtml:121
-msgid "The photo has been moved"
-msgstr "De foto is verplaatst"
-
-#: module/Photo/view/photo/photo-admin/index.phtml:143
 msgid ""
-"Are you sure you want to delete this photo? <strong>This action can not be "
-"reverted.</strong>"
+"You have successfully created an update proposal for the activity! If the "
+"activity was already approved, the proposal will be applied after it has "
+"been approved by the board. Otherwise, the update has already been applied "
+"to the activity."
 msgstr ""
-"Weet je zeker dat je deze foto wilt verwijderen? <strong>Deze actie kan niet "
-"ongedaan gemaakt worden.</strong>"
+"Je hebt met succes een update voorstel voor de activiteit gemaakt! Als de "
+"activiteit al was goedgekeurd, zal het voorstel worden toegepast nadat het "
+"is goedgekeurd door het bestuur. Anders is de update al toegepast op de "
+"activiteit."
 
-#: module/Photo/view/photo/photo-admin/index.phtml:146
-msgid "Please wait while your photo is being deleted."
-msgstr "Wacht terwijl de foto verwijderd wordt."
+msgid "You have to be logged in to subscribe for this activity"
+msgstr "Je moet ingelogd zijn om je voor deze activiteit in te schrijven"
 
-#: module/Photo/view/photo/photo-admin/index.phtml:152
-msgid "The photo has been deleted"
-msgstr "De foto is verwijderd"
+msgid "You might be able to view this page by logging in"
+msgstr "Mogelijk kun je deze pagina wel bekijken door in te loggen"
 
-#: module/Photo/view/photo/photo/index.phtml:82
-msgid "There are no photos in this year."
-msgstr "Er zijn geen foto's in dit jaar."
+msgid "You need to be logged in to sign off for this activity"
+msgstr "Je moet ingelogd zijn om je uit te schrijven voor deze activiteit"
 
-#: module/Photo/view/photo/photo/weekly.phtml:18
-msgid "Currently, no pictures of the week are available."
-msgstr "Op het moment zijn er geen foto's van de week beschikbaar."
+msgid "You need to be logged in to sign up for this activity"
+msgstr "Je moet ingelogd zijn om je voor deze activiteit in te schrijven"
 
-#: module/Photo/view/photo/photo/weekly.phtml:21
-msgid "Current photo of the week"
-msgstr "Huidige foto van de week"
+msgid "You need to log in to subscribe"
+msgstr "Je moet inloggen om in te schrijven"
 
-#: module/Photo/view/photo/photo/weekly.phtml:52
-msgid "Old photos of the week"
-msgstr "Oude foto's van de week"
+msgid "You were a member of:"
+msgstr "Je was een lid van:"
 
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:43
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:65
-#: module/User/src/Authentication/Adapter/UserAdapter.php:43
-#: module/User/src/Authentication/Adapter/UserAdapter.php:79
-msgid "The login and password combination is incorrect."
-msgstr "De combinatie van login en wachtwoord is onjuist."
+msgid ""
+"Your account for the GEWIS website has been registered, check your inbox for "
+"an activation e-mail."
+msgstr ""
+"Je account voor de GEWIS-website is geregistreerd, controleer je inbox voor "
+"een activerings e-mail."
 
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:53
-#: module/User/src/Authentication/Adapter/UserAdapter.php:67
-msgid "Too many login attempts, try again later."
-msgstr "Te veel login pogingen, probeer het later nog eens."
+msgid "Your account has been activated. You are now able to login."
+msgstr "Je account is geactiveerd. Je kunt nu inloggen."
 
-#: module/User/src/Authentication/Adapter/CompanyUserAdapter.php:78
-#: module/User/src/Authentication/Adapter/UserAdapter.php:92
+msgid "Your option has been added successfully"
+msgstr "De optie is succesvol toegevoegd"
+
+msgid "Your password"
+msgstr "Wachtwoord"
+
 msgid ""
 "Your password was found in a public data breach and is therefore considered "
 "insecure. Please request a password reset before continuing. We recommend "
@@ -5691,309 +3930,81 @@ msgstr ""
 "Wij raden aan een wachtwoord te gebruiken dat is gegenereerd door een goede "
 "wachtwoordmanager, zoals Bitwarden of 1Password."
 
-#: module/User/src/Authentication/Adapter/UserAdapter.php:57
-msgid "You cannot sign in to this account at this moment."
-msgstr "Je kunt momenteel niet inloggen op dit account."
+msgid "Your poll request has been received and will be reviewed shortly."
+msgstr "Je poll is aangevraagd en zal zo snel mogelijk bekeken worden."
 
-#: module/User/src/Authorization/GenericAclService.php:108
-#: module/User/src/Authorization/GenericAclService.php:135
-msgid ""
-"You are not allowed to perform this action. If you are not logged in please "
-"do so before continuing. If you are already logged in this action may "
-"require you to login in with a different account."
-msgstr ""
-"Je hebt niet de rechten om deze actie uit te voeren. Als je niet bent "
-"ingelogd, doe dat dan eerst voordat je verder gaat. Als je al bent ingelogd "
-"kan het zijn dat je voor deze actie moet inloggen met een ander account."
+msgid "Your profile picture will be chosen automatically instead."
+msgstr "Jouw profiel foto wordt in plaats hiervan automatisch gekozen."
 
-#: module/User/src/Controller/UserController.php:178
-msgid "You are not allowed to change passwords"
-msgstr "Je hebt niet de rechten om een wachtwoord te wijzigen"
+msgid "Zoek"
+msgstr "Zoek"
 
-#: module/User/src/Form/Activate.php:29 module/User/src/Form/UserLogin.php:43
-msgid "Your password"
-msgstr "Wachtwoord"
+msgid "Zoeken op lid"
+msgstr "Zoeken op lid"
 
-#: module/User/src/Form/Activate.php:39
-msgid "Verify your password"
-msgstr "Verifieer je wachtwoord"
+msgid "Zoom (z)"
+msgstr "Zoom (z)"
 
-#: module/User/src/Form/Activate.php:49
-#: module/User/view/user/user/activate.phtml:20
-#: module/User/view/user/user/activate.phtml:40
-msgid "Activate"
-msgstr "Activeer"
+msgid "and"
+msgstr "en"
 
-#: module/User/src/Form/ApiAppAuthorisation.php:37
-msgid "Authorise"
-msgstr "Sta toe"
+msgid "at"
+msgstr "bij"
 
-#: module/User/src/Form/ApiToken.php:35
-#: module/User/view/user/api-admin/add.phtml:45
-msgid "Create API token"
-msgstr "Maak een API token"
+msgid "course"
+msgid_plural "courses"
+msgstr[0] "vak"
+msgstr[1] "vakken"
 
-#: module/User/src/Form/CompanyUserLogin.php:34
-#: module/User/src/Form/CompanyUserReset.php:27
-msgid "Email address"
-msgstr "E-mailadres"
+msgid "disabled"
+msgstr "uitgeschakeld"
 
-#: module/User/src/Form/CompanyUserLogin.php:44
-#: module/User/view/user/user/activate.phtml:58
-msgid "Password"
-msgstr "Wachtwoord"
+msgid "disabled (Do Not Track)"
+msgstr "uitgeschakeld (volg-me-niet)"
 
-#: module/User/src/Form/CompanyUserLogin.php:54
-msgid "Log in as company"
-msgstr "Inloggen als bedrijf"
+msgid "edit"
+msgstr "wijzig"
 
-#: module/User/src/Form/CompanyUserReset.php:37
-msgid "Request password reset"
-msgstr "Wachtwoord reset aanvragen"
+msgid "email to the board of GEWIS"
+msgstr "een mail te sturen naar het bestuur van GEWIS"
 
-#: module/User/src/Form/Password.php:29
-msgid "Old password"
-msgstr "Oud wachtwoord"
+msgid "enabled"
+msgstr "ingeschakeld"
 
-#: module/User/src/Form/Password.php:39
-msgid "New password"
-msgstr "Nieuw wachtwoord"
+msgid "in the spotlight"
+msgstr "uitgelicht"
 
-#: module/User/src/Form/Password.php:49
-msgid "Verify new password"
-msgstr "Verifier nieuw wachtwoord"
+msgid "new"
+msgstr "nieuw"
 
-#: module/User/src/Form/Register.php:42
-#: module/User/view/user/user/register.phtml:14
-#: module/User/view/user/user/register.phtml:34
-msgid "Register"
-msgstr "Registreer"
+msgid "of"
+msgstr "van"
 
-#: module/User/src/Form/Register.php:65
-msgid ""
-"This member cannot create an account, please contact the secretary for more "
-"information."
-msgstr ""
-"Dit lid kan geen account aanmaken, neem contact op met de secretaris voor "
-"meer informatie."
+msgid "old"
+msgstr "oud"
 
-#: module/User/src/Form/Register.php:73
-msgid "There is no member with this membership number."
-msgstr "Er is geen lid met dit lidmaatschapsnummer."
-
-#: module/User/src/Form/Register.php:81
-msgid ""
-"You already attempted to register, please check your email or try again "
-"after 20 minutes."
-msgstr ""
-"Je hebt al geprobeerd te registreren, controleer je e-mail of probeer het na "
-"20 minuten opnieuw."
-
-#: module/User/src/Form/Register.php:89
-msgid "This member already has an account."
-msgstr "Dit lid heeft al een account."
-
-#: module/User/src/Form/UserLogin.php:33
-msgid "Membership number or email address"
-msgstr "Lidnummer of email adres"
-
-#: module/User/src/Form/UserLogin.php:53
-msgid "Log in as member"
-msgstr "Inloggen als lid"
-
-#: module/User/src/Form/UserLogin.php:63
-msgid "Remember me"
-msgstr "Onthoud mij"
-
-#: module/User/src/Form/UserReset.php:50
-#: module/User/view/partial/reset/company.phtml:46
-#: module/User/view/partial/reset/member.phtml:59
-#: module/User/view/user/user/reset-password.phtml:18
-#: module/User/view/user/user/reset-password.phtml:29
-msgid "Reset password"
-msgstr "Reset wachtwoord"
-
-#: module/User/src/Model/Enums/JWTClaims.php:40
-msgid "Family name"
-msgstr "Achternaam"
-
-#: module/User/src/Model/Enums/JWTClaims.php:41
-msgid "Given name"
-msgstr "Voornaam"
-
-#: module/User/src/Model/Enums/JWTClaims.php:42
-msgid "Is 18+?"
-msgstr "Is 18+?"
-
-#: module/User/src/Model/Enums/JWTClaims.php:43
-msgid "Member number"
-msgstr "Lidmaatschapsnummer"
-
-#: module/User/src/Service/ApiUser.php:46
-#: module/User/src/Service/ApiUser.php:74
-msgid "You are not allowed to view API tokens"
-msgstr "Je hebt niet de rechten om API tokens in te zien"
-
-#: module/User/src/Service/ApiUser.php:60
-msgid "You are not allowed to remove API tokens"
-msgstr "Je hebt niet de rechten om API tokens te verwijderen"
-
-#: module/User/src/Service/ApiUser.php:115
-msgid "You are not allowed to add API tokens"
-msgstr "Je hebt niet de rechten om API tokens toe te voegen"
-
-#: module/User/src/Service/User.php:105 module/User/src/Service/User.php:339
-msgid ""
-"You cannot use this password, it was found in a public data breach and is "
-"therefore considered insecure. We recommend using a password generated by a "
-"good password manager, such as Bitwarden or 1Password."
-msgstr ""
-"Je kunt dit wachtwoord niet gebruiken, het is gevonden in een openbaar "
-"datalek en wordt daarom als onveilig beschouwd. Wij raden aan een wachtwoord "
-"te gebruiken dat is gegenereerd door een goede wachtwoordmanager, zoals "
-"Bitwarden of 1Password."
-
-#: module/User/src/Service/User.php:326
-msgid "Password incorrect"
-msgstr "Wachtwoord incorrect"
-
-#: module/User/src/Service/User.php:481
-msgid "You are not allowed to change your password"
-msgstr "Je hebt niet de rechten om een wachtwoord te wijzigen"
-
-#: module/User/view/partial/login/company.phtml:77
-#: module/User/view/partial/login/member.phtml:87
 #, php-format
-msgid "If you forgot your password, go to the %sPassword reset page%s"
-msgstr ""
-"Als je je wachtwoord bent vergeten, ga naar de %sWachtwoord reset pagina %s"
+msgid "resolves to %s"
+msgstr "verwijst naar %s"
 
-#: module/User/view/partial/login/member.phtml:83
-#, php-format
-msgid "If you don't have an account yet, go to the %sRegistration page%s"
-msgstr "Als je nog geen account hebt, ga naar de %sRegistratie pagina%s"
+msgid "the organizing party"
+msgstr "de organiserende partij"
 
-#: module/User/view/partial/reset/member.phtml:51
+msgid "the secretary of GEWIS"
+msgstr "de secretaris van GEWIS"
+
 msgid ""
-"Have you forgotten your e-mail address and do you want to change it? Ask the "
-"secretary by going to GEWIS (preferred) or by sending an e-mail."
+"then this exam will be removed from the website. Using the summaries or "
+"exams on this website for commercial goals without the permission of the "
+"author is illegal."
 msgstr ""
-"Ben je jouw e-mailadres vergeten en wil je het wijzigen? Vraag het aan de "
-"secretaris door naar GEWIS te komen (aanbevolen) of door een e-mail te "
-"sturen."
+"dan zal dit tentamen worden verwijderd van de website. Het is niet "
+"toegestaan om de samenvattingen of tentamens op deze website zonder "
+"toestemming van de auteur te gebruiken voor commerciële doeleinden, dit is "
+"strafbaar."
 
-#: module/User/view/user/api-admin/add.phtml:15
-#: module/User/view/user/api-admin/index.phtml:15
-#: module/User/view/user/api-admin/index.phtml:17
-#: module/User/view/user/api-admin/remove.phtml:15
-msgid "API Tokens"
-msgstr "API Tokens"
+msgid "unavailable"
+msgstr "niet beschikbaar"
 
-#: module/User/view/user/api-admin/add.phtml:16
-msgid "Add Token"
-msgstr "Token toevoegen"
-
-#: module/User/view/user/api-admin/add.phtml:18
-msgid "Add a token"
-msgstr "Voeg een token toe"
-
-#: module/User/view/user/api-admin/add.phtml:53
-msgid "Token was successfully generated"
-msgstr "Token is gegenereerd"
-
-#: module/User/view/user/api-admin/add.phtml:61
-#: module/User/view/user/api-admin/index.phtml:23
-msgid "Token"
-msgstr "Token"
-
-#: module/User/view/user/api-admin/index.phtml:42
-msgid "Add new Token"
-msgstr "Voeg een nieuw Token toe"
-
-#: module/User/view/user/api-admin/remove.phtml:16
-msgid "Remove Token"
-msgstr "Verwijder token"
-
-#: module/User/view/user/api-authentication/redirect.phtml:21
-#, php-format
-msgid "You are being redirected to %s"
-msgstr "Je wordt doorgestuurd naar %s"
-
-#: module/User/view/user/api-authentication/redirect.phtml:30
-#, php-format
-msgid ""
-"If your browser does not redirect you back, please <a href=\"%s\">click "
-"here</a> to continue."
-msgstr ""
-"Als je  browser je niet doorstuurt, <a href=\"%s\">klik dan hier</a> om "
-"verder te gaan."
-
-#: module/User/view/user/api-authentication/token.phtml:28
-#, php-format
-msgid "Authorize %s to use your account?"
-msgstr "Geef je %s toestemming om je account te gebruiken?"
-
-#: module/User/view/user/api-authentication/token.phtml:37
-#, php-format
-msgid ""
-"It has been more than 90 days since you last used <strong>%s</strong>. As a "
-"reminder, the application has access to:"
-msgstr ""
-"Het is meer dan 90 dagen geleden dat je <strong>%s</strong> voor het laatst "
-"heeft gebruikt. Ter herinnering, de applicatie heeft toegang tot:"
-
-#: module/User/view/user/api-authentication/token.phtml:42
-msgid "The application will get the following information:"
-msgstr "De applicatie zal de volgende informatie krijgen:"
-
-#: module/User/view/user/user/activate.phtml:25
-msgid "Your account has been activated. You are now able to login."
-msgstr "Je account is geactiveerd. Je kunt nu inloggen."
-
-#: module/User/view/user/user/activate.phtml:53
-#, php-format
-msgid ""
-"Welcome %s. Create your password for the website and activate your account."
-msgstr ""
-"Welkom %s. Maak hier je wachtwoord voor de website en activeer je account."
-
-#: module/User/view/user/user/activate.phtml:72
-msgid "Verify password"
-msgstr "Verifier wachtwoord"
-
-#: module/User/view/user/user/change-password.phtml:20
-msgid "Password changed successfully"
-msgstr "Wachtwoord succesvol gewijzigd"
-
-#: module/User/view/user/user/login.phtml:16
-msgid "Log in"
-msgstr "Inloggen"
-
-#: module/User/view/user/user/logout.phtml:10
-msgid "You are logged out."
-msgstr "Je bent uitgelogd."
-
-#: module/User/view/user/user/register.phtml:19
-msgid ""
-"Your account for the GEWIS website has been registered, check your inbox for "
-"an activation e-mail."
-msgstr ""
-"Je account voor de GEWIS-website is geregistreerd, controleer je inbox voor "
-"een activerings e-mail."
-
-#: module/User/view/user/user/register.phtml:71
-#, php-format
-msgid ""
-"To read more about the benefits of becoming a member and how to become a "
-"member, go to this %sinformation page%s."
-msgstr ""
-"Om meer te lezen over de voordelen van het worden van een lid en hoe je een "
-"lid kunt worden, ga naar deze %sinformatie pagina%s."
-
-#: module/User/view/user/user/reset-password.phtml:23
-msgid ""
-"An e-mail has been sent with instructions for resetting your password. If "
-"you have not received an e-mail, try again in 20 minutes."
-msgstr ""
-"Er is een e-mail verzonden met instructies om je wachtwoord te resetten. Als "
-"je geen e-mail hebt ontvangen, probeer het dan over 20 minuten opnieuw."
+msgid "years"
+msgstr "jaren"

--- a/translate-helper
+++ b/translate-helper
@@ -6,6 +6,7 @@ cd `dirname $0`
 find ./module -iname "*.phtml" -print0 | sort -z | xargs -r0 xgettext \
     --language=PHP \
     --keyword=translate \
+    --keyword=translatePlural:1,2 \
     --output=./module/Application/language/gewisweb.pot \
     --force-po \
     --package-name=GEWISweb \
@@ -15,6 +16,7 @@ find ./module -iname "*.phtml" -print0 | sort -z | xargs -r0 xgettext \
 find ./module -iname "*.php" -print0 | sort -z | xargs -r0 xgettext \
     --language=PHP \
     --keyword=translate \
+    --keyword=translatePlural:1,2 \
     --output=./module/Application/language/gewisweb.pot \
     --force-po \
     --package-name=GEWISweb \

--- a/translate-helper
+++ b/translate-helper
@@ -9,8 +9,10 @@ find ./module -iname "*.phtml" -print0 | sort -z | xargs -r0 xgettext \
     --keyword=translatePlural:1,2 \
     --output=./module/Application/language/gewisweb.pot \
     --force-po \
+    --no-location \
+    --sort-output \
     --package-name=GEWISweb \
-    --package-version=0.1.0-dev \
+    --package-version=`git describe --dirty --always` \
     --copyright-holder=GEWIS \
 
 find ./module -iname "*.php" -print0 | sort -z | xargs -r0 xgettext \
@@ -19,27 +21,31 @@ find ./module -iname "*.php" -print0 | sort -z | xargs -r0 xgettext \
     --keyword=translatePlural:1,2 \
     --output=./module/Application/language/gewisweb.pot \
     --force-po \
+    --no-location \
+    --sort-output \
     --package-name=GEWISweb \
-    --package-version=0.1.0-dev \
+    --package-version=`git describe --dirty --always` \
     --copyright-holder=GEWIS \
     --join-existing \
 
 xgettext module/Application/language/additional-strings \
+    --language=C \
+    --from-code=UTF-8 \
+    --extract-all \
     --output=./module/Application/language/gewisweb.pot \
     --force-po \
+    --no-location \
+    --sort-output \
     --package-name=GEWISweb \
-    --package-version=0.1.0-dev \
+    --package-version=`git describe --dirty --always` \
     --copyright-holder=GEWIS \
     --join-existing \
-    --from-code=UTF-8 \
-    --language=C \
-    --extract-all \
 
 cd ./module/Application/language/
 
 # merge translation files
-msgmerge --sort-by-file -U nl.po gewisweb.pot
-msgmerge --sort-by-file -U en.po gewisweb.pot
+msgmerge --sort-output -U nl.po gewisweb.pot
+msgmerge --sort-output -U en.po gewisweb.pot
 
 # remove obsolete translations
 msgattrib --no-obsolete -o en.po en.po


### PR DESCRIPTION
The `translate-helper` now properly recognised the usage of `translatePlural`, which is also reflected in any capable PO editor.

Fixes GH-1656.