### PR TITLE
[GEWISDB] Move any `Member` association to `SubDecision` itself

### DIFF
--- a/module/Decision/src/Model/SubDecision.php
+++ b/module/Decision/src/Model/SubDecision.php
@@ -137,6 +137,20 @@ abstract class SubDecision
     protected string $content;
 
     /**
+     * The member involved in this sub-decision.
+     *
+     * Not all sub-decisions require this, as such it is nullable. However, sub-decisions that need the guarantee that
+     * this is not null or need to specify an inverse side can do so using an association override.
+     */
+    #[ManyToOne(targetEntity: Member::class)]
+    #[JoinColumn(
+        name: 'lidnr',
+        referencedColumnName: 'lidnr',
+        nullable: true,
+    )]
+    protected ?Member $member = null;
+
+    /**
      * Get the decision.
      */
     public function getDecision(): Decision
@@ -203,6 +217,22 @@ abstract class SubDecision
     public function setNumber(int $number): void
     {
         $this->number = $number;
+    }
+
+    /**
+     * Get the member.
+     */
+    public function getMember(): ?Member
+    {
+        return $this->member;
+    }
+
+    /**
+     * Set the member.
+     */
+    public function setMember(Member $member): void
+    {
+        $this->member = $member;
     }
 
     /**

--- a/module/Decision/src/Model/SubDecision/Board/Installation.php
+++ b/module/Decision/src/Model/SubDecision/Board/Installation.php
@@ -8,16 +8,27 @@ use DateTime;
 use Decision\Model\BoardMember;
 use Decision\Model\Member;
 use Decision\Model\SubDecision;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 
 /**
  * Installation as board member.
  */
 #[Entity]
+#[AssociationOverrides([
+    new AssociationOverride(
+        name: 'member',
+        joinColumns: new JoinColumn(
+            name: 'lidnr',
+            referencedColumnName: 'lidnr',
+            nullable: false,
+        ),
+    ),
+])]
 class Installation extends SubDecision
 {
     /**
@@ -25,21 +36,6 @@ class Installation extends SubDecision
      */
     #[Column(type: 'string')]
     protected string $function;
-
-    /**
-     * Member.
-     *
-     * Note that only members that are older than 18 years can be board members.
-     * Also, honorary, external and extraordinary members cannot be board members.
-     * (See the Statuten, Art. 13 Lid 2.
-     */
-    // TODO: Inversed relation
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-    )]
-    protected Member $member;
 
     /**
      * The date at which the installation is in effect.
@@ -92,18 +88,12 @@ class Installation extends SubDecision
 
     /**
      * Get the member.
+     *
+     * @psalm-suppress InvalidNullableReturnType
      */
     public function getMember(): Member
     {
         return $this->member;
-    }
-
-    /**
-     * Set the member.
-     */
-    public function setMember(Member $member): void
-    {
-        $this->member = $member;
     }
 
     /**

--- a/module/Decision/src/Model/SubDecision/Budget.php
+++ b/module/Decision/src/Model/SubDecision/Budget.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Decision\Model\SubDecision;
 
 use DateTime;
-use Decision\Model\Member;
 use Decision\Model\SubDecision;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 
 /**
  * Budget decision.
@@ -18,16 +15,6 @@ use Doctrine\ORM\Mapping\ManyToOne;
 #[Entity]
 class Budget extends SubDecision
 {
-    /**
-     * Budget author.
-     */
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-    )]
-    protected Member $author;
-
     /**
      * Name of the budget.
      */
@@ -60,22 +47,6 @@ class Budget extends SubDecision
      */
     #[Column(type: 'boolean')]
     protected bool $changes;
-
-    /**
-     * Get the author.
-     */
-    public function getAuthor(): Member
-    {
-        return $this->author;
-    }
-
-    /**
-     * Set the author.
-     */
-    public function setAuthor(Member $author): void
-    {
-        $this->author = $author;
-    }
 
     /**
      * Get the name.

--- a/module/Decision/src/Model/SubDecision/Installation.php
+++ b/module/Decision/src/Model/SubDecision/Installation.php
@@ -8,10 +8,11 @@ use Decision\Model\Member;
 use Decision\Model\OrganMember;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 
@@ -19,6 +20,17 @@ use Doctrine\ORM\Mapping\OneToOne;
  * Installation into organ.
  */
 #[Entity]
+#[AssociationOverrides([
+    new AssociationOverride(
+        name: 'member',
+        joinColumns: new JoinColumn(
+            name: 'lidnr',
+            referencedColumnName: 'lidnr',
+            nullable: false,
+        ),
+        inversedBy: 'installations',
+    ),
+])]
 class Installation extends FoundationReference
 {
     /**
@@ -26,19 +38,6 @@ class Installation extends FoundationReference
      */
     #[Column(type: 'string')]
     protected string $function;
-
-    /**
-     * Member.
-     */
-    #[ManyToOne(
-        targetEntity: Member::class,
-        inversedBy: 'installations',
-    )]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-    )]
-    protected Member $member;
 
     /**
      * Reappointment subdecisions if this installation was prolonged (can be done multiple times).
@@ -92,18 +91,12 @@ class Installation extends FoundationReference
 
     /**
      * Get the member.
+     *
+     * @psalm-suppress InvalidNullableReturnType
      */
     public function getMember(): Member
     {
         return $this->member;
-    }
-
-    /**
-     * Set the member.
-     */
-    public function setMember(Member $member): void
-    {
-        $this->member = $member;
     }
 
     /**

--- a/module/Decision/src/Model/SubDecision/Key/Granting.php
+++ b/module/Decision/src/Model/SubDecision/Key/Granting.php
@@ -6,28 +6,14 @@ namespace Decision\Model\SubDecision\Key;
 
 use DateTime;
 use Decision\Model\Keyholder;
-use Decision\Model\Member;
 use Decision\Model\SubDecision;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 
 #[Entity]
 class Granting extends SubDecision
 {
-    /**
-     * The member who is granted a keycode of GEWIS.
-     */
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-        nullable: true,
-    )]
-    protected ?Member $grantee = null;
-
     /**
      * Till when the keycode is granted.
      */
@@ -51,22 +37,6 @@ class Granting extends SubDecision
         mappedBy: 'grantingDec',
     )]
     protected Keyholder $keyholder;
-
-    /**
-     * Get the grantee.
-     */
-    public function getGrantee(): ?Member
-    {
-        return $this->grantee;
-    }
-
-    /**
-     * Set the grantee.
-     */
-    public function setGrantee(Member $grantee): void
-    {
-        $this->grantee = $grantee;
-    }
 
     /**
      * Get the date.


### PR DESCRIPTION
Changes from GEWISDB upstream, see GEWIS/gewisdb#363. Necessary for GDPR export functionality.