### PR TITLE
fix: index.php being interpreted as valid base path when assembling URLs

### DIFF
--- a/module/Activity/view/activity/activity/archive.phtml
+++ b/module/Activity/view/activity/activity/archive.phtml
@@ -27,7 +27,7 @@ use Laminas\View\Renderer\PhpRenderer;
                     <li role="presentation" class="dropdown">
                         <a class="dropdown-toggle"
                            data-toggle="dropdown"
-                           href="#"
+                           href="<?= $this->hashUrl() ?>"
                            role="button"
                            aria-haspopup="true"
                            aria-expanded="false">

--- a/module/Application/src/Module.php
+++ b/module/Application/src/Module.php
@@ -17,6 +17,7 @@ use Application\View\Helper\Acl;
 use Application\View\Helper\Diff;
 use Application\View\Helper\FileUrl;
 use Application\View\Helper\GlideUrl;
+use Application\View\Helper\HashUrl;
 use Application\View\Helper\JobCategories;
 use Application\View\Helper\Markdown;
 use Application\View\Helper\ModuleIsActive;
@@ -31,6 +32,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Router\Http\TreeRouteStack;
 use Laminas\Router\RouteStackInterface;
 use Laminas\Validator\AbstractValidator;
+use Laminas\View\Helper\ServerUrl;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
@@ -331,6 +333,12 @@ class Module
                     $helper->setUrlBuilder($container->get('glide_url_builder'));
 
                     return $helper;
+                },
+                'hashUrl' => static function (ContainerInterface $container) {
+                    $viewHelperManager = $container->get('ViewHelperManager');
+                    $serverUrlHelper = $viewHelperManager->get(ServerUrl::class);
+
+                    return new HashUrl($serverUrlHelper);
                 },
             ],
         ];

--- a/module/Application/src/Router/LanguageAwareTreeRouteStack.php
+++ b/module/Application/src/Router/LanguageAwareTreeRouteStack.php
@@ -45,6 +45,12 @@ class LanguageAwareTreeRouteStack extends TranslatorAwareTreeRouteStack
         // Store the original base URL.
         $oldBaseUrl = $this->getBaseUrl();
 
+        // Do not allow direct access using /index.php. As such, rewrite any link that is being assembled to be without
+        // it as base.
+        if (str_starts_with($oldBaseUrl, '/index.php')) {
+            $oldBaseUrl = '/';
+        }
+
         // Try to get the language, because we do not have access to the current request in this method we cannot add an
         // `else` clause to call `$this->getLanguage()` to get the language.
         $language = null;

--- a/module/Application/src/View/Helper/HashUrl.php
+++ b/module/Application/src/View/Helper/HashUrl.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\View\Helper;
+
+use Application\Model\Enums\Languages;
+use Laminas\View\Helper\AbstractHelper;
+use Laminas\View\Helper\ServerUrl;
+
+use function implode;
+use function preg_replace;
+
+/**
+ * View helper to generate URLs of the current page with a hash `#`.
+ */
+class HashUrl extends AbstractHelper
+{
+    public function __construct(private readonly ServerUrl $serverUrlHelper)
+    {
+    }
+
+    public function __invoke(): string
+    {
+        $path = null;
+        if (isset($_SERVER['REQUEST_URI'])) {
+            // Drop `/index.php` if it exists.
+            $path = preg_replace(
+                '/^((\/' . implode('|', Languages::stringValues()) . ')?\/index\.php)/',
+                '',
+                $_SERVER['REQUEST_URI'],
+            );
+        }
+
+        return $this->serverUrlHelper->__invoke($path) . '#';
+    }
+}

--- a/module/Application/src/View/HelperTrait.php
+++ b/module/Application/src/View/HelperTrait.php
@@ -9,6 +9,7 @@ use Application\View\Helper\Acl;
 use Application\View\Helper\Breadcrumbs;
 use Application\View\Helper\Diff;
 use Application\View\Helper\GlideUrl;
+use Application\View\Helper\HashUrl;
 use Application\View\Helper\HrefLang;
 use Application\View\Helper\ScriptUrl;
 use Company\Model\CompanyFeaturedPackage as CompanyFeaturedPackageModel;
@@ -37,6 +38,7 @@ use User\Model\CompanyUser as CompanyUserModel;
  * @method CompanyFeaturedPackageModel|null featuredCompanyPackage()
  * @method string fileUrl(string $path)
  * @method GlideUrl glideUrl()
+ * @method HashUrl hashUrl()
  * @method JobCategoryModel[] jobCategories()
  * @method string localisedTextElement(ElementInterface $element)
  * @method string localiseText(LocalisedTextModel $localisedText)

--- a/module/Application/view/partial/admin.phtml
+++ b/module/Application/view/partial/admin.phtml
@@ -127,7 +127,7 @@ use Laminas\View\Renderer\PhpRenderer;
                     <?php
                     if ($this->acl('education_service_acl')->isAllowed('course_document', 'upload')): ?>
                         <li class="dropdown <?= $this->moduleIsActive(['frontpage', 'exam']) ? 'active' : '' ?>">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
