### PR TITLE
Fix `<select>` for signup list field type not updating correctly

### DIFF
--- a/module/Activity/view/activity/activity/create.phtml
+++ b/module/Activity/view/activity/activity/create.phtml
@@ -270,7 +270,11 @@ $form->setAttribute('class', 'form-activity');
             Activity.removeField(e.target.dataset.signupListId);
         } else if (e.target.classList.contains('add-field')) {
             Activity.addField(e.target.dataset.signupListId);
-        } else if (e.target.classList.contains('signup-list-field-type')) {
+        }
+    });
+
+    document.addEventListener('change', (e) => {
+        if (e.target.classList.contains('signup-list-field-type')) {
             Activity.updateField(e.target.dataset.signupListId, e.target.dataset.fieldId);
         }
     });


### PR DESCRIPTION
The wrong event was used, `click` does not cause an (additional) update when the actual type is selected. This works properly with `change`, as the `<select>`s are still dynamic we need a global event listener for `change` on the page.

This fixes GH-1676.