### PR TITLE
Change activity admin approval view to use `diff` for description

### DIFF
--- a/module/Activity/view/activity/admin-approval/view.phtml
+++ b/module/Activity/view/activity/admin-approval/view.phtml
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Activity\Model\Activity as ActivityModel;
 use Application\Form\ModifyRequest as RequestForm;
+use Application\View\Helper\Diff;
 use Application\View\HelperTrait;
 use Laminas\View\Renderer\PhpRenderer;
 
@@ -141,14 +142,26 @@ $this->breadcrumbs()
                     <span class="flag-icon flag-icon-nl"></span>
                     <strong><?= $this->translate('Description') ?>:</strong>
                 </span>
-                <?= $this->escapeHtml($activity->getDescription()->getValueNL()) ?>
+                <?=
+                $this->diff(
+                    $activity->getDescription()->getValueNL(),
+                    $activity->getDescription()->getValueNL(),
+                    Diff::DIFF_RENDER_INLINE,
+                )
+                ?>
             </div>
             <div class="col-md-5">
                 <span class="approvable-property">
                     <span class="flag-icon flag-icon-en"></span>
                     <strong><?= $this->translate('Description') ?>:</strong>
                 </span>
-                <?= $this->escapeHtml($activity->getDescription()->getValueEN()) ?>
+                <?=
+                $this->diff(
+                    $activity->getDescription()->getValueEN(),
+                    $activity->getDescription()->getValueEN(),
+                    Diff::DIFF_RENDER_INLINE,
+                )
+                ?>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
This preserves the spacing/newlines to make it easier to read the descriptions before approving them.

**Before:**
![image](https://github.com/GEWIS/gewisweb/assets/4983571/03da1e2b-9606-4927-bdac-8f505abf389d)

**After:**
![image](https://github.com/GEWIS/gewisweb/assets/4983571/6b7602b1-0ecc-44dd-8adb-121596e19d68)


This closes GH-1704.