### PR TITLE
fix: route assembly not allowing null values for language

### DIFF
--- a/module/Application/src/Router/LanguageAwareTreeRouteStack.php
+++ b/module/Application/src/Router/LanguageAwareTreeRouteStack.php
@@ -48,9 +48,13 @@ class LanguageAwareTreeRouteStack extends TranslatorAwareTreeRouteStack
         // Try to get the language, because we do not have access to the current request in this method we cannot add an
         // `else` clause to call `$this->getLanguage()` to get the language.
         $language = null;
-        if (isset($params['language'])) {
+        if (array_key_exists('language', $params)) {
             // The language is already defined in the parameters for the route, so we can use that. This happens when
             // calling `url()` from a view while manually setting `['language' => '{language}']`.
+            // We do not use `isset()` to ensure that we can also do this when we explicitly set the `language` key to
+            // `null` in the URL builder: `['language' => null]`. This is necessary for routes that do not use the
+            // language-aware router (i.e. the API), as filtering in the actual route stack definitions to check whether
+            // the route will hit `/api` is more work.
             $language = $params['language'];
         } elseif (is_callable([$translator, 'getLocale'])) {
             // Otherwise, try to get the language from the translator. Note that `is_callable` is preferred here as

--- a/module/Application/view/partial/footer.phtml
+++ b/module/Application/view/partial/footer.phtml
@@ -21,7 +21,7 @@ use Laminas\View\Renderer\PhpRenderer;
                             <h3><?= $this->translate('Infimum') ?></h3>
                             <p id="infimum-footer"><?= $this->translate('Loading an infimum...') ?></p>
                             <script type="text/javascript" nonce="<?= NONCE_REPLACEMENT_STRING ?>">
-                                fetch('<?= $this->url('infimum') ?>')
+                                fetch('<?= $this->url('infimum', ['language' => null]) ?>')
                                     .then(result => result.json())
                                     .then(function (data) {
                                         document.getElementById('infimum-footer').textContent = data['content'];


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This ensures that if we have the need to use an API route in a view we can do this without requiring a language (which we just disabled).

Instead of calling `isset()` we simply do `array_key_exists()` to allow us to explicitly set the `language` option to `null`.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1860.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
