### PR TITLE
fix: ordering of `BoardInstallation`s on profile page

### DIFF
--- a/module/Decision/view/decision/member/view.phtml
+++ b/module/Decision/view/decision/member/view.phtml
@@ -62,7 +62,36 @@ $this->headTitle($this->translate('Members'));
                 </table>
                 <?php
                 /* @var BoardMember[] $boardInstalls */
-                $boardInstalls = array_reverse($member->getBoardInstallations()->toArray());
+                $boardInstalls = $member->getBoardInstallations()->toArray();
+
+                // Ensure proper sorting of board installations; most recent installations first but keep original
+                // ordering when comparing within meetings.
+                usort($boardInstalls, static function(BoardMember $a, BoardMember $b) {
+                    $aInstallationDec = $a->getInstallationDec();
+                    $bInstallationDec = $b->getInstallationDec();
+
+                    // While using the spaceship comparator (`<=>`) would have been fancy, we would still have needed an
+                    // if statement to check against the outcome of that comparison not being zero. So we simply do it
+                    // the "old-school" way.
+
+                    // Compare the meeting numbers.
+                    if ($aInstallationDec->getMeetingNumber() !== $bInstallationDec->getMeetingNumber()) {
+                        return $aInstallationDec->getMeetingNumber() < $bInstallationDec->getMeetingNumber() ? 1 : -1;
+                    }
+
+                    // If the meeting numbers are the same, compare the decision points and numbers.
+                    if ($aInstallationDec->getDecisionPoint() !== $bInstallationDec->getDecisionPoint()) {
+                        return $aInstallationDec->getDecisionPoint() < $bInstallationDec->getDecisionPoint() ? -1 : 1;
+                    }
+
+                    if ($aInstallationDec->getDecisionNumber() !== $bInstallationDec->getDecisionNumber()) {
+                        return $aInstallationDec->getDecisionNumber() < $bInstallationDec->getDecisionNumber() ? -1 : 1;
+                    }
+
+                    // If all the above are the same, compare the sequence numbers.
+                    return $aInstallationDec->getSequence() < $bInstallationDec->getSequence() ? -1 : 1;
+                });
+
                 if (!empty($boardInstalls)):
                     $now = new DateTime('now');
                     $associationYear = AssociationYear::fromDate($now);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

Ensure proper sorting of board installations; most recent installations first but keep original ordering when comparing within meetings.

While using the spaceship comparator (`<=>`) would have been fancy, we would still have needed an if statement to check against the outcome of that comparison not being zero. So we simply do it the "old-school" way.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1853.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
