### PR TITLE
Fix Imagick not building and breaking image builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,16 +14,14 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    IMAGE_NAME_GLIDE: ${{ vars.ABC_DOCKER_REGISTRY }}/web/gewisweb/glide
-    IMAGE_NAME_MATOMO: ${{ vars.ABC_DOCKER_REGISTRY }}/web/gewisweb/matomo
-    IMAGE_NAME_NGINX: ${{ vars.ABC_DOCKER_REGISTRY }}/web/gewisweb/nginx
-    IMAGE_NAME_WEB: ${{ vars.ABC_DOCKER_REGISTRY }}/web/gewisweb/web
     IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
     build:
         runs-on: ubuntu-latest
-
+        strategy:
+            matrix:
+                image: ['web', 'glide', 'matomo', 'nginx']
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -38,47 +36,14 @@ jobs:
                     username: ${{ secrets.SVC_GH_ABCWEB_USERNAME }}
                     password: ${{ secrets.SVC_GH_ABCWEB_PWD }}
 
-            -   name: Build and push web image
+            -   name: Build and push image
                 uses: docker/build-push-action@v6
                 with:
                     build-args: GIT_COMMIT=${{ github.sha }}
                     cache-from: type=gha
                     cache-to: type=gha,mode=max
-                    context: .
-                    file: ${{ env.IS_RELEASE && './docker/web/production/Dockerfile' || './docker/web/development/Dockerfile' }}
+                    context: ${{ matrix.image == 'web' && '.' || format('./docker/{0}', matrix.image) }}
+                    file: ${{ matrix.image == 'web' && (env.IS_RELEASE && './docker/web/production/Dockerfile' || './docker/web/development/Dockerfile') || format('./docker/{0}/Dockerfile', matrix.image) }}
                     platforms: linux/amd64
                     push: true
-                    tags: ${{ format('{0}:{1}', env.IMAGE_NAME_WEB, env.IS_RELEASE && format('{0},{1}:latest', github.ref_name, env.IMAGE_NAME_WEB) || 'development') }}
-
-            -   name: Build and push glide image
-                uses: docker/build-push-action@v6
-                with:
-                    cache-from: type=gha
-                    cache-to: type=gha,mode=max
-                    context: ./docker/glide
-                    file: ./docker/glide/Dockerfile
-                    platforms: linux/amd64
-                    push: true
-                    tags: ${{ format('{0}:{1}', env.IMAGE_NAME_GLIDE, env.IS_RELEASE && format('{0},{1}:latest', github.ref_name, env.IMAGE_NAME_GLIDE) || 'development') }}
-
-            -   name: Build and push matomo image
-                uses: docker/build-push-action@v6
-                with:
-                    cache-from: type=gha
-                    cache-to: type=gha,mode=max
-                    context: ./docker/matomo
-                    file: ./docker/matomo/Dockerfile
-                    platforms: linux/amd64
-                    push: true
-                    tags: ${{ format('{0}:{1}', env.IMAGE_NAME_MATOMO, env.IS_RELEASE && format('{0},{1}:latest', github.ref_name, env.IMAGE_NAME_MATOMO) || 'development') }}
-
-            -   name: Build and push nginx image
-                uses: docker/build-push-action@v6
-                with:
-                    cache-from: type=gha
-                    cache-to: type=gha,mode=max
-                    context: ./docker/nginx
-                    file: ./docker/nginx/Dockerfile
-                    platforms: linux/amd64
-                    push: true
-                    tags: ${{ format('{0}:{1}', env.IMAGE_NAME_NGINX, env.IS_RELEASE && format('{0},{1}:latest', github.ref_name, env.IMAGE_NAME_NGINX) || 'development') }}
+                    tags: ${{ format('{0}:{1}', format('{0}/web/gewisweb/{1}', vars.ABC_DOCKER_REGISTRY, matrix.image), env.IS_RELEASE && format('{0},{1}:latest', github.ref_name, format('{0}/web/gewisweb/{1}', vars.ABC_DOCKER_REGISTRY, matrix.image)) || 'development') }}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-fileinfo": "*",
         "ext-gd": "*",
         "ext-intl": "*",
-        "ext-imagick": "^3.5.0",
+        "ext-imagick": "*",
         "ext-mbstring": "*",
         "ext-memcached": "^3.0.0",
         "ext-openssl": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "838e16ce845cf49cdc498279db1aea1c",
