### PR TITLE
feat(activity): promoted ordering of signup lists

### DIFF
--- a/module/Activity/src/Model/Activity.php
+++ b/module/Activity/src/Model/Activity.php
@@ -21,6 +21,7 @@ use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\OrderBy;
 use User\Permissions\Resource\CreatorResourceInterface;
 use User\Permissions\Resource\OrganResourceInterface;
 
@@ -212,6 +213,10 @@ class Activity implements OrganResourceInterface, CreatorResourceInterface
         cascade: ['remove'],
         orphanRemoval: true,
     )]
+    #[OrderBy([
+        'promoted' => 'DESC',
+        'id' => 'ASC',
+    ])]
     protected Collection $signupLists;
 
     /**

--- a/module/Activity/src/Model/SignupList.php
+++ b/module/Activity/src/Model/SignupList.php
@@ -37,6 +37,7 @@ use User\Permissions\Resource\OrganResourceInterface;
  *     limitedCapacity: bool,
  *     fields: ImportedSignupFieldArrayType[],
  *     presenceTaken: bool,
+ *     promoted: bool,
  * }
  * @psalm-import-type LocalisedTextGdprArrayType from LocalisedTextModel as ImportedLocalisedTextGdprArrayType
  * @psalm-import-type SignupFieldGdprArrayType from SignupField as ImportedSignupFieldGdprArrayType
@@ -50,6 +51,7 @@ use User\Permissions\Resource\OrganResourceInterface;
  *     limitedCapacity: bool,
  *     fields: ImportedSignupFieldGdprArrayType[],
  *     presenceTaken: bool,
+ *     promoted: bool
  * }
  */
 #[Entity]
@@ -148,6 +150,12 @@ class SignupList implements OrganResourceInterface, CreatorResourceInterface
      */
     #[Column(type: 'boolean')]
     protected bool $presenceTaken = false;
+
+    /**
+     * Determines if the signup list should appear before other signup lists on the same activity.
+     */
+    #[Column(type: 'boolean')]
+    protected bool $promoted = false;
 
     public function __construct()
     {
@@ -324,6 +332,22 @@ class SignupList implements OrganResourceInterface, CreatorResourceInterface
     }
 
     /**
+     * Get whether signup list is promoted.
+     */
+    public function isPromoted(): bool
+    {
+        return $this->promoted;
+    }
+
+    /**
+     * Set promoted state of signup list.
+     */
+    public function setPromoted(bool $promoted): void
+    {
+        $this->promoted = $promoted;
+    }
+
+    /**
      * Returns an associative array representation of this object.
      *
      * @return SignupListArrayType
@@ -345,6 +369,7 @@ class SignupList implements OrganResourceInterface, CreatorResourceInterface
             'displaySubscribedNumber' => $this->getDisplaySubscribedNumber(),
             'limitedCapacity' => $this->getLimitedCapacity(),
             'presenceTaken' => $this->isPresenceTaken(),
+            'promoted' => $this->isPromoted(),
             'fields' => $fieldsArrays,
         ];
     }
@@ -369,6 +394,7 @@ class SignupList implements OrganResourceInterface, CreatorResourceInterface
             'displaySubscribedNumber' => $this->getDisplaySubscribedNumber(),
             'limitedCapacity' => $this->getLimitedCapacity(),
             'presenceTaken' => $this->isPresenceTaken(),
+            'promoted' => $this->isPromoted(),
             'fields' => $fieldsArrays,
         ];
     }

--- a/module/Application/migrations/Version20250501112959.php
+++ b/module/Application/migrations/Version20250501112959.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ * phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
+ */
+final class Version20250501112959 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Allow signup lists to be promoted over other signup lists.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE SignupList ADD promoted TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE SignupList DROP promoted');
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
It may happen that an activity has more than one signup list, in certain cases it may be preferred to use a different ordering than when the activity was made.

For example, when it is decided that an activity should be re-opened for signups but you want to preserve the original signup list I have to manually create a new signup list for this activity. To ensure that it is the first signup list in the overview, I have to make manual changes in the database to fix the positioning by altering the IDs of the signup lists (which is a pain).

Therefore, this introduces a structured approach to handle ordering directly within the codebase. The functionality is *NOT* exposed to activity organisers.

Although more complex ordering (like considering signup list open/close times) is possibly better, it is currently out-of-scope for this implementation (as I am not entirely sure it is possible with Doctrine without have to create custom queries).

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Related to ABC-2505-TBD.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
