### PR TITLE
Implement atomic database sync

### DIFF
--- a/config/autoload/gewisdb.local.php.dist
+++ b/config/autoload/gewisdb.local.php.dist
@@ -8,4 +8,6 @@ return [
     'user'     => getenv('DOCKER_DB2_USERNAME'),
     'password' => getenv('DOCKER_DB2_PASSWORD'),
     'dbname'   => getenv('DOCKER_DB2_DATABASE'),
+    'charset' => 'utf8',
+    'collate' => 'utf8_unicode_ci',
 ];

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -36,6 +36,8 @@ services:
             context: .
         depends_on:
             - mysql
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
     postfix:
         image: mailhog/mailhog
         env_file:

--- a/importdb.php
+++ b/importdb.php
@@ -1,135 +1,236 @@
 <?php
+
+declare(strict_types=1);
+
 /**
- * This is a separate script that copies the GEWIS Report Database to the Web
- * database.
+ * This is a separate script that copies the GEWIS Report Database to the website database.
  *
  * It is a simple PostgreSQL to MySQL copy script.
  */
 
-echo "Commencing sync with gewisdb\n";
+echo 'Commencing sync with GEWISDB...' . PHP_EOL;
 
 try {
-// connections
+    // Setting up connections.
     $config = include 'config/autoload/gewisdb.local.php';
 
-    $pgconn = new PDO('pgsql:host=' . $config['host'] . ';dbname=' . $config['dbname']
-        . ';user=' . $config['user'] . ';password=' . $config['password']);
-    $pgconn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pgconn = new PDO(
+        sprintf(
+            'pgsql:host=%s;port=%d;dbname=%s;options=\'--client_encoding=%s\'',
+            $config['host'],
+            $config['port'],
+            $config['dbname'],
+            $config['charset']
+        ),
+        $config['user'],
+        $config['password'],
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ],
+    );
 
     $doctrineConf = include 'config/autoload/doctrine.local.php';
     $params = $doctrineConf['doctrine']['connection']['orm_default']['params'];
 
     $myconn = new PDO(
-        'mysql:host=' . $params['host'] . ';dbname=' . $params['dbname'] . ';charset=' . $params['charset'],
+        sprintf(
+            'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+            $params['host'],
+            $params['port'],
+            $params['dbname'],
+            $params['charset'],
+        ),
         $params['user'],
-        $params['password']
+        $params['password'],
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $params['charset'] . ' COLLATE ' . $params['collate'],
+        ],
     );
-    $myconn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (Exception|Error $e) {
+    echo 'ERROR: Failed to connect to GEWISDB or GEWISWEB.' . PHP_EOL;
+    echo $e->getMessage() . PHP_EOL;
+    echo $e->getTraceAsString() . PHP_EOL;
+    exit(1);
+}
 
-    /* which tables to sync */
-    $tables = [
-        'Address',
-        'BoardMember',
-        'Decision',
-        'MailingList',
-        'Meeting',
-        'Member',
-        'members_mailinglists',
-        'Keyholder',
-        'Organ',
-        'OrganMember',
-        'organs_subdecisions',
-        'SubDecision'
-    ];
+/* which tables to sync */
+$tables = [
+    'Address',
+    'BoardMember',
+    'Decision',
+    'MailingList',
+    'Meeting',
+    'Member',
+    'members_mailinglists',
+    'Keyholder',
+    'Organ',
+    'OrganMember',
+    'organs_subdecisions',
+    'SubDecision'
+];
 
-    echo "Connection with gewisdb set up\n";
-    echo "Disabling foreign key constraints\n";
+echo "Connection with GEWISDB and GEWISWEB set up" . PHP_EOL;
+echo "Disabling foreign key constraints on GEWISWEB" . PHP_EOL;
 
