### PR TITLE
fix: organ membership functions inside links

### DIFF
--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -156,18 +156,16 @@ function getOrganDescription($organInformation, $lang)
                                                     <a href="<?= $this->url(
                                                         'member/view',
                                                         ['lidnr' => $membership['member']->getLidnr()],
-                                                    ) ?>">
-                                                        <?= $membership['member']->getFullName() ?>
-                                                        <?php if (!empty($membership['functions'])): ?>
-                                                            (<?= implode(
-                                                                ', ',
-                                                                array_map(
-                                                                    fn (string $value): string => $this->translate($value),
-                                                                    $membership['functions'],
-                                                                ),
-                                                            ) ?>)
-                                                        <?php endif ?>
-                                                    </a>
+                                                    ) ?>"><?= $membership['member']->getFullName() ?></a>
+                                                    <?php if (!empty($membership['functions'])): ?>
+                                                        (<?= implode(
+                                                            ', ',
+                                                            array_map(
+                                                                fn (string $value): string => $this->translate($value),
+                                                                $membership['functions'],
+                                                            ),
+                                                        ) ?>)
+                                                    <?php endif ?>
                                                 </li>
                                             <?php endforeach ?>
                                         </ul>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Moves the functions outside of the link. Also had to move the closing `</a>` tag back to prevent an additional space from appearing in the link text.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1871.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
