### PR TITLE
fix(company): localised text comparisons expecting null instead of empty string

### DIFF
--- a/module/Company/view/company/company/job-list.phtml
+++ b/module/Company/view/company/company/job-list.phtml
@@ -136,9 +136,9 @@ $this->headScript()
                                     <?= $this->escapeHtml($this->localiseText($job->getName())) ?>
                                 </h2>
                                 <p class="card-subtitle text-muted"><?= $this->escapeHtml($company->getName()) ?></p>
-                                <?php if (null !== $this->localiseText($job->getLocation())): ?>
+                                <?php if ('' !== ($location = $this->localiseText($job->getLocation()))): ?>
                                     <p class="job-location">
-                                        <?= $this->escapeHtml($this->localiseText($job->getLocation())) ?>
+                                        <?= $this->escapeHtml($location) ?>
                                     </p>
                                 <?php endif; ?>
                                 <div>

--- a/module/Company/view/company/company/jobs.phtml
+++ b/module/Company/view/company/company/jobs.phtml
@@ -120,16 +120,16 @@ $this->headScript()
                                 </a>
                             </p>
                         <?php endif; ?>
-                        <?php if (null !== $this->localiseText($job->getWebsite())): ?>
+                        <?php if ('' !== ($website = $this->localiseText($job->getWebsite()))): ?>
                             <p class="job-website">
-                                <a href="<?= $this->localiseText($job->getWebsite()) ?>" rel="noreferrer">
+                                <a href="<?= $website ?>" rel="noreferrer">
                                     <?= $this->translate('View Website') ?>
                                 </a>
                             </p>
                         <?php endif; ?>
-                        <?php if (null !== $this->localiseText($job->getAttachment())): ?>
+                        <?php if ('' !== ($attachment = $this->localiseText($job->getAttachment()))): ?>
                             <p class="job-vacancy">
-                                <a href="<?= $this->fileUrl($this->localiseText($job->getAttachment())) ?>">
+                                <a href="<?= $this->fileUrl($attachment) ?>">
                                     <?= $this->translate('View Attachment') ?>
                                 </a>
                             </p>

--- a/module/Company/view/partial/company/company/list/company.phtml
+++ b/module/Company/view/partial/company/company/list/company.phtml
@@ -22,13 +22,9 @@ $companyURL = $escaper->escapeHtmlAttr($this->localiseText($company->getWebsite(
         <div class="col-md-12">
             <h1 class="company-name">
                 <a href="<?= $companyURL ?>"><?= $this->escapeHtml($company->getName()) ?></a>
-                <?php
-                if (null !== $this->localiseText($company->getSlogan())):
-                ?>
-                    <small>&#124; <?= $this->escapeHtml($this->localiseText($company->getSlogan())) ?></small>
-                <?php
-                endif;
-                ?>
+                <?php if ('' !== ($slogan = $this->localiseText($company->getSlogan()))): ?>
+                    <small>&#124; <?= $this->escapeHtml($slogan) ?></small>
+                <?php endif; ?>
             </h1>
         </div>
         <div class="col-md-3">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Changes were made to the `LocaliseText` view helper in GH-1821. Unfortunately, I did not check if there were any existing checks against the original `null` output. Four of these checks were still present in our code base. This PR resolves that by changing the `null` to `''` (empty string).

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1869.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
