### PR TITLE
feat(frontpage): add overview for GMM bodies

### DIFF
--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-13 21:40+0100\n"
-"PO-Revision-Date: 2024-11-13 21:41+0100\n"
+"POT-Creation-Date: 2024-11-27 16:20+0100\n"
+"PO-Revision-Date: 2024-11-27 16:21+0100\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: en\n"
@@ -1365,6 +1365,9 @@ msgstr "GMM"
 msgid "GMM %d (%s)"
 msgstr "GMM %d (%s)"
 
+msgid "GMM Bodies"
+msgstr "GMM Bodies"
+
 msgid "GMM Committee"
 msgstr "GMM Committee"
 
@@ -2353,6 +2356,10 @@ msgstr "Poster Policy"
 msgid "Previous"
 msgstr "Previous"
 
+#, php-format
+msgid "Previous %s"
+msgstr "Previous %s"
+
 msgid "Previous exceptions"
 msgstr "Previous exceptions"
 
@@ -2982,6 +2989,10 @@ msgstr "There already exists a course with this code"
 msgid "There are a few rules:"
 msgstr "There are a few rules:"
 
+#, php-format
+msgid "There are currently no %s installed."
+msgstr "There are currently no %s installed."
+
 msgid "There are currently no activity categories..."
 msgstr "There are currently no activity categories..."
 
@@ -2997,6 +3008,10 @@ msgid ""
 msgstr ""
 "There are currently no summaries available. Consider submitting one yourself "
 "by sending an email to"
+
+#, php-format
+msgid "There are no abrogated %s."
+msgstr "There are no abrogated %s."
 
 msgid "There are no activities in the archive."
 msgstr "There are no activities in the archive."

--- a/module/Application/language/gewisweb.pot
+++ b/module/Application/language/gewisweb.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GEWISweb v2.8.6-797-g9074c8f18-dirty\n"
+"Project-Id-Version: GEWISweb v2.8.6-803-g35ae5011a-dirty\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-13 21:40+0100\n"
+"POT-Creation-Date: 2024-11-27 16:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1302,6 +1302,9 @@ msgstr ""
 msgid "GMM %d (%s)"
 msgstr ""
 
+msgid "GMM Bodies"
+msgstr ""
+
 msgid "GMM Committee"
 msgstr ""
 
@@ -2225,6 +2228,10 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
+#, php-format
+msgid "Previous %s"
+msgstr ""
+
 msgid "Previous exceptions"
 msgstr ""
 
@@ -2804,6 +2811,10 @@ msgstr ""
 msgid "There are a few rules:"
 msgstr ""
 
+#, php-format
+msgid "There are currently no %s installed."
+msgstr ""
+
 msgid "There are currently no activity categories..."
 msgstr ""
 
@@ -2816,6 +2827,10 @@ msgstr ""
 msgid ""
 "There are currently no summaries available. Consider submitting one yourself "
 "by sending an email to"
+msgstr ""
+
+#, php-format
+msgid "There are no abrogated %s."
 msgstr ""
 
 msgid "There are no activities in the archive."

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-13 21:40+0100\n"
-"PO-Revision-Date: 2024-11-13 21:42+0100\n"
+"POT-Creation-Date: 2024-11-27 16:20+0100\n"
+"PO-Revision-Date: 2024-11-27 16:22+0100\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: nl\n"
@@ -1378,6 +1378,9 @@ msgstr "ALV"
 msgid "GMM %d (%s)"
 msgstr "ALV %d (%s)"
 
+msgid "GMM Bodies"
+msgstr "ALV-organen"
+
 msgid "GMM Committee"
 msgstr "ALV-Commissie"
 
@@ -2377,6 +2380,10 @@ msgstr "Posterbeleid"
 msgid "Previous"
 msgstr "Vorige"
 
+#, php-format
+msgid "Previous %s"
+msgstr "Eerdere %s"
+
 msgid "Previous exceptions"
 msgstr "Vorige excepties"
 
@@ -3009,6 +3016,10 @@ msgstr "Er bestaat al een vak met deze code"
 msgid "There are a few rules:"
 msgstr "Er zijn een paar regels:"
 
+#, php-format
+msgid "There are currently no %s installed."
+msgstr "Er zijn momenteel geen %s geïnstalleerd."
+
 msgid "There are currently no activity categories..."
 msgstr "Er zijn momenteel geen activiteitencategorieën..."
 
@@ -3025,6 +3036,10 @@ msgid ""
 msgstr ""
 "Er zijn momenteel geen samenvattingen beschikbaar. Stuur er zelf een in door "
 "te mailen naar"
