### PR TITLE
feat: allow board to hide the current Photo of the Week

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ migration-list: replenish
 
 migration-diff: replenish
 		@docker compose exec -T web ./orm migrations:diff
-		@docker cp "$(shell docker compose ps -q web)":/code/module/Application/migrations ./module/Application/migrations
+		@docker cp "$(shell docker compose ps -q web)":/code/module/Application/migrations ./module/Application
 
 migration-up: replenish migration-list
 		@read -p "Enter the migration version to execute (e.g., Application\\Migrations\\Version20241020212355 -- note escaping the backslashes is required): " version; \

--- a/module/Activity/src/Controller/ActivityController.php
+++ b/module/Activity/src/Controller/ActivityController.php
@@ -274,7 +274,7 @@ class ActivityController extends AbstractActionController
                 }
 
                 $this->signupService->editSignUp($signup, $form->getData(FormInterface::VALUES_AS_ARRAY));
-                $message = $this->translator->translate('Successfully updated subscription');
+                $message = $this->translator->translate('Successfully updated subscription!');
             } else {
                 $this->signupService->signUp($signupList, $form->getData(FormInterface::VALUES_AS_ARRAY));
                 $message = $this->translator->translate('Successfully subscribed');

--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-14 00:00+0100\n"
-"PO-Revision-Date: 2024-12-14 00:01+0100\n"
+"POT-Creation-Date: 2025-01-02 11:44+0100\n"
+"PO-Revision-Date: 2025-01-02 11:44+0100\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: en\n"
@@ -299,6 +299,9 @@ msgstr ""
 
 msgid "Album title"
 msgstr "Album title"
+
+msgid "Albums"
+msgstr "Albums"
 
 msgid "Alcohol Policy"
 msgstr "Alcohol Policy"
@@ -1475,6 +1478,9 @@ msgstr ""
 msgid "Hidden"
 msgstr "Hidden"
 
+msgid "Hide Photo of the Week"
+msgstr "Hide Photo of the Week"
+
 msgid "Highlighted"
 msgstr "Highlighted"
 
@@ -1925,6 +1931,9 @@ msgstr "My Company"
 msgid "My Information"
 msgstr "My Information"
 
+msgid "My Photos"
+msgstr "My Photos"
+
 msgid "My activities"
 msgstr "My activities"
 
@@ -2007,78 +2016,6 @@ msgstr "No organ"
 
 msgid "None"
 msgstr "None"
-
-msgid "Not allowed to add photos."
-msgstr "Not allowed to add photos."
-
-msgid "Not allowed to add tags."
-msgstr "Not allowed to add tags."
-
-msgid "Not allowed to create albums"
-msgstr "Not allowed to create albums"
-
-msgid "Not allowed to delete albums."
-msgstr "Not allowed to delete albums."
-
-msgid "Not allowed to delete photos."
-msgstr "Not allowed to delete photos."
-
-msgid "Not allowed to download photos"
-msgstr "Not allowed to download photos"
-
-msgid "Not allowed to edit albums"
-msgstr "Not allowed to edit albums"
-
-msgid "Not allowed to edit albums."
-msgstr "Not allowed to edit albums."
-
-msgid "Not allowed to generate album covers."
-msgstr "Not allowed to generate album covers."
-
-msgid "Not allowed to move albums"
-msgstr "Not allowed to move albums"
-
-msgid "Not allowed to move photos"
-msgstr "Not allowed to move photos"
-
-msgid "Not allowed to remove tags."
-msgstr "Not allowed to remove tags."
-
-msgid "Not allowed to search albums"
-msgstr "Not allowed to search albums"
-
-msgid "Not allowed to search for members."
-msgstr "Not allowed to search for members."
-
-msgid "Not allowed to upload photos."
-msgstr "Not allowed to upload photos."
-
-msgid "Not allowed to view albums"
-msgstr "Not allowed to view albums"
-
-msgid "Not allowed to view albums without dates"
-msgstr "Not allowed to view albums without dates"
-
-msgid "Not allowed to view organ information"
-msgstr "Not allowed to view organ information"
-
-msgid "Not allowed to view photo details"
-msgstr "Not allowed to view photo details"
-
-msgid "Not allowed to view photos"
-msgstr "Not allowed to view photos"
-
-msgid "Not allowed to view previous photos of the week"
-msgstr "Not allowed to view previous photos of the week"
-
-msgid "Not allowed to view tags."
-msgstr "Not allowed to view tags."
-
-msgid "Not allowed to view the list of organs"
-msgstr "Not allowed to view the list of organs"
-
-msgid "Not allowed to vote for a photo of the week"
-msgstr "Not allowed to vote for a photo of the week"
 
 msgid "Notifications"
 msgstr "Notifications"
@@ -2260,11 +2197,14 @@ msgstr "Phone Number"
 msgid "Phone number"
 msgstr "Phone number"
 
+msgid "Photo of the Week"
+msgstr "Photo of the Week"
+
 msgid "Photo of the Week:<br> Week"
 msgstr "Photo of the Week:<br> Week"
 
-msgid "Photo of the week"
-msgstr "Photo of the week"
+msgid "Photo of the Weekly photo is already hidden. You cannot unhide it."
+msgstr "Photo of the Weekly photo is already hidden. You cannot unhide it."
 
 #, php-format
 msgid "Photo's of %s"
@@ -2789,8 +2729,8 @@ msgstr "Successfully unsubscribed"
 msgid "Successfully updated course information!"
 msgstr "Successfully updated course information!"
 
-msgid "Successfully updated subscription"
-msgstr "Successfully updated subscription"
+msgid "Successfully updated subscription!"
+msgstr "Successfully updated subscription!"
 
 msgid "SudoSOS"
 msgstr "SudoSOS"
@@ -3087,6 +3027,9 @@ msgstr "There currently is no poll."
 
 msgid "There is currently no option creation period planned."
 msgstr "There is currently no option creation period planned."
+
+msgid "There is no Photo of the Week that can be hidden."
+msgstr "There is no Photo of the Week that can be hidden."
 
 msgid "There is no company or update proposal that requires your approval."
 msgstr "There is no company or update proposal that requires your approval."
@@ -3699,8 +3642,8 @@ msgstr "You are currently using administrator privileges to use the website!"
 msgid "You are logged out."
 msgstr "You are logged out."
 
-msgid "You are not allowed authorize people."
-msgstr "You are not allowed authorize people."
+msgid "You are not allowed authorize people"
+msgstr "You are not allowed authorize people"
 
 msgid "You are not allowed to access the activities through the API"
 msgstr "You are not allowed to access the activities through the API"
@@ -3713,6 +3656,12 @@ msgstr "You are not allowed to add API tokens"
 
 msgid "You are not allowed to add courses"
 msgstr "You are not allowed to add courses"
+
+msgid "You are not allowed to add photos"
+msgstr "You are not allowed to add photos"
+
+msgid "You are not allowed to add tags"
+msgstr "You are not allowed to add tags"
 
 msgid "You are not allowed to administer activities"
 msgstr "You are not allowed to administer activities"
@@ -3849,8 +3798,11 @@ msgstr "You are not allowed to delete option calendar periods"
 msgid "You are not allowed to delete packages"
 msgstr "You are not allowed to delete packages"
 
-msgid "You are not allowed to delete pages."
-msgstr "You are not allowed to delete pages."
+msgid "You are not allowed to delete pages"
+msgstr "You are not allowed to delete pages"
+
+msgid "You are not allowed to delete photos"
+msgstr "You are not allowed to delete photos"
 
 msgid "You are not allowed to delete polls"
 msgstr "You are not allowed to delete polls"
@@ -3860,6 +3812,9 @@ msgstr "You are not allowed to delete this option"
 
 msgid "You are not allowed to download course documents"
 msgstr "You are not allowed to download course documents"
+
+msgid "You are not allowed to download photos"
+msgstr "You are not allowed to download photos"
 
 msgid "You are not allowed to edit albums"
 msgstr "You are not allowed to edit albums"
@@ -3900,8 +3855,8 @@ msgstr "You are not allowed to edit organ information"
 msgid "You are not allowed to edit packages"
 msgstr "You are not allowed to edit packages"
 
-msgid "You are not allowed to edit pages."
-msgstr "You are not allowed to edit pages."
+msgid "You are not allowed to edit pages"
+msgstr "You are not allowed to edit pages"
 
 msgid "You are not allowed to edit this organ's information"
 msgstr "You are not allowed to edit this organ's information"
@@ -3909,14 +3864,20 @@ msgstr "You are not allowed to edit this organ's information"
 msgid "You are not allowed to export member data"
 msgstr "You are not allowed to export member data"
 
+msgid "You are not allowed to generate album covers"
+msgstr "You are not allowed to generate album covers"
+
+msgid "You are not allowed to hide the photo of the week"
+msgstr "You are not allowed to hide the photo of the week"
+
 msgid "You are not allowed to list all job categories"
 msgstr "You are not allowed to list all job categories"
 
 msgid "You are not allowed to list all job labels"
 msgstr "You are not allowed to list all job labels"
 
-msgid "You are not allowed to list all news items."
-msgstr "You are not allowed to list all news items."
+msgid "You are not allowed to list all news items"
+msgstr "You are not allowed to list all news items"
 
 msgid "You are not allowed to list job categories"
 msgstr "You are not allowed to list job categories"
@@ -3924,11 +3885,17 @@ msgstr "You are not allowed to list job categories"
 msgid "You are not allowed to list job labels"
 msgstr "You are not allowed to list job labels"
 
-msgid "You are not allowed to list meetings."
-msgstr "You are not allowed to list meetings."
+msgid "You are not allowed to list meetings"
+msgstr "You are not allowed to list meetings"
 
 msgid "You are not allowed to list the companies"
 msgstr "You are not allowed to list the companies"
+
+msgid "You are not allowed to move albums"
+msgstr "You are not allowed to move albums"
+
+msgid "You are not allowed to move photos"
+msgstr "You are not allowed to move photos"
 
 msgid ""
 "You are not allowed to perform this action. If you are not logged in please "
@@ -3945,6 +3912,9 @@ msgstr "You are not allowed to remove API tokens"
 msgid "You are not allowed to remove external signups for this activity"
 msgstr "You are not allowed to remove external signups for this activity"
 
+msgid "You are not allowed to remove tags"
+msgstr "You are not allowed to remove tags"
+
 msgid "You are not allowed to rename meeting documents"
 msgstr "You are not allowed to rename meeting documents"
 
@@ -3954,8 +3924,14 @@ msgstr "You are not allowed to request polls"
 msgid "You are not allowed to revoke authorizations."
 msgstr "You are not allowed to revoke authorizations."
 
-msgid "You are not allowed to search decisions."
-msgstr "You are not allowed to search decisions."
+msgid "You are not allowed to search albums"
+msgstr "You are not allowed to search albums"
+
+msgid "You are not allowed to search decisions"
+msgstr "You are not allowed to search decisions"
+
+msgid "You are not allowed to search for members"
+msgstr "You are not allowed to search for members"
 
 msgid "You are not allowed to subscribe an external user to this sign-up list"
 msgstr "You are not allowed to subscribe an external user to this sign-up list"
@@ -3972,14 +3948,17 @@ msgstr "You are not allowed to update this activity"
 msgid "You are not allowed to upload exams"
 msgstr "You are not allowed to upload exams"
 
-msgid "You are not allowed to upload images."
-msgstr "You are not allowed to upload images."
+msgid "You are not allowed to upload images"
+msgstr "You are not allowed to upload images"
 
 msgid "You are not allowed to upload meeting documents."
 msgstr "You are not allowed to upload meeting documents."
 
 msgid "You are not allowed to upload meeting minutes."
 msgstr "You are not allowed to upload meeting minutes."
+
+msgid "You are not allowed to upload photos"
+msgstr "You are not allowed to upload photos"
 
 msgid "You are not allowed to use the external admin signup"
 msgstr "You are not allowed to use the external admin signup"
@@ -4008,8 +3987,8 @@ msgstr "You are not allowed to view albums without dates"
 msgid "You are not allowed to view all authorizations."
 msgstr "You are not allowed to view all authorizations."
 
-msgid "You are not allowed to view authorizations."
-msgstr "You are not allowed to view authorizations."
+msgid "You are not allowed to view authorizations"
+msgstr "You are not allowed to view authorizations"
 
 msgid "You are not allowed to view infima"
 msgstr "You are not allowed to view infima"
@@ -4017,20 +3996,35 @@ msgstr "You are not allowed to view infima"
 msgid "You are not allowed to view meeting documents."
 msgstr "You are not allowed to view meeting documents."
 
-msgid "You are not allowed to view meeting minutes."
-msgstr "You are not allowed to view meeting minutes."
+msgid "You are not allowed to view meeting minutes"
+msgstr "You are not allowed to view meeting minutes"
 
-msgid "You are not allowed to view meetings."
-msgstr "You are not allowed to view meetings."
+msgid "You are not allowed to view meetings"
+msgstr "You are not allowed to view meetings"
 
-msgid "You are not allowed to view members."
-msgstr "You are not allowed to view members."
+msgid "You are not allowed to view members"
+msgstr "You are not allowed to view members"
 
-msgid "You are not allowed to view membership info."
-msgstr "You are not allowed to view membership info."
+msgid "You are not allowed to view membership info"
+msgstr "You are not allowed to view membership info"
+
+msgid "You are not allowed to view organ information"
+msgstr "You are not allowed to view organ information"
+
+msgid "You are not allowed to view photo details"
+msgstr "You are not allowed to view photo details"
+
+msgid "You are not allowed to view photos"
+msgstr "You are not allowed to view photos"
+
+msgid "You are not allowed to view previous photos of the week"
+msgstr "You are not allowed to view previous photos of the week"
 
 msgid "You are not allowed to view sign-up lists"
 msgstr "You are not allowed to view sign-up lists"
+
+msgid "You are not allowed to view tags"
+msgstr "You are not allowed to view tags"
 
 msgid "You are not allowed to view the activities"
 msgstr "You are not allowed to view the activities"
@@ -4056,6 +4050,9 @@ msgstr "You are not allowed to view the featured company"
 msgid "You are not allowed to view the list of birthdays."
 msgstr "You are not allowed to view the list of birthdays."
 
+msgid "You are not allowed to view the list of organs"
+msgstr "You are not allowed to view the list of organs"
+
 msgid "You are not allowed to view the list of pages."
 msgstr "You are not allowed to view the list of pages."
 
@@ -4074,8 +4071,8 @@ msgstr "You are not allowed to view these documents!"
 msgid "You are not allowed to view this activity"
 msgstr "You are not allowed to view this activity"
 
-msgid "You are not allowed to view this page."
-msgstr "You are not allowed to view this page."
+msgid "You are not allowed to view this page"
+msgstr "You are not allowed to view this page"
 
 msgid "You are not allowed to view unapproved activities"
 msgstr "You are not allowed to view unapproved activities"
@@ -4100,11 +4097,23 @@ msgstr "You are not allowed to view update proposals of activities"
 msgid "You are not allowed to view update proposals of jobs"
 msgstr "You are not allowed to view update proposals of jobs"
 
-msgid "You are not allowed to vote on this poll."
-msgstr "You are not allowed to vote on this poll."
+msgid "You are not allowed to vote for a photo of the week"
+msgstr "You are not allowed to vote for a photo of the week"
+
+msgid "You are not allowed to vote on this poll"
+msgstr "You are not allowed to vote on this poll"
 
 msgid "You are not subscribed to this activity!"
 msgstr "You are not subscribed to this activity!"
+
+msgid ""
+"You can no longer hide the current Photo of the Week. Should it still be "
+"necessary to make the photo invisible (or even delete it) please contact the "
+"Application Management Committee immediately."
+msgstr ""
+"You can no longer hide the current Photo of the Week. Should it still be "
+"necessary to make the photo invisible (or even delete it) please contact the "
+"Application Management Committee immediately."
 
 msgid "You cannot create new jobs in expired job packages."
 msgstr "You cannot create new jobs in expired job packages."

--- a/module/Application/language/gewisweb.pot
+++ b/module/Application/language/gewisweb.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GEWISweb v2.8.6-841-ge7c572b99-dirty\n"
+"Project-Id-Version: GEWISweb v2.8.6-869-g590c66095-dirty\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-14 00:00+0100\n"
+"POT-Creation-Date: 2025-01-02 11:44+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -287,6 +287,9 @@ msgid ""
 msgstr ""
 
 msgid "Album title"
+msgstr ""
+
+msgid "Albums"
 msgstr ""
 
 msgid "Alcohol Policy"
@@ -1399,6 +1402,9 @@ msgstr ""
 msgid "Hidden"
 msgstr ""
 
+msgid "Hide Photo of the Week"
+msgstr ""
+
 msgid "Highlighted"
 msgstr ""
 
@@ -1818,6 +1824,9 @@ msgstr ""
 msgid "My Information"
 msgstr ""
 
+msgid "My Photos"
+msgstr ""
+
 msgid "My activities"
 msgstr ""
 
@@ -1898,78 +1907,6 @@ msgid "No organ"
 msgstr ""
 
 msgid "None"
-msgstr ""
-
-msgid "Not allowed to add photos."
-msgstr ""
-
-msgid "Not allowed to add tags."
-msgstr ""
-
-msgid "Not allowed to create albums"
-msgstr ""
-
-msgid "Not allowed to delete albums."
-msgstr ""
-
-msgid "Not allowed to delete photos."
-msgstr ""
-
-msgid "Not allowed to download photos"
-msgstr ""
-
-msgid "Not allowed to edit albums"
-msgstr ""
-
-msgid "Not allowed to edit albums."
-msgstr ""
-
-msgid "Not allowed to generate album covers."
-msgstr ""
-
-msgid "Not allowed to move albums"
-msgstr ""
-
-msgid "Not allowed to move photos"
-msgstr ""
-
-msgid "Not allowed to remove tags."
-msgstr ""
-
-msgid "Not allowed to search albums"
-msgstr ""
-
-msgid "Not allowed to search for members."
-msgstr ""
-
-msgid "Not allowed to upload photos."
-msgstr ""
-
-msgid "Not allowed to view albums"
-msgstr ""
-
-msgid "Not allowed to view albums without dates"
-msgstr ""
-
-msgid "Not allowed to view organ information"
-msgstr ""
-
-msgid "Not allowed to view photo details"
-msgstr ""
-
-msgid "Not allowed to view photos"
-msgstr ""
-
-msgid "Not allowed to view previous photos of the week"
-msgstr ""
-
-msgid "Not allowed to view tags."
-msgstr ""
-
-msgid "Not allowed to view the list of organs"
-msgstr ""
-
-msgid "Not allowed to vote for a photo of the week"
 msgstr ""
 
 msgid "Notifications"
@@ -2147,10 +2084,13 @@ msgstr ""
 msgid "Phone number"
 msgstr ""
 
+msgid "Photo of the Week"
+msgstr ""
+
 msgid "Photo of the Week:<br> Week"
 msgstr ""
 
-msgid "Photo of the week"
+msgid "Photo of the Weekly photo is already hidden. You cannot unhide it."
 msgstr ""
 
 #, php-format
@@ -2636,7 +2576,7 @@ msgstr ""
 msgid "Successfully updated course information!"
 msgstr ""
 
-msgid "Successfully updated subscription"
+msgid "Successfully updated subscription!"
 msgstr ""
 
 msgid "SudoSOS"
@@ -2903,6 +2843,9 @@ msgid "There currently is no poll."
 msgstr ""
 
 msgid "There is currently no option creation period planned."
+msgstr ""
+
+msgid "There is no Photo of the Week that can be hidden."
 msgstr ""
 
 msgid "There is no company or update proposal that requires your approval."
@@ -3456,7 +3399,7 @@ msgstr ""
 msgid "You are logged out."
 msgstr ""
 
-msgid "You are not allowed authorize people."
+msgid "You are not allowed authorize people"
 msgstr ""
 
 msgid "You are not allowed to access the activities through the API"
@@ -3469,6 +3412,12 @@ msgid "You are not allowed to add API tokens"
 msgstr ""
 
 msgid "You are not allowed to add courses"
+msgstr ""
+
+msgid "You are not allowed to add photos"
+msgstr ""
+
+msgid "You are not allowed to add tags"
 msgstr ""
 
 msgid "You are not allowed to administer activities"
@@ -3606,7 +3555,10 @@ msgstr ""
 msgid "You are not allowed to delete packages"
 msgstr ""
 
-msgid "You are not allowed to delete pages."
+msgid "You are not allowed to delete pages"
+msgstr ""
+
+msgid "You are not allowed to delete photos"
 msgstr ""
 
 msgid "You are not allowed to delete polls"
@@ -3616,6 +3568,9 @@ msgid "You are not allowed to delete this option"
 msgstr ""
 
 msgid "You are not allowed to download course documents"
+msgstr ""
+
+msgid "You are not allowed to download photos"
 msgstr ""
 
 msgid "You are not allowed to edit albums"
@@ -3657,7 +3612,7 @@ msgstr ""
 msgid "You are not allowed to edit packages"
 msgstr ""
 
-msgid "You are not allowed to edit pages."
+msgid "You are not allowed to edit pages"
 msgstr ""
 
 msgid "You are not allowed to edit this organ's information"
@@ -3666,13 +3621,19 @@ msgstr ""
 msgid "You are not allowed to export member data"
 msgstr ""
 
+msgid "You are not allowed to generate album covers"
+msgstr ""
+
+msgid "You are not allowed to hide the photo of the week"
+msgstr ""
+
 msgid "You are not allowed to list all job categories"
 msgstr ""
 
 msgid "You are not allowed to list all job labels"
 msgstr ""
 
-msgid "You are not allowed to list all news items."
+msgid "You are not allowed to list all news items"
 msgstr ""
 
 msgid "You are not allowed to list job categories"
@@ -3681,10 +3642,16 @@ msgstr ""
 msgid "You are not allowed to list job labels"
 msgstr ""
 
-msgid "You are not allowed to list meetings."
+msgid "You are not allowed to list meetings"
 msgstr ""
 
 msgid "You are not allowed to list the companies"
+msgstr ""
+
+msgid "You are not allowed to move albums"
+msgstr ""
+
+msgid "You are not allowed to move photos"
 msgstr ""
 
 msgid ""
@@ -3699,6 +3666,9 @@ msgstr ""
 msgid "You are not allowed to remove external signups for this activity"
 msgstr ""
 
+msgid "You are not allowed to remove tags"
+msgstr ""
+
 msgid "You are not allowed to rename meeting documents"
 msgstr ""
 
@@ -3708,7 +3678,13 @@ msgstr ""
 msgid "You are not allowed to revoke authorizations."
 msgstr ""
 
-msgid "You are not allowed to search decisions."
+msgid "You are not allowed to search albums"
+msgstr ""
+
+msgid "You are not allowed to search decisions"
+msgstr ""
+
+msgid "You are not allowed to search for members"
 msgstr ""
 
 msgid "You are not allowed to subscribe an external user to this sign-up list"
@@ -3726,13 +3702,16 @@ msgstr ""
 msgid "You are not allowed to upload exams"
 msgstr ""
 
-msgid "You are not allowed to upload images."
+msgid "You are not allowed to upload images"
 msgstr ""
 
 msgid "You are not allowed to upload meeting documents."
 msgstr ""
 
 msgid "You are not allowed to upload meeting minutes."
+msgstr ""
+
+msgid "You are not allowed to upload photos"
 msgstr ""
 
 msgid "You are not allowed to use the external admin signup"
@@ -3762,7 +3741,7 @@ msgstr ""
 msgid "You are not allowed to view all authorizations."
 msgstr ""
 
-msgid "You are not allowed to view authorizations."
+msgid "You are not allowed to view authorizations"
 msgstr ""
 
 msgid "You are not allowed to view infima"
@@ -3771,19 +3750,34 @@ msgstr ""
 msgid "You are not allowed to view meeting documents."
 msgstr ""
 
-msgid "You are not allowed to view meeting minutes."
+msgid "You are not allowed to view meeting minutes"
 msgstr ""
 
-msgid "You are not allowed to view meetings."
+msgid "You are not allowed to view meetings"
 msgstr ""
 
-msgid "You are not allowed to view members."
+msgid "You are not allowed to view members"
 msgstr ""
 
-msgid "You are not allowed to view membership info."
+msgid "You are not allowed to view membership info"
+msgstr ""
+
+msgid "You are not allowed to view organ information"
+msgstr ""
+
+msgid "You are not allowed to view photo details"
+msgstr ""
+
+msgid "You are not allowed to view photos"
+msgstr ""
+
+msgid "You are not allowed to view previous photos of the week"
 msgstr ""
 
 msgid "You are not allowed to view sign-up lists"
+msgstr ""
+
+msgid "You are not allowed to view tags"
 msgstr ""
 
 msgid "You are not allowed to view the activities"
@@ -3810,6 +3804,9 @@ msgstr ""
 msgid "You are not allowed to view the list of birthdays."
 msgstr ""
 
+msgid "You are not allowed to view the list of organs"
+msgstr ""
+
 msgid "You are not allowed to view the list of pages."
 msgstr ""
 
@@ -3828,7 +3825,7 @@ msgstr ""
 msgid "You are not allowed to view this activity"
 msgstr ""
 
-msgid "You are not allowed to view this page."
+msgid "You are not allowed to view this page"
 msgstr ""
 
 msgid "You are not allowed to view unapproved activities"
@@ -3853,10 +3850,19 @@ msgstr ""
 msgid "You are not allowed to view update proposals of jobs"
 msgstr ""
 
-msgid "You are not allowed to vote on this poll."
+msgid "You are not allowed to vote for a photo of the week"
+msgstr ""
+
+msgid "You are not allowed to vote on this poll"
 msgstr ""
 
 msgid "You are not subscribed to this activity!"
+msgstr ""
+
+msgid ""
+"You can no longer hide the current Photo of the Week. Should it still be "
+"necessary to make the photo invisible (or even delete it) please contact the "
+"Application Management Committee immediately."
 msgstr ""
 
 msgid "You cannot create new jobs in expired job packages."

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GEWISweb 0.1.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-14 00:00+0100\n"
-"PO-Revision-Date: 2024-12-14 00:01+0100\n"
+"POT-Creation-Date: 2025-01-02 11:44+0100\n"
+"PO-Revision-Date: 2025-01-02 11:44+0100\n"
 "Last-Translator: Tom Udding <web@gewis.nl>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: nl\n"
@@ -300,6 +300,9 @@ msgstr ""
 
 msgid "Album title"
 msgstr "Album titel"
+
+msgid "Albums"
+msgstr "Albums"
 
 msgid "Alcohol Policy"
 msgstr "Alcoholreglement"
@@ -1492,6 +1495,9 @@ msgstr ""
 msgid "Hidden"
 msgstr "Verborgen"
 
+msgid "Hide Photo of the Week"
+msgstr "Verberg Foto van de Week"
+
 msgid "Highlighted"
 msgstr "Uitgelicht"
 
@@ -1949,6 +1955,9 @@ msgstr "Mijn Bedrijf"
 msgid "My Information"
 msgstr "Mijn informatie"
 
+msgid "My Photos"
+msgstr "Mijn Foto’s"
+
 msgid "My activities"
 msgstr "Mijn activiteiten"
 
@@ -2030,78 +2039,6 @@ msgstr "Geen orgaan"
 
 msgid "None"
 msgstr "Geen"
-
-msgid "Not allowed to add photos."
-msgstr "Het is niet toegestaan om foto's toe te voegen."
-
-msgid "Not allowed to add tags."
-msgstr "Het is niet toegestaan om tags toe te voegen."
-
-msgid "Not allowed to create albums"
-msgstr "Het is niet toegestaan om albums te maken"
-
-msgid "Not allowed to delete albums."
-msgstr "Het is niet toegestaan om albums te verwijderen."
-
-msgid "Not allowed to delete photos."
-msgstr "Het is niet toegestaan om foto's te verwijderen."
-
-msgid "Not allowed to download photos"
-msgstr "Het is niet toegestaan om foto's te downloaden"
-
-msgid "Not allowed to edit albums"
-msgstr "Het is niet toegestaan om albums te wijzigen"
-
-msgid "Not allowed to edit albums."
-msgstr "Het is niet toegestaan om albums te wijzigen."
-
-msgid "Not allowed to generate album covers."
-msgstr "Het is niet toegestaan om albums-covers opnieuw te genereren."
-
-msgid "Not allowed to move albums"
-msgstr "Het is niet toegestaan om albums te verplaatsen"
-
-msgid "Not allowed to move photos"
-msgstr "Het is niet toegestaan om foto's te verplaatsen"
-
-msgid "Not allowed to remove tags."
-msgstr "Het is niet toegestaan om tags te verwijderen."
-
-msgid "Not allowed to search albums"
-msgstr "Het is niet toegestaan om albums te zoeken"
-
-msgid "Not allowed to search for members."
-msgstr "Het is niet toegestaan om te zoeken op leden."
-
-msgid "Not allowed to upload photos."
-msgstr "Het is niet toegestaan om foto's te uploaden."
-
-msgid "Not allowed to view albums"
-msgstr "Het is niet toegestaan om albums te zien"
-
-msgid "Not allowed to view albums without dates"
-msgstr "Het is niet toegestaan om albums te zien zonder data"
-
-msgid "Not allowed to view organ information"
-msgstr "Het is niet toegestaan om informatie over organen in te zien"
-
-msgid "Not allowed to view photo details"
-msgstr "Het is niet toegestaan om details van foto's te zien"
-
-msgid "Not allowed to view photos"
-msgstr "Het is niet toegestaan om foto's te zien"
-
-msgid "Not allowed to view previous photos of the week"
-msgstr "Not allowed to view previous photos of the week"
-
-msgid "Not allowed to view tags."
-msgstr "Het is niet toegestaan om tags te zien."
-
-msgid "Not allowed to view the list of organs"
-msgstr "Niet toegestaan om de lijst van organen te bekijken"
-
-msgid "Not allowed to vote for a photo of the week"
-msgstr "Het is niet toegestaan om te stemmen voor een foto van de week"
 
 msgid "Notifications"
 msgstr "Meldingen"
@@ -2283,11 +2220,16 @@ msgstr "Telefoonnummer"
 msgid "Phone number"
 msgstr "Telefoonnummer"
 
+msgid "Photo of the Week"
+msgstr "Foto van de Week"
+
 msgid "Photo of the Week:<br> Week"
 msgstr "Foto van de week<br> Week"
 
-msgid "Photo of the week"
-msgstr "Foto van de week"
+msgid "Photo of the Weekly photo is already hidden. You cannot unhide it."
+msgstr ""
+"De Foto van de Week is al verborgen. Je kunt de foto niet weer tevoorschijn "
+"halen."
 
 #, php-format
 msgid "Photo's of %s"
@@ -2814,7 +2756,7 @@ msgstr "Succesvol uitgeschreven"
 msgid "Successfully updated course information!"
 msgstr "Vakinformatie succesvol aangepast!"
 
-msgid "Successfully updated subscription"
+msgid "Successfully updated subscription!"
 msgstr "Inschrijving succesvol aangepast!"
 
 msgid "SudoSOS"
@@ -3121,6 +3063,9 @@ msgstr "Er is op het moment geen poll."
 
 msgid "There is currently no option creation period planned."
 msgstr "Er is momenteel geen optieperiode gepland."
+
+msgid "There is no Photo of the Week that can be hidden."
+msgstr "Er is geen Foto van de Week die verborgen kan worden."
 
 msgid "There is no company or update proposal that requires your approval."
 msgstr "Er is geen bedrijfs- of updatevoorstel die jouw goedkeuring vereist."
@@ -3741,8 +3686,8 @@ msgstr "Je gebruikt momenteel beheerdersprivileges om de website te gebruiken!"
 msgid "You are logged out."
 msgstr "Je bent uitgelogd."
 
-msgid "You are not allowed authorize people."
-msgstr "Je hebt niet de rechten om iemand te machtigen."
+msgid "You are not allowed authorize people"
+msgstr "Je hebt niet de rechten om iemand te machtigen"
 
 msgid "You are not allowed to access the activities through the API"
 msgstr "Je hebt niet de rechten om de activiteiten in te zien via de API"
@@ -3755,6 +3700,12 @@ msgstr "Je hebt niet de rechten om API tokens toe te voegen"
 
 msgid "You are not allowed to add courses"
 msgstr "Je hebt niet de rechten om vakken toe te voegen"
+
+msgid "You are not allowed to add photos"
+msgstr "Je hebt niet de rechten om foto's toe te voegen"
+
+msgid "You are not allowed to add tags"
+msgstr "Je hebt niet de rechten om tags toe te voegen"
 
 msgid "You are not allowed to administer activities"
 msgstr "Je hebt niet de rechten om activiteiten te beheren"
@@ -3897,8 +3848,11 @@ msgstr "Je hebt niet de rechten om optieperiodes te verwijderen"
 msgid "You are not allowed to delete packages"
 msgstr "Je hebt niet de rechten om pakketten te verwijderen"
 
-msgid "You are not allowed to delete pages."
-msgstr "Je hebt niet de rechten om pagina's te verwijderen."
+msgid "You are not allowed to delete pages"
+msgstr "Je hebt niet de rechten om pagina's te verwijderen"
+
+msgid "You are not allowed to delete photos"
+msgstr "Je hebt niet de rechten om foto's te verwijderen"
 
 msgid "You are not allowed to delete polls"
 msgstr "Je hebt niet de rechten om polls te verwijderen"
@@ -3908,6 +3862,9 @@ msgstr "Je hebt niet de rechten om deze optie te verwijderen"
 
 msgid "You are not allowed to download course documents"
 msgstr "Je hebt niet de rechten om documenten van vakken te downloaden"
+
+msgid "You are not allowed to download photos"
+msgstr "Je hebt niet de rechten om foto's te downloaden"
 
 msgid "You are not allowed to edit albums"
 msgstr "Je hebt niet de rechten om albums te wijzigen"
@@ -3948,8 +3905,8 @@ msgstr "Je hebt niet de rechten om organen te wijzigen"
 msgid "You are not allowed to edit packages"
 msgstr "Je hebt niet de rechten om pakketten te wijzigen"
 
-msgid "You are not allowed to edit pages."
-msgstr "Je hebt niet de rechten om pagina's te wijzigen."
+msgid "You are not allowed to edit pages"
+msgstr "Je hebt niet de rechten om pagina's te wijzigen"
 
 msgid "You are not allowed to edit this organ's information"
 msgstr "Je hebt niet de rechten om de informatie van dit orgaan te wijzigen"
@@ -3957,14 +3914,20 @@ msgstr "Je hebt niet de rechten om de informatie van dit orgaan te wijzigen"
 msgid "You are not allowed to export member data"
 msgstr "Je hebt niet de rechten om informatie over leden te exporteren"
 
+msgid "You are not allowed to generate album covers"
+msgstr "Je hebt niet de rechten om albums-covers opnieuw te genereren"
+
+msgid "You are not allowed to hide the photo of the week"
+msgstr "Not allowed to view previous photos of the week"
+
 msgid "You are not allowed to list all job categories"
 msgstr "Je hebt niet de rechten om alle vacaturecategorieën te bekijken"
 
 msgid "You are not allowed to list all job labels"
 msgstr "Je hebt niet de rechten om alle vacature-labels te bekijken"
 
-msgid "You are not allowed to list all news items."
-msgstr "Je hebt niet de rechten om alle nieuws items te bekijken."
+msgid "You are not allowed to list all news items"
+msgstr "Je hebt niet de rechten om alle nieuws items te bekijken"
 
 msgid "You are not allowed to list job categories"
 msgstr "Je hebt niet de rechten om vacaturecategorieën te bekijken"
@@ -3972,11 +3935,17 @@ msgstr "Je hebt niet de rechten om vacaturecategorieën te bekijken"
 msgid "You are not allowed to list job labels"
 msgstr "Je hebt niet de rechten om vacature-labels te bekijken"
 
-msgid "You are not allowed to list meetings."
-msgstr "Het is niet toegestaan om de lijst van vergaderingen te zien."
+msgid "You are not allowed to list meetings"
+msgstr "Je hebt niet de rechten om de lijst van vergaderingen te zien"
 
 msgid "You are not allowed to list the companies"
 msgstr "Je hebt niet de rechten om de lijst met bedrijven te zien"
+
+msgid "You are not allowed to move albums"
+msgstr "Je hebt niet de rechten om albums te verplaatsen"
+
+msgid "You are not allowed to move photos"
+msgstr "Je hebt niet de rechten om foto's te verplaatsen"
 
 msgid ""
 "You are not allowed to perform this action. If you are not logged in please "
@@ -3995,6 +3964,9 @@ msgstr ""
 "Je hebt niet de rechten om externe inschrijvingen te verwijderen voor deze "
 "activiteit"
 
+msgid "You are not allowed to remove tags"
+msgstr "Je hebt niet de rechten om tags te verwijderen"
+
 msgid "You are not allowed to rename meeting documents"
 msgstr "Je hebt niet de rechten om vergaderstukken te hernoemen"
 
@@ -4004,8 +3976,14 @@ msgstr "Je hebt niet de rechten om polls aan te vragen"
 msgid "You are not allowed to revoke authorizations."
 msgstr "Je hebt niet de rechten om machtigingen in te trekken."
 
-msgid "You are not allowed to search decisions."
-msgstr "Je hebt niet de rechten om besluiten te doorzoeken."
+msgid "You are not allowed to search albums"
+msgstr "Je hebt niet de rechten om albums te zoeken"
+
+msgid "You are not allowed to search decisions"
+msgstr "Je hebt niet de rechten om besluiten te doorzoeken"
+
+msgid "You are not allowed to search for members"
+msgstr "Je hebt niet de rechten om te zoeken op leden"
 
 msgid "You are not allowed to subscribe an external user to this sign-up list"
 msgstr ""
@@ -4023,16 +4001,19 @@ msgid "You are not allowed to update this activity"
 msgstr "Je hebt niet de rechten om deze activiteit te wijzigen"
 
 msgid "You are not allowed to upload exams"
-msgstr "Het is niet toegestaan om tentamens te uploaden"
+msgstr "Je hebt niet de rechten om tentamens te uploaden"
 
-msgid "You are not allowed to upload images."
-msgstr "Het is niet toegestaan om foto's te uploaden."
+msgid "You are not allowed to upload images"
+msgstr "Je hebt niet de rechten om afbeeldingen te uploaden"
 
 msgid "You are not allowed to upload meeting documents."
-msgstr "Het is niet toegestaan om vergaderstukken te uploaden."
+msgstr "Je hebt niet de rechten om vergaderstukken te uploaden."
 
 msgid "You are not allowed to upload meeting minutes."
-msgstr "Het is niet toegestaan om notulen te uploaden."
+msgstr "Je hebt niet de rechten om notulen te uploaden."
+
+msgid "You are not allowed to upload photos"
+msgstr "Je hebt niet de rechten om foto's te uploaden"
 
 msgid "You are not allowed to use the external admin signup"
 msgstr "Je hebt niet de rechten om een externe admin inschrijving te maken"
@@ -4061,29 +4042,44 @@ msgstr "Je hebt niet de rechten om ongedateerde albums te bekijken"
 msgid "You are not allowed to view all authorizations."
 msgstr "Je hebt niet de rechten om alle machtigingen te bekijken."
 
-msgid "You are not allowed to view authorizations."
-msgstr "Je hebt niet de rechten om all machtigingen te bekijken."
+msgid "You are not allowed to view authorizations"
+msgstr "Je hebt niet de rechten om all machtigingen te bekijken"
 
 msgid "You are not allowed to view infima"
 msgstr "Je hebt niet de rechten om infima te bekijken"
 
 msgid "You are not allowed to view meeting documents."
-msgstr "Het is niet toegestaan om vergaderstukken te zien."
+msgstr "Je hebt niet de rechten om vergaderstukken te zien."
 
-msgid "You are not allowed to view meeting minutes."
-msgstr "Het is niet toegestaan om notulen te zien."
+msgid "You are not allowed to view meeting minutes"
+msgstr "Je hebt niet de rechten om notulen te zien"
 
-msgid "You are not allowed to view meetings."
-msgstr "Het is niet toegestaan om vergaderingen te zien."
+msgid "You are not allowed to view meetings"
+msgstr "Je hebt niet de rechten om vergaderingen te zien"
 
-msgid "You are not allowed to view members."
-msgstr "Het is niet toegestaan om lidinformatie in te zien."
+msgid "You are not allowed to view members"
+msgstr "Je hebt niet de rechten om leden in te zien"
 
-msgid "You are not allowed to view membership info."
-msgstr "Het is niet toegestaan om lidinformatie in te zien."
+msgid "You are not allowed to view membership info"
+msgstr "Je hebt niet de rechten om lidinformatie in te zien"
+
+msgid "You are not allowed to view organ information"
+msgstr "Je hebt niet de rechten om informatie over organen in te zien"
+
+msgid "You are not allowed to view photo details"
+msgstr "Je hebt niet de rechten om details van foto's te zien"
+
+msgid "You are not allowed to view photos"
+msgstr "Je hebt niet de rechten om foto's te zien"
+
+msgid "You are not allowed to view previous photos of the week"
+msgstr "Not allowed to view previous photos of the week"
 
 msgid "You are not allowed to view sign-up lists"
 msgstr "Je hebt niet de rechten om inschrijflijsten te bekijken"
+
+msgid "You are not allowed to view tags"
+msgstr "Je hebt niet de rechten om tags te zien"
 
 msgid "You are not allowed to view the activities"
 msgstr "Je hebt niet de rechten om de activiteiten in te zien"
@@ -4109,7 +4105,10 @@ msgid "You are not allowed to view the featured company"
 msgstr "Je hebt niet de rechten om het uitgelichte bedrijf te zien"
 
 msgid "You are not allowed to view the list of birthdays."
-msgstr "Het is niet toegestaan om de lijst met verjaardagen te zien."
+msgstr "Je hebt niet de rechten om de lijst met verjaardagen te zien."
+
+msgid "You are not allowed to view the list of organs"
+msgstr "Niet toegestaan om de lijst van organen te bekijken"
 
 msgid "You are not allowed to view the list of pages."
 msgstr "Je hebt niet de rechten om de lijst met pagina's te bekijken."
@@ -4126,13 +4125,13 @@ msgstr ""
 "Je hebt niet de rechten om de goedkeuringsstatus van vacatures te bekijken"
 
 msgid "You are not allowed to view these documents!"
-msgstr "Het is niet toegestaan om document te zien."
+msgstr "Je hebt niet de rechten om document te zien!"
 
 msgid "You are not allowed to view this activity"
 msgstr "Je hebt niet de rechten om deze activiteit te bekijken"
 
-msgid "You are not allowed to view this page."
-msgstr "Je hebt niet de rechten om deze pagina te bekijken."
+msgid "You are not allowed to view this page"
+msgstr "Je hebt niet de rechten om deze pagina te bekijken"
 
 msgid "You are not allowed to view unapproved activities"
 msgstr "Je hebt niet de rechten om niet goedgekeurde activiteiten in te zien"
@@ -4159,11 +4158,23 @@ msgstr ""
 msgid "You are not allowed to view update proposals of jobs"
 msgstr "Je hebt niet de rechten om updatevoorstellen van vacatures te bekijken"
 
-msgid "You are not allowed to vote on this poll."
-msgstr "Je hebt niet de rechten om op deze poll te stemmen."
+msgid "You are not allowed to vote for a photo of the week"
+msgstr "Je hebt niet de rechten om te stemmen voor een foto van de week"
+
+msgid "You are not allowed to vote on this poll"
+msgstr "Je hebt niet de rechten om op deze poll te stemmen"
 
 msgid "You are not subscribed to this activity!"
 msgstr "Je bent niet ingeschreven voor deze activiteit!"
+
+msgid ""
+"You can no longer hide the current Photo of the Week. Should it still be "
+"necessary to make the photo invisible (or even delete it) please contact the "
+"Application Management Committee immediately."
+msgstr ""
+"Je kunt de huidige Foto van de Week niet langer verbergen. Mocht het toch "
+"nodig zijn om de foto onzichtbaar te maken (of zelfs te verwijderen) neem "
+"dan onmiddellijk contact op met de ApplicatieBeheerCommissie."
 
 msgid "You cannot create new jobs in expired job packages."
 msgstr "Je kan geen nieuwe vacatures maken in verlopen vacaturepakketen."

--- a/module/Application/migrations/Version20241020212355.php
+++ b/module/Application/migrations/Version20241020212355.php
@@ -9,6 +9,7 @@ use Doctrine\Migrations\AbstractMigration;
 
 /**
  * phpcs:disable Generic.Files.LineLength.TooLong
+ * phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
  */
 final class Version20241020212355 extends AbstractMigration
 {
@@ -19,7 +20,6 @@ final class Version20241020212355 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
         $this->addSql('CREATE TABLE Activity (id INT AUTO_INCREMENT NOT NULL, name_id INT NOT NULL, location_id INT NOT NULL, costs_id INT NOT NULL, approver_id INT DEFAULT NULL, creator_id INT NOT NULL, description_id INT NOT NULL, organ_id INT DEFAULT NULL, company_id INT DEFAULT NULL, beginTime DATETIME NOT NULL, endTime DATETIME NOT NULL, status INT NOT NULL, isMyFuture TINYINT(1) NOT NULL, requireGEFLITST TINYINT(1) NOT NULL, UNIQUE INDEX UNIQ_55026B0C71179CD6 (name_id), UNIQUE INDEX UNIQ_55026B0C64D218E (location_id), UNIQUE INDEX UNIQ_55026B0C27D66E0D (costs_id), INDEX IDX_55026B0CBB23766C (approver_id), INDEX IDX_55026B0C61220EA6 (creator_id), UNIQUE INDEX UNIQ_55026B0CD9F966B (description_id), INDEX IDX_55026B0CE4445171 (organ_id), INDEX IDX_55026B0C979B1AD6 (company_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE ActivityCategoryAssignment (activity_id INT NOT NULL, activitycategory_id INT NOT NULL, INDEX IDX_480AC9B381C06096 (activity_id), INDEX IDX_480AC9B324EF5392 (activitycategory_id), PRIMARY KEY(activity_id, activitycategory_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE ActivityCalendarOption (id INT AUTO_INCREMENT NOT NULL, proposal_id INT NOT NULL, type VARCHAR(255) DEFAULT NULL, status VARCHAR(255) DEFAULT NULL, beginTime DATETIME NOT NULL, endTime DATETIME NOT NULL, modifiedBy_id INT DEFAULT NULL, INDEX IDX_503F8985F4792058 (proposal_id), INDEX IDX_503F8985D6A05076 (modifiedBy_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
@@ -202,13 +202,10 @@ final class Version20241020212355 extends AbstractMigration
         $this->addSql('ALTER TABLE Vote ADD CONSTRAINT FK_FA222A5A7E9E4C8C FOREIGN KEY (photo_id) REFERENCES Photo (id)');
         $this->addSql('ALTER TABLE Vote ADD CONSTRAINT FK_FA222A5AEBB4B8AD FOREIGN KEY (voter_id) REFERENCES Member (lidnr)');
         $this->addSql('ALTER TABLE WeeklyPhoto ADD CONSTRAINT FK_E5D6E8E07E9E4C8C FOREIGN KEY (photo_id) REFERENCES Photo (id)');
-        // phpcs:enable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
     }
 
     public function down(Schema $schema): void
     {
-        // phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
         $this->throwIrreversibleMigrationException();
-        // phpcs:enable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
     }
 }

--- a/module/Application/migrations/Version20250102092706.php
+++ b/module/Application/migrations/Version20250102092706.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ * phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
+ */
+final class Version20250102092706 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Allow Photos of the Week to be hidden (see GH-1806).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE WeeklyPhoto ADD hidden TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE WeeklyPhoto DROP hidden');
+    }
+}

