### PR TITLE
fix: conflict in permissions for decisions for active members

### DIFF
--- a/module/Application/view/partial/admin.phtml
+++ b/module/Application/view/partial/admin.phtml
@@ -163,7 +163,7 @@ use Laminas\View\Renderer\PhpRenderer;
                             </ul>
                         </li>
                     <?php endif; ?>
-                    <?php if ($this->acl('decision_service_acl')->isAllowed('decision_admin', 'view')): ?>
+                    <?php if ($this->acl('decision_service_acl')->isAllowed('decision_organ_admin', 'view')): ?>
                         <li>
                             <a href="<?= $this->url('admin_organ') ?>">
                                 <?= $this->translate('Organs') ?>

--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -197,6 +197,7 @@ endif; ?>
                                 $this->acl('activity_service_acl')->isAllowed('activity_admin', 'view')
                                 || $this->acl('company_service_acl')->isAllowed('company_admin', 'view')
                                 || $this->acl('decision_service_acl')->isAllowed('decision_admin', 'view')
+                                || $this->acl('decision_service_acl')->isAllowed('decision_organ_admin', 'view')
                                 || $this->acl('education_service_acl')->isAllowed('education_admin', 'view')
                                 || $this->acl('frontpage_service_acl')->isAllowed('frontpage_admin', 'view')
                                 || $this->acl('photo_service_acl')->isAllowed('photo_admin', 'view')

--- a/module/Decision/src/Service/AclService.php
+++ b/module/Decision/src/Service/AclService.php
@@ -23,6 +23,7 @@ class AclService extends \User\Service\AclService
         $this->acl->addResource(new Resource('gdpr'));
         // Define administration part of this module, however, sub-permissions must be manually configured.
         $this->acl->addResource(new Resource('decision_admin'));
+        $this->acl->addResource(new Resource('decision_organ_admin'));
 
         // users are allowed to view the organs
         $this->acl->allow('guest', 'organ', 'list');
@@ -30,7 +31,7 @@ class AclService extends \User\Service\AclService
 
         // Organ members are allowed to edit organ information of their own organs
         $this->acl->allow('active_member', 'organ', 'edit');
-        $this->acl->allow('active_member', 'decision_admin', 'view');
+        $this->acl->allow('active_member', 'decision_organ_admin', 'view');
 
         // users are allowed to view and search members
         $this->acl->allow('user', 'member', ['view', 'view_self', 'search', 'birthdays']);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Active members were able to see the 'Meetings' tab due to the `decision_admin` being too broad.

We could have gone for a `viewOrgan` privilege on the `decision_admin` object, however, it feels better to make it a separate `decision_organ_admin`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