+
+#, php-format
+msgid "There are no abrogated %s."
+msgstr "Er zijn geen opgeheven %s."
 
 msgid "There are no activities in the archive."
 msgstr "Er zijn geen activiteiten in het archief."

--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use Application\View\HelperTrait;
+use Decision\Model\Enums\OrganTypes;
 use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Renderer\PhpRenderer;
 
 /** @var PhpRenderer|HelperTrait $this */
 
-$lang = $this->plugin('translate')->getTranslator()->getLocale();
+$translator = $this->plugin('translate')->getTranslator();
+$lang = $translator->getLocale();
 ?>
 <?php
 if ($this->identity()?->getMember()->isBoardMember()): ?>
@@ -287,6 +289,41 @@ endif; ?>
                             <a href="<?= $this->url('home/fraternity_list') ?>">
                                 <?= $this->translate('Fraternities') ?>
                             </a>
+                        </li>
+                        <li class="dropdown dropdown-submenu">
+                            <a href="<?= $this->hashUrl() ?>" role="button"
+                               class="dropdown-toggle visible-sm visible-xs" data-toggle="dropdown" aria-haspopup="true"
+                               aria-expanded="false">
+                                <?= $this->translate('GMM Bodies') ?>
+                                <span class="caret"></span>
+                            </a>
+                            <a href="<?= $this->hashUrl() ?>" role="button"
+                               class="hidden-sm hidden-xs">
+                                <?= $this->translate('GMM Bodies') ?>
+                                <span class="caret"></span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a href="<?= $this->url('home/gmm_bodies/rva_list') ?>">
+                                        <?= OrganTypes::RvA->getPluralName($translator) ?>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="<?= $this->url('home/gmm_bodies/kcc_list') ?>">
+                                        <?= OrganTypes::KCC->getPluralName($translator) ?>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="<?= $this->url('home/gmm_bodies/avw_list') ?>">
+                                        <?= OrganTypes::AVW->getPluralName($translator) ?>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="<?= $this->url('home/gmm_bodies/avc_list') ?>">
+                                        <?= OrganTypes::AVC->getPluralName($translator) ?>
+                                    </a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
                             <a href="<?= $this->url(

--- a/module/Decision/src/Model/Enums/OrganTypes.php
+++ b/module/Decision/src/Model/Enums/OrganTypes.php
@@ -29,4 +29,16 @@ enum OrganTypes: string
             self::RvA => $translator->translate('Advisory Board'),
         };
     }
+
+    public function getPluralName(Translator $translator): string
+    {
+        return match ($this) {
+            self::Committee => $translator->translate('Committees'),
+            self::AVC => $translator->translate('GMM Committees'),
+            self::Fraternity => $translator->translate('Fraternities'),
+            self::KCC => $translator->translate('Financial Audit Committees'),
+            self::AVW => $translator->translate('GMM Taskforces'),
+            self::RvA => $translator->translate('Advisory Boards'),
+        };
+    }
 }

--- a/module/Frontpage/config/module.config.php
+++ b/module/Frontpage/config/module.config.php
@@ -104,6 +104,54 @@ return [
                         ],
                         'priority' => 100,
                     ],
