### PR TITLE
fix: showing "planned" activities for abrogated bodies

### DIFF
--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -255,34 +255,36 @@ function getOrganDescription($organInformation, $lang)
                         <?php endif; ?>
                     </div>
                 </div>
-                <div class="panel panel-default agenda">
-                    <div class="panel-heading">
-                        <h3><?= $this->translate('Activities') ?></h3>
-                    </div>
-                    <div class="list-group">
-                        <?php if (empty($activities)): ?>
-                            <p class="list-group-item" href="<?= $this->hashUrl() ?>">
-                                <span class="list-group-item-text text-muted">
-                                    <?= $this->translate('No activities planned') ?>
-                                </span>
-                            </p>
-                        <?php else: ?>
-                            <?php foreach ($activities as $activity): ?>
-                                <a class="list-group-item"
-                                   href="<?= $this->url('activity/view', ['id' => $activity->getId()]) ?>">
+                <?php if (!$organ->isAbrogated()): ?>
+                    <div class="panel panel-default agenda">
+                        <div class="panel-heading">
+                            <h3><?= $this->translate('Activities') ?></h3>
+                        </div>
+                        <div class="list-group">
+                            <?php if (empty($activities)): ?>
+                                <p class="list-group-item" href="<?= $this->hashUrl() ?>">
+                                    <span class="list-group-item-text text-muted">
+                                        <?= $this->translate('No activities planned') ?>
+                                    </span>
+                                </p>
+                            <?php else: ?>
+                                <?php foreach ($activities as $activity): ?>
+                                    <a class="list-group-item"
+                                       href="<?= $this->url('activity/view', ['id' => $activity->getId()]) ?>">
 
-                                    <h4 class="list-group-item-heading"><?= $this->localiseText($activity->getName()) ?></h4>
-                                    <p class="list-group-item-text text-muted"><?= ucfirst($this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT)); ?></p>
-                                </a>
-                            <?php endforeach; ?>
-                        <?php endif; ?>
+                                        <h4 class="list-group-item-heading"><?= $this->localiseText($activity->getName()) ?></h4>
+                                        <p class="list-group-item-text text-muted"><?= ucfirst($this->dateFormat($activity->getBeginTime(), IntlDateFormatter::FULL, IntlDateFormatter::SHORT)); ?></p>
+                                    </a>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </div>
+                        <div class="panel-footer">
+                            <a href="<?= $this->url('activity') ?>" class="panel-footer__link">
+                                <?= $this->translate('Complete agenda') ?>
+                            </a>
+                        </div>
                     </div>
-                    <div class="panel-footer">
-                        <a href="<?= $this->url('activity') ?>" class="panel-footer__link">
-                            <?= $this->translate('Complete agenda') ?>
-                        </a>
-                    </div>
-                </div>
+                <?php endif; ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Abrogated bodies cannot plan any activities, as such, it does not make any sense to show the panel.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1926.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
