### PR TITLE
Switch activity subscription from well to modal

### DIFF
--- a/module/Activity/src/Controller/ActivityController.php
+++ b/module/Activity/src/Controller/ActivityController.php
@@ -158,11 +158,9 @@ class ActivityController extends AbstractActionController
         $view->setTemplate('activity/activity/view.phtml');
 
         // Retrieve and clear the request status from the session, if it exists.
-        if (isset($activitySession->success)) {
-            $view->setVariable('success', $activitySession->success);
-            unset($activitySession->success);
-            $view->setVariable('message', $activitySession->message);
-            unset($activitySession->message);
+        if (isset($activitySession->reopen)) {
+            $view->setVariable('reopen', $activitySession->reopen);
+            unset($activitySession->reopen);
         }
 
         return $view;
@@ -219,6 +217,8 @@ class ActivityController extends AbstractActionController
 
         /** @var Request $request */
         $request = $this->getRequest();
+        $activityRequestSession = new SessionContainer('activityRequest');
+        $activityRequestSession->reopen = false;
 
         if ($request->isPost()) {
             $form = $this->signupService->getForm($signupList);
@@ -229,7 +229,7 @@ class ActivityController extends AbstractActionController
             // Check if the form is valid
             if (!$form->isValid()) {
                 $error = $this->translator->translate('Invalid form');
-                $activityRequestSession = new SessionContainer('activityRequest');
+                $activityRequestSession->reopen = true;
                 $activityRequestSession->signupData = $postData->toArray();
 
                 return $this->redirectActivityRequest($activityId, $signupListId, false, $error);
@@ -268,6 +268,7 @@ class ActivityController extends AbstractActionController
         }
 
         $error = $this->translator->translate('Use the form to subscribe');
+        $activityRequestSession->reopen = true;
 
         return $this->redirectActivityRequest($activityId, $signupListId, false, $error);
     }
@@ -312,6 +313,8 @@ class ActivityController extends AbstractActionController
 
         /** @var Request $request */
         $request = $this->getRequest();
+        $activityRequestSession = new SessionContainer('activityRequest');
+        $activityRequestSession->reopen = false;
 
         if ($request->isPost()) {
             $form = $this->signupService->getExternalForm($signupList);
@@ -322,7 +325,7 @@ class ActivityController extends AbstractActionController
             // Check if the form is valid
             if (!$form->isValid()) {
                 $error = $this->translator->translate('Invalid form');
-                $activityRequestSession = new SessionContainer('activityRequest');
+                $activityRequestSession->reopen = true;
                 $activityRequestSession->signupData = $postData->toArray();
 
                 return $this->redirectActivityRequest($activityId, $signupListId, false, $error);
@@ -357,6 +360,7 @@ class ActivityController extends AbstractActionController
         }
 
         $error = $this->translator->translate('Use the form to subscribe');
+        $activityRequestSession->reopen = true;
 
         return $this->redirectActivityRequest($activityId, $signupListId, false, $error);
     }

--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -281,11 +281,9 @@ class AdminController extends AbstractActionController
         $result['signupLists'] = $signupLists;
 
         // Retrieve and clear the request status from the session, if it exists.
-        if (isset($activityAdminSession->success)) {
-            $result['success'] = $activityAdminSession->success;
-            unset($activityAdminSession->success);
-            $result['message'] = $activityAdminSession->message;
-            unset($activityAdminSession->message);
+        if (isset($activityAdminSession->reopen)) {
+            $result['reopen'] = $activityAdminSession->reopen;
+            unset($activityAdminSession->reopen);
         }
 
         $result['canSeeTimeOfSignup'] = $this->aclService->isAllowed('viewParticipantDetails', 'activity');
@@ -309,6 +307,8 @@ class AdminController extends AbstractActionController
 
         /** @var Request $request */
         $request = $this->getRequest();
+        $activityAdminSession = new SessionContainer('activityAdminRequest');
+        $activityAdminSession->reopen = false;
 
         if ($request->isPost()) {
             $form = $this->signupService->getExternalAdminForm($signupList);
@@ -318,7 +318,7 @@ class AdminController extends AbstractActionController
 
             // Check if the form is valid
             if (!$form->isValid()) {
-                $activityAdminSession = new SessionContainer('activityAdminRequest');
+                $activityAdminSession->reopen = true;
                 $activityAdminSession->signupData = $postData->toArray();
 
                 return $this->redirectActivityAdminRequest(
@@ -344,6 +344,8 @@ class AdminController extends AbstractActionController
                 $this->translator->translate('Successfully subscribed external participant'),
             );
         }
+
+        $activityAdminSession->reopen = true;
 
         return $this->redirectActivityAdminRequest(
             $activityId,

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -187,78 +187,108 @@ $this->headTitle($this->translate('Activities'));
                 </div>
                 <div class="col-md-12">
                     <?php if ($isSignedUp) : ?>
-                        <button class="btn btn-default btn-lg agenda-subscription-button" type="button"
-                                data-toggle="collapse" data-target="#subscriptionForm"
-                                aria-expanded="false" aria-controls="subscriptionForm">
-                            <?= $this->translate('Already subscribed') ?>
-                        </button>
+                        <?php if ($subscriptionCloseDatePassed) : ?>
+                            <button class="btn btn-default btn-lg" type="button" disabled="disabled">
+                                <span class="fas fa-user-check"></span> <?= $this->translate('Unsubscription period closed') ?>
+                            </button>
+                        <?php else: ?>
+                            <button class="btn btn-default btn-lg" type="button" data-toggle="modal"
+                                    data-target="#signoffModal" aria-hidden="true" aria-controls="signoffModal">
+                                <span class="fas fa-user-minus"></span> <?= $this->translate('Unsubscribe') ?>
+                            </button>
+                            <div class="modal fade" id="signoffModal" tabindex="-1" role="dialog" aria-hidden="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                            <h4 class="modal-title">
+                                                <?= sprintf(
+                                                    $this->translate('Unsubscribe from \'%s\''),
+                                                    $this->escapeHtml($this->localiseText($signupList->getName())),
+                                                ) ?>
+                                            </h4>
+                                        </div>
+                                        <div class="modal-body">
+                                            <p>
+                                                <?= $this->translate('Are you sure you want to unsubscribe?') ?>
+                                            </p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <?php
+                                            $signoffForm->setAttribute(
+                                                'action',
+                                                $this->url(
+                                                    'activity/signoff',
+                                                    ['id' => $activity->getId(), 'signupList' => $signupList->getId()],
+                                                ),
+                                            );
+                                            $signoffForm->prepare();
+                                            echo $this->form()->openTag($signoffForm);
+                                            echo $this->formElement($signoffForm->get('security'));
+                                            $submit = $signoffForm->get('submit');
+                                            $submit->setAttribute('class', 'btn btn-default');
+                                            echo $this->formSubmit($submit);
+                                            ?>
+                                            <button type="button" class="btn" data-dismiss="modal">
+                                                <?= $this->translate('Cancel') ?>
+                                            </button>
+                                            <?= $this->form()->closeTag(); ?>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endif; ?>
                     <?php elseif (!$signupOpen): ?>
-                        <button class="btn btn-default btn-lg agenda-subscription-button" type="button"
-                                data-toggle="collapse" data-target="#subscriptionForm"
-                                aria-expanded="false" disabled="disabled"
-                                aria-controls="subscriptionForm">
-                            <?= $this->translate('Subscription closed') ?>
+                        <button class="btn btn-default btn-lg" type="button" disabled="disabled">
+                            <span class="fas fa-user-xmark"></span> <?= $this->translate('Subscription period closed') ?>
                         </button>
                     <?php else: ?>
-                        <button class="btn btn-primary btn-lg agenda-subscription-button collapsed" type="button"
-                                data-toggle="collapse" data-target="#subscriptionForm" aria-expanded="false"
-                                aria-controls="subscriptionForm">
-                            <span class="fas fa-chevron-right"></span> <?= $this->translate('Subscribe now') ?>
-                        </button>
-                    <?php endif; ?>
-                </div>
-                <div class="col-md-6 collapse activity-subscription-form" id="subscriptionForm">
-                    <div class="well">
-                        <?php if ($isSignedUp) : ?>
-                            <h2><?= $this->translate('Unsubscribe yourself') ?></h2>
-                            <?php if ($subscriptionCloseDatePassed) : ?>
-                                <div>
-                                    <?= $this->translate('You are not allowed to unsubscribe after the deadline!') ?>
-                                </div>
-                            <?php else : ?>
-                                <div>
-                                    <?php
-                                    $signoffForm->setAttribute('action', $this->url('activity/signoff', ['id' => $activity->getId(), 'signupList' => $signupList->getId()]));
-                                    $signoffForm->prepare();
-                                    echo $this->form()->openTag($signoffForm);
-                                    echo $this->formElement($signoffForm->get('security'));
-                                    $submit = $signoffForm->get('submit');
-                                    $submit->setAttribute('class', 'btn btn-default');
-                                    echo $this->formSubmit($submit);
-                                    echo $this->form()->closeTag();
-                                    ?>
-                                </div>
-                            <?php endif; ?>
-                        <?php endif; ?>
-                        <?php if ($signupOpen && !$isAllowedToSubscribe): ?>
-                            <h2>
-                                <?= $this->translate('Subscribe yourself') ?>
-                            </h2>
-                            <a href="<?= $this->url('user/login', ['user_type' => 'member']) ?>">
-                                <?= $this->translate('Login to subscribe') ?>
+                        <?php if (!$isAllowedToSubscribe && $signupList->getOnlyGEWIS()): ?>
+                            <a href="<?= $this->url(
+                                'user/login',
+                                [
+                                    'user_type' => 'member',
+                                    'redirect_to' => base64_encode($this->serverUrl(true)),
+                                ],
+                            ) ?>"
+                               class="btn btn-primary btn-lg">
+                                <span class="fas fa-user-plus"></span> <?= $this->translate('Log in to subscribe') ?>
                             </a>
-                            <?php if (!$signupList->getOnlyGEWIS() && null !== $form): ?>
-                                <br/>
-                                <?= $this->translate('Or subscribe without a GEWIS membership: ') ?>
-                                <?= $this->partial('partial/signupForm', [
-                                    'form' => $form,
-                                    'signupList' => $signupList,
-                                ])
-                                ?>
-                            <?php endif; ?>
-                        <?php endif; ?>
-                        <?php if (null !== $form && $signupOpen && !$isSignedUp && $isAllowedToSubscribe): //display the form ?>
-                            <h2>
-                                <?= $this->translate('Subscribe yourself') ?>
-                            </h2>
+                        <?php elseif (!$isAllowedToSubscribe && !$signupList->getOnlyGEWIS()): ?>
+                            <button class="btn btn-primary btn-lg" type="button" data-toggle="modal"
+                                    data-target="#signupModal" aria-hidden="true" aria-controls="signupModal">
+                                <span class="fas fa-user-plus"></span> <?= $this->translate('Subscribe as external participant') ?>
+                            </button>
+                            <?= $this->partial('partial/signupForm', [
+                                'form' => $form,
+                                'signupList' => $signupList,
+                            ])
+                            ?>
+                        <?php else: ?>
+                            <button class="btn btn-primary btn-lg" type="button" data-toggle="modal"
+                                    data-target="#signupModal" aria-hidden="true" aria-controls="signupModal">
+                                <span class="fas fa-user-plus"></span> <?= $this->translate('Subscribe') ?>
+                            </button>
                             <?= $this->partial('partial/signupForm', [
                                 'form' => $form,
                                 'signupList' => $signupList,
                             ])
                             ?>
                         <?php endif; ?>
-                    </div>
+                        <?php if (isset($reopen) && $reopen): ?>
+                            <script nonce="<?= NONCE_REPLACEMENT_STRING ?>">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    $('#signupModal').modal('show');
+                                });
+                            </script>
+                        <?php endif; ?>
+                    <?php endif; ?>
                 </div>
+            </div>
+            <br>
+            <div class="row">
                 <div class="col-md-12">
                     <h2><?= $this->translate('Current subscriptions') ?></h2>
                     <div class="table-responsive">

--- a/module/Activity/view/activity/admin/participants.phtml
+++ b/module/Activity/view/activity/admin/participants.phtml
@@ -77,12 +77,23 @@ $this->breadcrumbs()
     </div>
     <div class="col-md-12">
         <?php if (isset($externalSignupForm)): //display the external signup form ?>
+            <button class="btn btn-primary btn-lg" type="button" data-toggle="modal"
+                    data-target="#signupModal" aria-hidden="true" aria-controls="signupModal">
+                <span class="fas fa-user-plus"></span> <?= $this->translate('Subscribe external participant') ?>
+            </button>
             <?= $this->partial('partial/signupForm', [
                 'form' => $externalSignupForm,
                 'activity' => $activity,
                 'signupList' => $signupList,
             ])
             ?>
+            <?php if (isset($reopen) && $reopen): ?>
+                <script nonce="<?= NONCE_REPLACEMENT_STRING ?>">
+                    document.addEventListener("DOMContentLoaded", function() {
+                        $('#signupModal').modal('show');
+                    });
+                </script>
+            <?php endif; ?>
         <?php endif; ?>
     </div>
 </div>

--- a/module/Activity/view/partial/signupForm.phtml
+++ b/module/Activity/view/partial/signupForm.phtml
@@ -76,49 +76,89 @@ function formElementRender(
 
 ?>
 
-<?php
-$form->setAttribute('action', $submitUrl);
-$form->setAttribute('class', 'form-signup');
-$form->prepare();
-echo $this->form()->openTag($form);
-?>
-<?php if ($showName): ?>
-    <?= formElementRender($form->get('fullName'), $this->translate('Full name'), 'fullName', false, $this) ?>
-    <?= formElementRender($form->get('email'), $this->translate('E-mail Address'), 'email', true, $this) ?>
-<?php endif; ?>
+<div class="modal fade" id="signupModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title">
+                    <?= sprintf(
+                        $this->translate('Subscribe to \'%s\''),
+                        $this->escapeHtml($this->localiseText($signupList->getName())),
+                    ) ?>
+                </h4>
+            </div>
+            <?php
+            $form->setAttribute('action', $submitUrl);
+            $form->setAttribute('class', 'form-signup');
+            $form->prepare();
+            echo $this->form()->openTag($form);
+            ?>
+                <div class="modal-body">
+                    <?php if ($showCaptcha): ?>
+                        <p>
+                            <strong>
+                                <?= sprintf(
+                                    $this->translate('Do you have a GEWIS account? <a href="%s">Log in to subscribe.</a>'),
+                                    $this->url(
+                                        'user/login',
+                                        [
+                                            'user_type' => 'member',
+                                            'redirect_to' => base64_encode($this->serverUrl(true)),
+                                        ],
+                                    ),
+                                ) ?>
+                            </strong> <?= $this->translate('Or subscribe without a GEWIS membership: ') ?>
+                        </p>
+                    <?php endif; ?>
 
-<?php if ($showCaptcha): ?>
-    <?= formElementRender($form->get('captcha'), $this->translate('CAPTCHA'), 'captcha', false, $this) ?>
-<?php endif; ?>
+                    <?php if ($showName): ?>
+                        <?= formElementRender($form->get('fullName'), $this->translate('Full name'), 'fullName', false, $this) ?>
+                        <?= formElementRender($form->get('email'), $this->translate('E-mail Address'), 'email', true, $this) ?>
+                    <?php endif; ?>
 
-<?php foreach ($signupList->getFields() as $field): ?>
-    <?= formElementRender(
-        $form->get(strval($field->getId())),
-        $this->escapeHtml($this->localiseText($field->getName())),
-        $field->getId(),
-        $field->isSensitive(),
-        $this,
-    ) ?>
-<?php endforeach; ?>
+                    <?php if ($showCaptcha): ?>
+                        <?= formElementRender($form->get('captcha'), $this->translate('CAPTCHA'), 'captcha', false, $this) ?>
+                    <?php endif; ?>
 
-<p>
-    <?= $agreementText ?> <a href="https://gewis.nl/data/regulations/activity-policy.pdf" target="_blank">
-        <?= $this->translate('Activity Policy') ?></a> <?= $this->translate('and') ?>
-    <a href="https://gewis.nl/data/regulations/alcohol-policy.pdf" target="_blank">
-        <?= $this->translate('Alcohol Policy') ?></a>.
-</p>
+                    <?php foreach ($signupList->getFields() as $field): ?>
+                        <?= formElementRender(
+                            $form->get(strval($field->getId())),
+                            $this->escapeHtml($this->localiseText($field->getName())),
+                            $field->getId(),
+                            $field->isSensitive(),
+                            $this,
+                        ) ?>
+                    <?php endforeach; ?>
 
-<p class="text-muted">
-    <em>
-        <?= $sensitiveStartText ?> <?= $this->translate('Fields that are marked with an \'¹\' will only be shared with the board and the organiser of the activity.') ?>
-    </em>
-</p>
+                    <p>
+                        <?= $agreementText ?> <a href="https://gewis.nl/data/regulations/activity-policy.pdf" target="_blank">
+                            <?= $this->translate('Activity Policy') ?></a> <?= $this->translate('and') ?>
+                        <a href="https://gewis.nl/data/regulations/alcohol-policy.pdf" target="_blank">
+                            <?= $this->translate('Alcohol Policy') ?></a>.
+                    </p>
 
-<?php
-$submit = $form->get('submit');
-$submit->setAttribute('class', 'btn btn-primary');
-$submit->setAttribute('value', $submitText);
-echo $this->formElement($form->get('security'));
-echo $this->formSubmit($submit);
-echo $this->form()->closeTag();
-?>
+                    <p class="text-muted">
+                        <em>
+                            <?= $sensitiveStartText ?> <?= $this->translate('Fields that are marked with an \'¹\' will only be shared with the board and the organiser of the activity.') ?>
+                        </em>
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <?php
+                    $submit = $form->get('submit');
+                    $submit->setAttribute('class', 'btn btn-primary');
+                    $submit->setAttribute('value', $submitText);
+                    echo $this->formElement($form->get('security'));
+                    echo $this->formSubmit($submit);
+                    ?>
+                    <button type="button" class="btn" data-dismiss="modal">
+                        <?= $this->translate('Cancel') ?>
+                    </button>
+                </div>
+            <?= $this->form()->closeTag() ?>
+        </div>
+    </div>
+</div>

--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-16 10:18+0100\n"
-"PO-Revision-Date: 2023-11-16 10:19+0100\n"
+"POT-Creation-Date: 2023-11-19 16:08+0100\n"
+"PO-Revision-Date: 2023-11-19 16:09+0100\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: en\n"
@@ -285,9 +285,6 @@ msgstr "All Activities"
 msgid "All rights reserved."
 msgstr "All rights reserved."
 
-msgid "Already subscribed"
-msgstr "Already subscribed"
-
 msgid "Already voted!"
 msgstr "Already voted!"
 
@@ -452,6 +449,9 @@ msgstr ""
 
 msgid "Are you sure you want to delete this poll?"
 msgstr "Are you sure you want to delete this poll?"
+
+msgid "Are you sure you want to unsubscribe?"
+msgstr "Are you sure you want to unsubscribe?"
 
 msgid "Are you sure you would like to authorize"
 msgstr "Are you sure you would like to authorize"
@@ -952,6 +952,10 @@ msgstr "Display GEWIS member count"
 
 msgid "Display number of subscribed members"
 msgstr "Display number of subscribed members"
+
+#, php-format
+msgid "Do you have a GEWIS account? <a href=\"%s\">Log in to subscribe.</a>"
+msgstr "Do you have a GEWIS account? <a href=\"%s\">Log in to subscribe.</a>"
 
 #, php-format
 msgid ""
@@ -1690,11 +1694,11 @@ msgstr "Log in as company"
 msgid "Log in as member"
 msgstr "Log in as member"
 
+msgid "Log in to subscribe"
+msgstr "Log in to subscribe"
+
 msgid "Login"
 msgstr "Login"
-
-msgid "Login to subscribe"
-msgstr "Login to subscribe"
 
 msgid "Login to view more information"
 msgstr "Login to view more information"
@@ -2671,14 +2675,15 @@ msgstr "Subscribe an external participant"
 msgid "Subscribe as external participant"
 msgstr "Subscribe as external participant"
 
-msgid "Subscribe now"
-msgstr "Subscribe now"
+msgid "Subscribe external participant"
+msgstr "Subscribe external participant"
 
-msgid "Subscribe yourself"
-msgstr "Subscribe yourself"
+#, php-format
+msgid "Subscribe to '%s'"
+msgstr "Subscribe to '%s'"
 
-msgid "Subscription closed"
-msgstr "Subscription closed"
+msgid "Subscription period closed"
+msgstr "Subscription period closed"
 
 msgid "Successfully added course!"
 msgstr "Successfully added course!"
@@ -3203,8 +3208,15 @@ msgstr "Unfortunately, there aren't any %s at the moment."
 msgid "Unknown"
 msgstr "Unknown"
 
-msgid "Unsubscribe yourself"
-msgstr "Unsubscribe yourself"
+msgid "Unsubscribe"
+msgstr "Unsubscribe"
+
+#, php-format
+msgid "Unsubscribe from '%s'"
+msgstr "Unsubscribe from '%s'"
+
+msgid "Unsubscription period closed"
+msgstr "Unsubscription period closed"
 
 msgid "Until"
 msgstr "Until"
@@ -3817,9 +3829,6 @@ msgstr "You are not allowed to subscribe to this sign-up list"
 
 msgid "You are not allowed to transfer jobs"
 msgstr "You are not allowed to transfer jobs"
-
-msgid "You are not allowed to unsubscribe after the deadline!"
-msgstr "You are not allowed to unsubscribe after the deadline!"
 
 msgid "You are not allowed to update this activity"
 msgstr "You are not allowed to update this activity"

--- a/module/Application/language/gewisweb.pot
+++ b/module/Application/language/gewisweb.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GEWISweb v2.8.6-563-g229793789-dirty\n"
+"Project-Id-Version: GEWISweb v2.8.6-570-g8364f44e3-dirty\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-16 10:29+0100\n"
+"POT-Creation-Date: 2023-11-19 16:08+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -276,9 +276,6 @@ msgstr ""
 msgid "All rights reserved."
 msgstr ""
 
-msgid "Already subscribed"
-msgstr ""
-
 msgid "Already voted!"
 msgstr ""
 
@@ -424,6 +421,9 @@ msgid ""
 msgstr ""
 
 msgid "Are you sure you want to delete this poll?"
+msgstr ""
+
+msgid "Are you sure you want to unsubscribe?"
 msgstr ""
 
 msgid "Are you sure you would like to authorize"
@@ -907,6 +907,10 @@ msgid "Display GEWIS member count"
 msgstr ""
 
 msgid "Display number of subscribed members"
+msgstr ""
+
+#, php-format
+msgid "Do you have a GEWIS account? <a href=\"%s\">Log in to subscribe.</a>"
 msgstr ""
 
 #, php-format
@@ -1595,10 +1599,10 @@ msgstr ""
 msgid "Log in as member"
 msgstr ""
 
-msgid "Login"
+msgid "Log in to subscribe"
 msgstr ""
 
-msgid "Login to subscribe"
+msgid "Login"
 msgstr ""
 
 msgid "Login to view more information"
@@ -2526,13 +2530,14 @@ msgstr ""
 msgid "Subscribe as external participant"
 msgstr ""
 
-msgid "Subscribe now"
+msgid "Subscribe external participant"
 msgstr ""
 
-msgid "Subscribe yourself"
+#, php-format
+msgid "Subscribe to '%s'"
 msgstr ""
 
-msgid "Subscription closed"
+msgid "Subscription period closed"
 msgstr ""
 
 msgid "Successfully added course!"
@@ -3008,7 +3013,14 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-msgid "Unsubscribe yourself"
+msgid "Unsubscribe"
+msgstr ""
+
+#, php-format
+msgid "Unsubscribe from '%s'"
+msgstr ""
+
+msgid "Unsubscription period closed"
 msgstr ""
 
 msgid "Until"
@@ -3584,9 +3596,6 @@ msgid "You are not allowed to subscribe to this sign-up list"
 msgstr ""
 
 msgid "You are not allowed to transfer jobs"
-msgstr ""
-
-msgid "You are not allowed to unsubscribe after the deadline!"
 msgstr ""
 
 msgid "You are not allowed to update this activity"

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-16 10:29+0100\n"
-"PO-Revision-Date: 2023-11-16 10:29+0100\n"
+"POT-Creation-Date: 2023-11-19 16:08+0100\n"
+"PO-Revision-Date: 2023-11-19 16:12+0100\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: nl\n"
@@ -286,9 +286,6 @@ msgstr "Alle Activiteiten"
 msgid "All rights reserved."
 msgstr "Alle rechten voorbehouden."
 
-msgid "Already subscribed"
-msgstr "Je bent al ingeschreven"
-
 msgid "Already voted!"
 msgstr "Je hebt al gestemd!"
 
@@ -453,6 +450,9 @@ msgstr ""
 
 msgid "Are you sure you want to delete this poll?"
 msgstr "Weet je zeker dat je deze poll wilt verwijderen?"
+
+msgid "Are you sure you want to unsubscribe?"
+msgstr "Weet je zeker dat je je wilt uitschrijven?"
 
 msgid "Are you sure you would like to authorize"
 msgstr "Weet je zeker dat je wilt machtigen"
@@ -959,6 +959,11 @@ msgstr "Toon aantal GEWIS leden"
 
 msgid "Display number of subscribed members"
 msgstr "Toon aantal deelnemers"
+
+#, php-format
+msgid "Do you have a GEWIS account? <a href=\"%s\">Log in to subscribe.</a>"
+msgstr ""
+"Heb je een GEWIS-account? <a href=\"%s\">Log in om je in te schrijven.</a>"
 
 #, php-format
 msgid ""
@@ -1712,11 +1717,11 @@ msgstr "Inloggen als bedrijf"
 msgid "Log in as member"
 msgstr "Inloggen als lid"
 
+msgid "Log in to subscribe"
+msgstr "Log in om in te schrijven"
+
 msgid "Login"
 msgstr "Login"
-
-msgid "Login to subscribe"
-msgstr "Login om in te schrijven"
 
 msgid "Login to view more information"
 msgstr "Log in om meer informatie te zien"
@@ -2694,14 +2699,15 @@ msgstr "Inschrijven zonder GEWIS lidmaatschap"
 msgid "Subscribe as external participant"
 msgstr "Inschrijven zonder GEWIS lidmaatschap"
 
-msgid "Subscribe now"
-msgstr "Schrijf je in"
+msgid "Subscribe external participant"
+msgstr "Inschrijven externe deelnemer"
 
-msgid "Subscribe yourself"
-msgstr "Inschrijven"
+#, php-format
+msgid "Subscribe to '%s'"
+msgstr "Inschrijven voor '%s'"
 
-msgid "Subscription closed"
-msgstr "Inschrijving gesloten"
+msgid "Subscription period closed"
+msgstr "Inschrijvingsperiode gesloten"
 
 msgid "Successfully added course!"
 msgstr "Vak succesvol toegevoegd!"
@@ -3241,8 +3247,15 @@ msgstr "Helaas zijn er momenteel geen %s."
 msgid "Unknown"
 msgstr "Onbekend"
 
-msgid "Unsubscribe yourself"
+msgid "Unsubscribe"
 msgstr "Uitschrijven"
+
+#, php-format
+msgid "Unsubscribe from '%s'"
+msgstr "Uitschrijven van '%s'"
+
+msgid "Unsubscription period closed"
+msgstr "Uitschrijvingsperiode gesloten"
 
 msgid "Until"
 msgstr "Tot"
@@ -3868,9 +3881,6 @@ msgstr ""
 
 msgid "You are not allowed to transfer jobs"
 msgstr "Je hebt niet de rechten om vacatures te verplaatsen"
-
-msgid "You are not allowed to unsubscribe after the deadline!"
-msgstr "Uitschrijven na de uitschrijfdeadline is niet toegestaan!"
 
 msgid "You are not allowed to update this activity"
 msgstr "Je hebt niet de rechten om deze activiteit te wijzigen"


### PR DESCRIPTION
To make it easier to subscribe to activities, the subscription form is now a modal. This prevents the page from scrolling and allows for some magic auto re-openings of the modal if there is an error.

This also changes the states the activity subscription button can be in to ensure that it is easier to see what will happen.

**Can subscribe as GEWIS member (logged in)**
![image](https://github.com/GEWIS/gewisweb/assets/4983571/4a3b8126-1510-4a1c-afc7-0914118acb68)
![image](https://github.com/GEWIS/gewisweb/assets/4983571/8834e6d7-4f9a-483a-9d1d-054fb6507df4)

**Can subscribe as GEWIS member (logged out)**
![image](https://github.com/GEWIS/gewisweb/assets/4983571/7362bef9-e375-4851-9ee8-b2c26c0841d8)

**Can subscribe as external participant**
![image](https://github.com/GEWIS/gewisweb/assets/4983571/1b066286-8795-45c0-a985-021ef8815d8a)
![image](https://github.com/GEWIS/gewisweb/assets/4983571/a3fa1a62-0832-4aac-bbb8-f668f8e3adca)

**Subscribed and can unsubscribe**
![image](https://github.com/GEWIS/gewisweb/assets/4983571/9f62e17b-92aa-45eb-a4c8-7d562f28085e)
![image](https://github.com/GEWIS/gewisweb/assets/4983571/00cbfab4-07c7-4434-bec1-35d8582b965d)

**Subscribed and cannot unsubscribe**
![image](https://github.com/GEWIS/gewisweb/assets/4983571/db71a3c9-786c-4a1c-a5cf-3d7bc507b15f)

**Not subscribed and cannot (un)subscribe**
![image](https://github.com/GEWIS/gewisweb/assets/4983571/9c2ef4ea-27b2-4892-b8c2-10d364a7923c)



Closes GH-1752.