### PR TITLE
Add functionality to request GDPR information

### DIFF
--- a/module/Activity/src/Mapper/Activity.php
+++ b/module/Activity/src/Mapper/Activity.php
@@ -7,6 +7,7 @@ namespace Activity\Mapper;
 use Activity\Model\Activity as ActivityModel;
 use Application\Mapper\BaseMapper;
 use DateTime;
+use Decision\Model\Member as MemberModel;
 use Decision\Model\Organ as OrganModel;
 use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
@@ -293,6 +294,34 @@ class Activity extends BaseMapper
             ->andWhere('a.status = :status')
             ->setParameter('status', ActivityModel::STATUS_APPROVED)
             ->orderBy('a.beginTime', 'DESC');
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Get all activities that were created by a member.
+     *
+     * @return ActivityModel[]
+     */
+    public function findAllActivitiesCreatedByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.creator = :member')
+            ->setParameter('member', $member);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Get all activities that were approved or rejected by a member.
+     *
+     * @return ActivityModel[]
+     */
+    public function findAllActivitiesApprovedByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->where('a.approver = :member')
+            ->setParameter('member', $member);
 
         return $qb->getQuery()->getResult();
     }

--- a/module/Activity/src/Mapper/Signup.php
+++ b/module/Activity/src/Mapper/Signup.php
@@ -8,6 +8,7 @@ use Activity\Model\ExternalSignup as ExternalSignupModel;
 use Activity\Model\SignupList as SignupListModel;
 use Activity\Model\UserSignup as UserSignupModel;
 use Application\Mapper\BaseMapper;
+use Decision\Model\Member as MemberModel;
 use User\Model\User as UserModel;
 
 /**
@@ -60,6 +61,20 @@ class Signup extends BaseMapper
             ->setParameter('signupList', $signupList);
 
         return $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * Get all sign-ups for a specific member.
+     *
+     * @return UserSignupModel[]
+     */
+    public function findSignupsByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('s');
+        $qb->where('s.user = :member')
+            ->setParameter('member', $member);
+
+        return $qb->getQuery()->getResult();
     }
 
     protected function getRepositoryName(): string

--- a/module/Activity/src/Model/Activity.php
+++ b/module/Activity/src/Model/Activity.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Activity\Model;
 
+use Application\Model\LocalisedText as LocalisedTextModel;
 use Application\Model\Traits\IdentifiableTrait;
 use Company\Model\Company as CompanyModel;
 use DateTime;
+use DateTimeInterface;
 use Decision\Model\Member as MemberModel;
 use Decision\Model\Organ as OrganModel;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -45,6 +47,24 @@ use User\Permissions\Resource\OrganResourceInterface;
  *     requireGEFLITST: bool,
  *     categories: ImportedActivityCategoryArrayType[],
  *     signupLists: ImportedSignupListArrayType[],
+ * }
+ * @psalm-import-type LocalisedTextGdprArrayType from LocalisedTextModel as ImportedLocalisedTextGdprArrayType
+ * @psalm-import-type ActivityCategoryGdprArrayType from ActivityCategory as ImportedActivityCategoryGdprArrayType
+ * @psalm-import-type SignupListGdprArrayType from SignupList as ImportedSignupListGdprArrayType
+ * @psalm-type ActivityGdprArrayType = array{
+ *     id: int,
+ *     name: ImportedLocalisedTextGdprArrayType,
+ *     beginTime: string,
+ *     endTime: string,
+ *     location: ImportedLocalisedTextGdprArrayType,
+ *     costs: ImportedLocalisedTextGdprArrayType,
+ *     description: ImportedLocalisedTextGdprArrayType,
+ *     organ: ?int,
+ *     company: ?int,
+ *     isMyFuture: bool,
+ *     requireGEFLITST: bool,
+ *     categories: ImportedActivityCategoryGdprArrayType[],
+ *     signupLists: ImportedSignupListGdprArrayType[],
  * }
  */
 #[Entity]
@@ -501,6 +521,40 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
             'descriptionEn' => $this->getDescription()->getValueEN(),
             'organ' => $this->getOrgan(),
             'company' => $this->getCompany(),
+            'isMyFuture' => $this->getIsMyFuture(),
+            'requireGEFLITST' => $this->getRequireGEFLITST(),
+            'categories' => $categoriesArrays,
+            'signupLists' => $signupListsArrays,
+        ];
+    }
+
+    /**
+     * @return ActivityGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        /** @var ImportedSignupListGdprArrayType[] $signupListsArrays */
+        $signupListsArrays = [];
+        foreach ($this->getSignupLists() as $signupList) {
+            $signupListsArrays[] = $signupList->toGdprArray();
+        }
+
+        /** @var ImportedActivityCategoryGdprArrayType[] $categoriesArrays */
+        $categoriesArrays = [];
+        foreach ($this->getCategories() as $category) {
+            $categoriesArrays[] = $category->toGdprArray();
+        }
+
+        return [
+            'id' => $this->getId(),
+            'name' => $this->getName()->toGdprArray(),
+            'beginTime' => $this->getBeginTime()->format(DateTimeInterface::ATOM),
+            'endTime' => $this->getEndTime()->format(DateTimeInterface::ATOM),
+            'location' => $this->getLocation()->toGdprArray(),
+            'costs' => $this->getCosts()->toGdprArray(),
+            'description' => $this->getDescription()->toGdprArray(),
+            'organ' => $this->getOrgan()?->getId(),
+            'company' => $this->getCompany()?->getId(),
             'isMyFuture' => $this->getIsMyFuture(),
             'requireGEFLITST' => $this->getRequireGEFLITST(),
             'categories' => $categoriesArrays,

--- a/module/Activity/src/Model/ActivityCategory.php
+++ b/module/Activity/src/Model/ActivityCategory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Activity\Model;
 
+use Application\Model\LocalisedText as LocalisedTextModel;
 use Application\Model\Traits\IdentifiableTrait;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -19,6 +20,11 @@ use Doctrine\ORM\Mapping\OneToOne;
  *     id: int,
  *     name: ?string,
  *     nameEn: ?string,
+ * }
+ * @psalm-import-type LocalisedTextGdprArrayType from LocalisedTextModel as ImportedLocalisedTextGdprArrayType
+ * @psalm-type ActivityCategoryGdprArrayType = array{
+ *     id: int,
+ *     name: ImportedLocalisedTextGdprArrayType,
  * }
  */
 #[Entity]
@@ -103,6 +109,17 @@ class ActivityCategory
             'id' => $this->getId(),
             'name' => $this->getName()->getValueNL(),
             'nameEn' => $this->getName()->getValueEN(),
+        ];
+    }
+
+    /**
+     * @return ActivityCategoryGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'name' => $this->getName()->toGdprArray(),
         ];
     }
 }

--- a/module/Activity/src/Model/SignupField.php
+++ b/module/Activity/src/Model/SignupField.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Activity\Model;
 
+use Application\Model\LocalisedText as LocalisedTextModel;
 use Application\Model\Traits\IdentifiableTrait;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -27,6 +28,17 @@ use Doctrine\ORM\Mapping\OneToOne;
  *     maximumValue: ?int,
  *     options: array<array-key, ?string>,
  *     optionsEn: array<array-key, ?string>,
+ * }
+ * @psalm-import-type LocalisedTextGdprArrayType from LocalisedTextModel as ImportedLocalisedTextGdprArrayType
+ * @psalm-import-type SignupOptionGdprArrayType from SignupOption as ImportedSignupOptionGdprArrayType
+ * @psalm-type SignupFieldGdprArrayType = array{
+ *     id: int,
+ *     sensitive: bool,
+ *     name: ImportedLocalisedTextGdprArrayType,
+ *     type: int,
+ *     minimumValue: ?int,
+ *     maximumValue: ?int,
+ *     options: ?ImportedSignupOptionGdprArrayType[],
  * }
  */
 #[Entity]
@@ -206,6 +218,28 @@ class SignupField
             'maximumValue' => $this->getMaximumValue(),
             'options' => $optionsArrays,
             'optionsEn' => $optionsEn,
+        ];
+    }
+
+    /**
+     * @return SignupFieldGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        /** @var ImportedSignupOptionGdprArrayType[] $options */
+        $options = [];
+        foreach ($this->getOptions() as $option) {
+            $options[] = $option->toGdprArray();
+        }
+
+        return [
+            'id' => $this->getId(),
+            'sensitive' => $this->isSensitive(),
+            'name' => $this->getName()->toGdprArray(),
+            'type' => $this->getType(),
+            'minimumValue' => $this->getMinimumValue(),
+            'maximumValue' => $this->getMaximumValue(),
+            'options' => $options,
         ];
     }
 }

--- a/module/Activity/src/Model/SignupFieldValue.php
+++ b/module/Activity/src/Model/SignupFieldValue.php
@@ -12,6 +12,13 @@ use Doctrine\ORM\Mapping\ManyToOne;
 
 /**
  * SignupFieldValue model.
+ *
+ * @psalm-import-type SignupOptionGdprArrayType from SignupOption as ImportedSignupOptionGdprArrayType
+ * @psalm-type SignupFieldValueGdprArrayType = array{
+ *     id: int,
+ *     value: ?string,
+ *     option: ?ImportedSignupOptionGdprArrayType,
+ * }
  */
 #[Entity]
 class SignupFieldValue
@@ -60,7 +67,7 @@ class SignupFieldValue
         name: 'option_id',
         referencedColumnName: 'id',
     )]
