### PR TITLE
Add `activity:gdpr:delete-old-signups` command to remove old `Signup`s

### DIFF
--- a/docker/web/development/crontab
+++ b/docker/web/development/crontab
@@ -12,3 +12,5 @@
 # 58 1 * * * { . /code/config/bash.env && /usr/local/bin/php /code/importdb.php; } > /code/data/logs/cron-importdb.log 2>&1
 # 0 23 * * * { . /code/config/bash.env && /usr/local/bin/php /code/web activity:calendar:notify; } > /code/data/logs/cron-activitycalendar.log 2>&1
 # 0 * * * * { . /code/config/bash.env && /code/publicarchive.sh; } > /code/data/logs/cron-publicarchive.log 2>&1
+# Automated GDPR related tasks below:
+# 0 3 * * * { . /code/config/bash.env && /usr/local/bin/php /code/web activity:gdpr:delete-old-signups; } > /code/data/logs/cron-gdpr-activity-signups.log 2>&1

--- a/docker/web/production/crontab
+++ b/docker/web/production/crontab
@@ -12,3 +12,5 @@
 58 1 * * * { . /code/config/bash.env && /usr/local/bin/php /code/importdb.php; } > /code/data/logs/cron-importdb.log 2>&1
 0 23 * * * { . /code/config/bash.env && /usr/local/bin/php /code/web activity:calendar:notify; } > /code/data/logs/cron-activitycalendar.log 2>&1
 0 * * * * { . /code/config/bash.env && /code/publicarchive.sh; } > /code/data/logs/cron-publicarchive.log 2>&1
+# Automated GDPR related tasks below:
+0 3 * * * { . /code/config/bash.env && /usr/local/bin/php /code/web activity:gdpr:delete-old-signups; } > /code/data/logs/cron-gdpr-activity-signups.log 2>&1

--- a/module/Activity/config/module.config.php
+++ b/module/Activity/config/module.config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Activity;
 
 use Activity\Command\CalendarNotify;
+use Activity\Command\DeleteOldSignups;
 use Activity\Controller\ActivityCalendarController;
 use Activity\Controller\ActivityController;
 use Activity\Controller\AdminApprovalController;
@@ -497,6 +498,7 @@ return [
     'laminas-cli' => [
         'commands' => [
             'activity:calendar:notify' => CalendarNotify::class,
+            'activity:gdpr:delete-old-signups' => DeleteOldSignups::class,
         ],
     ],
     'doctrine' => [

--- a/module/Activity/src/Command/DeleteOldSignups.php
+++ b/module/Activity/src/Command/DeleteOldSignups.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Activity\Command;
+
+use Activity\Service\Signup as SignupService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'activity:gdpr:delete-old-signups',
+    description: 'Delete sign-ups for activities older than 5 years',
+)]
+class DeleteOldSignups extends Command
+{
+    public function __construct(private readonly SignupService $signupService)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $this->signupService->deleteOldSignups();
+
+        return Command::SUCCESS;
+    }
+}

--- a/module/Activity/src/Command/Factory/DeleteOldSignupsFactory.php
+++ b/module/Activity/src/Command/Factory/DeleteOldSignupsFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Activity\Command\Factory;
+
+use Activity\Command\DeleteOldSignups;
+use Activity\Service\Signup as SignupService;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class DeleteOldSignupsFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): DeleteOldSignups {
+        /** @var SignupService $signupService */
+        $signupService = $container->get('activity_service_signup');
+
+        return new DeleteOldSignups($signupService);
+    }
+}

--- a/module/Activity/src/Module.php
+++ b/module/Activity/src/Module.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Activity;
 
-use Activity\Command\CalendarNotify;
+use Activity\Command\CalendarNotify as CalendarNotifyCommand;
+use Activity\Command\DeleteOldSignups as DeleteOldSignupsCommand;
+use Activity\Command\Factory\DeleteOldSignupsFactory as DeleteOldSignupsCommandFactory;
 use Activity\Form\Activity as ActivityForm;
 use Activity\Form\ActivityCalendarOption as ActivityCalendarOptionForm;
 use Activity\Form\ActivityCalendarPeriod as ActivityCalendarPeriodForm;
@@ -283,13 +285,14 @@ class Module
                     );
                 },
                 'activity_service_acl' => AclServiceFactory::class,
-                CalendarNotify::class => static function (ContainerInterface $container) {
-                    $calendarNotify = new CalendarNotify();
+                CalendarNotifyCommand::class => static function (ContainerInterface $container) {
+                    $calendarNotify = new CalendarNotifyCommand();
                     $calendarService = $container->get('activity_service_calendar');
                     $calendarNotify->setCalendarService($calendarService);
 
                     return $calendarNotify;
                 },
+                DeleteOldSignupsCommand::class => DeleteOldSignupsCommandFactory::class,
             ],
         ];
     }

--- a/module/Activity/src/Service/Signup.php
+++ b/module/Activity/src/Service/Signup.php
@@ -356,6 +356,17 @@ class Signup
         $this->removeSignUp($signup);
     }
 
+    /**
+     * Delete all sign-ups for activities that are older than 5 years.
+     *
+     * We can automatically DELETE all sign-ups at once instead of retrieving them and iterating over them before using
+     * `$this->removeSignup()` to remove them.
+     */
+    public function deleteOldSignups(): void
+    {
+        $this->signupMapper->deleteSignupsForActivitiesOlderThan5Years();
+    }
+
     public static function isInSubscriptionWindow(
         DateTime $openDate,
         DateTime $closeDate,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,6 +36,7 @@
         <exclude-pattern>module/Company/src/Controller/Factory/AdminControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Company/src/Controller/Factory/CompanyControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Company/src/Controller/Factory/CompanyAccountControllerFactory.php</exclude-pattern>
+        <exclude-pattern>module/Activity/src/Command/Factory/DeleteOldSignupsFactory.php</exclude-pattern>
         <exclude-pattern>module/Activity/src/Controller/Factory/ActivityCalendarControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Activity/src/Controller/Factory/AdminApprovalControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Activity/src/Controller/Factory/AdminControllerFactory.php</exclude-pattern>


### PR DESCRIPTION
In accordance with GEWIS' privacy policy, `Signup`s for an `Activity` that ended 5 years ago should be removed. Previously, I did this manually, however, as I am doing less and less for GEWISWEB this process should be automated.

As such, this command is the first in a series of command that will automate some GDPR related tasks. All these tasks are expected to be executed between 03:00 and 05:00 each day.

Closes GH-1430 (**note:** applies to all `Signup` types, not just external).