### PR TITLE
Do not show 'update subscription' when there are no fields to update

### DIFF
--- a/module/Activity/src/Controller/ActivityController.php
+++ b/module/Activity/src/Controller/ActivityController.php
@@ -263,6 +263,16 @@ class ActivityController extends AbstractActionController
 
             // Let user edit subscription details
             if (null !== ($signup = $this->signupMapper->getSignUp($signupList, $identity))) {
+                if (0 === $signupList->getFields()->count()) {
+                    return $this->redirect()->toRoute(
+                        'activity/view/signuplist',
+                        [
+                            'id' => $activityId,
+                            'signupList' => $signupListId,
+                        ],
+                    );
+                }
+
                 $this->signupService->editSignUp($signup, $form->getData(FormInterface::VALUES_AS_ARRAY));
                 $message = $this->translator->translate('Successfully updated subscription');
             } else {

--- a/module/Activity/view/activity/activity/view.phtml
+++ b/module/Activity/view/activity/activity/view.phtml
@@ -6,20 +6,23 @@ use Activity\Form\Signup as SignupForm;
 use Activity\Model\{
     Activity as ActivityModel,
     SignupField as SignupFieldModel,
+    SignupList as SignupListModel
 };
 use Application\Form\ModifyRequest as RequestForm;
 use Application\View\HelperTrait;
+use Doctrine\Common\Collections\Collection;
 use Laminas\View\Renderer\PhpRenderer;
 
 /**
  * @var PhpRenderer|HelperTrait $this
  * @var ActivityModel $activity
- * @var SignupFieldModel $fields
+ * @var Collection<array-key, SignupFieldModel> $fields
  * @var SignupForm $form
  * @var bool $isAllowedToSubscribe
  * @var bool $isArchived
  * @var bool $isSignedUp
  * @var int $memberSignups
+ * @var SignupListModel $signupList
  * @var bool $signupOpen
  * @var RequestForm $signoffForm
  * @var bool $subscriptionCloseDatePassed
@@ -192,15 +195,20 @@ $this->headTitle($this->translate('Activities'));
                                 <span class="fas fa-user-check"></span> <?= $this->translate('Unsubscription period closed') ?>
                             </button>
                         <?php else: ?>
+                            <?php
+                            $hasFields = !$fields->isEmpty();
+                            ?>
                             <div class="col">
                                 <button class="btn btn-default btn-lg" type="button" data-toggle="modal"
                                         data-target="#signoffModal" aria-hidden="true" aria-controls="signoffModal">
                                     <span class="fas fa-user-minus"></span> <?= $this->translate('Unsubscribe') ?>
                                 </button>
-                                <button class="btn btn-primary btn-lg" type="button" data-toggle="modal"
-                                        data-target="#signupModal" aria-hidden="true" aria-controls="signupModal">
-                                    <span class="fas fa-user-pen"></span> <?= $this->translate('Update subscription') ?>
-                                </button>
+                                <?php if ($hasFields): ?>
+                                    <button class="btn btn-primary btn-lg" type="button" data-toggle="modal"
+                                            data-target="#signupModal" aria-hidden="true" aria-controls="signupModal">
+                                        <span class="fas fa-user-pen"></span> <?= $this->translate('Update subscription') ?>
+                                    </button>
+                                <?php endif; ?>
                             </div>
                             <!-- modal to sign out -->
                             <div class="modal fade" id="signoffModal" tabindex="-1" role="dialog" aria-hidden="true">
@@ -246,13 +254,15 @@ $this->headTitle($this->translate('Activities'));
                                     </div>
                                 </div>
                             </div>
-                            <!-- modal to edit subscription details -->
-                            <?= $this->partial('partial/signupForm', [
-                                'form' => $form,
-                                'signupList' => $signupList,
-                                'update' => true,
-                            ])
-                            ?>
+                            <?php if ($hasFields): ?>
+                                <!-- modal to edit subscription details -->
+                                <?= $this->partial('partial/signupForm', [
+                                    'form' => $form,
+                                    'signupList' => $signupList,
+                                    'update' => true,
+                                ])
+                                ?>
+                            <?php endif; ?>
                         <?php endif; ?>
                     <?php elseif (!$signupOpen): ?>
                         <button class="btn btn-default btn-lg" type="button" disabled="disabled">


### PR DESCRIPTION
If a sign-up list does not have any fields, there is no need to show the 'update subscription'-button and modal (as nothing can be changed).

Fixes GH-1805.