### PR TITLE
fix: no backlinking in breadcrumbs to GMM body overviews from GMM bodies

### DIFF
--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -282,12 +282,12 @@ endif; ?>
                         </li>
                         <li>
                             <a href="<?= $this->url('home/committee_list') ?>">
-                                <?= $this->translate('Committees') ?>
+                                <?= OrganTypes::Committee->getPluralName($translator) ?>
                             </a>
                         </li>
                         <li>
                             <a href="<?= $this->url('home/fraternity_list') ?>">
-                                <?= $this->translate('Fraternities') ?>
+                                <?= OrganTypes::Fraternity->getPluralName($translator) ?>
                             </a>
                         </li>
                         <li class="dropdown dropdown-submenu">

--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -23,7 +23,8 @@ use Laminas\View\Renderer\PhpRenderer;
 // set title
 $this->headTitle($organ->getName());
 
-$lang = $this->plugin('translate')->getTranslator()->getLocale();
+$translator = $this->plugin('translate')->getTranslator();
+$lang = $translator->getLocale();
 $organInformation = $organ->getApprovedOrganInformation();
 function getOrganDescription($organInformation, $lang)
 {
@@ -57,22 +58,41 @@ function getOrganDescription($organInformation, $lang)
         <div class="container">
             <ol class="breadcrumb">
                 <li class="active">
+                    <a href="<?= $this->url(
+                        'home/page',
+                        [
+                            'category' => 'vereniging',
+                            'categoryEn' => 'association',
+                        ],
+                    ) ?>">
+                        <?= $this->translate('Association') ?>
+                    </a>
+                </li>
+                <li class="active">
                     <?php if (OrganTypes::Fraternity === $organ->getType()): ?>
                         <a href="<?= $this->url('home/fraternity_list') ?>">
-                            <?= $this->translate('Fraternities') ?>
+                            <?= OrganTypes::Fraternity->getPluralName($translator) ?>
                         </a>
                     <?php elseif (OrganTypes::Committee === $organ->getType()): ?>
                         <a href="<?= $this->url('home/committee_list') ?>">
-                            <?= $this->translate('Committees') ?>
+                            <?= OrganTypes::Committee->getPluralName($translator) ?>
                         </a>
                     <?php elseif (OrganTypes::AVC === $organ->getType()): ?>
-                        <?= $this->translate('GMM Committees') ?>
+                        <a href="<?= $this->url('home/gmm_bodies/avc_list') ?>">
+                            <?= OrganTypes::AVC->getPluralName($translator) ?>
+                        </a>
                     <?php elseif (OrganTypes::AVW === $organ->getType()): ?>
-                        <?= $this->translate('GMM Taskforces') ?>
+                        <a href="<?= $this->url('home/gmm_bodies/avw_list') ?>">
+                            <?= OrganTypes::AVW->getPluralName($translator) ?>
+                        </a>
                     <?php elseif (OrganTypes::KCC === $organ->getType()): ?>
-                        <?= $this->translate('Financial Audit Committees') ?>
+                        <a href="<?= $this->url('home/gmm_bodies/kcc_list') ?>">
+                            <?= OrganTypes::KCC->getPluralName($translator) ?>
+                        </a>
                     <?php elseif (OrganTypes::RvA === $organ->getType()): ?>
-                        <?= $this->translate('Advisory Boards') ?>
+                        <a href="<?= $this->url('home/gmm_bodies/rva_list') ?>">
+                            <?= OrganTypes::RvA->getPluralName($translator) ?>
+                        </a>
                     <?php endif; ?>
                 </li>
                 <li class="active">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Ensures that backlinks are available in the breadcrumbs.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1929.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