-    protected ?SignupOption $option;
+    protected ?SignupOption $option = null;
 
     public function getField(): SignupField
     {
@@ -109,5 +116,17 @@ class SignupFieldValue
     public function setOption(?SignupOption $option): void
     {
         $this->option = $option;
+    }
+
+    /**
+     * @return SignupFieldValueGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'value' => $this->getValue(),
+            'option' => $this->getOption()->toGdprArray(),
+        ];
     }
 }

--- a/module/Activity/src/Model/SignupList.php
+++ b/module/Activity/src/Model/SignupList.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Activity\Model;
 
+use Application\Model\LocalisedText as LocalisedTextModel;
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Decision\Model\Member as MemberModel;
 use Decision\Model\Organ as OrganModel;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -34,6 +36,18 @@ use User\Permissions\Resource\OrganResourceInterface;
  *     displaySubscribedNumber: bool,
  *     limitedCapacity: bool,
  *     fields: ImportedSignupFieldArrayType[],
+ * }
+ * @psalm-import-type LocalisedTextGdprArrayType from LocalisedTextModel as ImportedLocalisedTextGdprArrayType
+ * @psalm-import-type SignupFieldGdprArrayType from SignupField as ImportedSignupFieldGdprArrayType
+ * @psalm-type SignupListGdprArrayType = array{
+ *     id: int,
+ *     name: ImportedLocalisedTextGdprArrayType,
+ *     openDate: string,
+ *     closeDate: string,
+ *     onlyGEWIS: bool,
+ *     displaySubscribedNumber: bool,
+ *     limitedCapacity: bool,
+ *     fields: ImportedSignupFieldGdprArrayType[],
  * }
  */
 #[Entity]
@@ -290,6 +304,29 @@ class SignupList implements OrganResourceInterface, CreatorResourceInterface
             'nameEn' => $this->getName()->getValueEN(),
             'openDate' => $this->getOpenDate(),
             'closeDate' => $this->getCloseDate(),
+            'onlyGEWIS' => $this->getOnlyGEWIS(),
+            'displaySubscribedNumber' => $this->getDisplaySubscribedNumber(),
+            'limitedCapacity' => $this->getLimitedCapacity(),
+            'fields' => $fieldsArrays,
+        ];
+    }
+
+    /**
+     * @return SignupListGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        /** @var ImportedSignupFieldGdprArrayType[] $fieldsArrays */
+        $fieldsArrays = [];
+        foreach ($this->getFields() as $field) {
+            $fieldsArrays[] = $field->toGdprArray();
+        }
+
+        return [
+            'id' => $this->getId(),
+            'name' => $this->getName()->toGdprArray(),
+            'openDate' => $this->getOpenDate()->format(DateTimeInterface::ATOM),
+            'closeDate' => $this->getCloseDate()->format(DateTimeInterface::ATOM),
             'onlyGEWIS' => $this->getOnlyGEWIS(),
             'displaySubscribedNumber' => $this->getDisplaySubscribedNumber(),
             'limitedCapacity' => $this->getLimitedCapacity(),

--- a/module/Activity/src/Model/SignupOption.php
+++ b/module/Activity/src/Model/SignupOption.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Activity\Model;
 
+use Application\Model\LocalisedText as LocalisedTextModel;
 use Application\Model\Traits\IdentifiableTrait;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
@@ -13,6 +14,12 @@ use Doctrine\ORM\Mapping\OneToOne;
 /**
  * SignupOption model.
  * Contains the possible options of a field of type ``option''.
+ *
+ * @psalm-import-type LocalisedTextGdprArrayType from LocalisedTextModel as ImportedLocalisedTextGdprArrayType
+ * @psalm-type SignupOptionGdprArrayType = array{
+ *     id: int,
+ *     value: ImportedLocalisedTextGdprArrayType,
+ * }
  */
 #[Entity]
 class SignupOption
@@ -90,6 +97,17 @@ class SignupOption
             'id' => $this->getId(),
             'value' => $this->getValue()->getValueNL(),
             'valueEn' => $this->getValue()->getValueEN(),
+        ];
+    }
+
+    /**
+     * @return SignupOptionGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'value' => $this->getValue()->toGdprArray(),
         ];
     }
 }

--- a/module/Application/src/Model/LocalisedText.php
+++ b/module/Application/src/Model/LocalisedText.php
@@ -12,6 +12,11 @@ use Laminas\Session\Container as SessionContainer;
 
 /**
  * Class LocalisedText: stores Dutch and English versions of text fields.
+ *
+ * @psalm-type LocalisedTextGdprArrayType = array{
+ *     valueEN: ?string,
+ *     valueNL: ?string,
+ * }
  */
 abstract class LocalisedText
 {
@@ -105,5 +110,16 @@ abstract class LocalisedText
             'en' => $this->valueEN,
             default => throw new InvalidArgumentException('Locale not supported: ' . $locale),
         };
+    }
+
+    /**
+     * @return LocalisedTextGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'valueEN' => $this->getValueEN(),
+            'valueNL' => $this->getValueNL(),
+        ];
     }
 }

--- a/module/Application/src/Model/Traits/ApprovableTrait.php
+++ b/module/Application/src/Model/Traits/ApprovableTrait.php
@@ -7,6 +7,7 @@ namespace Application\Model\Traits;
 use Application\Model\ApprovableText as ApprovableTextModel;
 use Application\Model\Enums\ApprovableStatus;
 use DateTime;
+use DateTimeInterface;
 use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\JoinColumn;
@@ -17,6 +18,13 @@ use Doctrine\ORM\Mapping\OneToOne;
  * A trait which provides basic (repeated) functionality for approvable entities.
  *
  * TODO: Make activities also use this trait.
+ *
+ * @psalm-type ApprovableTraitGdprArrayType = array{
+ *     id: int,
+ *     approved: int,
+ *     approvedAt: ?string,
+ *     approvableText: ?string,
+ * }
  */
 trait ApprovableTrait
 {
@@ -105,5 +113,18 @@ trait ApprovableTrait
     public function setApprovableText(?ApprovableTextModel $approvableText): void
     {
         $this->approvableText = $approvableText;
+    }
+
+    /**
+     * @return ApprovableTraitGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'approved' => $this->getApproved()->value,
+            'approvedAt' => $this->getApprovedAt()?->format(DateTimeInterface::ATOM),
+            'approvableText' => $this->getApprovableText()?->getMessage(),
+        ];
     }
 }

--- a/module/Application/view/partial/admin.phtml
+++ b/module/Application/view/partial/admin.phtml
@@ -156,17 +156,17 @@ use Laminas\View\Renderer\PhpRenderer;
                             </a>
                             <ul class="dropdown-menu">
                                 <li>
-                                    <a href="<?= $this->url('admin_decision/minutes') ?>"><?= $this->translate(
+                                    <a href="<?= $this->url('decision_admin/minutes') ?>"><?= $this->translate(
                                             'Minutes'
                                         ) ?></a>
                                 </li>
                                 <li>
-                                    <a href="<?= $this->url('admin_decision/document') ?>"><?= $this->translate(
+                                    <a href="<?= $this->url('decision_admin/document') ?>"><?= $this->translate(
                                             'Documents'
                                         ) ?></a>
                                 </li>
                                 <li>
-                                    <a href="<?= $this->url('admin_decision/authorizations') ?>"><?= $this->translate(
+                                    <a href="<?= $this->url('decision_admin/authorizations') ?>"><?= $this->translate(
                                             'Authorizations'
                                         ) ?></a>
                                 </li>
@@ -220,9 +220,9 @@ use Laminas\View\Renderer\PhpRenderer;
                             </a>
                             <ul class="dropdown-menu">
                                 <li>
-                                    <a href="<?= $this->url('user_admin/api') ?>"><?= $this->translate(
-                                            'API Users'
-                                        ) ?></a>
+                                    <a href="<?= $this->url('user_admin/api') ?>">
+                                        <?= $this->translate('API Users') ?>
+                                    </a>
                                 </li>
                             </ul>
                         </li>

--- a/module/Company/src/Mapper/Company.php
+++ b/module/Company/src/Mapper/Company.php
@@ -8,6 +8,7 @@ use Application\Mapper\BaseMapper;
 use Application\Model\Enums\ApprovableStatus;
 use Company\Model\Company as CompanyModel;
 use Company\Model\Proposals\CompanyUpdate as CompanyUpdateModel;
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 
 /**
@@ -91,6 +92,20 @@ class Company extends BaseMapper
 
         $qb->setParameter('approved', ApprovableStatus::Unapproved)
             ->setParameter('isUpdate', false);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Get all companies that were approved or rejected by a specific member.
+     *
+     * @return CompanyModel[]
+     */
+    public function findAllCompaniesApprovedByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('c');
+        $qb->where('c.approver = :member')
+            ->setParameter('member', $member);
 
         return $qb->getQuery()->getResult();
     }

--- a/module/Company/src/Mapper/Job.php
+++ b/module/Company/src/Mapper/Job.php
@@ -8,6 +8,7 @@ use Application\Mapper\BaseMapper;
 use Application\Model\Enums\ApprovableStatus;
 use Company\Model\Job as JobModel;
 use Company\Model\Proposals\JobUpdate as JobUpdateModel;
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Query\Expr\Join;
 
 use function count;
@@ -173,6 +174,20 @@ class Job extends BaseMapper
         $qb->setParameter('proposalId', $proposalId);
 
         return $qb->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * Get all jobs that were approved or rejected by a specific member.
+     *
+     * @return JobModel[]
+     */
+    public function findAllJobsApprovedByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('j');
+        $qb->where('j.approver = :member')
+            ->setParameter('member', $member);
+
+        return $qb->getQuery()->getResult();
     }
 
     protected function getRepositoryName(): string

--- a/module/Decision/config/module.config.php
+++ b/module/Decision/config/module.config.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Decision;
 
 use Decision\Controller\AdminController;
+use Decision\Controller\AdminMemberController;
 use Decision\Controller\DecisionController;
 use Decision\Controller\Factory\AdminControllerFactory;
+use Decision\Controller\Factory\AdminMemberControllerFactory;
 use Decision\Controller\Factory\DecisionControllerFactory;
 use Decision\Controller\Factory\MemberControllerFactory;
 use Decision\Controller\Factory\OrganAdminControllerFactory;
@@ -125,7 +127,7 @@ return [
                 ],
                 'priority' => 100,
             ],
