### PR TITLE
Change `HEALTHCHECK` for MariaDB

### DIFF
--- a/.github/workflows/static-analysis-phpstan.yml
+++ b/.github/workflows/static-analysis-phpstan.yml
@@ -24,7 +24,7 @@ jobs:
                     MYSQL_PASSWORD: gewis
                 ports:
                     - 3306:3306
-                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+                options: --health-cmd="/usr/local/bin/healthcheck.sh --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=5
 
         steps:
             -   name: Checkout head branch


### PR DESCRIPTION
MariaDB v11.* saw the removal of all `mysql*` commands to better distinguish it from MySQL. However, this was of course not (clearly) communicated resulting in breaking many healthchecks.

On top of that, their own healthcheck contained a bug that required the usage of an empty root password. This was fixed a few days ago so now everything should work again with the changes in this commit.

Fixes GH-1659.