+    "content-hash": "3e65bf0fa02f322033a7364795c506c1",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -13503,7 +13503,7 @@
         "ext-fileinfo": "*",
         "ext-gd": "*",
         "ext-intl": "*",
-        "ext-imagick": "^3.5.0",
+        "ext-imagick": "*",
         "ext-mbstring": "*",
         "ext-memcached": "^3.0.0",
         "ext-openssl": "*",

--- a/docker/glide/Dockerfile
+++ b/docker/glide/Dockerfile
@@ -19,9 +19,17 @@ RUN apk add --no-cache --virtual .build-deps \
         gd \
         opcache \
         zip \
-    && pecl install imagick \
-    && docker-php-ext-enable imagick \
-    && rm -r /tmp/pear \
+# START OF IMAGICK PATCH
+    # && pecl install imagick \
+    # Install Imagick from source as building it for PHP 8.3 keeps intermittently failing. This has been extensively
+    # documented at https://github.com/Imagick/imagick/issues/640. We do not need to patch anything, we will just use
+    # the current HEAD of the master branch (this is still 28f27044e435a2b203e32675e942eb8de620ee58).
+    && mkdir -p /usr/src/php/ext/imagick \
+    && curl -fsSL https://github.com/Imagick/imagick/archive/28f27044e435a2b203e32675e942eb8de620ee58.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1 \
+    && docker-php-ext-install imagick \
+    # && docker-php-ext-enable imagick \
+    # && rm -r /tmp/pear \
+# END OF IMAGICK PATCH
     && runtimeDeps="$( \
             scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
             | tr ',' '\n' \

--- a/docker/web/development/Dockerfile
+++ b/docker/web/development/Dockerfile
@@ -58,8 +58,16 @@ RUN apk add --no-cache --virtual .build-deps \
         pdo_pgsql \
         pdo_sqlite \
         zip \
-    && pecl install imagick \
-    && docker-php-ext-enable imagick \
+# START OF IMAGICK PATCH
+    # && pecl install imagick \
+    # Install Imagick from source as building it for PHP 8.3 keeps intermittently failing. This has been extensively
+    # documented at https://github.com/Imagick/imagick/issues/640. We do not need to patch anything, we will just use
+    # the current HEAD of the master branch (this is still 28f27044e435a2b203e32675e942eb8de620ee58).
+    && mkdir -p /usr/src/php/ext/imagick \
+    && curl -fsSL https://github.com/Imagick/imagick/archive/28f27044e435a2b203e32675e942eb8de620ee58.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1 \
+    && docker-php-ext-install imagick \
+    # && docker-php-ext-enable imagick \
+# END OF IMAGICK PATCH
     && pecl install memcached \
     && docker-php-ext-enable memcached \
     && pecl install xdebug \

--- a/docker/web/production/Dockerfile
+++ b/docker/web/production/Dockerfile
@@ -49,8 +49,16 @@ RUN apk add --no-cache --virtual .build-deps \
         pdo_mysql \
         pdo_pgsql \
         zip \
-    && pecl install -o imagick \
-    && docker-php-ext-enable imagick \
+# START OF IMAGICK PATCH
+    # && pecl install imagick \
+    # Install Imagick from source as building it for PHP 8.3 keeps intermittently failing. This has been extensively
+    # documented at https://github.com/Imagick/imagick/issues/640. We do not need to patch anything, we will just use
+    # the current HEAD of the master branch (this is still 28f27044e435a2b203e32675e942eb8de620ee58).
+    && mkdir -p /usr/src/php/ext/imagick \
+    && curl -fsSL https://github.com/Imagick/imagick/archive/28f27044e435a2b203e32675e942eb8de620ee58.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1 \
+    && docker-php-ext-install imagick \
+    # && docker-php-ext-enable imagick \
+# END OF IMAGICK PATCH
     && pecl install -o memcached \
     && docker-php-ext-enable memcached \
     && rm -r /tmp/pear \


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This has happened intermittently since we upgraded to PHP 8.3. Unfortunately, there is still no new release of Imagick. However, the fix is already present in the repository. As such, we manually build and install Imagick from source.

Futhermore, to improve the Docker image GitHub action we remove all of the duplication that existed for the `build-push`es. One downside is decreased legibility of the expressions.

`GIT_COMMIT` is not used for Glide, Matomo, and NGINX, however, Docker will simply ignore it for those images.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1845 and closes GH-1846.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [X] Other _(please specify)_