-            'admin_decision' => [
+            'decision_admin' => [
                 'type' => Literal::class,
                 'options' => [
                     'route' => '/admin/decision',
@@ -141,6 +143,30 @@ return [
                             'route' => '[/:action]',
                             'constraints' => [
                                 'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                        ],
+                    ],
+                    'member' => [
+                        'type' => Literal::class,
+                        'options' => [
+                            'route' => '/member',
+                            'defaults' => [
+                                'controller' => AdminMemberController::class,
+                            ],
+                        ],
+                        'may_terminate' => false,
+                        'child_routes' => [
+                            'gdpr' => [
+                                'type' => Segment::class,
+                                'options' => [
+                                    'route' => '/:lidnr',
+                                    'constraints' => [
+                                        'type' => '[0-9]+',
+                                    ],
+                                    'defaults' => [
+                                        'action' => 'memberGdpr',
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -363,6 +389,7 @@ return [
     'controllers' => [
         'factories' => [
             AdminController::class => AdminControllerFactory::class,
+            AdminMemberController::class => AdminMemberControllerFactory::class,
             DecisionController::class => DecisionControllerFactory::class,
             MemberController::class => MemberControllerFactory::class,
             OrganAdminController::class => OrganAdminControllerFactory::class,

--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -55,7 +55,7 @@ class AdminController extends AbstractActionController
                         $this->translator->translate('Meeting minutes uploaded'),
                     );
 
-                    return $this->redirect()->toRoute('admin_decision/minutes');
+                    return $this->redirect()->toRoute('decision_admin/minutes');
                 }
             }
         }
@@ -156,7 +156,7 @@ class AdminController extends AbstractActionController
                 }
 
                 return $this->redirect()->toRoute(
-                    'admin_decision/document',
+                    'decision_admin/document',
                     [
                         'type' => $document->getMeeting()->getType()->value,
                         'number' => $document->getMeeting()->getNumber(),
@@ -188,7 +188,7 @@ class AdminController extends AbstractActionController
             }
         }
 
-        return $this->redirect()->toRoute('admin_decision/document');
+        return $this->redirect()->toRoute('decision_admin/document');
     }
 
     public function changePositionDocumentAction(): mixed

--- a/module/Decision/src/Controller/AdminMemberController.php
+++ b/module/Decision/src/Controller/AdminMemberController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Decision\Controller;
+
+use Decision\Service\AclService;
+use Decision\Service\Gdpr as GdprService;
+use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\Mvc\I18n\Translator;
+use Laminas\View\Model\JsonModel;
+use User\Permissions\NotAllowedException;
+
+class AdminMemberController extends AbstractActionController
+{
+    public function __construct(
+        private readonly AclService $aclService,
+        private readonly Translator $translator,
+        private readonly GdprService $gdprService,
+    ) {
+    }
+
+    public function memberGdprAction(): JsonModel
+    {
+        if (!$this->aclService->isAllowed('export', 'gdpr')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to export member data'),
+            );
+        }
+
+        return new JsonModel($this->gdprService->getMemberData((int) $this->params()->fromRoute('lidnr')));
+    }
+}

--- a/module/Decision/src/Controller/Factory/AdminMemberControllerFactory.php
+++ b/module/Decision/src/Controller/Factory/AdminMemberControllerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Decision\Controller\Factory;
+
+use Decision\Controller\AdminMemberController;
+use Laminas\Mvc\I18n\Translator as MvcTranslator;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class AdminMemberControllerFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): AdminMemberController {
+        return new AdminMemberController(
+            $container->get('decision_service_acl'),
+            $container->get(MvcTranslator::class),
+            $container->get('decision_service_gdpr'),
+        );
+    }
+}

--- a/module/Decision/src/Mapper/Authorization.php
+++ b/module/Decision/src/Mapper/Authorization.php
@@ -73,6 +73,28 @@ class Authorization extends BaseMapper
         return $qb->getQuery()->getResult();
     }
 
+    /**
+     * Find all authorizations granted by or granted to a specific member. This includes revoked authorizations.
+     *
+     * @return AuthorizationModel[]
+     */
+    public function findByMember(
+        MemberModel $member,
+        bool $authorizer,
+    ): array {
+        $qb = $this->getRepository()->createQueryBuilder('a');
+
+        if ($authorizer) {
+            $qb->where('a.authorizer = :authorizer')
+                ->setParameter('authorizer', $member);
+        } else {
+            $qb->Where('a.recipient = :recipient')
+                ->setParameter('recipient', $member);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
     protected function getRepositoryName(): string
     {
         return AuthorizationModel::class;

--- a/module/Decision/src/Mapper/SubDecision.php
+++ b/module/Decision/src/Mapper/SubDecision.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Decision\Mapper;
+
+use Application\Mapper\BaseMapper;
+use Decision\Model\Member as MemberModel;
+use Decision\Model\SubDecision as SubDecisionModel;
+
+use function addcslashes;
+
+/**
+ * @template-extends BaseMapper<SubDecisionModel>
+ */
+class SubDecision extends BaseMapper
+{
+    /**
+     * Search sub-decisions.
+     *
+     * @return SubDecisionModel[]
+     */
+    public function findByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('s');
+        $qb->select('s')
+            ->where('s.content LIKE :full_name')
+            ->orWhere('s.member = :member');
+
+        $qb->setParameter('full_name', '%' . addcslashes($member->getFullName(), '%_') . '%')
+            ->setParameter('member', $member);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    protected function getRepositoryName(): string
+    {
+        return SubDecisionModel::class;
+    }
+}

--- a/module/Decision/src/Model/Address.php
+++ b/module/Decision/src/Model/Address.php
@@ -13,6 +13,16 @@ use Doctrine\ORM\Mapping\ManyToOne;
 
 /**
  * Address model.
+ *
+ * @psalm-type AddressGdprArrayType = array{
+ *     type: string,
+ *     street: string,
+ *     number: string,
+ *     postalCode: string,
+ *     city: string,
+ *     postalRegion: string,
+ *     phone: string,
+ *  }
  */
 #[Entity]
 class Address
@@ -212,5 +222,21 @@ class Address
     public function setPhone(string $phone): void
     {
         $this->phone = $phone;
+    }
+
+    /**
+     * @return AddressGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'type' => $this->getType()->value,
+            'street' => $this->getStreet(),
+            'number' => $this->getNumber(),
+            'postalCode' => $this->getPostalCode(),
+            'city' => $this->getCity(),
+            'postalRegion' => $this->getCountry(),
+            'phone' => $this->getPhone(),
+        ];
     }
 }

--- a/module/Decision/src/Model/Authorization.php
+++ b/module/Decision/src/Model/Authorization.php
@@ -6,6 +6,7 @@ namespace Decision\Model;
 
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
@@ -14,6 +15,12 @@ use Doctrine\ORM\Mapping\UniqueConstraint;
 
 /**
  * Authorization model.
+ *
+ * @psalm-type AuthorizationGdprArrayType = array{
+ *     meeting_number: int,
+ *     createdAt: string,
+ *     revokedAt: ?string,
+ * }
  */
 #[Entity]
 #[UniqueConstraint(
@@ -35,7 +42,7 @@ class Authorization
     protected Member $authorizer;
 
     /**
-     * Member receiving this authorization..
+     * Member receiving this authorization.
      */
     #[ManyToOne(targetEntity: Member::class)]
     #[JoinColumn(
@@ -113,5 +120,17 @@ class Authorization
     public function setRevokedAt(?DateTime $revokedAt): void
     {
         $this->revokedAt = $revokedAt;
+    }
+
+    /**
+     * @return AuthorizationGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'meeting_number' => $this->getMeetingNumber(),
+            'createdAt' => $this->getCreatedAt()->format(DateTimeInterface::ATOM),
+            'revokedAt' => $this->getRevokedAt()?->format(DateTimeInterface::ATOM),
+        ];
     }
 }

--- a/module/Decision/src/Model/MailingList.php
+++ b/module/Decision/src/Model/MailingList.php
@@ -13,6 +13,12 @@ use Doctrine\ORM\Mapping\ManyToMany;
 
 /**
  * Mailing List model.
+ *
+ * @psalm-type MailingListGdprArrayType = array{
+ *     name: string,
+ *     description_en: string,
+ *     description_nl: string,
+ * }
  */
 #[Entity]
 class MailingList
@@ -178,5 +184,17 @@ class MailingList
     public function addMember(Member $member): void
     {
         $this->members[] = $member;
+    }
+
+    /**
+     * @return MailingListGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'name' => $this->getName(),
+            'description_en' => $this->getEnDescription(),
+            'description_nl' => $this->getNlDescription(),
+        ];
     }
 }

--- a/module/Decision/src/Model/Member.php
+++ b/module/Decision/src/Model/Member.php
@@ -25,7 +25,7 @@ use User\Model\User as UserModel;
 /**
  * Member model.
  *
- * @psalm-type MemberArrayType = array{
+ * @psalm-type MemberGdprArrayType = array{
  *     lidnr: int,
  *     email: ?string,
  *     fullName: string,
@@ -33,11 +33,16 @@ use User\Model\User as UserModel;
  *     middleName: string,
  *     initials: string,
  *     firstName: string,
+ *     birth: string,
  *     generation: int,
- *     hidden: bool,
- *     deleted: bool,
+ *     type: string,
+ *     paid: int,
+ *     changedOn: string,
  *     membershipEndsOn: ?string,
  *     expiration: string,
+ *     supremum: ?string,
+ *     hidden: bool,
+ *     deleted: bool,
  * }
  */
 #[Entity]
@@ -152,15 +157,6 @@ class Member
      */
     #[Column(type: 'integer')]
     protected int $paid = 0;
-
-    /**
-     * Iban number.
-     */
-    #[Column(
-        type: 'string',
-        nullable: true,
-    )]
-    protected ?string $iban = null;
 
     /**
      * If the member receives a 'supremum'.
@@ -525,22 +521,6 @@ class Member
     }
 
     /**
-     * Get the IBAN.
-     */
-    public function getIban(): ?string
-    {
-        return $this->iban;
-    }
-
-    /**
-     * Set the IBAN.
-     */
-    public function setIban(?string $iban): void
-    {
-        $this->iban = $iban;
-    }
-
-    /**
      * Get if the member wants a supremum.
      */
     public function getSupremum(): ?string
@@ -698,9 +678,9 @@ class Member
     /**
      * Convert most relevant items to array.
      *
-     * @return MemberArrayType
+     * @return MemberGdprArrayType
      */
-    public function toArray(): array
+    public function toGdprArray(): array
     {
         return [
             'lidnr' => $this->getLidnr(),
@@ -710,11 +690,16 @@ class Member
             'middleName' => $this->getMiddleName(),
             'initials' => $this->getInitials(),
             'firstName' => $this->getFirstName(),
+            'birth' => $this->getBirth()->format(DateTimeInterface::ATOM),
             'generation' => $this->getGeneration(),
+            'type' => $this->getType()->value,
+            'paid' => $this->getPaid(),
+            'changedOn' => $this->getChangedOn()->format(DateTimeInterface::ATOM),
+            'membershipEndsOn' => $this->getMembershipEndsOn()?->format(DateTimeInterface::ATOM),
+            'expiration' => $this->getExpiration()->format(DateTimeInterface::ATOM),
+            'supremum' => $this->getSupremum(),
             'hidden' => $this->getHidden(),
             'deleted' => $this->getDeleted(),
-            'membershipEndsOn' => $this->getMembershipEndsOn()?->format(DateTimeInterface::ISO8601) ?? null,
-            'expiration' => $this->getExpiration()->format(DateTimeInterface::ISO8601),
         ];
     }
 

--- a/module/Decision/src/Model/SubDecision.php
+++ b/module/Decision/src/Model/SubDecision.php
@@ -31,6 +31,15 @@ use Doctrine\ORM\Mapping\ManyToOne;
 
 /**
  * SubDecision model.
+ *
+ * @psalm-type SubDecisionGdprArrayType = array{
+ *     meeting_type: string,
+ *     meeting_number: int,
+ *     decision_point: int,
+ *     decision_number: int,
+ *     subdecision_number: int,
+ *     ...,
+ * }
  */
 #[Entity]
 #[InheritanceType(value: 'SINGLE_TABLE')]
@@ -249,5 +258,20 @@ abstract class SubDecision
     public function setContent(string $content): void
     {
         $this->content = $content;
+    }
+
+    /**
+     * @return SubDecisionGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'meeting_type' => $this->getMeetingType()->value,
+            'meeting_number' => $this->getMeetingNumber(),
+            'decision_point' => $this->getDecisionPoint(),
+            'decision_number' => $this->getDecisionNumber(),
+            'subdecision_number' => $this->getNumber(),
+            'content' => $this->getContent(),
+        ];
     }
 }

--- a/module/Decision/src/Model/SubDecision/Foundation.php
+++ b/module/Decision/src/Model/SubDecision/Foundation.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Decision\Model\SubDecision;
 
-use Decision\Model\Enums\MeetingTypes;
 use Decision\Model\Enums\OrganTypes;
 use Decision\Model\Organ;
 use Decision\Model\SubDecision;
@@ -149,37 +148,5 @@ class Foundation extends SubDecision
             $this->getDecisionNumber(),
             $this->getNumber(),
         );
-    }
-
-    /**
-     * Get an array with all information.
-     *
-     * Mostly useful for usage with JSON.
-     *
-     * @return array{
-     *     meeting_type: MeetingTypes,
-     *     meeting_number: int,
-     *     decision_point: int,
-     *     decision_number: int,
-     *     subdecision_number: int,
-     *     abbr: string,
-     *     name: string,
-     *     organtype: OrganTypes,
-     * }
-     */
-    public function toArray(): array
-    {
-        $decision = $this->getDecision();
-
-        return [
-            'meeting_type' => $decision->getMeeting()->getType(),
-            'meeting_number' => $decision->getMeeting()->getNumber(),
-            'decision_point' => $decision->getPoint(),
-            'decision_number' => $decision->getNumber(),
-            'subdecision_number' => $this->getNumber(),
-            'abbr' => $this->getAbbr(),
-            'name' => $this->getName(),
-            'organtype' => $this->getOrganType(),
-        ];
     }
 }

--- a/module/Decision/src/Module.php
+++ b/module/Decision/src/Module.php
@@ -19,7 +19,9 @@ use Decision\Mapper\MeetingDocument as MeetingDocumentMapper;
 use Decision\Mapper\MeetingMinutes as MeetingMinutesMapper;
 use Decision\Mapper\Member as MemberMapper;
 use Decision\Mapper\Organ as OrganMapper;
+use Decision\Mapper\SubDecision as SubDecisionMapper;
 use Decision\Service\Decision as DecisionService;
+use Decision\Service\Gdpr as GdprService;
 use Decision\Service\Member as MemberService;
 use Decision\Service\MemberInfo as MemberInfoService;
 use Decision\Service\Organ as OrganService;
@@ -109,6 +111,49 @@ class Module
                         $authorizationRevocationForm,
                     );
                 },
