### PR TITLE
Return empty string instead of `null` for double `null` in `LocalisedText`

### DIFF
--- a/module/Application/src/View/Helper/LocaliseText.php
+++ b/module/Application/src/View/Helper/LocaliseText.php
@@ -10,12 +10,10 @@ use Laminas\View\Helper\AbstractHelper;
 class LocaliseText extends AbstractHelper
 {
     /**
-     * Determines the correct value for an element.
-     *
-     * @return string|null The localised value of `$localisedText` or null if no translation exists.
+     * Returns the localised value of an element.
      */
-    public function __invoke(LocalisedTextModel $localisedText): ?string
+    public function __invoke(LocalisedTextModel $localisedText): string
     {
-        return $localisedText->getText();
+        return $localisedText->getText() ?? '';
     }
 }


### PR DESCRIPTION
The `LocaliseText` view helper is used in places where strings are expected and not `null`s. As such, it makes more sense to perform a `null` coalescing check and return an empty string `''` if there are double `null`s in the `LocalisedText` object.

Fixes GH-1820.