### PR TITLE
fix: body information not formatted as Markdown

### DIFF
--- a/module/Frontpage/view/frontpage/organ/organ.phtml
+++ b/module/Frontpage/view/frontpage/organ/organ.phtml
@@ -117,7 +117,7 @@ function getOrganDescription($organInformation, $lang)
         <div class="row">
             <div class="col-md-8">
                 <h1 class="h-wrap"><?= $this->escapeHtml($organ->getName()) ?></h1>
-                <?php echo getOrganDescription($organInformation, $lang) ?>
+                <?= $this->markdown(getOrganDescription($organInformation, $lang)) ?>
             </div>
             <div class="col-md-4">
                 <div class="panel panel-default">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The editor only supports Markdown, however, the actual page relied on the description(s) having HTML in them. This ensures that Markdown is supported on both ends.

As GH-1903 is not finished and more people noticed this oversight, this fix has been fast-tracked.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

This `cherry-pick`s a single fix from GH-1903 and closes ABC-2411-503.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