-// to not trip up InnoDB
+try {
+    // Disabling the foreign key constraints on GEWISWEB is necessary to silence InnoDB as (mostly) members can be
+    // removed while they are still referenced elsewhere.
     $myconn->query('SET foreign_key_checks = 0');
-    $myconn->query('START TRANSACTION');
+} catch (PDOException $e) {
+    echo 'ERROR: Failed to disable foreign key constraints on GEWISWEB.' . PHP_EOL;
+    exit(1);
+}
 
-    $pks = $myconn->query("SELECT TABLE_NAME, COLUMN_NAME
-                    FROM INFORMATION_SCHEMA.key_column_usage 
-                    WHERE table_schema = '" . $params['dbname'] . "' AND CONSTRAINT_NAME = 'PRIMARY'")
-                    ->fetchAll(PDO::FETCH_COLUMN|PDO::FETCH_GROUP);
+try {
+    // Start the actual synchronisation.
+    echo 'Creating restore point for GEWISWEB...' . PHP_EOL;
+    $myconn->query('START TRANSACTION');
+    echo 'Restore point for GEWISWEB created.' . PHP_EOL;
+
+    $pksQuery = <<<'PKS'
+SELECT TABLE_NAME, COLUMN_NAME
+FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+WHERE TABLE_SCHEMA = '%s' AND CONSTRAINT_NAME = 'PRIMARY'
+PKS;
+    $pks = $myconn->query(sprintf($pksQuery, $params['dbname']))
+        ->fetchAll(PDO::FETCH_COLUMN|PDO::FETCH_GROUP);
 
     foreach ($tables as $table) {
-        $query = "SELECT * FROM $table";
-        $stmt = $pgconn->query($query);
-        echo "Table $table\n";
+        $query = sprintf('SELECT * FROM %s', $table);
+        $pgStmt = $pgconn->query($query);
+        echo 'Syncing table "' . $table . '"...' . PHP_EOL;
 
-        $insertcount = 0;
+        $insertCount = 0;
         // Insert new data
-        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $fields = '(' . implode(', ', array_keys($row)) . ')';
-            $values = '(' . implode(', ', array_map(function ($a) {
-                    return ':' . $a;
-                }, array_keys($row))) . ')';
-            $updates = implode(', ', array_map(function ($a) {
-                return $a . '=VALUES(' . $a . ')';
-            }, array_keys($row)));
+        while ($pgData = $pgStmt->fetch(PDO::FETCH_ASSOC)) {
+            $fields = sprintf(
+                '(%s)',
+                implode(
+                    ', ',
+                    array_keys($pgData),
+                ),
+            );
+            $values = sprintf(
+                '(%s)',
+                implode(
+                    ', ',
+                    array_map(
+                        function ($a) {
+                            return ':' . $a;
+                        },
+                        array_keys($pgData),
+                    ),
+                ),
+            );
+            $updates = implode(
+                ', ',
+                array_map(
+                    function ($a) {
+                        return $a . '=VALUES(' . $a . ')';
+                    },
+                    array_keys($pgData),
+                ),
+            );
 
-            $data = $row;
+            $data = $pgData;
 
             // see if we can fetch about 256 more rows (gigantic speed increase)
-            for ($i = 0; $i < 256 && ($row2 = $stmt->fetch(PDO::FETCH_ASSOC)); $i++) {
-                $values .= ', (' . implode(', ', array_map(function ($a) use ($i) {
-                        return ':' . $a . $i;
-                    }, array_keys($row2))) . ')';
-                foreach ($row2 as $key => $value) {
+            for ($i = 0; $i < 256 && ($pgData2 = $pgStmt->fetch(PDO::FETCH_ASSOC)); $i++) {
+                $values .= sprintf(
+                    ', (%s)',
+                    implode(
+                        ', ',
+                        array_map(
+                            function ($a) use ($i) {
+                                return ':' . $a . $i;
+                            },
+                            array_keys($pgData2),
+                        ),
+                    ),
+                );
+
+                foreach ($pgData2 as $key => $value) {
                     $data[$key . $i] = $value;
                 }
             }
 
-            $sql = "INSERT IGNORE INTO $table $fields VALUES $values ON DUPLICATE KEY UPDATE $updates";
-            $stmtt = $myconn->prepare($sql);
+            $sql = sprintf(
+                'INSERT IGNORE INTO %s %s VALUES %s ON DUPLICATE KEY UPDATE %s',
+                $table,
+                $fields,
+                $values,
+                $updates,
+            );
+            $insertStmt = $myconn->prepare($sql);
 
             try {
-                $stmtt->execute($data);
-                $insertcount += $stmtt->rowCount();
+                $insertStmt->execute($data);
+                $insertCount += $insertStmt->rowCount();
             } catch (Exception $e) {
-                echo "ERROR: Failed to import data of table " . $table . "\n";
-                echo $e->getMessage();
-                echo "\n";
-                echo $e->getTraceAsString();
-                echo "\n\n";
+                echo 'ERROR: Failed to import data of table "' . $table . '"' . PHP_EOL;
+                echo $e->getMessage() . PHP_EOL;
+                echo $e->getTraceAsString() . PHP_EOL;
             }
 
             echo '.';
         }
-        echo PHP_EOL . "Inserted or updated " . $insertcount . " rows in $table (updates count double)" . PHP_EOL;
+
+        echo PHP_EOL . PHP_EOL;
+        echo 'Inserted or updated ' . $insertCount . ' rows in "' . $table . '" (updates count double)' . PHP_EOL;
 
         // Removing old data
-        $id_sql = "SELECT " . $pks[$table][0] . " FROM $table";
-        $ids = $pgconn->query($id_sql)->fetchAll(PDO::FETCH_COLUMN);
-        if (count($ids) === 0) $ids = [null];
-        $del_sql = "DELETE FROM $table WHERE " . $pks[$table][0] . " NOT IN (" . str_repeat('?,', count($ids) - 1) . '?' . ")";
-        $del_stmt = $myconn->prepare($del_sql);
-        try {
-            $del_stmt->execute($ids);
-            echo "Deleted " . $del_stmt->rowCount() . " rows from $table" . PHP_EOL;
-        } catch (Exception $e) {
-            echo "ERROR: Failed to remove data from table " . $table . PHP_EOL;
-            echo $e->getMessage();
-            echo "\n";
-            echo $e->getTraceAsString();
-            echo "\n\n";
+        $idSql = sprintf(
+            'SELECT %s FROM %s',
+            $pks[$table][0],
+            $table,
+        );
+        $ids = $pgconn->query($idSql)->fetchAll(PDO::FETCH_COLUMN);
+
+        if (0 === count($ids)) {
+            $ids = [null];
         }
-        
-        echo "\n\n";
+
+        $deletionSql = sprintf(
+            "DELETE FROM %s WHERE %s NOT IN (%s?)",
+            $table,
+            $pks[$table][0],
+            str_repeat('?,', count($ids) - 1),
+        );
+        $removeStmt = $myconn->prepare($deletionSql);
+
+        try {
+            $removeStmt->execute($ids);
+            echo 'Deleted ' . $removeStmt->rowCount() . ' rows from "' . $table . '"' . PHP_EOL;
+        } catch (Exception $e) {
+            echo 'ERROR: Failed to remove data from table "' . $table . '"' . PHP_EOL;
+            echo $e->getMessage() . PHP_EOL;
+            echo $e->getTraceAsString() . PHP_EOL;
+        }
+
+        echo PHP_EOL;
     }
 
-    echo "Enabling foreign key constraints\n";
-
+    echo 'Committing transaction...' . PHP_EOL;
     $myconn->query('COMMIT');
-    $myconn->query('SET foreign_key_checks = 1');
 
-    echo "Sync with gewisdb completed \n\n\n";
-} catch (Exception $e) {
-    echo "ERROR: Sync with gewisdb failed because of exception\n";
-    echo $e->getMessage();
-    echo "\n";
-    echo $e->getTraceAsString();
-    echo "\n\n\n";
+    echo 'Transaction committed.' . PHP_EOL;
+    echo 'Sync with GEWISDB completed!' . PHP_EOL;
+} catch (Exception|Error $e) {
+    echo 'ERROR: Sync with GEWISDB failed because of exception' . PHP_EOL;
+    echo $e->getMessage() . PHP_EOL;
+    echo $e->getTraceAsString() . PHP_EOL;
+
+    echo 'Restoring GEWISWEB...' . PHP_EOL;
+    try {
+        $myconn->query('ROLLBACK');
+        echo 'Restored GEWISWEB state.' . PHP_EOL;
+    } catch (PDOException) {
+        echo 'ERROR: Could not restore GEWISWEB' . PHP_EOL;
+        echo $e->getMessage() . PHP_EOL;
+        echo $e->getTraceAsString() . PHP_EOL;
+    }
+} finally {
+    echo 'Enabling foreign key constraints...' . PHP_EOL;
+    $myconn->query('SET foreign_key_checks = 1');
 }


### PR DESCRIPTION
With this pull request, the database sync no longer truncates all data in the table, but instead uses inserts, updates and deletes. 

This fixes GH-1688 (as well as fixes GH-1474)

## Changes
The `TRUNCATE` statement is removed (which had an implicit `COMMIT`, causing the website to be unavailable for a short period of time during sync and is replaced by `INSERT ... ON DUPLICATE KEY UPDATE` in combination with a `DELETE FROM` statement that removes no longer existing entries. Foreign key checks are still disabled because the foreign keys do not have any cascading settings.

## Consequences
We assume that the primary key does not change over the lifetime of a record since we are not able to pick up changes to that. Hence, we are not able to update the `User` object when a `Member` changes `lidnr`. However, this assumption was also made with the previous solution. 

## Why would we want this
It enhances user experience by not throwing errors during the database sync. Furthermore, it paves the way into more frequent (or on-demand) syncs because sync becomes seamless. These may allow members to sign in without waiting a day when their email address has been updated or they have just been registered. 

Optionally, a partial sync could be done separately which does not remove any rows but instead only relies on inserts and updates, but tests show that the delete statements do add little overhead. 

## Why would we not want this
The script becomes more advanced and does not work for newer (non-MariaDB) MySQL out of the box. To use MySQL 8.0 and newer, it is needed to make the following changes:

```diff
function ($a) {
-    return $a . '=VALUES(' . $a . ')';
+    return $a . '=new.' . $a;
},
```

```diff
$sql = sprintf(
-    'INSERT IGNORE INTO %s %s VALUES %s ON DUPLICATE KEY UPDATE %s',
+    'INSERT IGNORE INTO %s %s VALUES %s as new ON DUPLICATE KEY UPDATE %s',
    $table,
```

If we are ever going to have auto incrementing columns in the database, we need to also make sure that the `AUTO_INCREMENT` value is reset to the max of that column to prevent exhausting available numbers. The reason for this is that the `INSERT` statement always reserves a new incrementing value. Currently, we do not have any default value set to `AUTO_INCREMENT` in the MySQL side. 

## Tests performed
This pull request has been tested on tables with 10k simple entries and 12 regular ones (and some extra `sleep(5)` statements to simulate slowness). I suggest testing this on test.gewis.nl to see what happens in practice. Groups of rows have been edited with simple mysql statements and deleted to see how the sync behaves. 

```python
import secrets
for i in range(12,10000):
    print("INSERT INTO \"public\".\"member\" (\"lidnr\", \"email\", \"lastname\", \"middlename\", \"initials\", \"firstname\", \"generation\", \"type\", \"changedon\", \"membershipendson\", \"birth\", \"expiration\", \"paid\", \"supremum\", \"authenticationkey\") VALUES ('" + str(i) + "', 'test" + str(i) + "@gewis.nl', 'Mechanical Engineering', 'van', 'M.', 'Marco', '2023', 'external', '2023-08-22', '2023-07-01', '2000-01-01', '2024-07-01', '15', NULL, '" + secrets.token_hex(64) + "');")
```