+                'decision_service_gdpr' => static function (ContainerInterface $container) {
+                    $aclService = $container->get('decision_service_acl');
+                    $translator = $container->get(MvcTranslator::class);
+                    $activityMapper = $container->get('activity_mapper_activity');
+                    $apiAppAuthenticationMapper = $container->get('user_mapper_apiappauthentication');
+                    $authorizationMapper = $container->get('decision_mapper_authorization');
+                    $companyMapper = $container->get('company_mapper_company');
+                    $courseDocumentMapper = $container->get('education_mapper_courseDocument');
+                    $jobMapper = $container->get('company_mapper_job');
+                    $loginAttemptMapper = $container->get('user_mapper_loginAttempt');
+                    $memberMapper = $container->get('decision_mapper_member');
+                    $pollMapper = $container->get('frontpage_mapper_poll');
+                    $pollCommentMapper = $container->get('frontpage_mapper_poll_comment');
+                    $photoMapper = $container->get('photo_mapper_photo');
+                    $profilePhotoMapper = $container->get('photo_mapper_profile_photo');
+                    $signupMapper = $container->get('activity_mapper_signup');
+                    $subDecisionMapper = $container->get('decision_mapper_subDecision');
+                    $tagMapper = $container->get('photo_mapper_tag');
+                    $userMapper = $container->get('user_mapper_user');
+                    $voteMapper = $container->get('photo_mapper_vote');
+
+                    return new GdprService(
+                        $aclService,
+                        $translator,
+                        $activityMapper,
+                        $apiAppAuthenticationMapper,
+                        $authorizationMapper,
+                        $companyMapper,
+                        $courseDocumentMapper,
+                        $jobMapper,
+                        $loginAttemptMapper,
+                        $memberMapper,
+                        $pollMapper,
+                        $pollCommentMapper,
+                        $photoMapper,
+                        $profilePhotoMapper,
+                        $signupMapper,
+                        $subDecisionMapper,
+                        $tagMapper,
+                        $userMapper,
+                        $voteMapper,
+                    );
+                },
                 'decision_service_member' => static function (ContainerInterface $container) {
                     $aclService = $container->get('decision_service_acl');
                     $translator = $container->get(MvcTranslator::class);
@@ -166,6 +211,11 @@ class Module
                 },
                 'decision_mapper_decision' => static function (ContainerInterface $container) {
                     return new DecisionMapper(
+                        $container->get('doctrine.entitymanager.orm_default'),
+                    );
+                },
+                'decision_mapper_subDecision' => static function (ContainerInterface $container) {
+                    return new SubDecisionMapper(
                         $container->get('doctrine.entitymanager.orm_default'),
                     );
                 },

--- a/module/Decision/src/Service/AclService.php
+++ b/module/Decision/src/Service/AclService.php
@@ -18,6 +18,7 @@ class AclService extends \User\Service\AclService
         $this->acl->addResource('authorization');
         $this->acl->addResource('files');
         $this->acl->addResource('regulations');
+        $this->acl->addResource('gdpr');
 
         // users are allowed to view the organs
         $this->acl->allow('guest', 'organ', 'list');
@@ -45,5 +46,8 @@ class AclService extends \User\Service\AclService
         // graduates may not do a few things, so limit them.
         $this->acl->deny('graduate', 'member', ['view', 'search', 'birthdays']);
         $this->acl->deny('graduate', 'authorization', ['create', 'revoke', 'view_own']);
+
+        // do not allow board to perform GDPR requests
+        $this->acl->deny('board', 'gdpr');
     }
 }