+                    'gmm_bodies' => [
+                        'type' => Literal::class,
+                        'options' => [
+                            'route' => 'association/gmm-bodies',
+                            'defaults' => [
+                                'controller' => OrganController::class,
+                            ],
+                        ],
+                        'may_terminate' => false,
+                        'child_routes' => [
+                            'avc_list' => [
+                                'type' => Literal::class,
+                                'options' => [
+                                    'route' => '/gmm-committees',
+                                    'defaults' => [
+                                        'action' => 'avcList',
+                                    ],
+                                ],
+                            ],
+                            'avw_list' => [
+                                'type' => Literal::class,
+                                'options' => [
+                                    'route' => '/gmm-taskforces',
+                                    'defaults' => [
+                                        'action' => 'avwList',
+                                    ],
+                                ],
+                            ],
+                            'kcc_list' => [
+                                'type' => Literal::class,
+                                'options' => [
+                                    'route' => '/financial-audit-committees',
+                                    'defaults' => [
+                                        'action' => 'kccList',
+                                    ],
+                                ],
+                            ],
+                            'rva_list' => [
+                                'type' => Literal::class,
+                                'options' => [
+                                    'route' => '/advisory-boards',
+                                    'defaults' => [
+                                        'action' => 'rvaList',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
             ],
             'admin_page' => [
@@ -389,6 +437,10 @@ return [
             'news-admin/edit' => __DIR__ . '/../view/frontpage/news-admin/edit.phtml',
             'organ/committee-list' => __DIR__ . '/../view/frontpage/organ/committee-list.phtml',
             'organ/fraternity-list' => __DIR__ . '/../view/frontpage/organ/fraternity-list.phtml',
+            'frontpage/organ/avc-list' => __DIR__ . '/../view/frontpage/organ/gmm-body.phtml',
+            'frontpage/organ/avw-list' => __DIR__ . '/../view/frontpage/organ/gmm-body.phtml',
+            'frontpage/organ/kcc-list' => __DIR__ . '/../view/frontpage/organ/gmm-body.phtml',
+            'frontpage/organ/rva-list' => __DIR__ . '/../view/frontpage/organ/gmm-body.phtml',
         ],
     ],
     'doctrine' => [

--- a/module/Frontpage/src/Controller/OrganController.php
+++ b/module/Frontpage/src/Controller/OrganController.php
@@ -48,6 +48,35 @@ class OrganController extends AbstractActionController
         );
     }
 
+    public function avcListAction(): ViewModel
+    {
+        return $this->getBodies(OrganTypes::AVC);
+    }
+
+    public function avwListAction(): ViewModel
+    {
+        return $this->getBodies(OrganTypes::AVW);
+    }
+
+    public function kccListAction(): ViewModel
+    {
+        return $this->getBodies(OrganTypes::KCC);
+    }
+
+    public function rvaListAction(): ViewModel
+    {
+        return $this->getBodies(OrganTypes::RvA);
+    }
+
+    private function getBodies(OrganTypes $organType): ViewModel
+    {
+        return new ViewModel([
+            'organType' => $organType,
+            'active' => $this->organService->findActiveOrgansByType($organType),
+            'abrogated' => $this->organService->findAbrogatedOrgansByType($organType),
+        ]);
+    }
+
     public function organAction(): ViewModel
     {
         $type = OrganTypes::from($this->params()->fromRoute('type'));

--- a/module/Frontpage/view/frontpage/organ/gmm-body.phtml
+++ b/module/Frontpage/view/frontpage/organ/gmm-body.phtml
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Decision\Model\Enums\OrganTypes;
+use Decision\Model\Organ as OrganModel;
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var OrganModel[] $active
+ * @var OrganModel[] $abrogated
+ * @var OrganTypes $organType
+ */
+
+$translator = $this->plugin('translate')->getTranslator();
+$lang = $translator->getLocale();
+
+$namePlural = $organType->getPluralName($translator);
+
+$this->headTitle($namePlural);
+?>
+<section class="section">
+    <div class="container">
+        <h1><?= $namePlural ?></h1>
+        <div class="row">
+            <?php if (empty($active)): ?>
+                <div class="col-md-12">
+                    <p>
+                        <?= sprintf(
+                            $this->translate('There are currently no %s installed.'),
+                            $namePlural,
+                        ) ?>
+                    </p>
+                </div>
+            <?php else: ?>
+                <?php
+                foreach ($active as $avc) {
+                    echo $this->partial('partial/organ-card.phtml', [
+                        'organ' => $avc,
+                        'lang' => $lang,
+                    ]);
+                }
+                ?>
+            <?php endif; ?>
+        </div>
+        <hr>
+        <h3>
+            <?= sprintf(
+                $this->translate('Previous %s'),
+                $namePlural,
+            ) ?>
+        </h3>
+        <div class="row">
+            <?php if (empty($abrogated)): ?>
+                <div class="col-md-12">
+                    <p>
+                        <?= sprintf(
+                            $this->translate('There are no abrogated %s.'),
+                            $namePlural,
+                        ) ?>
+                    </p>
+                </div>
+            <?php else: ?>
+                <?php
+                foreach ($abrogated as $avc) {
+                    echo $this->partial('partial/organ-card.phtml', [
+                        'organ' => $avc,
+                        'lang' => $lang,
+                    ]);
+                }
+                ?>
+            <?php endif; ?>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Apparently this was brought up at the last GMM, but unfortunately it remains difficult to communicate things. Fortunately, there was an issue open for this before, so it was already clear what needed to be done without me receiving the additional information.

This adds a new dropdown to the 'Association' menu for "GMM Bodies":
- Advisory Boards,
- Financial Audit Committees,
- GMM Taskforces, and
- GMM Committees.

Each links to a new page for an overview of that specific type of GMM body. The page also includes a historical overview of those GMM bodies.

No other new functionality has been added, as everything necessary for this was already implemented.

---

While we have always used "organs" instead of "bodies" this is an incorrect translations (like many of our translations in the past). This is the first attempt to try and fix that.

---

Opted to not add notice that the Financial Audit Committees before 2021 were actually GMM Committees.


## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Closes GH-1890.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
