### PR TITLE
Fix configuration issue that caused invalid memcached connections

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -70,7 +70,13 @@ return [
                     throw new RuntimeException('Unable to retrieve and set options for Memcached');
                 }
 
-                $options->setServers(['memcached', '11211']);
+                $options->setServers([
+                    [
+                        'host' => 'memcached',
+                        'port' => 11211,
+                    ],
+                ]);
+                $options->setNamespace('DoctrineORMModule');
 
                 return new LaminasStorageCache($memcached);
             },

--- a/module/Application/src/Module.php
+++ b/module/Application/src/Module.php
@@ -186,15 +186,22 @@ class Module
                 },
                 'application_cache_infimum' => static function () {
                     $cache = new Memcached();
-                    // The TTL is 5 minutes (60 seconds * 5), as Supremum has a 5 minute cache on their end too. There
-                    // is no need to keep requesting an infimum if we get the same one back for 5 minutes.
                     $options = $cache->getOptions();
+
                     if (!($options instanceof MemcachedOptions)) {
                         throw new RuntimeException('Unable to retrieve and set options for Memcached');
                     }
 
+                    // The TTL is 5 minutes (60 seconds * 5), as Supremum has a 5 minute cache on their end too. There
+                    // is no need to keep requesting an infimum if we get the same one back for 5 minutes.
                     $options->setTtl(60 * 5);
-                    $options->setServers(['memcached', '11211']);
+                    $options->setServers([
+                        [
+                            'host' => 'memcached',
+                            'port' => 11211,
+                        ],
+                    ]);
+                    $options->setNamespace('Infima');
 
                     return $cache;
                 },


### PR DESCRIPTION
Apparently this broke for Doctrine but not for the infima API. Why this is the case I do not know. In the meantime I also added namespaces to separate the two things a bit more.

This fixes GH-1679.