--- a/module/Decision/src/Service/Gdpr.php
+++ b/module/Decision/src/Service/Gdpr.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Decision\Service;
+
+use Activity\Mapper\Activity as ActivityMapper;
+use Activity\Mapper\Signup as SignupMapper;
+use Activity\Model\Activity as ActivityModel;
+use Activity\Model\Signup as SignupModel;
+use Company\Mapper\Company as CompanyMapper;
+use Company\Mapper\Job as JobMapper;
+use Decision\Mapper\Authorization as AuthorizationMapper;
+use Decision\Mapper\Member as MemberMapper;
+use Decision\Mapper\SubDecision as SubDecisionMapper;
+use Decision\Model\Address as AddressModel;
+use Decision\Model\Authorization as AuthorizationModel;
+use Decision\Model\MailingList as MailingListModel;
+use Decision\Model\Member as MemberModel;
+use Decision\Model\SubDecision as SubDecisionModel;
+use Education\Mapper\CourseDocument as CourseDocumentMapper;
+use Education\Model\CourseDocument as CourseDocumentModel;
+use Frontpage\Mapper\Poll as PollMapper;
+use Frontpage\Mapper\PollComment as PollCommentMapper;
+use Frontpage\Model\Poll as PollModel;
+use Frontpage\Model\PollComment as PollCommentModel;
+use Frontpage\Model\PollVote as PollVoteModel;
+use Laminas\Mvc\I18n\Translator;
+use Photo\Mapper\Photo as PhotoMapper;
+use Photo\Mapper\ProfilePhoto as ProfilePhotoMapper;
+use Photo\Mapper\Tag as TagMapper;
+use Photo\Mapper\Vote as VoteMapper;
+use Photo\Model\Photo as PhotoModel;
+use Photo\Model\ProfilePhoto as ProfilePhotoModel;
+use Photo\Model\Tag as TagModel;
+use Photo\Model\Vote as VoteModel;
+use User\Mapper\ApiAppAuthentication as ApiAppAuthenticationMapper;
+use User\Mapper\LoginAttempt as LoginAttemptMapper;
+use User\Mapper\User as UserMapper;
+use User\Model\ApiAppAuthentication as ApiAppAuthenticationModel;
+use User\Model\LoginAttempt as LoginAttemptModel;
+use User\Model\User as UserModel;
+use User\Permissions\NotAllowedException;
+
+/**
+ * GDPR service.
+ *
+ * @psalm-import-type ActivityGdprArrayType from ActivityModel as ImportedActivityGdprArrayType
+ * @psalm-import-type AddressGdprArrayType from AddressModel as ImportedAddressGdprArrayType
+ * @psalm-import-type ApiAppAuthenticationGdprArrayType from ApiAppAuthenticationModel as ImportedApiAppAuthenticationGdprArrayType
+ * @psalm-type ImportedApprovableTraitGdprArrayType = array{
+ *     id: int,
+ *     approved: int,
+ *     approvedAt: ?string,
+ *     approvableText: ?string,
+ * } // Psalm does not (yet) support importing types from traits, as such this is re-defined here.
+ * @psalm-import-type AuthorizationGdprArrayType from AuthorizationModel as ImportedAuthorizationGdprArrayType
+ * @psalm-import-type CourseDocumentGdprArrayType from CourseDocumentModel as ImportedCourseDocumentGdprArrayType
+ * @psalm-import-type LoginAttemptGdprArrayType from LoginAttemptModel as ImportedLoginAttemptGdprArrayType
+ * @psalm-import-type MailingListGdprArrayType from MailingListModel as ImportedMailingListGdprArrayType
+ * @psalm-import-type MemberGdprArrayType from MemberModel as ImportedMemberGdprArrayType
+ * @psalm-import-type PhotoGdprArrayType from PhotoModel as ImportedPhotoGdprArrayType
+ * @psalm-import-type PollGdprArrayType from PollModel as ImportedPollGdprArrayType
+ * @psalm-import-type PollCommentGdprArrayType from PollCommentModel as ImportedPollCommentGdprArrayType
+ * @psalm-import-type PollVoteGdprArrayType from PollVoteModel as ImportedPollVoteGdprArrayType
+ * @psalm-import-type ProfilePhotoGdprArrayType from ProfilePhotoModel as ImportedProfilePhotoGdprArrayType
+ * @psalm-import-type SignupGdprArrayType from SignupModel as ImportedSignupGdprArrayType
+ * @psalm-import-type SubDecisionGdprArrayType from SubDecisionModel as ImportedSubDecisionGdprArrayType
+ * @psalm-import-type TagGdprArrayType from TagModel as ImportedTagGdprArrayType
+ * @psalm-import-type UserGdprArrayType from UserModel as ImportedUserGdprArrayType
+ * @psalm-import-type VoteGdprArrayType from VoteModel as ImportedVoteGdprArrayType
+ */
+class Gdpr
+{
+    public function __construct(
+        private readonly AclService $aclService,
+        private readonly Translator $translator,
+        private readonly ActivityMapper $activityMapper,
+        private readonly ApiAppAuthenticationMapper $apiAppAuthenticationMapper,
+        private readonly AuthorizationMapper $authorizationMapper,
+        private readonly CompanyMapper $companyMapper,
+        private readonly CourseDocumentMapper $courseDocumentMapper,
+        private readonly JobMapper $jobMapper,
+        private readonly LoginAttemptMapper $loginAttemptMapper,
+        private readonly MemberMapper $memberMapper,
+        private readonly PollMapper $pollMapper,
+        private readonly PollCommentMapper $pollCommentMapper,
+        private readonly PhotoMapper $photoMapper,
+        private readonly ProfilePhotoMapper $profilePhotoMapper,
+        private readonly SignupMapper $signupMapper,
+        private readonly SubDecisionMapper $subDecisionMapper,
+        private readonly TagMapper $tagMapper,
+        private readonly UserMapper $userMapper,
+        private readonly VoteMapper $voteMapper,
+    ) {
+    }
+
+    /**
+     * @return array<never, never>|array{
+     *     member: array{
+     *         information: ImportedMemberGdprArrayType,
+     *         user_information: ?ImportedUserGdprArrayType,
+     *         profile_photo: ?ImportedProfilePhotoGdprArrayType,
+     *         addresses: ImportedAddressGdprArrayType[],
+     *         lists: ImportedMailingListGdprArrayType[],
+     *         login_attempts: ImportedLoginAttemptGdprArrayType[],
+     *         app_authentications: ImportedApiAppAuthenticationGdprArrayType[],
+     *     },
+     *     activities: array{
+     *         signups: ImportedSignupGdprArrayType[],
+     *         created: ImportedActivityGdprArrayType[],
+     *         approved: array<array-key, array{id: int}>,
+     *     },
+     *     companies: array{
+     *         approved: array{
+     *             companies: ImportedApprovableTraitGdprArrayType[],
+     *             jobs: ImportedApprovableTraitGdprArrayType[],
+     *         },
+     *     },
+     *     decisions: array{
+     *         sub_decisions: ImportedSubDecisionGdprArrayType[],
+     *         meeting_authorizations: array{
+     *             sent: ImportedAuthorizationGdprArrayType[],
+     *             received: ImportedAuthorizationGdprArrayType[],
+     *         },
+     *     },
+     *     education: array{
+     *         authored_documents: ImportedCourseDocumentGdprArrayType[],
+     *     },
+     *     photos: array{
+     *         tags: ImportedTagGdprArrayType[],
+     *         votes: ImportedVoteGdprArrayType[],
+     *         photographer: ImportedPhotoGdprArrayType[],
+     *     },
+     *     polls: array{
+     *         votes: ImportedPollVoteGdprArrayType[],
+     *         comments: ImportedPollCommentGdprArrayType[],
+     *         created: ImportedPollGdprArrayType[],
+     *         approved: ImportedPollGdprArrayType[],
+     *     },
+     * }
+     */
+    public function getMemberData(int $lidnr): array
+    {
+        if (!$this->aclService->isAllowed('export', 'gdpr')) {
+            // This is a very sensitive action, so we do this ACL check twice.
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to export member data'),
+            );
+        }
+
+        $member = $this->memberMapper->findByLidnr($lidnr);
+
+        if (null === $member) {
+            return [];
+        }
+
+        /// MEMBER INFORMATION
+        /** @var ImportedAddressGdprArrayType[] $addresses */
+        $addresses = [];
+        foreach ($member->getAddresses() as $address) {
+            $addresses[] = $address->toGdprArray();
+        }
+
+        /** @var ImportedMailingListGdprArrayType[] $lists */
+        $lists = [];
+        foreach ($member->getLists() as $list) {
+            $lists[] = $list->toGdprArray();
+        }
+
+        /** @var ImportedLoginAttemptGdprArrayType[] $loginAttempts */
+        $loginAttempts = [];
+        foreach ($this->loginAttemptMapper->getAttemptsByMember($member) as $loginAttempt) {
+            $loginAttempts[] = $loginAttempt->toGdprArray();
+        }
+
+        /** @var ImportedApiAppAuthenticationGdprArrayType[] $apiAppAuthentications */
+        $apiAppAuthentications = [];
+        foreach ($this->apiAppAuthenticationMapper->getMemberAuthenticationsPerApiApp($member) as $appAuthentication) {
+            $apiAppAuthentications[] = $appAuthentication->toGdprArray();
+        }
+
+        /// ACTIVITY INFORMATION
+        /** @var ImportedSignupGdprArrayType[] $signups */
+        $signups = [];
+        foreach ($this->signupMapper->findSignupsByMember($member) as $signup) {
+            $signups[] = $signup->toGdprArray();
+        }
+
+        /** @var ImportedActivityGdprArrayType[] $createdActivities */
+        $createdActivities = [];
+        foreach ($this->activityMapper->findAllActivitiesCreatedByMember($member) as $activity) {
+            $createdActivities[] = $activity->toGdprArray();
+        }
+
+        /** @var array<array-key, array{id: int}> $approvedActivities */
+        $approvedActivities = [];
+        foreach ($this->activityMapper->findAllActivitiesApprovedByMember($member) as $activity) {
+            // TODO: When implementing GH-1685 update this to be similar to how it is done in the company module.
+            $approvedActivities[] = ['id' => $activity->getId()];
+        }
+
+        /// COMPANY INFORMATION
+        /** @var ImportedApprovableTraitGdprArrayType[] $approvedCompanies */
+        $approvedCompanies = [];
+        foreach ($this->companyMapper->findAllCompaniesApprovedByMember($member) as $company) {
+            $approvedCompanies[] = $company->toGdprArray();
+        }
+
+        /** @var ImportedApprovableTraitGdprArrayType[] $approvedJobs */
+        $approvedJobs = [];
+        foreach ($this->jobMapper->findAllJobsApprovedByMember($member) as $job) {
+            $approvedJobs[] = $job->toGdprArray();
+        }
+
+        /// DECISION INFORMATION
+        /** @var ImportedSubDecisionGdprArrayType[] $subDecisions */
+        $subDecisions = [];
+        foreach ($this->subDecisionMapper->findByMember($member) as $subDecision) {
+            $subDecisions[] = $subDecision->toGdprArray();
+        }
+
+        /** @var ImportedAuthorizationGdprArrayType[] $sentAuthorizations */
+        $sentAuthorizations = [];
+        foreach ($this->authorizationMapper->findByMember($member, true) as $authorization) {
+            $sentAuthorizations[] = $authorization->toGdprArray();
+        }
+
+        /** @var ImportedAuthorizationGdprArrayType[] $receivedAuthorizations */
+        $receivedAuthorizations = [];
+        foreach ($this->authorizationMapper->findByMember($member, false) as $authorization) {
+            $receivedAuthorizations[] = $authorization->toGdprArray();
+        }
+
+        /// EDUCATION INFORMATION
+        /** @var ImportedCourseDocumentGdprArrayType[] $summaries */
+        $summaries = [];
+        foreach ($this->courseDocumentMapper->findSummariesByAuthor($member) as $summary) {
+            $summaries[] = $summary->toGdprArray();
+        }
+
+        /// PHOTO INFORMATION
+        /** @var ImportedTagGdprArrayType[] $tags */
+        $tags = [];
+        foreach ($this->tagMapper->getTagsByLidnr($lidnr) as $tag) {
+            $tags[] = $tag->toGdprArray();
+        }
+
+        /** @var ImportedVoteGdprArrayType[] $votes */
+        $votes = [];
+        foreach ($this->voteMapper->getVotesByLidnr($lidnr) as $vote) {
+            $votes[] = $vote->toGdprArray();
+        }
+
+        /** @var ImportedPhotoGdprArrayType[] $photos */
+        $photos = [];
+        foreach ($this->photoMapper->findPhotosByMember($member) as $photo) {
+            $photos[] = $photo->toGdprArray();
+        }
+
+        /// POLL INFORMATION
+        /** @var ImportedPollVoteGdprArrayType[] $pollVotes */
+        $pollVotes = [];
+        foreach ($this->pollMapper->findVotesByMember($member) as $pollVote) {
+            $pollVotes[] = $pollVote->toGdprArray();
+        }
+
+        /** @var ImportedPollCommentGdprArrayType[] $pollComments */
+        $pollComments = [];
+        foreach ($this->pollCommentMapper->findByMember($member) as $pollComment) {
+            $pollComments[] = $pollComment->toGdprArray();
+        }
+
+        /** @var ImportedPollGdprArrayType[] $createdPolls */
+        $createdPolls = [];
+        foreach ($this->pollMapper->findPollsCreatedByMember($member) as $poll) {
+            $createdPolls[] = $poll->toGdprArray();
+        }
+
+        /** @var ImportedPollGdprArrayType[] $approvedPolls */
+        $approvedPolls = [];
+        foreach ($this->pollMapper->findPollsApprovedByMember($member) as $poll) {
+            $approvedPolls[] = $poll->toGdprArray();
+        }
+
+        return [
+            'member' => [
+                'information' => $member->toGdprArray(),
+                'user_information' => $this->userMapper->find($member->getLidnr())?->toGdprArray(),
+                'profile_photo' => $this->profilePhotoMapper->getProfilePhotoByLidnr($lidnr)?->toGdprArray() ?? null,
+                'addresses' => $addresses,
+                'lists' => $lists,
+                'login_attempts' => $loginAttempts,
+                'app_authentications' => $apiAppAuthentications,
+            ],
+            'activities' => [
+                'signups' => $signups,
+                'created' => $createdActivities,
+                'approved' => $approvedActivities,
+            ],
+            'companies' => [
+                'approved' => [
+                    'companies' => $approvedCompanies,
+                    'jobs' => $approvedJobs,
+                ],
+            ],
+            'decisions' => [
+                'sub_decisions' => $subDecisions,
+                'meeting_authorizations' => [
+                    'sent' => $sentAuthorizations,
+                    'received' => $receivedAuthorizations,
+                ],
+            ],
+            'education' => [
+                'authored_documents' => $summaries,
+            ],
+            'photos' => [
+                'tags' => $tags,
+                'votes' => $votes,
+                'photographer' => $photos,
+            ],
+            'polls' => [
+                'votes' => $pollVotes,
+                'comments' => $pollComments,
+                'created' => $createdPolls,
+                'approved' => $approvedPolls,
+            ],
+        ];
+    }
+}

