### PR TITLE
fix: not setting language in router on first requests

### DIFF
--- a/module/Application/src/Router/LanguageAwareTreeRouteStack.php
+++ b/module/Application/src/Router/LanguageAwareTreeRouteStack.php
@@ -158,6 +158,10 @@ class LanguageAwareTreeRouteStack extends TranslatorAwareTreeRouteStack
         // Store the original base URL (likely only just set above).
         $oldBaseUrl = $this->getBaseUrl();
 
+        // Always try to get/set language. This ensures that we always have a language set if this is the very first
+        // request, and we do an early return (e.g. for `/api` or `/index.php`).
+        $this->getLanguage($request);
+
         // Do not allow direct access using /index.php. It is too difficult to properly configure this in NGINX, as we
         // want to keep using the Laminas-generated 404 page and not a generic NGINX 404 page.
         if (str_starts_with($oldBaseUrl, '/index.php')) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
An issue existed for `/api` and `/index.php` (and potentially more routes) where there was no language known in the router if this was the very first request.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1879.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
