### PR TITLE
fix: index.php being directly usable in routing

### DIFF
--- a/module/Application/src/Router/LanguageAwareTreeRouteStack.php
+++ b/module/Application/src/Router/LanguageAwareTreeRouteStack.php
@@ -152,6 +152,12 @@ class LanguageAwareTreeRouteStack extends TranslatorAwareTreeRouteStack
         // Store the original base URL (likely only just set above).
         $oldBaseUrl = $this->getBaseUrl();
 
+        // Do not allow direct access using /index.php. It is too difficult to properly configure this in NGINX, as we
+        // want to keep using the Laminas-generated 404 page and not a generic NGINX 404 page.
+        if (str_starts_with($oldBaseUrl, '/index.php')) {
+            return null;
+        }
+
         // Get the path from the URI, strip the base from it, and finally split it on `/`s.
         $uri = $request->getUri();
         $strippedPath = ltrim(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Does not allow `/index.php` to be the basepath. This prevents having a duplicate of each page:
- / !== /index.php/
- /some-route/example !== /index.php/some-route/example

Should make all search engine indexers a bit more happy.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1867.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