+                            <a href="<?= $this->hashUrl() ?>" class="dropdown-toggle" data-toggle="dropdown" role="button"
                                aria-haspopup="true" aria-expanded="false">
                                 <?= $this->translate('Education') ?> <span class="caret"></span>
                             </a>
@@ -154,7 +154,7 @@ use Laminas\View\Renderer\PhpRenderer;
                     <?php
                     if ($this->acl('decision_service_acl')->isAllowed('meeting', 'upload_minutes')): ?>
                         <li class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown"
+                            <a href="<?= $this->hashUrl() ?>" class="dropdown-toggle" data-toggle="dropdown"
                                role="button" aria-haspopup="true" aria-expanded="false">
                                 <?= $this->translate('Meetings') ?> <span class="caret"></span>
                             </a>
@@ -218,7 +218,7 @@ use Laminas\View\Renderer\PhpRenderer;
                     <?php
                     if ($this->acl('user_service_acl')->isAllowed('apiuser', 'add')): ?>
                         <li class="dropdown <?= $this->moduleIsActive(['user']) ? 'active' : '' ?>">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
+                            <a href="<?= $this->hashUrl() ?>" class="dropdown-toggle" data-toggle="dropdown" role="button"
                                aria-haspopup="true" aria-expanded="false">
                                 <?= $this->translate('Users') ?> <span class="caret"></span>
                             </a>

--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -41,14 +41,14 @@ endif; ?>
 <nav class="navbar navbar-gewis navbar-static-top rainbow" role="navigation">
     <div class="container">
         <div class="navbar-header navbar-left pull-left">
-            <a href="<?= $this->url('home') ?>" class="navbar-brand">
+            <a href="/<?= $lang ?>/" class="navbar-brand">
                 <div class="gi gewis-base"></div>
             </a>
         </div>
         <div class="navbar-header navbar-right pull-right">
             <ul class="nav navbar-nav pull-left no-collapse">
                 <li class="dropdown pull-right">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                    <a href="<?= $this->hashUrl() ?>" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                        aria-expanded="false">
                         <span class="fas fa-globe-europe"></span>
                         <span class="sr-only"><?= $this->translate('Language settings') ?></span>
@@ -94,7 +94,7 @@ endif; ?>
                 <?php
                 if (null === $this->identity() && null === $this->companyIdentity()): ?>
                     <li class="dropdown pull-right">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                        <a href="<?= $this->hashUrl() ?>" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                            aria-expanded="false">
                             <span class="fas fa-user"></span>
                             <?= $this->translate('Members') ?>
@@ -129,7 +129,7 @@ endif; ?>
                     <?php
                     $company = $this->companyIdentity()->getCompany(); ?>
                     <li class="dropdown pull-right">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                        <a href="<?= $this->hashUrl() ?>" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                            aria-expanded="false">
                             <?= $this->escapeHtml($company->getName()) ?>
                             <span class="caret"></span>
@@ -157,7 +157,7 @@ endif; ?>
                     <?php
                     $member = $this->identity()->getMember(); ?>
                     <li class="dropdown pull-right">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                        <a href="<?= $this->hashUrl() ?>" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                            aria-expanded="false">
                             <?= $this->escapeHtml($member->getFirstName()) ?>
                             <span class="caret"></span>
@@ -306,13 +306,13 @@ endif; ?>
                             </a>
                         </li>
                         <li class="dropdown dropdown-submenu">
-                            <a href="#" role="button"
+                            <a href="<?= $this->hashUrl() ?>" role="button"
                                class="dropdown-toggle visible-sm visible-xs" data-toggle="dropdown" aria-haspopup="true"
                                aria-expanded="false">
                                 <?= $this->translate('Useful Information') ?>
                                 <span class="caret"></span>
                             </a>
-                            <a href="#" role="button"
+                            <a href="<?= $this->hashUrl() ?>" role="button"
                                class="hidden-sm hidden-xs">
                                 <?= $this->translate('Useful Information') ?>
                                 <span class="caret"></span>

--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -241,7 +241,7 @@ function getOrganDescription($organInformation, $lang)
                     </div>
                     <div class="list-group">
                         <?php if (empty($activities)): ?>
-                            <p class="list-group-item" href="#">
+                            <p class="list-group-item" href="<?= $this->hashUrl() ?>">
                                 <span class="list-group-item-text text-muted">
                                     <?= $this->translate('No activities planned') ?>
                                 </span>

--- a/module/Photo/view/partial/years.phtml
+++ b/module/Photo/view/partial/years.phtml
@@ -33,7 +33,7 @@ if ($admin) {
                 <li role="presentation" class="dropdown">
                     <a class="dropdown-toggle"
                        data-toggle="dropdown"
-                       href="#"
+                       href="<?= $this->hashUrl() ?>"
                        role="button"
                        aria-haspopup="true"
                        aria-expanded="false">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This prevents all URLs from including `/index.php/` when using the URL view helper. To ensure that this also properly works for URLs constructed by the browser, we now have the `HashUrl` view helper for that.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