--- a/module/Decision/view/decision/admin/authorizations.phtml
+++ b/module/Decision/view/decision/admin/authorizations.phtml
@@ -22,7 +22,7 @@ $this->breadcrumbs()
                     <?php foreach ($meetings as $meeting): ?>
                         <option
                             value="<?= $this->url(
-                                'admin_decision/authorizations',
+                                'decision_admin/authorizations',
                                 ['number' => $meeting->getNumber()],
                             ) ?>"
                             <?= ($meeting->getNumber() === $number) ? 'selected' : '' ?>

--- a/module/Decision/view/decision/admin/document.phtml
+++ b/module/Decision/view/decision/admin/document.phtml
@@ -19,8 +19,8 @@ use Laminas\View\Renderer\PhpRenderer;
 
 $this->scriptUrl()->requireUrls(
     [
-        'admin_decision/delete_document',
-        'admin_decision/rename_document',
+        'decision_admin/delete_document',
+        'decision_admin/rename_document',
     ],
     ['document_id'],
 );
@@ -120,7 +120,7 @@ else:
 
                                 $form->setAttributes([
                                     'class' => 'form-reorder-document',
-                                    'action' => $this->url('admin_decision/position_document/post')
+                                    'action' => $this->url('decision_admin/position_document/post')
                                 ]);
                                 $form->populateValues([
                                     'document' => $document->getId()
@@ -327,14 +327,14 @@ else:
         });
 
         document.getElementById('meeting-selector').addEventListener('change', e => {
-            window.location = '<?= $this->url('admin_decision/document') ?>/' + e.target.value;
+            window.location = '<?= $this->url('decision_admin/document') ?>/' + e.target.value;
         });
 
         document.querySelectorAll('.btn-delete').forEach((element) => {
             element.addEventListener('click', () => {
                 document.querySelector('#delete-document-name').textContent = element.dataset.documentName;
                 document.querySelector('.form-delete').action = URLHelper.url(
-                    'admin_decision/delete_document',
+                    'decision_admin/delete_document',
                     {'document_id': element.dataset.documentId},
                 );
                 $('#deleteModal').modal('show');
@@ -345,7 +345,7 @@ else:
             element.addEventListener('click', () => {
                 document.querySelector('#new-document-name').value = element.dataset.documentName;
                 document.querySelector('.form-rename').action = URLHelper.url(
-                    'admin_decision/rename_document',
+                    'decision_admin/rename_document',
                     {'document_id': element.dataset.documentId},
                 );
                 $('#renameModal').modal('show');

--- a/module/Decision/view/decision/admin/minutes.phtml
+++ b/module/Decision/view/decision/admin/minutes.phtml
@@ -17,7 +17,7 @@ $this->breadcrumbs()
 
 $form->prepare();
 
-$form->setAttribute('action', $this->url('admin_decision/default', ['action' => 'minutes']));
+$form->setAttribute('action', $this->url('decision_admin/default', ['action' => 'minutes']));
 $form->setAttribute('method', 'post');
 
 $form->setAttribute('class', 'form-horizontal');

--- a/module/Education/src/Mapper/CourseDocument.php
+++ b/module/Education/src/Mapper/CourseDocument.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Education\Mapper;
 
 use Application\Mapper\BaseMapper;
+use Decision\Model\Member as MemberModel;
 use Education\Model\Course as CourseModel;
 use Education\Model\CourseDocument as CourseDocumentModel;
 use Education\Model\Exam as ExamModel;
 use Education\Model\Summary as SummaryModel;
+
+use function addcslashes;
 
 /**
  * Mapper for course documents.
@@ -31,6 +34,20 @@ class CourseDocument extends BaseMapper
             ->andWhere('d INSTANCE OF :type')
             ->setParameter('course', $course)
             ->setParameter('type', $this->getEntityManager()->getClassMetadata($type));
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Get all summaries created by a specific member.
+     *
+     * @return SummaryModel[]
+     */
+    public function findSummariesByAuthor(MemberModel $member): array
+    {
+        $qb = $this->getEntityManager()->getRepository(SummaryModel::class)->createQueryBuilder('d');
+        $qb->where('d.author LIKE :full_name')
+            ->setParameter('full_name', '%' . addcslashes($member->getFullName(), '%_') . '%');
 
         return $qb->getQuery()->getResult();
     }

--- a/module/Education/src/Model/Course.php
+++ b/module/Education/src/Model/Course.php
@@ -21,6 +21,11 @@ use function implode;
 
 /**
  * Course.
+ *
+ * @psalm-type CourseGdprArrayType = array{
+ *     code: string,
+ *     name: string,
+ * }
  */
 #[Entity]
 class Course implements ResourceInterface
@@ -184,6 +189,17 @@ class Course implements ResourceInterface
     public function clearSimilarCoursesTo(): void
     {
         $this->similarCoursesTo->clear();
+    }
+
+    /**
+     * @return CourseGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'code' => $this->getCode(),
+            'name' => $this->getName(),
+        ];
     }
 
     /**

--- a/module/Education/src/Model/CourseDocument.php
+++ b/module/Education/src/Model/CourseDocument.php
@@ -7,6 +7,7 @@ namespace Education\Model;
 use Application\Model\Enums\Languages;
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -16,6 +17,17 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
+/**
+ * @psalm-import-type CourseGdprArrayType from Course as ImportedCourseGdprArrayType
+ * @psalm-type CourseDocumentGdprArrayType = array{
+ *     id: int,
+ *     course: ImportedCourseGdprArrayType,
+ *     date: string,
+ *     language: string,
+ *     scanned: bool,
+ *     path: string,
+ * }
+ */
 #[Entity]
 #[InheritanceType(value: 'SINGLE_TABLE')]
 #[DiscriminatorColumn(
@@ -151,6 +163,21 @@ abstract class CourseDocument implements ResourceInterface
     public function setScanned(bool $scanned): void
     {
         $this->scanned = $scanned;
+    }
+
+    /**
+     * @return CourseDocumentGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'course' => $this->getCourse()->toGdprArray(),
+            'date' => $this->getDate()->format(DateTimeInterface::ATOM),
+            'language' => $this->getLanguage()->value,
+            'scanned' => $this->getScanned(),
+            'path' => $this->getFilename(),
+        ];
     }
 
     public function getResourceId(): string

--- a/module/Frontpage/src/Mapper/Poll.php
+++ b/module/Frontpage/src/Mapper/Poll.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Frontpage\Mapper;
 
 use Application\Mapper\BaseMapper;
+use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use DoctrineORMModule\Paginator\Adapter\DoctrinePaginator as DoctrineAdapter;
 use Frontpage\Model\Poll as PollModel;
@@ -71,6 +72,49 @@ class Poll extends BaseMapper
             ->orderBy('p.expiryDate', 'DESC');
 
         return new DoctrineAdapter(new Paginator($qb));
+    }
+
+    /**
+     * Get all poll votes casted by a specific member.
+     *
+     * @return PollVoteModel[]
+     */
+    public function findVotesByMember(MemberModel $member): array
+    {
+        $qb = $this->getEntityManager()->getRepository(PollVoteModel::class)->createQueryBuilder('v');
+        $qb->where('v.respondent = :member')
+            ->orderBy('v.poll', 'DESC')
+            ->setParameter('member', $member);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Get all polls created by a specific member.
+     *
+     * @return PollModel[]
+     */
+    public function findPollsCreatedByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('p');
+        $qb->where('p.creator = :member')
+            ->setParameter('member', $member);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Get all polls approved by a specific member.
+     *
+     * @return PollModel[]
+     */
+    public function findPollsApprovedByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('p');
+        $qb->where('p.approver = :member')
+            ->setParameter('member', $member);
+
+        return $qb->getQuery()->getResult();
     }
 
     protected function getRepositoryName(): string

--- a/module/Frontpage/src/Mapper/PollComment.php
+++ b/module/Frontpage/src/Mapper/PollComment.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Frontpage\Mapper;
 
 use Application\Mapper\BaseMapper;
+use Decision\Model\Member as MemberModel;
 use Frontpage\Model\PollComment as PollCommentModel;
 
 /**
@@ -14,6 +15,21 @@ use Frontpage\Model\PollComment as PollCommentModel;
  */
 class PollComment extends BaseMapper
 {
+    /**
+     * Get all poll comments made by specific member.
+     *
+     * @return PollCommentModel[]
+     */
+    public function findByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('c');
+        $qb->where('c.user = :member')
+            ->orderBy('c.createdOn', 'DESC')
+            ->setParameter('member', $member);
+
+        return $qb->getQuery()->getResult();
+    }
+
     protected function getRepositoryName(): string
     {
         return PollCommentModel::class;

--- a/module/Frontpage/src/Model/PollComment.php
+++ b/module/Frontpage/src/Model/PollComment.php
@@ -6,6 +6,7 @@ namespace Frontpage\Model;
 
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -15,6 +16,13 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 /**
  * Poll comment.
+ *
+ * @psalm-type PollCommentGdprArrayType = array{
+ *     id: int,
+ *     createdOn: string,
+ *     author: string,
+ *     content: string,
+ * }
  */
 #[Entity]
 class PollComment implements ResourceInterface
@@ -142,6 +150,19 @@ class PollComment implements ResourceInterface
     public function setCreatedOn(DateTime $createdOn): void
     {
         $this->createdOn = $createdOn;
+    }
+
+    /**
+     * @return PollCommentGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'createdOn' => $this->getCreatedOn()->format(DateTimeInterface::ATOM),
+            'author' => $this->getAuthor(),
+            'content' => $this->getContent(),
+        ];
     }
 
     /**

--- a/module/Frontpage/src/Model/PollVote.php
+++ b/module/Frontpage/src/Model/PollVote.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frontpage\Model;
 
+use Application\Model\LocalisedText as LocalisedTextModel;
 use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
@@ -15,6 +16,12 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 /**
  * Poll response
  * Represents a vote on a poll option.
+ *
+ * @psalm-import-type LocalisedTextGdprArrayType from LocalisedTextModel as ImportedLocalisedTextGdprArrayType
+ * @psalm-type PollVoteGdprArrayType = array{
+ *     poll_id: int,
+ *     option: ImportedLocalisedTextGdprArrayType,
+ * }
  */
 #[Entity]
 #[UniqueConstraint(
@@ -64,6 +71,11 @@ class PollVote implements ResourceInterface
     )]
     protected MemberModel $respondent;
 
+    public function getPoll(): Poll
+    {
+        return $this->poll;
+    }
+
     public function getPollOption(): PollOption
     {
         return $this->pollOption;
@@ -82,6 +94,17 @@ class PollVote implements ResourceInterface
     public function setRespondent(MemberModel $respondent): void
     {
         $this->respondent = $respondent;
+    }
+
+    /**
+     * @return PollVoteGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'poll_id' => $this->getPoll()->getId(),
+            'option' => $this->getPollOption()->getText()->toGdprArray(),
+        ];
     }
 
     /**

--- a/module/Photo/src/Mapper/Photo.php
+++ b/module/Photo/src/Mapper/Photo.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Photo\Mapper;
 
 use Application\Mapper\BaseMapper;
+use Decision\Model\Member as MemberModel;
 use Photo\Model\Album as AlbumModel;
 use Photo\Model\MemberAlbum as MemberAlbumModel;
 use Photo\Model\Photo as PhotoModel;
+
+use function addcslashes;
 
 /**
  * Mappers for Photo.
@@ -149,6 +152,20 @@ class Photo extends BaseMapper
                 'album' => $album,
             ],
         );
+    }
+
+    /**
+     * Get all photos that have the member as its author.
+     *
+     * @return PhotoModel[]
+     */
+    public function findPhotosByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('p');
+        $qb->where('p.artist LIKE :full_name')
+            ->setParameter('full_name', '%' . addcslashes($member->getFullName(), '%_') . '%');
+
+        return $qb->getQuery()->getResult();
     }
 
     protected function getRepositoryName(): string

--- a/module/Photo/src/Mapper/Vote.php
+++ b/module/Photo/src/Mapper/Vote.php
@@ -76,6 +76,18 @@ class Vote extends BaseMapper
         return 0 !== count($qb->getQuery()->getResult());
     }
 
+    /**
+     * @return VoteModel[]
+     */
+    public function getVotesByLidnr(int $lidnr): array
+    {
+        return $this->getRepository()->findBy(
+            [
+                'voter' => $lidnr,
+            ],
+        );
+    }
+
     protected function getRepositoryName(): string
     {
         return VoteModel::class;

--- a/module/Photo/src/Model/Photo.php
+++ b/module/Photo/src/Model/Photo.php
@@ -6,6 +6,7 @@ namespace Photo\Model;
 
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
@@ -41,6 +42,11 @@ use function getimagesize;
  *     largeThumbPath: string,
  *     longitude: ?float,
  *     latitude: ?float,
+ * }
+ * @psalm-type PhotoGdprArrayType = array{
+ *     id: int,
+ *     dateTime: string,
+ *     path: string,
  * }
  */
 #[Entity]
@@ -610,6 +616,18 @@ class Photo implements ResourceInterface
             'largeThumbPath' => $this->getLargeThumbPath(),
             'longitude' => $this->getLongitude(),
             'latitude' => $this->getLatitude(),
+        ];
+    }
+
+    /**
+     * @return PhotoGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'dateTime' => $this->getDateTime()->format(DateTimeInterface::ATOM),
+            'path' => $this->getPath(),
         ];
     }
 

--- a/module/Photo/src/Model/ProfilePhoto.php
+++ b/module/Photo/src/Model/ProfilePhoto.php
@@ -6,6 +6,7 @@ namespace Photo\Model;
 
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -16,6 +17,13 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 /**
  * ProfilePhoto.
+ *
+ * @psalm-import-type PhotoGdprArrayType from Photo as ImportedPhotoGdprArrayType
+ * @psalm-type ProfilePhotoGdprArrayType = array{
+ *     dateTime: string,
+ *     explicit: bool,
+ *     photo: ImportedPhotoGdprArrayType,
+ * }
  */
 #[Entity]
 class ProfilePhoto implements ResourceInterface
@@ -97,6 +105,18 @@ class ProfilePhoto implements ResourceInterface
     public function setExplicit(bool $explicit): void
     {
         $this->explicit = $explicit;
+    }
+
+    /**
+     * @return ProfilePhotoGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'dateTime' => $this->getDateTime()->format(DateTimeInterface::ATOM),
+            'explicit' => $this->isExplicit(),
+            'photo' => $this->getPhoto()->toGdprArray(),
+        ];
     }
 
     /**

--- a/module/Photo/src/Model/Tag.php
+++ b/module/Photo/src/Model/Tag.php
@@ -15,6 +15,12 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 /**
  * Tag.
+ *
+ * @psalm-import-type PhotoGdprArrayType from Photo as ImportedPhotoGdprArrayType
+ * @psalm-type TagGdprArrayType = array{
+ *     id: int,
+ *     photo: ImportedPhotoGdprArrayType,
+ * }
  */
 #[Entity]
 #[Table(name: 'Tag')]
@@ -83,6 +89,17 @@ class Tag implements ResourceInterface
             'id' => $this->getId(),
             'photo_id' => $this->getPhoto()->getId(),
             'member_id' => $this->getMember()->getLidnr(),
+        ];
+    }
+
+    /**
+     * @return TagGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'photo' => $this->getPhoto()->toGdprArray(),
         ];
     }
 

--- a/module/Photo/src/Model/Vote.php
+++ b/module/Photo/src/Model/Vote.php
@@ -6,6 +6,7 @@ namespace Photo\Model;
 
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Decision\Model\Member as MemberModel;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -14,6 +15,13 @@ use Doctrine\ORM\Mapping\ManyToOne;
 
 /**
  * Vote, represents a vote for a photo of the week.
+ *
+ * @psalm-import-type PhotoGdprArrayType from Photo as ImportedPhotoGdprArrayType
+ * @psalm-type VoteGdprArrayType = array{
+ *     id: int,
+ *     dateTime: string,
+ *     photo: ImportedPhotoGdprArrayType,
+ * }
  */
 #[Entity]
 class Vote