--- a/module/Application/view/partial/admin.phtml
+++ b/module/Application/view/partial/admin.phtml
@@ -188,9 +188,23 @@ use User\Service\AclService as UserAclService;
                         </li>
                     <?php endif; ?>
                     <?php if ($this->acl(PhotoAclService::class)->isAllowed('photo_admin', 'view')): ?>
-                        <li>
-                            <a href="<?= $this->url('admin_photo') ?>"><?= $this->translate('Photos') ?></a>
-                        </li>
+                    <li class="dropdown <?= $this->moduleIsActive(['photo']) ? 'active' : '' ?>">
+                        <a href="<?= $this->hashUrl() ?>" class="dropdown-toggle" data-toggle="dropdown" role="button"
+                           aria-haspopup="true" aria-expanded="false">
+                            <?= $this->translate('Photos') ?> <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            <?php if ($this->acl(PhotoAclService::class)->isAllowed('album', 'edit')): ?>
+                                <li>
+                                    <a href="<?= $this->url('admin_photo') ?>"><?= $this->translate('Albums') ?></a>
+                                </li>
+                            <?php endif; ?>
+                            <?php if ($this->acl(PhotoAclService::class)->isAllowed('photo', 'edit')): ?>
+                                <li>
+                                    <a href="<?= $this->url('admin_photo/weekly') ?>"><?= $this->translate('Photo of the Week') ?></a>
+                                </li>
+                            <?php endif; ?>
+                        </ul>
                     <?php endif; ?>
                     <?php if ($this->acl(FrontpageAclService::class)->isAllowed('poll', 'approve')): ?>
                         <li class="<?= $this->moduleIsActive(['frontpage', 'poll']) ? 'active' : '' ?>">

