### PR TITLE
Fix comments on historical polls

### DIFF
--- a/module/Frontpage/src/Controller/PollController.php
+++ b/module/Frontpage/src/Controller/PollController.php
@@ -89,7 +89,7 @@ class PollController extends AbstractActionController
     /**
      * Submits a comment.
      */
-    public function commentAction(): ViewModel
+    public function commentAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('create', 'poll_comment')) {
             throw new NotAllowedException(
@@ -115,7 +115,7 @@ class PollController extends AbstractActionController
 
             if ($this->pollCommentForm->isValid()) {
                 if ($this->pollService->createComment($poll, $this->pollCommentForm->getData())) {
-                    $this->pollCommentForm->setData(['author' => '', 'content' => '']);
+                    return $this->redirect()->toRoute('poll');
                 }
             }
         }

--- a/module/Frontpage/src/Controller/PollController.php
+++ b/module/Frontpage/src/Controller/PollController.php
@@ -44,7 +44,7 @@ class PollController extends AbstractActionController
                     $details,
                     [
                         'poll' => $poll,
-                        'commentForm' => $this->pollCommentForm,
+                        'commentForm' => $poll->isActive() ? $this->pollCommentForm : null,
                     ],
                 ),
             );
@@ -100,7 +100,10 @@ class PollController extends AbstractActionController
         $pollId = (int) $this->params()->fromRoute('poll_id');
         $poll = $this->pollService->getPoll($pollId);
 
-        if (null === $poll) {
+        if (
+            null === $poll
+            || !$poll->isActive()
+        ) {
             return $this->notFoundAction();
         }
 

--- a/module/Frontpage/src/Model/Poll.php
+++ b/module/Frontpage/src/Model/Poll.php
@@ -216,6 +216,6 @@ class Poll implements ResourceInterface
      */
     public function isActive(): bool
     {
-        return $this->getExpiryDate() > new DateTime();
+        return $this->isApproved() && $this->getExpiryDate() > new DateTime();
     }
 }

--- a/module/Frontpage/view/frontpage/poll/index.phtml
+++ b/module/Frontpage/view/frontpage/poll/index.phtml
@@ -82,7 +82,12 @@ $this->headTitle($this->translate('Polls'));
                     </div>
                 <?php endforeach ?>
             <?php endif ?>
-            <?php if ($this->acl('frontpage_service_acl')->isAllowed('poll_comment', 'create')): ?>
+            <?php
+            if (
+                $this->acl('frontpage_service_acl')->isAllowed('poll_comment', 'create')
+                && isset($commentForm)
+            ):
+            ?>
                 <hr>
                 <h3><?= $this->translate('Comment on this poll') ?></h3>
                 <?php


### PR DESCRIPTION
It was possible to create comments on historical polls, this is not wanted or useful. Therefore, this functionality has been removed.

As GH-1674 appears to be related to user "error" I have added a forced redirect after creating a comment, this will ensure that that the form is always clear and accidentally refreshing and explicitly resubmitting the form is no longer possible.