### PR TITLE
Add search highlighting to decision search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "ext-exif": "*",
         "ext-fileinfo": "*",
         "ext-gd": "*",
+        "ext-iconv": "*",
         "ext-intl": "*",
         "ext-imagick": "^3.5.0",
         "ext-mbstring": "*",

--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -123,6 +123,7 @@ class DecisionController extends AbstractActionController
                 return new ViewModel(
                     [
                         'result' => $result,
+                        'prompt' => $form->getData()['query'],
                         'form' => $form,
                     ],
                 );

--- a/module/Decision/view/decision/decision/search.phtml
+++ b/module/Decision/view/decision/decision/search.phtml
@@ -4,14 +4,61 @@ declare(strict_types=1);
 
 use Application\View\HelperTrait;
 use Decision\Form\SearchDecision as SearchDecisionForm;
+use Decision\Model\Decision as DecisionModel;
 use Laminas\View\Renderer\PhpRenderer;
 
 /**
  * @var PhpRenderer|HelperTrait $this
  * @var SearchDecisionForm $form
+ * @var DecisionModel[]|null $result
+ * @var string|null $prompt
  */
 
 $this->headTitle($this->translate('Search for decision'));
+
+/**
+ * Insert `<mark>` around a search prompt in the content of a decision.
+ */
+function highlightSearch(
+    string $decision,
+    string $search,
+): string {
+    // Convert the decision to something that is easily searchable (i.e. it MUST NOT contain any non-ASCII characters).
+    $transliteratedDecision = iconv(
+        'UTF-8',
+        'ASCII//TRANSLIT//IGNORE',
+        transliterator_transliterate('Any-Latin; Latin-ASCII', $decision),
+    );
+    // Do the same for the search prompt, as otherwise searches WITH non-ASCII characters will not work.
+    $search = iconv(
+        'UTF-8',
+        'ASCII//TRANSLIT//IGNORE',
+        transliterator_transliterate('Any-Latin; Latin-ASCII', $search),
+    );
+
+    $offset = 0;
+    $output = '';
+    $length = mb_strlen($search);
+
+    // There is a very important assumption here; the transliterated version of the decision MUST be exactly as long as
+    // the original version. Otherwise, the insertion is done with an incorrect offset.
+    while (false !== ($position = mb_stripos($transliteratedDecision, $search, $offset, 'UTF-8'))) {
+        // Progressively insert markers into the original decision.
+        $output .= sprintf('%s%s%s%s',
+            mb_substr($decision, $offset, $position - $offset, 'UTF-8'),
+            '<mark>',
+            mb_substr($decision, $position, $length, 'UTF-8'),
+            '</mark>',
+        );
+
+        $offset = $position + $length;
+    }
+
+    // Add the final part of the decision back.
+    $output .= mb_substr($decision, $offset, null, 'UTF-8');
+
+    return $output;
+}
 ?>
 <section class="section">
     <div class="container">
@@ -78,7 +125,12 @@ $this->headTitle($this->translate('Search for decision'));
                                     ) ?>
                                 </a>
                             </strong>
-                            <span class="decision-content"><?= $this->escapeHtml($decision->getContent()) ?></span>
+                            <span class="decision-content">
+                                <?= highlightSearch(
+                                    $this->escapeHtml($decision->getContent()),
+                                    $this->escapeHtml($prompt),
+                                ) ?>
+                            </span>
                         </li>
                     <?php endforeach ?>
                 </ul>


### PR DESCRIPTION
This allows you to quickly identify your search prompt in the contents of the returned decisions. Through transliteration it is possible to highlight accented text (which is also done by MariaDB) when searching with plain ASCII text, and vice-versa.

The markers are progressively inserted into the original decision contents by iterating with `mb_stripos` (note: case-insensitive).

![image](https://github.com/GEWIS/gewisweb/assets/4983571/e7b1c77f-0249-499c-b3f4-1c00535d8585)

---

Original implementation used `preg_replace`, however, this does not work with the accented characters:

```php
<?= preg_replace(
    sprintf('/(%s)/i', preg_quote($this->escapeHtml($prompt), '/')),
    '<mark>$1</mark>',
    $this->escapeHtml($decision->getContent()),
) ?>
```

For example, searching for `geinstalleerd` would return results containing `geïnstalleerd`. However, these would not be highlighted.

Closes GH-1763.