--- a/module/Application/view/partial/main-nav.phtml
+++ b/module/Application/view/partial/main-nav.phtml
@@ -598,13 +598,7 @@ endif; ?>
                                     <?= $this->translate('Photos') ?>
                                 </a>
                             </li>
-                            <li>
-                                <a href="<?= $this->url('photo/weekly') ?>">
-                                    <?= $this->translate('Photo of the week') ?>
-                                </a>
-                            </li>
-                            <?php
-                            if (null != $this->identity()): ?>
+                            <?php if (null != $this->identity()): ?>
                                 <li>
                                     <a href="<?= $this->url(
                                         'photo/album',
@@ -613,11 +607,15 @@ endif; ?>
                                             'album_type' => 'member',
                                         ],
                                     ) ?>">
-                                        <?= $this->translate('My photo\'s') ?>
+                                        <?= $this->translate('My Photos') ?>
                                     </a>
                                 </li>
-                            <?php
-                            endif; ?>
+                            <?php endif; ?>
+                            <li>
+                                <a href="<?= $this->url('photo/weekly') ?>">
+                                    <?= $this->translate('Photo of the Week') ?>
+                                </a>
+                            </li>
                         </ul>
                     <?php
                     endif; ?>

--- a/module/Company/src/Controller/AdminController.php
+++ b/module/Company/src/Controller/AdminController.php
@@ -808,7 +808,7 @@ class AdminController extends AbstractActionController
             && !$this->aclService->isAllowed('create', 'job')
             && !$this->aclService->isAllowed('edit', 'job')
         ) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to upload images.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to upload images'));
         }
 
         // Get parameter

