### PR TITLE
fix(matomo): not accepting SSL connection for database

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -83,6 +83,7 @@ MATOMO_DATABASE_PORT=3306
 MATOMO_DATABASE_USERNAME=gewis
 MATOMO_DATABASE_PASSWORD=gewis
 MATOMO_DATABASE_DBNAME=gewis
+MATOMO_DATABASE_SSL=0
 MATOMO_DOMAIN=http://localhost:82
 
 # These are the environment variables for PhpMyAdmin, only used in docker-compose.override.yaml for development

--- a/docker/matomo/Dockerfile
+++ b/docker/matomo/Dockerfile
@@ -1,4 +1,4 @@
-FROM matomo:5.1-fpm-alpine AS gewisweb_matomo
+FROM matomo:5.2-fpm-alpine AS gewisweb_matomo
 
 RUN apk add --no-cache --virtual .build-deps \
         tzdata \
@@ -29,4 +29,4 @@ RUN curl -L -o AnalyticsOptOut.zip \
 
 COPY --chown=www-data:www-data config.ini.php ./config/config.ini.php.template
 
-CMD ["/bin/sh" , "-c" , "envsubst '${MATOMO_DATABASE_HOST} ${MATOMO_DATABASE_PORT} ${MATOMO_DATABASE_USERNAME} ${MATOMO_DATABASE_PASSWORD} ${MATOMO_DATABASE_DBNAME}' < /var/www/html/config/config.ini.php.template > /var/www/html/config/config.ini.php && chown www-data:www-data /var/www/html/config/config.ini.php && php-fpm -F -O"]
+CMD ["/bin/sh" , "-c" , "envsubst '${MATOMO_DATABASE_HOST} ${MATOMO_DATABASE_PORT} ${MATOMO_DATABASE_USERNAME} ${MATOMO_DATABASE_PASSWORD} ${MATOMO_DATABASE_DBNAME} ${MATOMO_DATABASE_SSL}' < /var/www/html/config/config.ini.php.template > /var/www/html/config/config.ini.php && chown www-data:www-data /var/www/html/config/config.ini.php && php-fpm -F -O"]

--- a/docker/matomo/config.ini.php
+++ b/docker/matomo/config.ini.php
@@ -11,6 +11,9 @@ adapter = PDO\MYSQL
 type = InnoDB
 schema = Mysql
 
+enable_ssl = ${MATOMO_DATABASE_SSL}
+ssl_ca_path = "/etc/ssl/certs/"
+
 [General]
 force_ssl=0
 assume_secure_protocol = 1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds new environment variable `MATOMO_DATABASE_SSL` to allow Matomo to connect to a database over SSL. CA path defaults to `/etc/ssl/certs/` (Alpine).

Do not know how I missed this when doing GH-1914 and GH-1915.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
