### PR TITLE
fix: time diff calculation for activities

### DIFF
--- a/module/Application/src/View/Helper/TimeDiff.php
+++ b/module/Application/src/View/Helper/TimeDiff.php
@@ -26,13 +26,11 @@ class TimeDiff extends AbstractHelper
         DateTime $end,
     ): string {
         $diffInterval = $start->diff($end);
-        $days = false === $diffInterval->days ? 0 : $diffInterval->days;
-
         $diff = [
             'year' => $diffInterval->y,
             'month' => $diffInterval->m,
-            'week' => (int) floor($days / 7) % 4,
-            'day' => $days % 7,
+            'week' => (int) floor($diffInterval->d / 7),
+            'day' => $diffInterval->d % 7,
             'hour' => $diffInterval->h,
             'minute' => $diffInterval->i,
             'second' => $diffInterval->s,
@@ -40,7 +38,11 @@ class TimeDiff extends AbstractHelper
 
         $units = [];
         $result = [];
-        if (0 === $days) {
+        if (
+            0 === $diff['year']
+            && 0 === $diff['month']
+            && 0 === $diff['day']
+        ) {
             if (
                 0 === $diff['hour']
                 && 0 === $diff['minute']


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
An error in the logic existed due to a lack of documentation. As a result, the estimated times were off by up to 30 days.

As an example, an activity that takes place on February 14, 2025 at 17:00 would state that this was in "1 month and 5 days" (at the time of writing this commit message). We all know that this is not the case, because that would actually be January 21, 2025.

The `d` property of a `DateInterval` is now used directly instead of doing our own calculations with the `days` property (_all_ days between both dates, not just the difference after substracting years and months).

**Before:**
![image](https://github.com/user-attachments/assets/145eceef-c05d-4867-9761-63c0b353c38a)

**After:**
![image](https://github.com/user-attachments/assets/b475fe00-19a7-420d-a0d6-8892f2b5b57a)

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