--- a/module/Company/src/Controller/CompanyAccountController.php
+++ b/module/Company/src/Controller/CompanyAccountController.php
@@ -446,7 +446,7 @@ class CompanyAccountController extends AbstractActionController
             && !$this->aclService->isAllowed('createOwn', 'job')
             && !$this->aclService->isAllowed('editOwn', 'job')
         ) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to upload images.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to upload images'));
         }
 
         /** @var Request $request */

--- a/module/Decision/src/Controller/DecisionController.php
+++ b/module/Decision/src/Controller/DecisionController.php
@@ -129,7 +129,7 @@ class DecisionController extends AbstractActionController
     public function searchAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('search', 'decision')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to search decisions.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to search decisions'));
         }
 
         /** @var Request $request */

--- a/module/Decision/src/Controller/MemberController.php
+++ b/module/Decision/src/Controller/MemberController.php
@@ -35,7 +35,7 @@ class MemberController extends AbstractActionController
     {
         if (!$this->aclService->isAllowed('view', 'meeting')) {
             throw new NotAllowedException(
-                $this->translator->translate('You are not allowed to view meetings.'),
+                $this->translator->translate('You are not allowed to view meetings'),
             );
         }
 
@@ -93,7 +93,7 @@ class MemberController extends AbstractActionController
     public function searchAction(): JsonModel|ViewModel
     {
         if (!$this->aclService->isAllowed('search', 'member')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to search for members.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to search for members'));
         }
 
         $name = $this->params()->fromQuery('q');

--- a/module/Decision/src/Service/Decision.php
+++ b/module/Decision/src/Service/Decision.php
@@ -89,7 +89,7 @@ class Decision
         ?MeetingTypes $type = null,
     ): array {
         if (!$this->aclService->isAllowed('list_meetings', 'decision')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to list meetings.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to list meetings'));
         }
 
         return $this->meetingMapper->findAllMeetings($limit, $type);
@@ -108,7 +108,7 @@ class Decision
         MeetingTypes $type,
     ): array {
         if (!$this->aclService->isAllowed('list_meetings', 'decision')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to list meetings.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to list meetings'));
         }
 
         return $this->meetingMapper->findPast($limit, $type);
@@ -120,7 +120,7 @@ class Decision
     public function getMeetingsByType(MeetingTypes $type): array
     {
         if (!$this->aclService->isAllowed('list_meetings', 'decision')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to list meetings.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to list meetings'));
         }
 
         return $this->meetingMapper->findByType($type);
@@ -136,7 +136,7 @@ class Decision
         int $number,
     ): ?MeetingModel {
         if (!$this->aclService->isAllowed('view', 'meeting')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view meetings.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view meetings'));
         }
 
         return $this->meetingMapper->findMeeting($type, $number);
@@ -194,7 +194,7 @@ class Decision
     public function getMeetingMinutesDownload(MeetingModel $meeting): ?Stream
     {
         if (!$this->aclService->isAllowed('view_minutes', 'meeting')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view meeting minutes.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view meeting minutes'));
         }
 
         if (null === $meeting->getMinutes()) {
@@ -397,7 +397,7 @@ class Decision
     public function getUserAuthorization(MeetingModel $meeting): ?AuthorizationModel
     {
         if (!$this->aclService->isAllowed('view_own', 'authorization')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view authorizations.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view authorizations'));
         }
 
         return $this->authorizationMapper->findUserAuthorization(
@@ -549,7 +549,7 @@ class Decision
     public function getAuthorizationForm(): AuthorizationForm
     {
         if (!$this->aclService->isAllowed('create', 'authorization')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed authorize people.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed authorize people'));
         }
 
         return $this->authorizationForm;

--- a/module/Decision/src/Service/Member.php
+++ b/module/Decision/src/Service/Member.php
@@ -47,7 +47,7 @@ class Member
                 || $lidnr !== $this->aclService->getUserIdentityOrThrowException()->getLidnr()
             )
         ) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view members.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view members'));
         }
 
         return $this->memberMapper->findByLidnr($lidnr);

--- a/module/Decision/src/Service/MemberInfo.php
+++ b/module/Decision/src/Service/MemberInfo.php
@@ -62,11 +62,11 @@ class MemberInfo
     public function getMembershipInfo(?int $lidnr = null): ?array
     {
         if (null === $lidnr && !$this->aclService->isAllowed('view_self', 'member')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view membership info.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view membership info'));
         }
 
         if (null !== $lidnr && !$this->aclService->isAllowed('view', 'member')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view members.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view members'));
         }
 
         if (null === $lidnr) {

--- a/module/Decision/src/Service/Organ.php
+++ b/module/Decision/src/Service/Organ.php
@@ -73,7 +73,9 @@ class Organ
     public function getOrgans(bool $abrogated = false): array
     {
         if (!$this->aclService->isAllowed('list', 'organ')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view the list of organs'));
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to view the list of organs'),
+            );
         }
 
         if (!$abrogated) {
@@ -89,7 +91,9 @@ class Organ
     public function getOrgan(int $id): ?OrganModel
     {
         if (!$this->aclService->isAllowed('view', 'organ')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view organ information'));
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to view organ information'),
+            );
         }
 
         return $this->organMapper->findOrgan($id);

--- a/module/Frontpage/src/Controller/PageAdminController.php
+++ b/module/Frontpage/src/Controller/PageAdminController.php
@@ -74,7 +74,7 @@ class PageAdminController extends AbstractActionController
     public function editAction(): Response|ViewModel
     {
         if (!$this->aclService->isAllowed('edit', 'page')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to edit pages.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to edit pages'));
         }
 
         $pageId = (int) $this->params()->fromRoute('page_id');
@@ -116,7 +116,7 @@ class PageAdminController extends AbstractActionController
     public function deleteAction(): Response
     {
         if (!$this->aclService->isAllowed('delete', 'page')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to delete pages.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to delete pages'));
         }
 
         $pageId = (int) $this->params()->fromRoute('page_id');
@@ -131,7 +131,7 @@ class PageAdminController extends AbstractActionController
             !$this->aclService->isAllowed('create', 'page')
             && !$this->aclService->isAllowed('edit', 'page')
         ) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to upload images.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to upload images'));
         }
 
         /** @var Request $request */

--- a/module/Frontpage/src/Service/Frontpage.php
+++ b/module/Frontpage/src/Service/Frontpage.php
@@ -19,6 +19,7 @@ use Laminas\Mvc\I18n\Translator;
 use Photo\Mapper\Tag as TagMapper;
 use Photo\Model\Photo as PhotoModel;
 use Photo\Model\Tag as TagModel;
+use Photo\Model\WeeklyPhoto as WeeklyPhotoModel;
 use Photo\Service\Photo as PhotoService;
 
 use function abs;
@@ -71,7 +72,7 @@ class Frontpage
      *     birthdays: BirthdaysArrayType,
      *     birthdayPhoto: ?PhotoModel,
      *     activities: ActivityModel[],
-     *     weeklyPhoto: ?PhotoModel,
+     *     weeklyPhoto: ?WeeklyPhotoModel,
      *     poll: array{
      *         canVote: bool,
      *         poll: ?PollModel,
@@ -97,7 +98,7 @@ class Frontpage
             'birthdays' => $birthdayInfo['birthdays'],
             'birthdayPhoto' => $birthdayInfo['tag']?->getPhoto(),
             'activities' => $activities,
-            'weeklyPhoto' => $weeklyPhoto?->getPhoto(),
+            'weeklyPhoto' => $weeklyPhoto,
             'poll' => $pollDetails,
             'news' => $news,
             'companyBanner' => $companyBanner,

--- a/module/Frontpage/src/Service/News.php
+++ b/module/Frontpage/src/Service/News.php
@@ -42,7 +42,7 @@ class News
     public function getPaginatorAdapter(): DoctrinePaginator
     {
         if (!$this->aclService->isAllowed('list', 'news_item')) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to list all news items.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to list all news items'));
         }
 
         return $this->newsItemMapper->getPaginatorAdapter();

--- a/module/Frontpage/src/Service/Page.php
+++ b/module/Frontpage/src/Service/Page.php
@@ -57,7 +57,7 @@ class Page
         $page = $this->pageMapper->findPage($language, $category, $subCategory, $name);
 
         if (null !== $page && !$this->aclService->isAllowed('view', $page)) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to view this page.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view this page'));
         }
 
         return $page;

--- a/module/Frontpage/src/Service/Poll.php
+++ b/module/Frontpage/src/Service/Poll.php
@@ -181,7 +181,7 @@ class Poll
 
         $poll = $pollOption->getPoll();
         if (!$this->canVote($poll)) {
-            throw new NotAllowedException($this->translator->translate('You are not allowed to vote on this poll.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to vote on this poll'));
         }
 
         $pollVote = new PollVoteModel();

--- a/module/Frontpage/view/frontpage/frontpage/home.phtml
+++ b/module/Frontpage/view/frontpage/frontpage/home.phtml
@@ -207,19 +207,27 @@ $lang = $this->plugin('translate')->getTranslator()->getLocale();
                     </div>
                 </div>
 
-                <?php if (null !== $weeklyPhoto): ?>
+                <?php
+                if (
+                    null !== $weeklyPhoto
+                    && (
+                        !$weeklyPhoto->isHidden()
+                        || null !== $this->identity()
+                    )
+                ): ?>
+                    <?php $photo = $weeklyPhoto->getPhoto(); ?>
                     <div class="panel panel-default">
                         <div class="panel-heading panel-heading--full-height">
                             <h3>
                                 <a href="<?= $this->url(
                                     'photo/album',
                                     [
-                                        'album_id' => $weeklyPhoto->getAlbum()->getId(),
+                                        'album_id' => $photo->getAlbum()->getId(),
                                         'album_type' => 'album',
-                                        'photo_id' => $weeklyPhoto->getId(),
+                                        'photo_id' => $photo->getId(),
                                     ],
                                 ) ?>">
-                                    <?= $this->translate('Photo of the week') ?>
+                                    <?= $this->translate('Photo of the Week') ?>
                                 </a>
                             </h3>
                         </div>
@@ -229,13 +237,13 @@ $lang = $this->plugin('translate')->getTranslator()->getLocale();
                                 href="<?= $this->url(
                                     'photo/album',
                                     [
-                                        'album_id' => $weeklyPhoto->getAlbum()->getId(),
+                                        'album_id' => $photo->getAlbum()->getId(),
                                         'album_type' => 'album',
                                         'photo_id' => $weeklyPhoto->getId(),
                                     ],
                                 ) ?>">
                                 <?php
-                                $wAspectRatio = $weeklyPhoto->getAspectRatio();
+                                $wAspectRatio = $photo->getAspectRatio();
 
                                 $wThumbnailWidth = $photoConfig['small_thumb_size']['width'];
                                 $wThumbnailSize = [
@@ -251,16 +259,16 @@ $lang = $this->plugin('translate')->getTranslator()->getLocale();
                                 ?>
                                 <img
                                     class="img-responsive"
-                                    src="<?= $this->glideUrl()->getUrl($weeklyPhoto->getPath(), $wThumbnailSize) ?>"
+                                    src="<?= $this->glideUrl()->getUrl($photo->getPath(), $wThumbnailSize) ?>"
                                     srcset="<?= sprintf(
                                         "%s %sw, %s %sw",
                                         $this->glideUrl()->getUrl(
-                                            $weeklyPhoto->getPath(),
+                                            $photo->getPath(),
                                             $wThumbnailSize,
                                         ),
                                         $wThumbnailSize['w'],
                                         $this->glideUrl()->getUrl(
-                                            $weeklyPhoto->getPath(),
+                                            $photo->getPath(),
                                             $wLargeSize,
                                         ),
                                         $wLargeSize['w'],

--- a/module/Photo/config/module.config.php
+++ b/module/Photo/config/module.config.php
@@ -328,6 +328,16 @@ return [
                             ],
                         ],
                     ],
+                    'weekly' => [
+                        'type' => Literal::class,
+                        'options' => [
+                            'route' => '/weekly',
+                            'defaults' => [
+                                'controller' => PhotoAdminController::class,
+                                'action' => 'weekly',
+                            ],
+                        ],
+                    ],
                 ],
                 'priority' => 100,
             ],

--- a/module/Photo/src/Controller/AlbumController.php
+++ b/module/Photo/src/Controller/AlbumController.php
@@ -48,7 +48,9 @@ class AlbumController extends AbstractActionController
             )
             && !$this->aclService->isAllowed('nodate', 'album')
         ) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view albums without dates'));
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to view albums without dates'),
+            );
         }
 
         $hasRecentVote = $this->photoService->hasRecentVote();

