### PR TITLE
feat: better language-aware link management

### DIFF
--- a/module/Application/src/View/Helper/HrefLang.php
+++ b/module/Application/src/View/Helper/HrefLang.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Application\View\Helper;
 
 use Application\Model\Enums\Languages;
+use InvalidArgumentException;
 use Laminas\View\Helper\Placeholder\Container\AbstractStandalone;
 
+use function is_string;
 use function sprintf;
 
 /**
@@ -18,14 +20,27 @@ class HrefLang extends AbstractStandalone
     /**
      * Set a specific `hreflang`.
      *
+     * @psalm-param Languages|'x-default' $language
+     *
      * @return $this
      */
     public function setHrefLang(
-        Languages $language,
+        Languages|string $language,
         string $url,
     ): self {
-        if (!$this->getContainer()->offsetExists($language->value)) {
-            $this->getContainer()->offsetSet($language->value, $url);
+        if (
+            is_string($language) // @phpstan-ignore booleanAnd.alwaysFalse (bad inference from 'x-default')
+            && 'x-default' !== $language // @phpstan-ignore notIdentical.alwaysFalse (bad inference from 'x-default')
+        ) {
+            throw new InvalidArgumentException('Only \'x-default\' is supported as alternative to Languages.');
+        }
+
+        if ($language instanceof Languages) {
+            $language = $language->value;
+        }
+
+        if (!$this->getContainer()->offsetExists($language)) {
+            $this->getContainer()->offsetSet($language, $url);
         }
 
         return $this;

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -56,7 +56,8 @@ use Laminas\View\Renderer\PhpRenderer;
         }
 
         $this->hrefLang()->setHrefLang(Languages::EN, $this->serverUrl($this->basePath('en' . $strippedPath)))
-            ->setHrefLang(Languages::NL, $this->serverUrl($this->basePath('nl' . $strippedPath)));
+            ->setHrefLang(Languages::NL, $this->serverUrl($this->basePath('nl' . $strippedPath)))
+            ->setHrefLang('x-default', $this->serverUrl($this->basePath(ltrim($strippedPath, '/'))));
     }
 
     echo $this->hrefLang();

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -19,7 +19,7 @@ use Laminas\View\Renderer\PhpRenderer;
         ->appendName('viewport', 'width=device-width, initial-scale=1.0')
     ?>
 
-    <!-- Display alternate language links-->
+    <!-- START alternate language links -->
     <?php
     if (isset($_SERVER['REQUEST_URI'])) {
         $strippedPath = ltrim(
@@ -55,6 +55,10 @@ use Laminas\View\Renderer\PhpRenderer;
 
     echo $this->hrefLang();
     ?>
+    <!-- END alternate language links -->
+    <!-- START canonical link -->
+    <?= $this->placeholder('canonicalLink') ?>
+    <!-- END canonical link -->
 
     <!-- Preload fonts-->
     <?php

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -42,22 +42,15 @@ use Laminas\View\Renderer\PhpRenderer;
             $strippedPath = '';
         }
 
-        // If we are at the "root", remove the slash.
-        if ('/' === $strippedPath) {
-            $strippedPath = '';
-        }
-
-        if (
-            '' !== $strippedPath
-            && !str_starts_with($strippedPath, '/')
-        ) {
-            // If not at the "root", add the slash back if it is not present.
+        if (!str_starts_with($strippedPath, '/')) {
+            // Add a nice slash back, if we are at the "root" we will get `/{lang}/` instead of `/{lang}`. If not at the
+            // "root" we get `/{lang}/{...}` instead of `/{lang}{...}` (note: incorrect concat).
             $strippedPath = '/' . $strippedPath;
         }
 
         $this->hrefLang()->setHrefLang(Languages::EN, $this->serverUrl($this->basePath('en' . $strippedPath)))
             ->setHrefLang(Languages::NL, $this->serverUrl($this->basePath('nl' . $strippedPath)))
-            ->setHrefLang('x-default', $this->serverUrl($this->basePath(ltrim($strippedPath, '/'))));
+            ->setHrefLang('x-default', $this->serverUrl($this->basePath($strippedPath)));
     }
 
     echo $this->hrefLang();

--- a/module/Frontpage/config/module.config.php
+++ b/module/Frontpage/config/module.config.php
@@ -43,7 +43,7 @@ return [
                     'page' => [
                         'type' => Segment::class,
                         'options' => [
-                            'route' => '[:category[/:sub_category][/:name][/]]',
+                            'route' => '[:category[/:sub_category][/:name]]',
                             'constraints' => [
                                 'category' => '[a-zA-Z][a-zA-Z0-9_-]*',
                                 'sub_category' => '[a-zA-Z][a-zA-Z0-9_-]*',

--- a/module/User/view/user/user/login.phtml
+++ b/module/User/view/user/user/login.phtml
@@ -16,6 +16,13 @@ use User\Form\UserLogin as UserLoginForm;
 
 $this->headTitle($this->translate('Log in'));
 
+if (false !== ($path = parse_url($this->serverUrl(true), PHP_URL_PATH))) {
+    $this->placeholder('canonicalLink')->set(sprintf(
+        '<link rel="canonical" href="%s">',
+        $this->serverUrl($path),
+    ));
+}
+
 $isMember = ('member' === $userType);
 ?>
 <section class="section">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

Adds `x-default` for the alternative `hreflang`s that points to the origin without a language-aware router bit set. Fixes an issue where leading/trailing slashes were the bane of my existence. And ensures that all login pages are canonicalised to remove the `redirect_to`.

Hopefully, this keeps Google (and the other indexers) happy for quite some time.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