@@ -51,6 +59,11 @@ class Vote
         $this->dateTime = new DateTime();
     }
 
+    public function getDateTime(): DateTime
+    {
+        return $this->dateTime;
+    }
+
     public function setPhoto(Photo $photo): void
     {
         $this->photo = $photo;
@@ -59,5 +72,17 @@ class Vote
     public function getPhoto(): Photo
     {
         return $this->photo;
+    }
+
+    /**
+     * @return VoteGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'dateTime' => $this->getDateTime()->format(DateTimeInterface::ATOM),
+            'photo' => $this->getPhoto()->toGdprArray(),
+        ];
     }
 }

--- a/module/User/src/Mapper/ApiAppAuthentication.php
+++ b/module/User/src/Mapper/ApiAppAuthentication.php
@@ -51,6 +51,22 @@ class ApiAppAuthentication extends BaseMapper
         return $qb->getQuery()->getOneOrNullResult();
     }
 
+    /**
+     * @return ApiAppAuthenticationModel[]
+     */
+    public function getMemberAuthenticationsPerApiApp(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('a');
+        $qb->select('a, app')
+            ->leftJoin(ApiAppModel::class, 'app', 'WITH', 'a.apiApp = app.id')
+            ->where('a.user = :user_id')
+            ->groupBy('app.appId')
+            ->orderBy('a.time', 'DESC')
+            ->setParameter('user_id', $member->getLidnr());
+
+        return $qb->getQuery()->getResult();
+    }
+
     protected function getRepositoryName(): string
     {
         return ApiAppAuthenticationModel::class;

--- a/module/User/src/Mapper/LoginAttempt.php
+++ b/module/User/src/Mapper/LoginAttempt.php
@@ -7,6 +7,7 @@ namespace User\Mapper;
 use Application\Mapper\BaseMapper;
 use Application\Model\IdentityInterface;
 use DateTime;
+use Decision\Model\Member as MemberModel;
 use User\Model\CompanyUser as CompanyUserModel;
 use User\Model\LoginAttempt as LoginAttemptModel;
 use User\Model\User as UserModel;
@@ -38,6 +39,19 @@ class LoginAttempt extends BaseMapper
         }
 
         return $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @return LoginAttemptModel[]
+     */
+    public function getAttemptsByMember(MemberModel $member): array
+    {
+        $qb = $this->getRepository()->createQueryBuilder('l');
+        $qb->where('l.user = :user')
+            ->orderBy('l.time', 'DESC')
+            ->setParameter('user', $member->getLidnr());
+
+        return $qb->getQuery()->getResult();
     }
 
     protected function getRepositoryName(): string

--- a/module/User/src/Model/ApiAppAuthentication.php
+++ b/module/User/src/Model/ApiAppAuthentication.php
@@ -6,6 +6,7 @@ namespace User\Model;
 
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
@@ -13,6 +14,12 @@ use Doctrine\ORM\Mapping\ManyToOne;
 
 /**
  * Log when a member has authenticated for an external app.
+ *
+ * @psalm-type ApiAppAuthenticationGdprArrayType = array{
+ *     id: int,
+ *     app_id: string,
+ *     time: string,
+ * }
  */
 #[Entity]
 class ApiAppAuthentication
@@ -75,5 +82,17 @@ class ApiAppAuthentication
     public function setTime(DateTime $time): void
     {
         $this->time = $time;
+    }
+
+    /**
+     * @return ApiAppAuthenticationGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'app_id' => $this->getApiApp()->getAppId(),
+            'time' => $this->getTime()->format(DateTimeInterface::ATOM),
+        ];
     }
 }

--- a/module/User/src/Model/Enums/UserRoles.php
+++ b/module/User/src/Model/Enums/UserRoles.php
@@ -19,6 +19,7 @@ enum UserRoles: string
     case Graduate = 'graduate';
     case ActiveMember = 'active_member';
     case CompanyAdmin = 'company_admin';
+    case Board = 'board';
     case Admin = 'admin';
 
     public function getName(Translator $translator): string
@@ -32,6 +33,7 @@ enum UserRoles: string
             self::Graduate => $translator->translate('Graduate'),
             self::ActiveMember => $translator->translate('Active Member'),
             self::CompanyAdmin => $translator->translate('Company Admin'),
+            self::Board => $translator->translate('Board'),
             self::Admin => $translator->translate('Admin'),
         };
     }
@@ -52,7 +54,8 @@ enum UserRoles: string
             self::Graduate->value => $translator->translate('Graduate - Authenticated graduate'),
             self::ActiveMember->value => $translator->translate('Active Member - Authenticated member and in an organ'),
             self::CompanyAdmin->value => $translator->translate('Company Admin - C4 members'),
-            self::Admin->value => $translator->translate('Admin - Board and Tom'),
+            self::Board->value => $translator->translate('Admin - Board'),
+            self::Admin->value => $translator->translate('Admin - Tom'),
         ];
     }
 }

--- a/module/User/src/Model/LoginAttempt.php
+++ b/module/User/src/Model/LoginAttempt.php
@@ -6,6 +6,7 @@ namespace User\Model;
 
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
@@ -15,6 +16,12 @@ use User\Model\User as UserModel;
 
 /**
  * A failed login attempt.
+ *
+ * @psalm-type LoginAttemptGdprArrayType = array{
+ *     id: int,
+ *     time: string,
+ *     ip: string,
+ * }
  */
 #[Entity]
 class LoginAttempt
@@ -91,5 +98,17 @@ class LoginAttempt
     public function setTime(DateTime $time): void
     {
         $this->time = $time;
+    }
+
+    /**
+     * @return LoginAttemptGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'time' => $this->getTime()->format(DateTimeInterface::ATOM),
+            'ip' => $this->getIp(),
+        ];
     }
 }

--- a/module/User/src/Model/User.php
+++ b/module/User/src/Model/User.php
@@ -18,6 +18,8 @@ use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use RuntimeException;
 
+use User\Model\Enums\UserRoles;
+
 use function count;
 use function in_array;
 use function sprintf;
@@ -170,27 +172,28 @@ class User implements IdentityInterface
     public function getRoleId(): string
     {
         $roleNames = $this->getRoleNames();
-        if (
-            in_array('admin', $roleNames)
-            || $this->getMember()->isBoardMember()
-        ) {
-            return 'admin';
+        if (in_array('admin', $roleNames)) {
+            return UserRoles::Admin->value;
+        }
+
+        if ($this->getMember()->isBoardMember()) {
+            return UserRoles::Board->value;
         }
 
         if (in_array('company_admin', $roleNames)) {
-            return 'company_admin';
+            return UserRoles::CompanyAdmin->value;
         }
 
         if (empty($roleNames)) {
             if (MembershipTypes::Graduate === $this->getMember()->getType()) {
-                return 'graduate';
+                return UserRoles::Graduate->value;
             }
 
             if (count($this->getMember()->getCurrentOrganInstallations()) > 0) {
-                return 'active_member';
+                return UserRoles::ActiveMember->value;
             }
 
-            return 'user';
+            return UserRoles::User->value;
         }
 
         throw new RuntimeException(

--- a/module/User/src/Model/UserRole.php
+++ b/module/User/src/Model/UserRole.php
@@ -6,6 +6,7 @@ namespace User\Model;
 
 use Application\Model\Traits\IdentifiableTrait;
 use DateTime;
+use DateTimeInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
@@ -16,6 +17,11 @@ use User\Model\Enums\UserRoles;
  * User role model.
  *
  * This specifies all the roles of a user.
+ *
+ * @psalm-type UserRoleGdprArrayType = array{
+ *     role: string,
+ *     expiration: ?string,
+ * }
  */
 #[Entity]
 class UserRole
@@ -108,5 +114,16 @@ class UserRole
     {
         return null !== $this->expiration
             && (new DateTime('now')) < $this->expiration;
+    }
+
+    /**
+     * @return UserRoleGdprArrayType
+     */
+    public function toGdprArray(): array
+    {
+        return [
+            'role' => $this->getRole()->value,
+            'expiration' => $this->getExpiration()?->format(DateTimeInterface::ATOM),
+        ];
     }
 }

