### PR TITLE
Fix list of authorizations not showing for specific meetings

### DIFF
--- a/module/Decision/src/Controller/AdminController.php
+++ b/module/Decision/src/Controller/AdminController.php
@@ -221,23 +221,17 @@ class AdminController extends AbstractActionController
         $meetings = $this->decisionService->getMeetingsByType(MeetingTypes::ALV);
         $number = (int) $this->params()->fromRoute('number');
 
-        $authorizations = [
-            'valid' => [],
-            'revoked' => [],
-        ];
-
         if (
             0 === $number
             && !empty($meetings)
         ) {
             $number = $meetings[0]->getNumber();
-            $authorizations = $this->decisionService->getAllAuthorizations($number);
         }
 
         return new ViewModel(
             [
                 'meetings' => $meetings,
-                ...$authorizations,
+                ...$this->decisionService->getAllAuthorizations($number),
                 'number' => $number,
             ],
         );


### PR DESCRIPTION
A change was made in GH-1628 which resulted in the authorizations only being queried iff the meeting number was undefined or zero. This prevented the board from checking past authorizations.