### PR TITLE
Do not allow viewing unapproved activities by the world

### DIFF
--- a/module/Activity/src/Controller/ActivityController.php
+++ b/module/Activity/src/Controller/ActivityController.php
@@ -72,6 +72,12 @@ class ActivityController extends AbstractActionController
             return $this->notFoundAction();
         }
 
+        if (ActivityModel::STATUS_APPROVED !== $activity->getStatus()) {
+            if (!$this->aclService->isAllowed('update', $activity)) {
+                return $this->notFoundAction();
+            }
+        }
+
         // If the Activity has a sign-up list always display it by redirecting the request.
         if (0 !== $activity->getSignupLists()->count()) {
             return $this->forward()->dispatch(


### PR DESCRIPTION
If an activity is not `APPROVED` it is only accessible to the board and the organiser.

This fixes GH-1705.