--- a/module/User/src/Service/AclService.php
+++ b/module/User/src/Service/AclService.php
@@ -67,6 +67,7 @@ class AclService extends GenericAclService
          * - graduate: an old GEWIS-member, has limited privileges
          * - company: a company which uses the career section of the website
          * - apiuser: Automated tool given access by an admin
+         * - board: Members of the board, they have almost all privileges
          * - admin: Defined administrators
          */
         $this->acl->addRole(new Role(UserRoles::Guest->value));
@@ -78,13 +79,17 @@ class AclService extends GenericAclService
         $this->acl->addRole(new Role(UserRoles::Graduate->value), UserRoles::User->value);
         $this->acl->addrole(new Role(UserRoles::CompanyAdmin->value), UserRoles::ActiveMember->value);
         $this->acl->addRole(new Role(UserRoles::Admin->value));
+        $this->acl->addRole(new Role(UserRoles::Board->value), UserRoles::Admin->value);
 
-        // admins (this includes board members) are allowed to do everything
+        // admins (this includes board members) are allowed to do everything (board not actually)
         $this->acl->allow(UserRoles::Admin->value);
 
         // configure the user ACL
         $this->acl->addResource(new Resource('apiuser'));
         $this->acl->addResource(new Resource('user'));
+
+        // Do not allow the board to touch API tokens
+        $this->acl->deny(UserRoles::Board->value, 'apiuser');
 
         $this->acl->allow(UserRoles::User->value, 'user', ['password_change']);
         $this->acl->allow(UserRoles::Company->value, 'user', ['password_change']);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,6 +48,7 @@
         <exclude-pattern>module/Education/src/Controller/Factory/EducationControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Decision/src/Controller/Factory/DecisionControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Decision/src/Controller/Factory/AdminControllerFactory.php</exclude-pattern>
+        <exclude-pattern>module/Decision/src/Controller/Factory/AdminMemberControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Decision/src/Controller/Factory/OrganControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Decision/src/Controller/Factory/MemberControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Decision/src/Controller/Factory/OrganAdminControllerFactory.php</exclude-pattern>


### PR DESCRIPTION
This makes `board` a separate role in the ACL to ensure that the board cannot access API users and GDPR exports.

The GDPR export functionality covers:
- [X] Activities
  - [X] Sign-ups
  - [X] Created
  - [X] Approved
- [X] Companies
  - [X] Companies approved
  - [X] Jobs approved 
- [X] Decisions
  - [X] Decisions (from GEWISDB)
  - [X] GMM authorizations
  - [X] Member information (from GEWISDB)
- [X] Education
  - [X] Uploaded summaries 
- [X] Frontpage
  - [X] Polls created
  - [X] Poll comments
  - [X] Poll votes 
- [X] Photos
  - [X] Photographer
  - [X] Tags
  - [X] Votes
- [X] User
  - [X] Extra information (roles, login attempts, etc)

There is no UI for this (yet) as this is intended to be moved to the actual API in the future.

This closes GH-1773.