### PR TITLE
fix: matomo using `DEBUG` level instead of `WARN` for logging

### DIFF
--- a/docker/matomo/config.ini.php
+++ b/docker/matomo/config.ini.php
@@ -23,7 +23,7 @@ proxy_ips[] = 172.*.*.*/8
 
 [log]
 log_writers[] = file
-log_level = DEBUG
+log_level = WARN
 
 [Plugins]
 ; list of plugins (in order they will be loaded) that are activated by default in the Matomo platform


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Changes the log level for Matomo from `DEBUG` to `WARN`. It resolves an issue where the log files keep growing to many GBs.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1809.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
