### PR TITLE
fix(navbar): submenus not properly closing on mobile

### DIFF
--- a/public/js/navbar.js
+++ b/public/js/navbar.js
@@ -1,14 +1,16 @@
 // Handle submenus
-$('li.dropdown-submenu [data-toggle=dropdown]').on('click', function(event) {
+$('li.dropdown-submenu > [data-toggle=dropdown]').on('click touchstart', function(event) {
     event.preventDefault();
     event.stopPropagation();
 
+    var parent = $(this).parent();
+
     // Also update aria-expanded for accessibility purposes.
-    if ($(this).parent().hasClass('open')) {
-        $(this).parent().removeClass('open');
+    if (parent.hasClass('open')) {
+        parent.removeClass('open');
         $(this).attr('aria-expanded', 'false');
     } else {
-        $(this).parent().addClass('open');
+        parent.addClass('open');
         $(this).attr('aria-expanded', 'true');
     }
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Instead of properly closing the submenus on mobile, they would shift left and still be usable. This has been addressed by improved element targeting and the inclusion of the `touchstart` event.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->
Unfortunately, it was a long-standing problem, but it was recently brought to my attention again.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
