### PR TITLE
fix: photo details route not setting language to null

### DIFF
--- a/module/Photo/view/photo/album/index.phtml
+++ b/module/Photo/view/photo/album/index.phtml
@@ -270,7 +270,7 @@ $this->scriptUrl()->requireUrl('member/search')
                             ) ?>"
                         <?php endif; ?>
                         data-profile-photo-url="<?= $this->url('photo/set_profile_photo', ['photo_id' => $item->getId()]) ?>"
-                        data-details-url="<?= $this->url('api_photo/details', ['photo_id' => $item->getId()]) ?>"
+                        data-details-url="<?= $this->url('api_photo/details', ['photo_id' => $item->getId(), 'language' => null]) ?>"
                         data-vote-url="<?= $this->url('photo/photo/vote', ['photo_id' => $item->getId()]) ?>"
                         <?php if (null !== $weeklyPhoto): ?>
                             data-weekly-date="<?= $weeklyPhoto->getWeek()->format('c') ?>"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Forces the `api_photo/details` to set `language` to `null` to prevent prepending a language-prefix.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1863.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
