### PR TITLE
Fix BAC website URL

### DIFF
--- a/module/Frontpage/view/frontpage/frontpage/home.phtml
+++ b/module/Frontpage/view/frontpage/frontpage/home.phtml
@@ -177,7 +177,7 @@ $lang = $this->plugin('translate')->getTranslator()->getLocale();
                         <p class="small">
                             <?= sprintf(
                                 $this->translate('Donderdags is er %sborrel%s van 16.30 tot 19.00 uur.'),
-                                '<a href="https://bac.gewis.nl">',
+                                '<a href="https://mannendispuutdebac.nl">',
                                 '</a>'
                             )
                             ?>


### PR DESCRIPTION
Replaced the old bac.gewis.nl link with the brand new and better mannendispuutdebac.nl.