### PR TITLE
Add `UserRoles` enum and make `requiredRole` a `Select` for `Page`

### DIFF
--- a/module/Application/test/BaseControllerTest.php
+++ b/module/Application/test/BaseControllerTest.php
@@ -18,6 +18,7 @@ use Laminas\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use User\Authentication\AuthenticationService;
 use User\Model\CompanyUser;
+use User\Model\Enums\UserRoles;
 use User\Model\NewCompanyUser;
 use User\Model\User;
 use User\Model\UserRole;
@@ -235,7 +236,7 @@ abstract class BaseControllerTest extends AbstractHttpControllerTestCase
 
         if ('user' !== $role) {
             $roleModel = new UserRole();
-            $roleModel->setRole($role);
+            $roleModel->setRole(UserRoles::from($role));
 
             $roles = new ArrayCollection([$roleModel]);
         } else {

--- a/module/Frontpage/src/Form/Page.php
+++ b/module/Frontpage/src/Form/Page.php
@@ -6,6 +6,7 @@ namespace Frontpage\Form;
 
 use Laminas\Filter\StringToLower;
 use Laminas\Filter\ToNull;
+use Laminas\Form\Element\Select;
 use Laminas\Form\Element\Submit;
 use Laminas\Form\Element\Text;
 use Laminas\Form\Element\Textarea;
@@ -13,6 +14,7 @@ use Laminas\Form\Form;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\Validator\StringLength;
+use User\Model\Enums\UserRoles;
 
 class Page extends Form implements InputFilterProviderInterface
 {
@@ -84,10 +86,10 @@ class Page extends Form implements InputFilterProviderInterface
         $this->add(
             [
                 'name' => 'requiredRole',
-                'type' => Text::class,
+                'type' => Select::class,
                 'options' => [
                     'label' => $translator->translate('Required role'),
-                    'value' => 'guest',
+                    'value_options' => UserRoles::getFormValueOptions($translator),
                 ],
             ],
         );

--- a/module/Frontpage/src/Hydrator/Strategy/PageRoleHydratorStrategy.php
+++ b/module/Frontpage/src/Hydrator/Strategy/PageRoleHydratorStrategy.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frontpage\Hydrator\Strategy;
+
+use Laminas\Hydrator\Strategy\StrategyInterface;
+use User\Model\Enums\UserRoles;
+
+class PageRoleHydratorStrategy implements StrategyInterface
+{
+    public function extract(
+        mixed $value,
+        ?object $object = null,
+    ): string {
+        if ($value instanceof UserRoles) {
+            return $value->value;
+        }
+
+        return UserRoles::from($value)->value;
+    }
+
+    public function hydrate(
+        mixed $value,
+        ?array $data,
+    ): UserRoles {
+        if ($value instanceof UserRoles) {
+            return $value;
+        }
+
+        return UserRoles::from($value);
+    }
+}

--- a/module/Frontpage/src/Model/Page.php
+++ b/module/Frontpage/src/Model/Page.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\UniqueConstraint;
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
+use User\Model\Enums\UserRoles;
 
 /**
  * Page.
@@ -73,8 +74,11 @@ class Page implements ResourceInterface
     /**
      * The minimal role required to view a page.
      */
-    #[Column(type: 'string')]
-    protected string $requiredRole;
+    #[Column(
+        type: 'string',
+        enumType: UserRoles::class,
+    )]
+    protected UserRoles $requiredRole;
 
     public function getDutchTitle(): string
     {
@@ -111,7 +115,7 @@ class Page implements ResourceInterface
         return $this->dutchContent;
     }
 
-    public function getRequiredRole(): string
+    public function getRequiredRole(): UserRoles
     {
         return $this->requiredRole;
     }
@@ -151,7 +155,7 @@ class Page implements ResourceInterface
         $this->dutchContent = $dutchContent;
     }
 
-    public function setRequiredRole(string $requiredRole): void
+    public function setRequiredRole(UserRoles $requiredRole): void
     {
         $this->requiredRole = $requiredRole;
     }

--- a/module/Frontpage/src/Module.php
+++ b/module/Frontpage/src/Module.php
@@ -10,6 +10,7 @@ use Frontpage\Form\Page as PageForm;
 use Frontpage\Form\Poll as PollForm;
 use Frontpage\Form\PollApproval as PollApprovalForm;
 use Frontpage\Form\PollComment as PollCommentForm;
+use Frontpage\Hydrator\Strategy\PageRoleHydratorStrategy;
 use Frontpage\Mapper\NewsItem as NewsItemMapper;
 use Frontpage\Mapper\Page as PageMapper;
 use Frontpage\Mapper\Poll as PollMapper;
