### PR TITLE
fix: alternate href lang missing / when language is not in the path

### DIFF
--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -47,6 +47,14 @@ use Laminas\View\Renderer\PhpRenderer;
             $strippedPath = '';
         }
 
+        if (
+            '' !== $strippedPath
+            && !str_starts_with($strippedPath, '/')
+        ) {
+            // If not at the "root", add the slash back if it is not present.
+            $strippedPath = '/' . $strippedPath;
+        }
+
         $this->hrefLang()->setHrefLang(Languages::EN, $this->serverUrl($this->basePath('en' . $strippedPath)))
             ->setHrefLang(Languages::NL, $this->serverUrl($this->basePath('nl' . $strippedPath)));
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Addresses a flaw in my logic where the root slash stripped while constructing the URL is never added back resulting in broken URLs when the language tags are not present; `/some/example/page` becomes `/(en|nl)some/example/page` instead of `/(en|nl)/some/example/page`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
