### PR TITLE
Fix missing ACL checks for activity update proposals and generic crash

### DIFF
--- a/module/Activity/src/Controller/AdminApprovalController.php
+++ b/module/Activity/src/Controller/AdminApprovalController.php
@@ -34,14 +34,13 @@ class AdminApprovalController extends AbstractActionController
      */
     public function viewAction(): ViewModel
     {
-        $id = (int) $this->params()->fromRoute('id');
-
-        if (!$this->aclService->isAllowed('approval', 'activity')) {
+        if (!$this->aclService->isAllowed('approve', 'activity')) {
             throw new NotAllowedException(
-                $this->translator->translate('You are not allowed to view the approval of this activity'),
+                $this->translator->translate('You are not allowed to view the approval status of activities'),
             );
         }
 
+        $id = (int) $this->params()->fromRoute('id');
         $activity = $this->activityQueryService->getActivity($id);
 
         if (null === $activity) {
@@ -63,6 +62,12 @@ class AdminApprovalController extends AbstractActionController
      */
     public function approveAction(): Response|ViewModel
     {
+        if (!$this->aclService->isAllowed('approve', 'activity')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to change the approval status of activities'),
+            );
+        }
+
         return $this->setApprovalStatus('approve');
     }
 
@@ -116,6 +121,12 @@ class AdminApprovalController extends AbstractActionController
      */
     public function disapproveAction(): Response|ViewModel
     {
+        if (!$this->aclService->isAllowed('approve', 'activity')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to change the approval status of activities'),
+            );
+        }
+
         return $this->setApprovalStatus('disapprove');
     }
 
@@ -124,6 +135,12 @@ class AdminApprovalController extends AbstractActionController
      */
     public function resetAction(): Response|ViewModel
     {
+        if (!$this->aclService->isAllowed('approve', 'activity')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to change the approval status of activities'),
+            );
+        }
+
         return $this->setApprovalStatus('reset');
     }
 
@@ -132,8 +149,13 @@ class AdminApprovalController extends AbstractActionController
      */
     public function viewProposalAction(): ViewModel
     {
-        $id = (int) $this->params()->fromRoute('id');
+        if (!$this->aclService->isAllowed('approve', 'activity')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to view update proposals of activities'),
+            );
+        }
 
