### PR TITLE
fix: attendance mode bugs

### DIFF
--- a/module/Activity/src/Controller/AdminController.php
+++ b/module/Activity/src/Controller/AdminController.php
@@ -550,11 +550,10 @@ class AdminController extends AbstractActionController
         }
 
         $now = new DateTime();
-        $interval = new DateInterval('PT30M');
         if (
             ActivityModel::STATUS_APPROVED !== $activity->getStatus() ||
-            $now < $activity->getBeginTime()->sub($interval) ||
-            $now > $activity->getEndTime()->add($interval)
+            $now < $activity->getBeginTime()->sub(new DateInterval('PT30M')) ||
+            $now > $activity->getEndTime()->add(new DateInterval('PT2H'))
         ) {
             $response->setStatusCode(400);
 
@@ -615,7 +614,12 @@ class AdminController extends AbstractActionController
                 continue;
             }
 
+            $signupList = $signup->getSignupList();
+
             $signup->setDrawn(false);
+            $signupList->setPresenceTaken(true);
+
+            $entityManager->persist($signupList);
             $entityManager->persist($signup);
         }
 

--- a/module/Activity/view/activity/admin/participantsTable.phtml
+++ b/module/Activity/view/activity/admin/participantsTable.phtml
@@ -16,7 +16,7 @@ use Laminas\View\Renderer\PhpRenderer;
 <?php
 $activityApproved = ActivityModel::STATUS_APPROVED === $activity->getStatus();
 $attendanceModeTimeStarted = new DateTime() > $activity->getBeginTime()->modify('-30 min');
-$attendanceModeTimeEnded = new DateTime() > $activity->getEndTime()->modify('+30 min');
+$attendanceModeTimeEnded = new DateTime() > $activity->getEndTime()->modify('+2 hour');
 ?>
 <div data-controller="participants-table"
     <?php if (isset($signupList)): ?>


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the title above. -->

# Description

- Open the signup for 2 hours after the activity instead of only 30 minutes. This proved to be to little time in practice.
- Show the presence column in the table when signups are drawn out and the column would not show normally yet. This is the case when attendance-mode did not open yet before an activity. Attendance mode still opens at the normal time. 
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->


## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
