### PR TITLE
fix: api route being language aware

### DIFF
--- a/module/Application/src/Router/LanguageAwareTreeRouteStack.php
+++ b/module/Application/src/Router/LanguageAwareTreeRouteStack.php
@@ -162,7 +162,15 @@ class LanguageAwareTreeRouteStack extends TranslatorAwareTreeRouteStack
         // Check if the zeroth element of the stripped path is a supported language. Note that the zeroth element is
         // always defined due to the nature of the `explode()` call above.
         //
-        // Here are some example of that behaviour (note that `{baseUrl}` can be `domain/` or even `domain/path/`):
+        // All `/api` routes should not be language aware. As such, we do not allow using '{baseUrl}/{language}/api'.
+        if (
+            isset($strippedPathParts[1])
+            && 'api' === $strippedPathParts[1]
+        ) {
+            return null;
+        }
+
+        // Here are some example of standard behaviour (note that `{baseUrl}` can be `domain/` or even `domain/path/`):
         //
         // '{baseUrl}/en'
         // array(1) {
@@ -198,6 +206,10 @@ class LanguageAwareTreeRouteStack extends TranslatorAwareTreeRouteStack
 
             $session = new SessionContainer('lang');
             $session->lang = $language;
+        } elseif ('api' === $strippedPathParts[0]) {
+            // The language was not provided through the URL, but we are dealing with `/api` which should not be
+            // language aware. As such, we default to English to keep the router happy.
+            $language = Languages::EN->value;
         } else {
             // The language was not provided through the URL, so we need to determine it based on some other factors.
             $language = $this->getLanguage($request);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
It is not necessary for the API routes to be language-aware, we should only allow `/api` and not `/{language}/api`.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1813.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
