### PR TITLE
Add `user:gdpr:delete-old-loginattempts` command to remove old `LoginAttempt`s

### DIFF
--- a/docker/web/development/crontab
+++ b/docker/web/development/crontab
@@ -14,3 +14,4 @@
 # 0 * * * * { . /code/config/bash.env && /code/publicarchive.sh; } > /code/data/logs/cron-publicarchive.log 2>&1
 # Automated GDPR related tasks below:
 # 0 3 * * * { . /code/config/bash.env && /usr/local/bin/php /code/web activity:gdpr:delete-old-signups; } > /code/data/logs/cron-gdpr-activity-signups.log 2>&1
+# 0 4 * * * { . /code/config/bash.env && /usr/local/bin/php /code/web user:gdpr:delete-old-loginattempts; } > /code/data/logs/cron-gdpr-user-loginattempts.log 2>&1

--- a/docker/web/production/crontab
+++ b/docker/web/production/crontab
@@ -14,3 +14,4 @@
 0 * * * * { . /code/config/bash.env && /code/publicarchive.sh; } > /code/data/logs/cron-publicarchive.log 2>&1
 # Automated GDPR related tasks below:
 0 3 * * * { . /code/config/bash.env && /usr/local/bin/php /code/web activity:gdpr:delete-old-signups; } > /code/data/logs/cron-gdpr-activity-signups.log 2>&1
+0 4 * * * { . /code/config/bash.env && /usr/local/bin/php /code/web user:gdpr:delete-old-loginattempts; } > /code/data/logs/cron-gdpr-user-loginattempts.log 2>&1

--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -7,6 +7,7 @@ namespace User;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Segment;
+use User\Command\DeleteOldLoginAttempts;
 use User\Controller\ApiAdminController;
 use User\Controller\ApiAuthenticationController;
 use User\Controller\Factory\ApiAdminControllerFactory;
@@ -181,6 +182,11 @@ return [
         ],
         'template_map' => [
             'user_token/redirect' => __DIR__ . '/../view/user/api-authentication/redirect.phtml',
+        ],
+    ],
+    'laminas-cli' => [
+        'commands' => [
+            'user:gdpr:delete-old-loginattempts' => DeleteOldLoginAttempts::class,
         ],
     ],
     'doctrine' => [

--- a/module/User/src/Authentication/Service/LoginAttempt.php
+++ b/module/User/src/Authentication/Service/LoginAttempt.php
@@ -62,4 +62,14 @@ class LoginAttempt
 
         return $this->loginAttemptMapper->getFailedAttemptCount($since, $ip, $user) > $maxLoginAttempts;
     }
+
+    /**
+     * Delete all (failed) login attempts that are older than 3 months.
+     *
+     * We can automatically DELETE all login attempts at once instead of retrieving them and iterating over them.
+     */
+    public function deletedOldLoginAttempts(): void
+    {
+        $this->loginAttemptMapper->deleteLoginAttemptsOtherThan3Months();
+    }
 }

--- a/module/User/src/Command/DeleteOldLoginAttempts.php
+++ b/module/User/src/Command/DeleteOldLoginAttempts.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace User\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use User\Authentication\Service\LoginAttempt as LoginAttemptService;
+
+#[AsCommand(
+    name: 'user:gdpr:delete-old-loginattempts',
+    description: 'Delete (failed) login attempts older than 3 months',
+)]
+class DeleteOldLoginAttempts extends Command
+{
+    public function __construct(private readonly LoginAttemptService $loginAttemptService)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $this->loginAttemptService->deletedOldLoginAttempts();
+
+        return Command::SUCCESS;
+    }
+}

--- a/module/User/src/Command/Factory/DeleteOldLoginAttemptsFactory.php
+++ b/module/User/src/Command/Factory/DeleteOldLoginAttemptsFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Activity\Command\Factory;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+use User\Authentication\Service\LoginAttempt as LoginAttemptService;
+use User\Command\DeleteOldLoginAttempts;
+
+class DeleteOldLoginAttemptsFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): DeleteOldLoginAttempts {
+        /** @var LoginAttemptService $loginAttemptService */
+        $loginAttemptService = $container->get('user_service_loginattempt');
+
+        return new DeleteOldLoginAttempts($loginAttemptService);
+    }
+}

--- a/module/User/src/Mapper/LoginAttempt.php
+++ b/module/User/src/Mapper/LoginAttempt.php
@@ -6,6 +6,7 @@ namespace User\Mapper;
 
 use Application\Mapper\BaseMapper;
 use Application\Model\IdentityInterface;
+use DateInterval;
 use DateTime;
 use Decision\Model\Member as MemberModel;
 use User\Model\CompanyUser as CompanyUserModel;
@@ -57,5 +58,19 @@ class LoginAttempt extends BaseMapper
     protected function getRepositoryName(): string
     {
         return LoginAttemptModel::class;
+    }
+
+    /**
+     * Delete all (failed) login attempts older than 3 months.
+     */
+    public function deleteLoginAttemptsOtherThan3Months(): void
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->delete($this->getRepositoryName(), 'l')
+            ->where('l.time <= :date');
+
+        $qb->setParameter('date', (new DateTime())->sub(new DateInterval('P3M')));
+
+        $qb->getQuery()->execute();
     }
 }

--- a/module/User/src/Module.php
+++ b/module/User/src/Module.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace User;
 
+use Activity\Command\Factory\DeleteOldLoginAttemptsFactory as DeleteOldLoginAttemptsCommandFactory;
 use Doctrine\Laminas\Hydrator\DoctrineObject;
 use Laminas\Authentication\AuthenticationService as LaminasAuthenticationService;
 use Laminas\Crypt\Password\Bcrypt;
@@ -21,6 +22,7 @@ use User\Authentication\Service\LoginAttempt as LoginAttemptService;
 use User\Authentication\Storage\CompanyUserSession;
 use User\Authentication\Storage\UserSession;
 use User\Authorization\AclServiceFactory;
+use User\Command\DeleteOldLoginAttempts as DeleteOldLoginAttemptsCommands;
 use User\Form\Activate as ActivateForm;
 use User\Form\ApiAppAuthorisation as ApiAppAuthorisationForm;
 use User\Form\ApiToken as ApiTokenForm;
@@ -395,6 +397,7 @@ class Module
                     return $remote->getIpAddress();
                 },
                 'user_service_acl' => AclServiceFactory::class,
+                DeleteOldLoginAttemptsCommands::class => DeleteOldLoginAttemptsCommandFactory::class,
             ],
         ];
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -70,6 +70,7 @@
         <exclude-pattern>module/Photo/src/Controller/Factory/Plugin/AlbumPluginFactory.php</exclude-pattern>
         <exclude-pattern>module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/Photo/src/Controller/Factory/TagControllerFactory.php</exclude-pattern>
+        <exclude-pattern>module/User/src/Command/Factory/DeleteOldLoginAttemptsFactory.php</exclude-pattern>
         <exclude-pattern>module/User/src/Controller/Factory/ApiAuthenticationControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/User/src/Controller/Factory/UserControllerFactory.php</exclude-pattern>
         <exclude-pattern>module/User/src/Controller/Factory/ApiAdminControllerFactory.php</exclude-pattern>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

There is no retention period specified for old (failed) `LoginAttempt`s in GEWIS' privacy policy. Previously, I did this manually and removed any records older than 2 years, however, as I am doing less and less for GEWISWEB this process should be automated.

As such, this command will automate the removal of any (failed) `LoginAttempt`s older than 3 months.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
