### PR TITLE
Fix sub-albums not showing 'new' label if created a week after parent

### DIFF
--- a/module/Photo/view/photo/album/index.phtml
+++ b/module/Photo/view/photo/album/index.phtml
@@ -197,7 +197,7 @@ $this->scriptUrl()->requireUrl('member/search')
                                 <?php endif; ?>
                                 <div class="caption">
                                     <p>
-                                        <?php if ($album->getCreatedAt() >= $lastWeek): ?>
+                                        <?php if ($item->getCreatedAt() >= $lastWeek): ?>
                                             <span class="label label-primary">
                                                 <?= $this->translate('NEW') ?>
                                             </span>&nbsp;


### PR DESCRIPTION
The check used `$album`, the parent and not `$item` the sub-album. As such, sub-albums created a week after the parent album did not show the 'new' label.

Was not caught since its introduction in GH-1570.