### PR TITLE
Show historic overview of members for abrogated organs

### DIFF
--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -15,6 +15,8 @@ use Laminas\View\Renderer\PhpRenderer;
  * @var PhpRenderer|HelperTrait $this
  * @var Activity[] $activities
  * @var array<array-key, array{member: MemberModel, functions: array<array-key, string>}> $activeMembers
+ * @var array<array-key, MemberModel> $inactiveMembers
+ * @var array<array-key, MemberModel> $oldMembers
  * @var OrganModel $organ
  */
 
@@ -142,28 +144,44 @@ function getOrganDescription($organInformation, $lang)
         <div class="row">
             <div class="col-md-12">
                 <?php if ($this->acl('decision_service_acl')->isAllowed('organ', 'view')): ?>
-                    <h1><?= $this->translate('Active members') ?></h1>
-                    <ul>
-                        <?php foreach ($activeMembers as $membership): ?>
-                            <li>
-                                <a href="<?= $this->url(
-                                    'member/view',
-                                    ['lidnr' => $membership['member']->getLidnr()],
-                                ) ?>">
-                                    <?= $membership['member']->getFullName() ?>
-                                    <?php if (!empty($membership['functions'])): ?>
-                                        (<?= implode(
-                                            ', ',
-                                            array_map(
-                                                fn (string $value): string => $this->translate($value),
-                                                $membership['functions'],
-                                            ),
-                                        ) ?>)
-                                    <?php endif ?>
-                                </a>
-                            </li>
-                        <?php endforeach ?>
-                    </ul>
+                    <?php if (null === $organ->getAbrogationDate()): ?>
+                        <h1><?= $this->translate('Active members') ?></h1>
+                        <ul>
+                            <?php foreach ($activeMembers as $membership): ?>
+                                <li>
+                                    <a href="<?= $this->url(
+                                        'member/view',
+                                        ['lidnr' => $membership['member']->getLidnr()],
+                                    ) ?>">
+                                        <?= $membership['member']->getFullName() ?>
+                                        <?php if (!empty($membership['functions'])): ?>
+                                            (<?= implode(
+                                                ', ',
+                                                array_map(
+                                                    fn (string $value): string => $this->translate($value),
+                                                    $membership['functions'],
+                                                ),
+                                            ) ?>)
+                                        <?php endif ?>
+                                    </a>
+                                </li>
+                            <?php endforeach ?>
+                        </ul>
+                    <?php else: ?>
+                        <h1><?= $this->translate('Old members') ?></h1>
+                        <ul>
+                            <?php foreach ($oldMembers as $member): ?>
+                                <li>
+                                    <a href="<?= $this->url(
+                                        'member/view',
+                                        ['lidnr' => $member->getLidnr()],
+                                    ) ?>">
+                                        <?= $member->getFullName() ?>
+                                    </a>
+                                </li>
+                            <?php endforeach ?>
+                        </ul>
+                    <?php endif; ?>
                 <?php else: ?>
                     <?= $this->translate('Login to view more information') ?>
                 <?php endif; ?>


### PR DESCRIPTION
Replaces the 'Active members' with an 'Old members' section. This is similar to the detailed organ overview.