### PR TITLE
fix(photo): combination of week number and year being wrong

### DIFF
--- a/module/Photo/view/photo/album/index.phtml
+++ b/module/Photo/view/photo/album/index.phtml
@@ -390,13 +390,23 @@ $this->scriptUrl()->requireUrl('member/search')
         }
     };
 
-    Date.prototype.getWeekNumber = function() {
+    Date.prototype._getAdjustedUTCDate = function() {
         let d = new Date(Date.UTC(this.getFullYear(), this.getMonth(), this.getDate()));
         let dayNum = d.getUTCDay() || 7;
         d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+
+        return d;
+    };
+
+    Date.prototype.getWeekNumber = function() {
+        let d = this._getAdjustedUTCDate();
         let yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
 
-        return Math.ceil((((d - yearStart) / 86400000) + 1) / 7)
+        return Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
+    };
+
+    Date.prototype.getWeekYear = function() {
+        return this._getAdjustedUTCDate().getUTCFullYear();
     };
 </script>
 <script type="module" nonce="<?= NONCE_REPLACEMENT_STRING ?>">
@@ -768,7 +778,7 @@ $this->scriptUrl()->requireUrl('member/search')
                     if (undefined !== weeklyDate) {
                         let date = new Date(weeklyDate)
                         let currentWeek = date.getWeekNumber();
-                        el.innerHTML = `<span class="fas fa-award"></span> <?= $this->translate('Photo of the Week:<br> Week') ?> ${currentWeek} <?= $this->translate('of') ?> ${date.getUTCFullYear()}`;
+                        el.innerHTML = `<span class="fas fa-award"></span> <?= $this->translate('Photo of the Week:<br> Week') ?> ${currentWeek} <?= $this->translate('of') ?> ${date.getWeekYear()}`;
                         el.hidden = false;
                     } else {
                         el.hidden = true;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Week number is based on ISO 8601, which allows January 1 to fall on Mon-Thu for that week to be the first week of the year. However, we cannot get the year from the date itself, because if (for example for this year) that date still falls in December the year is one year too low.


## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-1966.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