@@ -130,7 +131,9 @@ class Module
                     $form = new PageForm(
                         $container->get(MvcTranslator::class),
                     );
-                    $form->setHydrator($container->get('frontpage_hydrator'));
+                    $hydrator = $container->get('frontpage_hydrator');
+                    $hydrator->addStrategy('requiredRole', new PageRoleHydratorStrategy());
+                    $form->setHydrator($hydrator);
 
                     return $form;
                 },

--- a/module/Frontpage/src/Service/AclService.php
+++ b/module/Frontpage/src/Service/AclService.php
@@ -14,7 +14,7 @@ class AclService extends \User\Service\AclService
     public function setPages(array $pages): void
     {
         foreach ($pages as $page) {
-            $requiredRole = $page->getRequiredRole();
+            $requiredRole = $page->getRequiredRole()->value;
             $this->acl->addResource($page);
             $this->acl->allow($requiredRole, $page, 'view');
         }

--- a/module/Frontpage/src/Service/Page.php
+++ b/module/Frontpage/src/Service/Page.php
@@ -14,6 +14,7 @@ use Laminas\Mvc\I18n\Translator;
 use Laminas\Stdlib\Parameters;
 use Laminas\Validator\File\Extension;
 use Laminas\Validator\File\IsImage;
+use User\Model\Enums\UserRoles;
 use User\Permissions\NotAllowedException;
 
 /**
@@ -175,7 +176,7 @@ class Page
         $page->setEnglishTitle($data['englishTitle']);
         $page->setEnglishContent($data['englishContent']);
 
-        $page->setRequiredRole($data['requiredRole']);
+        $page->setRequiredRole(UserRoles::from($data['requiredRole']));
 
         return $page;
     }

--- a/module/Frontpage/view/frontpage/page-admin/edit.phtml
+++ b/module/Frontpage/view/frontpage/page-admin/edit.phtml
@@ -134,7 +134,7 @@ Set the minimal role required to view this page. All visitors whom have this rol
     $element->setAttribute('required', 'required');
     ?>
     <?= $this->formLabel($element); ?>
-    <?= $this->formText($element); ?>
+    <?= $this->formSelect($element); ?>
     <?= $this->formElementErrors($element); ?>
 </div>
 <hr>

--- a/module/User/src/Model/Enums/UserRoles.php
+++ b/module/User/src/Model/Enums/UserRoles.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace User\Model\Enums;
+
+use Laminas\Mvc\I18n\Translator;
+
+/**
+ * Enum for all the possible roles that exist within the ACL.
+ */
+enum UserRoles: string
+{
+    case Guest = 'guest';
+    case TueGuest = 'tueguest';
+    case ApiUser = 'apiuser';
+    case Company = 'company';
+    case User = 'user';
+    case Graduate = 'graduate';
+    case ActiveMember = 'active_member';
+    case CompanyAdmin = 'company_admin';
+    case Admin = 'admin';
+
+    public function getName(Translator $translator): string
+    {
+        return match ($this) {
+            self::Guest => $translator->translate('Guest'),
+            self::TueGuest => $translator->translate('TU/e Guest'),
+            self::ApiUser => $translator->translate('API User'),
+            self::Company => $translator->translate('Company'),
+            self::User => $translator->translate('User'),
+            self::Graduate => $translator->translate('Graduate'),
+            self::ActiveMember => $translator->translate('Active Member'),
+            self::CompanyAdmin => $translator->translate('Company Admin'),
+            self::Admin => $translator->translate('Admin'),
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getFormValueOptions(Translator $translator): array
+    {
+        return [
+            self::Guest->value => $translator->translate('Guest - Anyone who can access the website'),
+            self::TueGuest->value => $translator->translate(
+                'TU/e Guest - Anyone who can access the website from within the TU/e',
+            ),
+            self::ApiUser->value => $translator->translate('API User - Authenticated automated program'),
+            self::Company->value => $translator->translate('Company - Authenticated company representative'),
+            self::User->value => $translator->translate('User - Authenticated member'),
+            self::Graduate->value => $translator->translate('Graduate - Authenticated graduate'),
+            self::ActiveMember->value => $translator->translate('Active Member - Authenticated member and in an organ'),
+            self::CompanyAdmin->value => $translator->translate('Company Admin - C4 members'),
+            self::Admin->value => $translator->translate('Admin - Board and Tom'),
+        ];
+    }
+}

--- a/module/User/src/Model/User.php
+++ b/module/User/src/Model/User.php
@@ -157,7 +157,7 @@ class User implements IdentityInterface
         $names = [];
 
         foreach ($this->getRoles() as $role) {
-            $names[] = $role->getRole();
+            $names[] = $role->getRole()->value;
         }
 
         return $names;
@@ -166,7 +166,10 @@ class User implements IdentityInterface
     public function getRoleId(): string
     {
         $roleNames = $this->getRoleNames();
-        if (in_array('admin', $roleNames) || $this->getMember()->isBoardMember()) {
+        if (
+            in_array('admin', $roleNames)
+            || $this->getMember()->isBoardMember()
+        ) {
             return 'admin';
         }
 

--- a/module/User/src/Model/UserRole.php
+++ b/module/User/src/Model/UserRole.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
+use User\Model\Enums\UserRoles;
 
 /**
  * User role model.
@@ -36,8 +37,11 @@ class UserRole
     /**
      * The user's role.
      */
-    #[Column(type: 'string')]
-    protected string $role;
+    #[Column(
+        type: 'string',
+        enumType: UserRoles::class,
+    )]
+    protected UserRoles $role;
 
     /**
      * Get the membership number.
@@ -58,7 +62,7 @@ class UserRole
     /**
      * Get the role.
      */
-    public function getRole(): string
+    public function getRole(): UserRoles
     {
         return $this->role;
     }
@@ -66,7 +70,7 @@ class UserRole
     /**
      * Set the role.
      */
-    public function setRole(string $role): void
+    public function setRole(UserRoles $role): void
     {
         $this->role = $role;
     }

--- a/module/User/src/Service/AclService.php
+++ b/module/User/src/Service/AclService.php
@@ -16,6 +16,7 @@ use User\Authentication\AuthenticationService as UserAuthenticationService;
 use User\Authentication\Storage\CompanyUserSession;
 use User\Authentication\Storage\UserSession;
 use User\Authorization\GenericAclService;
+use User\Model\Enums\UserRoles;
 
 class AclService extends GenericAclService
 {
@@ -68,24 +69,24 @@ class AclService extends GenericAclService
          * - apiuser: Automated tool given access by an admin
          * - admin: Defined administrators
          */
-        $this->acl->addRole(new Role('guest'));
-        $this->acl->addRole(new Role('tueguest'), 'guest');
-        $this->acl->addRole(new Role('user'), 'tueguest');
-        $this->acl->addRole(new Role('company'), 'guest');
-        $this->acl->addrole(new Role('apiuser'), 'guest');
-        $this->acl->addrole(new Role('active_member'), 'user');
-        $this->acl->addRole(new Role('graduate'), 'user');
-        $this->acl->addrole(new Role('company_admin'), 'active_member');
-        $this->acl->addRole(new Role('admin'));
+        $this->acl->addRole(new Role(UserRoles::Guest->value));
+        $this->acl->addRole(new Role(UserRoles::TueGuest->value), UserRoles::Guest->value);
+        $this->acl->addRole(new Role(UserRoles::User->value), UserRoles::TueGuest->value);
+        $this->acl->addRole(new Role(UserRoles::Company->value), UserRoles::Guest->value);
+        $this->acl->addrole(new Role(UserRoles::ApiUser->value), UserRoles::Guest->value);
+        $this->acl->addrole(new Role(UserRoles::ActiveMember->value), UserRoles::User->value);
+        $this->acl->addRole(new Role(UserRoles::Graduate->value), UserRoles::User->value);
+        $this->acl->addrole(new Role(UserRoles::CompanyAdmin->value), UserRoles::ActiveMember->value);
+        $this->acl->addRole(new Role(UserRoles::Admin->value));
 
         // admins (this includes board members) are allowed to do everything
-        $this->acl->allow('admin');
+        $this->acl->allow(UserRoles::Admin->value);
 
         // configure the user ACL
         $this->acl->addResource(new Resource('apiuser'));
         $this->acl->addResource(new Resource('user'));
 
-        $this->acl->allow('user', 'user', ['password_change']);
-        $this->acl->allow('company', 'user', ['password_change']);
+        $this->acl->allow(UserRoles::User->value, 'user', ['password_change']);
+        $this->acl->allow(UserRoles::Company->value, 'user', ['password_change']);
     }
 }


### PR DESCRIPTION
This changes a small part of the `ACL` role instantiation, by making `UserRole`s use the `UserRoles` enum. This enum also contains supporting code for allowing it to be used in the `Page` form to make the "required role" field a select field instead of a textual field.

This closes GH-1673.