--- a/module/Photo/src/Controller/ApiController.php
+++ b/module/Photo/src/Controller/ApiController.php
@@ -61,7 +61,7 @@ class ApiController extends AbstractActionController
             !$this->aclService->isAllowed('view', 'tag')
             && !$this->aclService->isAllowed('view', 'vote')
         ) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view photo details'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view photo details'));
         }
 
         $photoId = (int) $this->params()->fromRoute('photo_id');

--- a/module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/PhotoAdminControllerFactory.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Photo\Controller\Factory;
 
+use Laminas\Mvc\I18n\Translator as MvcTranslator;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Photo\Controller\PhotoAdminController;
+use Photo\Service\AclService;
 use Photo\Service\Album as AlbumService;
 use Photo\Service\Photo as PhotoService;
 use Psr\Container\ContainerInterface;
@@ -21,8 +23,11 @@ class PhotoAdminControllerFactory implements FactoryInterface
         ?array $options = null,
     ): PhotoAdminController {
         return new PhotoAdminController(
+            $container->get(AclService::class),
+            $container->get(MvcTranslator::class),
             $container->get(AlbumService::class),
             $container->get(PhotoService::class),
+            $container->get('config')['photo'],
         );
     }
 }

--- a/module/Photo/src/Controller/Factory/PhotoControllerFactory.php
+++ b/module/Photo/src/Controller/Factory/PhotoControllerFactory.php
@@ -23,8 +23,8 @@ class PhotoControllerFactory implements FactoryInterface
         ?array $options = null,
     ): PhotoController {
         return new PhotoController(
-            $container->get(MvcTranslator::class),
             $container->get(AclService::class),
+            $container->get(MvcTranslator::class),
             $container->get(AlbumService::class),
             $container->get(PhotoService::class),
             $container->get('config')['photo'],

--- a/module/Photo/src/Controller/PhotoAdminController.php
+++ b/module/Photo/src/Controller/PhotoAdminController.php
@@ -4,19 +4,31 @@ declare(strict_types=1);
 
 namespace Photo\Controller;
 
+use DateTime;
 use Laminas\Http\Request;
+use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\JsonModel;
+use Laminas\View\Model\ViewModel;
+use Photo\Service\AclService;
 use Photo\Service\Album as AlbumService;
 use Photo\Service\Photo as PhotoService;
+use User\Permissions\NotAllowedException;
 
 use function intval;
 
 class PhotoAdminController extends AbstractActionController
 {
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
+     */
     public function __construct(
+        private readonly AclService $aclService,
+        private readonly Translator $translator,
         private readonly AlbumService $albumService,
         private readonly PhotoService $photoService,
+        private readonly array $photoConfig,
     ) {
     }
 
@@ -25,6 +37,10 @@ class PhotoAdminController extends AbstractActionController
      */
     public function moveAction(): JsonModel
     {
+        if (!$this->aclService->isAllowed('move', 'album')) {
+            throw new NotAllowedException($this->translator->translate('You are not allowed to move photos'));
+        }
+
         /** @var Request $request */
         $request = $this->getRequest();
         $result = [];
@@ -43,6 +59,10 @@ class PhotoAdminController extends AbstractActionController
      */
     public function deleteAction(): JsonModel
     {
+        if (!$this->aclService->isAllowed('delete', 'photo')) {
+            throw new NotAllowedException($this->translator->translate('You are not allowed to delete photos'));
+        }
+
         /** @var Request $request */
         $request = $this->getRequest();
 
@@ -53,5 +73,50 @@ class PhotoAdminController extends AbstractActionController
         }
 
         return new JsonModel($result);
+    }
+
+    public function weeklyAction(): Response|ViewModel
+    {
+        if (!$this->aclService->isAllowed('edit', 'photo')) {
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to hide the photo of the week'),
+            );
+        }
+
+        $potw = $this->photoService->getCurrentPhotoOfTheWeek();
+        if (null === $potw) {
+            return new ViewModel([
+                'noPhoto' => true,
+            ]);
+        }
+
+        if ($potw->isHidden()) {
+            return new ViewModel([
+                'alreadyHidden' => true,
+            ]);
+        }
+
+        $now = new DateTime('now');
+        if (
+            1 !== (int) $now->format('N')
+            || 12 <= (int) $now->format('G')
+        ) {
+            return new ViewModel([
+                'wrongTime' => true,
+            ]);
+        }
+
+        /** @var Request $request */
+        $request = $this->getRequest();
+        if ($request->isPost()) {
+            $this->photoService->hidePhotoOfTheWeek($potw);
+
+            return $this->redirect()->toRoute('admin_photo/weekly');
+        }
+
+        return new ViewModel([
+            'potw' => $potw,
+            'config' => $this->photoConfig,
+        ]);
     }
 }

--- a/module/Photo/src/Controller/PhotoController.php
+++ b/module/Photo/src/Controller/PhotoController.php
@@ -31,8 +31,8 @@ class PhotoController extends AbstractActionController
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
      */
     public function __construct(
-        private readonly Translator $translator,
         private readonly AclService $aclService,
+        private readonly Translator $translator,
         private readonly AlbumService $albumService,
         private readonly PhotoService $photoService,
         private readonly array $photoConfig,
@@ -42,7 +42,7 @@ class PhotoController extends AbstractActionController
     public function indexAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('view', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view albums'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view albums'));
         }
 
         $years = $this->albumService->getAlbumYears();