+        $id = (int) $this->params()->fromRoute('id');
         $proposal = $this->activityQueryService->getProposal($id);
 
         if (null === $proposal) {
@@ -154,6 +176,12 @@ class AdminApprovalController extends AbstractActionController
      */
     public function applyProposalAction(): Response|ViewModel
     {
+        if (!$this->aclService->isAllowed('approve', 'activity')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to change the update proposal status of activities'),
+            );
+        }
+
         $id = (int) $this->params()->fromRoute('id');
         /** @var Request $request */
         $request = $this->getRequest();
@@ -193,6 +221,12 @@ class AdminApprovalController extends AbstractActionController
      */
     public function revokeProposalAction(): Response|ViewModel
     {
+        if (!$this->aclService->isAllowed('approve', 'activity')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to change the update proposal status of activities'),
+            );
+        }
+
         $id = (int) $this->params()->fromRoute('id');
         /** @var Request $request */
         $request = $this->getRequest();

--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -414,7 +414,7 @@ class AdminController extends AbstractActionController
         $unapprovedActivities = null;
         $approvedActivities = null;
 
-        if ($this->aclService->isAllowed('approval', 'activity')) {
+        if ($this->aclService->isAllowed('approve', 'activity')) {
             $admin = true;
             $disapprovedActivities = $this->activityQueryService->getDisapprovedActivities();
             $unapprovedActivities = $this->activityQueryService->getUnapprovedActivities();

--- a/module/Activity/src/Service/AclService.php
+++ b/module/Activity/src/Service/AclService.php
@@ -50,6 +50,7 @@ class AclService extends \User\Service\AclService
         );
 
         $this->acl->allow('admin', 'activity', 'viewParticipantDetails');
+        $this->acl->allow('admin', 'activity', 'approve');
 
         $this->acl->allow('user', 'activityApi', 'list');
         $this->acl->allow('apiuser', 'activityApi', 'list');

--- a/module/Activity/src/Service/Activity.php
+++ b/module/Activity/src/Service/Activity.php
@@ -749,12 +749,6 @@ class Activity
      */
     public function approve(ActivityModel $activity): void
     {
-        if (!$this->aclService->isAllowed('approve', 'activity')) {
-            throw new NotAllowedException(
-                $this->translator->translate('You are not allowed to change the status of the activity'),
-            );
-        }
-
         $activity->setStatus(ActivityModel::STATUS_APPROVED);
         $activity->setApprover($this->aclService->getUserIdentityOrThrowException()->getMember());
         $em = $this->entityManager;
@@ -767,12 +761,6 @@ class Activity
      */
     public function reset(ActivityModel $activity): void
     {
-        if (!$this->aclService->isAllowed('reset', 'activity')) {
-            throw new NotAllowedException(
-                $this->translator->translate('You are not allowed to change the status of the activity'),
-            );
-        }
-
         $activity->setStatus(ActivityModel::STATUS_TO_APPROVE);
         $activity->setApprover(null);
         $em = $this->entityManager;
@@ -785,12 +773,6 @@ class Activity
      */
     public function disapprove(ActivityModel $activity): void
     {
-        if (!$this->aclService->isAllowed('disapprove', 'activity')) {
-            throw new NotAllowedException(
-                $this->translator->translate('You are not allowed to change the status of the activity'),
-            );
-        }
-
         $activity->setStatus(ActivityModel::STATUS_DISAPPROVED);
         $activity->setApprover($this->aclService->getUserIdentityOrThrowException()->getMember());
         $em = $this->entityManager;

--- a/module/Activity/view/activity/admin-approval/view-proposal.phtml
+++ b/module/Activity/view/activity/admin-approval/view-proposal.phtml
@@ -68,9 +68,9 @@ $this->breadcrumbs()
                 $newOrganisingParty = $new->getOrgan()->getName() . ' ';
                 $newOrganisingParty .= $this->translate('and') . ' ';
                 $newOrganisingParty .= $new->getCompany()->getName();
-            } else if (null !== $old->getOrgan()) {
+            } else if (null !== $new->getOrgan()) {
                 $newOrganisingParty = $new->getOrgan()->getName();
-            } else if (null !== $old->getCompany()) {
+            } else if (null !== $new->getCompany()) {
                 $newOrganisingParty = $new->getCompany()->getName();
             } else {
                 $newOrganisingParty = $new->getCreator()->getFullName();

--- a/module/Company/src/Controller/AdminApprovalController.php
+++ b/module/Company/src/Controller/AdminApprovalController.php
@@ -161,7 +161,7 @@ class AdminApprovalController extends AbstractActionController
     {
         if (!$this->aclService->isAllowed('approve', 'job')) {
             throw new NotAllowedException(
-                $this->translator->translate('You are not allowed to approve update proposals of jobs'),
+                $this->translator->translate('You are not allowed to view update proposals of jobs'),
             );
         }
 
@@ -191,7 +191,7 @@ class AdminApprovalController extends AbstractActionController
     {
         if (!$this->aclService->isAllowed('approve', 'job')) {
             throw new NotAllowedException(
-                $this->translator->translate('You are not allowed to approve update proposals of jobs'),
+                $this->translator->translate('You are not allowed to change the update proposal status of jobs'),
             );
         }
 


### PR DESCRIPTION
This fixes a minor issue that could lead to being unable to see activity update proposals when the proposal did not have an organ or company as organiser while the original activity does have one/both of them.

This also fixes a security issue related to activity update proposals, which allowed everyone to view and subsequently approve/reject these proposals.

Both issues have been addressed with improved checks.

This fixes GH-1667 and fixes GH-1668.