@@ -77,7 +77,7 @@ class PhotoController extends AbstractActionController
     public function searchAction(): ViewModel
     {
         if (!$this->aclService->isAllowed('search', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to search albums'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to search albums'));
         }
 
         /** @var Request $request */
@@ -144,7 +144,7 @@ class PhotoController extends AbstractActionController
     public function downloadAction(): ?Stream
     {
         if (!$this->aclService->isAllowed('download', 'photo')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to download photos'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to download photos'));
         }
 
         $photoId = (int) $this->params()->fromRoute('photo_id');
@@ -159,7 +159,7 @@ class PhotoController extends AbstractActionController
     {
         if (!$this->aclService->isAllowed('view', 'photo')) {
             throw new NotAllowedException(
-                $this->translator->translate('Not allowed to view previous photos of the week'),
+                $this->translator->translate('You are not allowed to view previous photos of the week'),
             );
         }
 
@@ -216,7 +216,7 @@ class PhotoController extends AbstractActionController
     {
         if (!$this->aclService->isAllowed('add', 'vote')) {
             throw new NotAllowedException(
-                $this->translator->translate('Not allowed to vote for a photo of the week'),
+                $this->translator->translate('You are not allowed to vote for a photo of the week'),
             );
         }
 

--- a/module/Photo/src/Controller/TagController.php
+++ b/module/Photo/src/Controller/TagController.php
@@ -24,7 +24,7 @@ class TagController extends AbstractActionController
     public function addAction(): JsonModel
     {
         if (!$this->aclService->isAllowed('add', 'tag')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to add tags.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to add tags'));
         }
 
         /** @var Request $request */
@@ -50,7 +50,7 @@ class TagController extends AbstractActionController
     public function removeAction(): JsonModel
     {
         if (!$this->aclService->isAllowed('remove', 'tag')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to remove tags.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to remove tags'));
         }
 
         /** @var Request $request */

--- a/module/Photo/src/Model/WeeklyPhoto.php
+++ b/module/Photo/src/Model/WeeklyPhoto.php
@@ -40,6 +40,12 @@ class WeeklyPhoto implements ResourceInterface
     )]
     protected Photo $photo;
 
+    /**
+     * If a photo of the week is hidden, it is not shown to visitors who are NOT logged in.
+     */
+    #[Column(type: 'boolean')]
+    protected bool $hidden = false;
+
     public function getWeek(): DateTime
     {
         return $this->week;
@@ -58,6 +64,16 @@ class WeeklyPhoto implements ResourceInterface
     public function setPhoto(Photo $photo): void
     {
         $this->photo = $photo;
+    }
+
+    public function isHidden(): bool
+    {
+        return $this->hidden;
+    }
+
+    public function setHidden(bool $hidden): void
+    {
+        $this->hidden = $hidden;
     }
 
     /**

--- a/module/Photo/src/Service/Admin.php
+++ b/module/Photo/src/Service/Admin.php
@@ -59,7 +59,7 @@ class Admin
         bool $move = false,
     ): bool|PhotoModel {
         if (!$this->aclService->isAllowed('add', 'photo')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to add photos.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to add photos'));
         }
 
         $storagePath = $this->storageService->storeFile($path, false);
@@ -197,7 +197,7 @@ class Admin
     public function checkUploadAllowed(): void
     {
         if (!$this->aclService->isAllowed('upload', 'photo')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to upload photos.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to upload photos'));
         }
     }
 }

--- a/module/Photo/src/Service/Album.php
+++ b/module/Photo/src/Service/Album.php
@@ -94,7 +94,9 @@ class Album
     public function getAlbumsWithoutDate(): array
     {
         if (!$this->aclService->isAllowed('nodate', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view albums without dates'));
+            throw new NotAllowedException(
+                $this->translator->translate('You are not allowed to view albums without dates'),
+            );
         }
 
         return $this->albumMapper->getAlbumsWithoutDate();
@@ -145,7 +147,7 @@ class Album
         array $data,
     ): AlbumModel {
         if (!$this->aclService->isAllowed('create', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to create albums'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to create albums'));
         }
 
         $album = new AlbumModel();
@@ -177,7 +179,7 @@ class Album
         string $type = 'album',
     ): MemberAlbumModel|AlbumModel|WeeklyAlbumModel|null {
         if (!$this->aclService->isAllowed('view', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view albums'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view albums'));
         }
 
         $album = match ($type) {
@@ -191,7 +193,7 @@ class Album
             null !== $album
             && !$this->aclService->isAllowed('view', $album)
         ) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view albums'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view albums'));
         }
 
         return $album;
@@ -303,7 +305,7 @@ class Album
     public function updateAlbum(): bool
     {
         if (!$this->aclService->isAllowed('edit', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to edit albums'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to edit albums'));
         }
 
         $this->albumMapper->flush();
@@ -321,7 +323,7 @@ class Album
     public function getAlbumForm(?int $albumId = null): AlbumForm
     {
         if (!$this->aclService->isAllowed('edit', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to edit albums.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to edit albums'));
         }
 
         $form = $this->albumForm;
@@ -349,7 +351,7 @@ class Album
         ?int $parentId,
     ): bool {
         if (!$this->aclService->isAllowed('move', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to move albums'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to move albums'));
         }
 
         $album = $this->getAlbum($albumId);
@@ -383,7 +385,7 @@ class Album
     public function deleteAlbum(int $albumId): void
     {
         if (!$this->aclService->isAllowed('delete', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to delete albums.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to delete albums'));
         }
 
         $album = $this->getAlbum($albumId);
@@ -404,7 +406,7 @@ class Album
     public function generateAlbumCover(int $albumId): ?string
     {
         if (!$this->aclService->isAllowed('edit', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to generate album covers.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to generate album covers'));
         }
 
         $album = $this->getAlbum($albumId);
@@ -451,10 +453,6 @@ class Album
         int $photoId,
         int $albumId,
     ): bool {
-        if (!$this->aclService->isAllowed('move', 'album')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to move photos'));
-        }
-
         $photo = $this->photoService->getPhoto($photoId);
         $album = $this->getAlbum($albumId);
 

--- a/module/Photo/src/Service/Photo.php
+++ b/module/Photo/src/Service/Photo.php
@@ -70,7 +70,7 @@ class Photo
         ?int $maxResults = null,
     ): array {
         if (!$this->aclService->isAllowed('view', 'photo')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view photos'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view photos'));
         }
 
         return $this->photoMapper->getAlbumPhotos(
@@ -92,7 +92,7 @@ class Photo
         }
 
         if (!$this->aclService->isAllowed('download', $photo)) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to download photos'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to download photos'));
         }
 
         $path = $photo->getPath();
@@ -111,7 +111,7 @@ class Photo
     public function getPhoto(int $id): ?PhotoModel
     {
         if (!$this->aclService->isAllowed('view', 'photo')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view photos'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view photos'));
         }
 
         return $this->photoMapper->find($id);
@@ -146,10 +146,6 @@ class Photo
      */
     public function deletePhoto(int $photoId): bool
     {
-        if (!$this->aclService->isAllowed('delete', 'photo')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to delete photos.'));
-        }
-
         $photo = $this->getPhoto($photoId);
         if (null === $photo) {
             return false;
@@ -527,7 +523,7 @@ class Photo
         int $lidnr,
     ): ?TagModel {
         if (!$this->aclService->isAllowed('view', 'tag')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view tags.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view tags'));
         }
 
         return $this->tagMapper->findTag($photoId, $lidnr);
@@ -576,7 +572,7 @@ class Photo
     public function getTagsForMember(MemberModel $member): array
     {
         if (!$this->aclService->isAllowed('view', 'tag')) {
-            throw new NotAllowedException($this->translator->translate('Not allowed to view tags.'));
+            throw new NotAllowedException($this->translator->translate('You are not allowed to view tags'));
         }
 
         return $this->tagMapper->getTagsByLidnr($member->getLidnr());
@@ -600,5 +596,16 @@ class Photo
         $lidnr = $this->aclService->getUserIdentityOrThrowException()->getLidnr();
 
         return $this->voteMapper->hasRecentVote($lidnr);
+    }
+
+    /**
+     * Hide a Photo of the Week.
+     */
+    public function hidePhotoOfTheWeek(WeeklyPhotoModel $potw): void
+    {
+        $potw->setHidden(true);
+
+        $this->weeklyPhotoMapper->persist($potw);
+        $this->weeklyPhotoMapper->flush();
     }
 }

--- a/module/Photo/view/photo/photo-admin/weekly.phtml
+++ b/module/Photo/view/photo/photo-admin/weekly.phtml
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+use Photo\Model\WeeklyPhoto as WeeklyPhotoModel;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var true|null $alreadyHidden
+ * @var true|null $noPhoto
+ * @var true|null $wrongTime
+ * @var WeeklyPhotoModel|null $potw
+ */
+
+$this->breadcrumbs()
+    ->addBreadcrumb($this->translate('Photo of the Week'));
+?>
+<div class="row">
+    <div class="col-md-12">
+        <h2><?= $this->translate('Photo of the Week') ?></h2>
+    </div>
+</div>
+<div class="row">
+    <?php if (isset($alreadyHidden) && $alreadyHidden): ?>
+        <div class="col-md-12">
+            <p>
+                <?= $this->translate('Photo of the Weekly photo is already hidden. You cannot unhide it.'); ?>
+            </p>
+        </div>
+    <?php elseif (isset($wrongTime) && $wrongTime): ?>
+        <div class="col-md-12">
+            <p>
+                <?= $this->translate('You can no longer hide the current Photo of the Week. Should it still be necessary to make the photo invisible (or even delete it) please contact the Application Management Committee immediately.'); ?>
+            </p>
+        </div>
+    <?php elseif (isset($noPhoto) && $noPhoto): ?>
+        <div class="col-md-12">
+            <p>
+                <?= $this->translate('There is no Photo of the Week that can be hidden.'); ?>
+            </p>
+        </div>
+    <?php else: ?>
+        <div class="col-md-6">
+            <?php
+            $photo = $potw->getPhoto();
+            $width = $config['large_thumb_size']['width'];
+            $largeSize = [
+                'w' => $width,
+                'h' => round($width * $photo->getAspectRatio())
+            ];
+            ?>
+            <a href="<?= $this->url(
+                'photo/album',
+                [
+                    'album_id' => $photo->getAlbum()->getId(),
+                    'album_type' => 'album',
+                    'photo_id' => $photo->getId(),
+                ],
+            ) ?>">
+                <img
+                    class="img-responsive"
+                    src="<?= $this->glideUrl()->getUrl($photo->getPath(), $largeSize) ?>"
+                    alt=""
+                />
+            </a>
+        </div>
+        <div class="col-md-6">
+            <form method="POST">
+                <input type="submit" name="submit" value="<?= $this->translate('Hide Photo of the Week') ?>"
+                       class="btn btn-danger"/>
+            </form>
+        </div>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
On Mondays, between 00:00 and 12:00 the board can hide the current Photo of the
Week. After it is hidden, it is only shown to logged in members and graduates.

---

Slight scope creep in this PR as I changed a lot of unrelated translations.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Closes GH-1806.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
