### PR TITLE
feat(activity): add a mandatory category to activities

### DIFF
--- a/migrations/Version20260528095542.php
+++ b/migrations/Version20260528095542.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ * phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
+ */
+final class Version20260528095542 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add a mandatory category to activities, replacing isMyFuture (now the career category); GH-2052.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Add as nullable first so existing rows remain valid, then backfill and enforce NOT NULL.
+        $this->addSql('ALTER TABLE Activity ADD category VARCHAR(255) DEFAULT NULL');
+        // The career category replaces isMyFuture (decided with the external affairs officer).
+        $this->addSql('UPDATE Activity SET category = \'career\' WHERE isMyFuture = 1');
+        // Existing activities have no category; mark them uncategorised (not selectable for new activities).
+        $this->addSql('UPDATE Activity SET category = \'uncategorised\' WHERE category IS NULL');
+        $this->addSql('ALTER TABLE Activity CHANGE category category VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE Activity DROP isMyFuture');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Activity ADD isMyFuture TINYINT(1) DEFAULT NULL');
+        $this->addSql('UPDATE Activity SET isMyFuture = 1 WHERE category = \'career\'');
+        $this->addSql('UPDATE Activity SET isMyFuture = 0 WHERE isMyFuture IS NULL');
+        $this->addSql('ALTER TABLE Activity CHANGE isMyFuture isMyFuture TINYINT(1) NOT NULL');
+        $this->addSql('ALTER TABLE Activity DROP category');
+    }
+}

--- a/src/DataFixtures/Activity/ActivityFixture.php
+++ b/src/DataFixtures/Activity/ActivityFixture.php
@@ -8,6 +8,7 @@ use App\DataFixtures\Decision\MemberFixture;
 use App\Entity\Activity\Activity;
 use App\Entity\Activity\ActivityLabel;
 use App\Entity\Activity\ActivityLocalisedText;
+use App\Entity\Activity\Enums\ActivityCategories;
 use App\Entity\Activity\SignupList;
 use App\Entity\Decision\Member;
 use DateTime;
@@ -29,7 +30,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 'status' => Activity::STATUS_APPROVED,
                 'beginTime' => '-2 months 20:00',
                 'endTime' => '-2 months 23:30',
-                'isMyFuture' => false,
+                'category' => ActivityCategories::Recreational,
                 'requireGEFLITST' => false,
                 'requireZettle' => false,
                 'name' => [
@@ -74,7 +75,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 'status' => Activity::STATUS_APPROVED,
                 'beginTime' => '-3 weeks 19:30',
                 'endTime' => '-3 weeks 22:00',
-                'isMyFuture' => false,
+                'category' => ActivityCategories::Workshop,
                 'requireGEFLITST' => false,
                 'requireZettle' => false,
                 'name' => [
@@ -118,7 +119,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 'status' => Activity::STATUS_APPROVED,
                 'beginTime' => '+2 weeks 19:00',
                 'endTime' => '+2 weeks 23:00',
-                'isMyFuture' => false,
+                'category' => ActivityCategories::SocialDrink,
                 'requireGEFLITST' => false,
                 'requireZettle' => false,
                 'name' => [
@@ -144,7 +145,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 'status' => Activity::STATUS_TO_APPROVE,
                 'beginTime' => '+3 weeks 12:30',
                 'endTime' => '+3 weeks 14:00',
-                'isMyFuture' => false,
+                'category' => ActivityCategories::Education,
                 'requireGEFLITST' => false,
                 'requireZettle' => false,
                 'name' => [
@@ -175,7 +176,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 'status' => Activity::STATUS_APPROVED,
                 'beginTime' => '+1 month 17:00',
                 'endTime' => '+1 month 22:00',
-                'isMyFuture' => false,
+                'category' => ActivityCategories::Party,
                 'requireGEFLITST' => true,
                 'requireZettle' => true,
                 'name' => [
@@ -214,7 +215,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 'status' => Activity::STATUS_APPROVED,
                 'beginTime' => '+5 weeks 18:00',
                 'endTime' => '+5 weeks 23:59',
-                'isMyFuture' => false,
+                'category' => ActivityCategories::Conference,
                 'requireGEFLITST' => true,
                 'requireZettle' => true,
                 'name' => [
@@ -264,14 +265,14 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                     ],
                 ],
             ],
-            // Upcoming My Future activity, approved, organised by an active (external) member.
+            // Upcoming career activity, approved, organised by an active (external) member.
             // Signup list open to non-GEWIS members.
             [
                 'creator' => 8018,
                 'status' => Activity::STATUS_APPROVED,
                 'beginTime' => '+6 weeks 13:00',
                 'endTime' => '+6 weeks 17:00',
-                'isMyFuture' => true,
+                'category' => ActivityCategories::Career,
                 'requireGEFLITST' => false,
                 'requireZettle' => false,
                 'name' => [
@@ -326,7 +327,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
             $activity->setEndTime(new DateTime($data['endTime']));
             $activity->setCreator($this->getReference('member-' . $data['creator'], Member::class));
             $activity->setStatus($data['status']);
-            $activity->setIsMyFuture($data['isMyFuture']);
+            $activity->setCategory($data['category']);
             $activity->setRequireGEFLITST($data['requireGEFLITST']);
             $activity->setRequireZettle($data['requireZettle']);
 

--- a/src/Entity/Activity/Activity.php
+++ b/src/Entity/Activity/Activity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity\Activity;
 
+use App\Entity\Activity\Enums\ActivityCategories;
 use App\Entity\Application\LocalisedText as LocalisedTextModel;
 use App\Entity\Application\Traits\IdentifiableTrait;
 use App\Entity\Career\Company as CompanyModel;
@@ -44,7 +45,7 @@ use Doctrine\ORM\Mapping\OrderBy;
  *     descriptionEn: ?string,
  *     organ: ?OrganModel,
  *     company: ?CompanyModel,
- *     isMyFuture: bool,
+ *     category: string,
  *     requireGEFLITST: bool,
  *     requireZettle: bool,
  *     labels: ImportedActivityLabelArrayType[],
@@ -63,7 +64,7 @@ use Doctrine\ORM\Mapping\OrderBy;
  *     description: ImportedLocalisedTextGdprArrayType,
  *     organ: ?int,
  *     company: ?int,
- *     isMyFuture: bool,
+ *     category: string,
  *     requireGEFLITST: bool,
  *     requireZettle: bool,
  *     labels: ImportedActivityLabelGdprArrayType[],
@@ -252,10 +253,13 @@ class Activity
     private ?CompanyModel $company = null;
 
     /**
-     * Is this a My Future related activity.
+     * The (single, mandatory) category of this activity.
      */
-    #[Column(type: Types::BOOLEAN)]
-    private bool $isMyFuture;
+    #[Column(
+        type: Types::STRING,
+        enumType: ActivityCategories::class,
+    )]
+    private ActivityCategories $category;
 
     /**
      * Whether this activity needs a GEFLITST photographer.
@@ -477,14 +481,14 @@ class Activity
         $this->company = $company;
     }
 
-    public function getIsMyFuture(): bool
+    public function getCategory(): ActivityCategories
     {
-        return $this->isMyFuture;
+        return $this->category;
     }
 
-    public function setIsMyFuture(bool $isMyFuture): void
+    public function setCategory(ActivityCategories $category): void
     {
-        $this->isMyFuture = $isMyFuture;
+        $this->category = $category;
     }
 
     public function getRequireGEFLITST(): bool
@@ -556,7 +560,7 @@ class Activity
             'descriptionEn' => $this->getDescription()->getValueEN(),
             'organ' => $this->getOrgan(),
             'company' => $this->getCompany(),
-            'isMyFuture' => $this->getIsMyFuture(),
+            'category' => $this->getCategory()->value,
             'requireGEFLITST' => $this->getRequireGEFLITST(),
             'requireZettle' => $this->getRequireZettle(),
             'labels' => $labelsArrays,
@@ -591,7 +595,7 @@ class Activity
             'description' => $this->getDescription()->toGdprArray(),
             'organ' => $this->getOrgan()?->getId(),
             'company' => $this->getCompany()?->getId(),
-            'isMyFuture' => $this->getIsMyFuture(),
+            'category' => $this->getCategory()->value,
             'requireGEFLITST' => $this->getRequireGEFLITST(),
             'requireZettle' => $this->getRequireZettle(),
             'labels' => $labelsArrays,

--- a/src/Entity/Activity/Enums/ActivityCategories.php
+++ b/src/Entity/Activity/Enums/ActivityCategories.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Activity\Enums;
+
+use Override;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Enum for the (single, mandatory) category of an activity.
+ */
+enum ActivityCategories: string implements TranslatableInterface
+{
+    case ActiveSocial = 'active-social';
+    case Announcement = 'announcement';
+    case Career = 'career';
+    case Competition = 'competition';
+    case Conference = 'conference';
+    case Cultural = 'cultural';
+    case Education = 'education';
+    case External = 'external';
+    case InterestList = 'interest-list';
+    case InterestMeeting = 'interest-meeting';
+    case Meeting = 'meeting';
+    case Party = 'party';
+    case PromoMerch = 'promo-merch';
+    case Recreational = 'recreational';
+    case SaveTheDate = 'save-the-date';
+    case SocialDrink = 'social-drink';
+    case Sports = 'sports';
+    case Weekend = 'weekend';
+    case Workshop = 'workshop';
+    case Other = 'other';
+
+    // Only ever assigned to legacy activities by a migration; it must never be selectable for new activities.
+    case Uncategorised = 'uncategorised';
+
+    #[Override]
+    public function trans(
+        TranslatorInterface $translator,
+        ?string $locale = null,
+    ): string {
+        return match ($this) {
+            self::ActiveSocial => $translator->trans(
+                'Active & social',
+                locale: $locale,
+            ),
+            self::Announcement => $translator->trans(
+                'Announcement',
+                locale: $locale,
+            ),
+            self::Career => $translator->trans(
+                'Career',
+                locale: $locale,
+            ),
+            self::Competition => $translator->trans(
+                'Competition',
+                locale: $locale,
+            ),
+            self::Conference => $translator->trans(
+                'Conference',
+                locale: $locale,
+            ),
+            self::Cultural => $translator->trans(
+                'Cultural',
+                locale: $locale,
+            ),
+            self::Education => $translator->trans(
+                'Education',
+                locale: $locale,
+            ),
+            self::External => $translator->trans(
+                'External',
+                locale: $locale,
+            ),
+            self::InterestList => $translator->trans(
+                'Interest list',
+                locale: $locale,
+            ),
+            self::InterestMeeting => $translator->trans(
+                'Interest meeting',
+                locale: $locale,
+            ),
+            self::Meeting => $translator->trans(
+                'Meeting',
+                locale: $locale,
+            ),
+            self::Party => $translator->trans(
+                'Party',
+                locale: $locale,
+            ),
+            self::PromoMerch => $translator->trans(
+                'Promo & merchandise',
+                locale: $locale,
+            ),
+            self::Recreational => $translator->trans(
+                'Recreational',
+                locale: $locale,
+            ),
+            self::SaveTheDate => $translator->trans(
+                'Save the date',
+                locale: $locale,
+            ),
+            self::SocialDrink => $translator->trans(
+                'Social drink',
+                locale: $locale,
+            ),
+            self::Sports => $translator->trans(
+                'Sports',
+                locale: $locale,
+            ),
+            self::Weekend => $translator->trans(
+                'Weekend',
+                locale: $locale,
+            ),
+            self::Workshop => $translator->trans(
+                'Workshop',
+                locale: $locale,
+            ),
+            self::Other => $translator->trans(
+                'Other',
+                locale: $locale,
+            ),
+            self::Uncategorised => $translator->trans(
+                'Uncategorised',
+                locale: $locale,
+            ),
+        };
+    }
+}

--- a/src/Repository/Activity/ActivityRepository.php
+++ b/src/Repository/Activity/ActivityRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository\Activity;
 
 use App\Entity\Activity\Activity;
+use App\Entity\Activity\Enums\ActivityCategories;
 use App\Entity\Activity\SignupList;
 use App\Entity\Activity\UserSignup;
 use App\Entity\Decision\Member;
@@ -71,7 +72,11 @@ class ActivityRepository extends ServiceEntityRepository
 
         // For now 'career' is the only category, however this may change in the future
         if ('career' === $category) {
-            $qb->andWhere('a.isMyFuture = 1');
+            $qb->andWhere('a.category = :category')
+                ->setParameter(
+                    'category',
+                    ActivityCategories::Career->value,
+                );
         }
 
         $qb->setParameter(

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -41,6 +41,10 @@
         <source>Active</source>
         <target state="translated">Active</target>
       </trans-unit>
+      <trans-unit id="lZsKsne" resname="Active &amp; social">
+        <source>Active &amp; social</source>
+        <target><![CDATA[Active & social]]></target>
+      </trans-unit>
       <trans-unit id="3cz4hJw" resname="Active Member">
         <source>Active Member</source>
         <target state="translated">Active Member</target>
@@ -112,6 +116,10 @@
       <trans-unit id="3eX.3WJ" resname="Analytics are currently">
         <source>Analytics are currently</source>
         <target state="translated">Analytics are currently</target>
+      </trans-unit>
+      <trans-unit id="2RsMs_8" resname="Announcement">
+        <source>Announcement</source>
+        <target>Announcement</target>
       </trans-unit>
       <trans-unit id="YZX3vFh" resname="Answers">
         <source>Answers</source>
@@ -269,9 +277,17 @@
         <source>Company Users</source>
         <target state="translated">Company Users</target>
       </trans-unit>
+      <trans-unit id="mXPg4vS" resname="Competition">
+        <source>Competition</source>
+        <target>Competition</target>
+      </trans-unit>
       <trans-unit id="EcOGjmx" resname="Complete agenda">
         <source>Complete agenda</source>
         <target state="translated">Complete agenda</target>
+      </trans-unit>
+      <trans-unit id="cydhnYq" resname="Conference">
+        <source>Conference</source>
+        <target>Conference</target>
       </trans-unit>
       <trans-unit id="stB18m_" resname="Confidential Contact Person (CCP)">
         <source>Confidential Contact Person (CCP)</source>
@@ -304,6 +320,10 @@
       <trans-unit id="BGi6GGx" resname="Create Activity">
         <source>Create Activity</source>
         <target state="translated">Create Activity</target>
+      </trans-unit>
+      <trans-unit id="EMb_Fre" resname="Cultural">
+        <source>Cultural</source>
+        <target>Cultural</target>
       </trans-unit>
       <trans-unit id="ukaFrcB" resname="Current password">
         <source>Current password</source>
@@ -633,6 +653,14 @@
         <source>Install an authenticator app such as Ente Auth or 2FAS on your phone.</source>
         <target state="translated">Install an authenticator app such as Ente Auth or 2FAS on your phone.</target>
       </trans-unit>
+      <trans-unit id="aIlBisN" resname="Interest list">
+        <source>Interest list</source>
+        <target>Interest list</target>
+      </trans-unit>
+      <trans-unit id="jhj4D5a" resname="Interest meeting">
+        <source>Interest meeting</source>
+        <target>Interest meeting</target>
+      </trans-unit>
       <trans-unit id="j3ZMNbB" resname="Interim">
         <source>Interim</source>
         <target state="translated">Interim</target>
@@ -752,6 +780,10 @@
       <trans-unit id="Vuyl_8H" resname="Mail address">
         <source>Mail address</source>
         <target state="translated">Mail address</target>
+      </trans-unit>
+      <trans-unit id="dQZZmIL" resname="Meeting">
+        <source>Meeting</source>
+        <target>Meeting</target>
       </trans-unit>
       <trans-unit id="Cg3S2oo" resname="Member">
         <source>Member</source>
@@ -905,6 +937,10 @@
         <source>Pagination</source>
         <target state="translated">Pagination</target>
       </trans-unit>
+      <trans-unit id="eI1dGQ5" resname="Party">
+        <source>Party</source>
+        <target>Party</target>
+      </trans-unit>
       <trans-unit id="GqmFSHc" resname="Password">
         <source>Password</source>
         <target state="translated">Password</target>
@@ -941,6 +977,10 @@
         <source>Privacy Policy</source>
         <target state="translated">Privacy Policy</target>
       </trans-unit>
+      <trans-unit id="M8W_jVO" resname="Promo &amp; merchandise">
+        <source>Promo &amp; merchandise</source>
+        <target><![CDATA[Promo & merchandise]]></target>
+      </trans-unit>
       <trans-unit id="YRI5E0j" resname="QR code">
         <source>QR code</source>
         <target state="translated">QR code</target>
@@ -948,6 +988,10 @@
       <trans-unit id="9Iuz1j8" resname="Reality collapsed. Please go back before the singularity spreads.">
         <source>Reality collapsed. Please go back before the singularity spreads.</source>
         <target state="translated">Reality collapsed. Please go back before the singularity spreads.</target>
+      </trans-unit>
+      <trans-unit id="3BS.OCQ" resname="Recreational">
+        <source>Recreational</source>
+        <target>Recreational</target>
       </trans-unit>
       <trans-unit id="wtanMIv" resname="Regenerate backup codes">
         <source>Regenerate backup codes</source>
@@ -992,6 +1036,10 @@
       <trans-unit id="aq2eM8Q" resname="Roles">
         <source>Roles</source>
         <target state="translated">Roles</target>
+      </trans-unit>
+      <trans-unit id="Nj16X3T" resname="Save the date">
+        <source>Save the date</source>
+        <target>Save the date</target>
       </trans-unit>
       <trans-unit id="2Fymdn1" resname="Save them now: write them down, print this page, or store them in a secure place. Each code can be used once if you lose access to your authenticator app. When you regenerate, all previous codes are invalidated.">
         <source>Save them now: write them down, print this page, or store them in a secure place. Each code can be used once if you lose access to your authenticator app. When you regenerate, all previous codes are invalidated.</source>
@@ -1052,6 +1100,14 @@
       <trans-unit id="lIY1Kot" resname="Signed in %date%">
         <source>Signed in %date%</source>
         <target state="translated">Signed in %date%</target>
+      </trans-unit>
+      <trans-unit id="e9EhDeS" resname="Social drink">
+        <source>Social drink</source>
+        <target>Social drink</target>
+      </trans-unit>
+      <trans-unit id="U_RKQ4r" resname="Sports">
+        <source>Sports</source>
+        <target>Sports</target>
       </trans-unit>
       <trans-unit id="oBphsD9" resname="Stale">
         <source>Stale</source>
@@ -1189,6 +1245,10 @@
         <source>Treasurer</source>
         <target state="translated">Treasurer</target>
       </trans-unit>
+      <trans-unit id="UryytzR" resname="Uncategorised">
+        <source>Uncategorised</source>
+        <target>Uncategorised</target>
+      </trans-unit>
       <trans-unit id="7ZQ9oWO" resname="Unknown device">
         <source>Unknown device</source>
         <target state="translated">Unknown device</target>
@@ -1253,6 +1313,10 @@
         <source>We found a pointer to &lt;code&gt;NULL&lt;/code&gt; instead of this page</source>
         <target state="translated"><![CDATA[We found a pointer to <code>NULL</code> instead of this page]]></target>
       </trans-unit>
+      <trans-unit id="jUNxBhp" resname="Weekend">
+        <source>Weekend</source>
+        <target>Weekend</target>
+      </trans-unit>
       <trans-unit id="qLp0Jrc" resname="Welcome to the website of study association GEWIS, the study association of the department of Mathematics &amp; Computer Science at Eindhoven University of Technology.">
         <source>Welcome to the website of study association GEWIS, the study association of the department of Mathematics &amp; Computer Science at Eindhoven University of Technology.</source>
         <target state="translated"><![CDATA[Welcome to the website of study association GEWIS, the study association of the department of Mathematics & Computer Science at Eindhoven University of Technology.]]></target>
@@ -1264,6 +1328,10 @@
       <trans-unit id="klYLh_k" resname="Which is basically the same thing.">
         <source>Which is basically the same thing.</source>
         <target state="translated">Which is basically the same thing.</target>
+      </trans-unit>
+      <trans-unit id="4EUNMUa" resname="Workshop">
+        <source>Workshop</source>
+        <target>Workshop</target>
       </trans-unit>
       <trans-unit id="vIs6CbG" resname="You are about to reset multi-factor authentication for:">
         <source>You are about to reset multi-factor authentication for:</source>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -41,6 +41,10 @@
         <source>Active</source>
         <target state="translated">Actief</target>
       </trans-unit>
+      <trans-unit id="lZsKsne" resname="Active &amp; social">
+        <source>Active &amp; social</source>
+        <target><![CDATA[Actief & sociaal]]></target>
+      </trans-unit>
       <trans-unit id="3cz4hJw" resname="Active Member">
         <source>Active Member</source>
         <target state="translated">Actief lid</target>
@@ -112,6 +116,10 @@
       <trans-unit id="3eX.3WJ" resname="Analytics are currently">
         <source>Analytics are currently</source>
         <target state="translated">Analytics zijn momenteel</target>
+      </trans-unit>
+      <trans-unit id="2RsMs_8" resname="Announcement">
+        <source>Announcement</source>
+        <target>Aankondiging</target>
       </trans-unit>
       <trans-unit id="YZX3vFh" resname="Answers">
         <source>Answers</source>
@@ -269,9 +277,17 @@
         <source>Company Users</source>
         <target state="translated">Bedrijfsgebruikers</target>
       </trans-unit>
+      <trans-unit id="mXPg4vS" resname="Competition">
+        <source>Competition</source>
+        <target>Competitie</target>
+      </trans-unit>
       <trans-unit id="EcOGjmx" resname="Complete agenda">
         <source>Complete agenda</source>
         <target state="translated">Volledige agenda</target>
+      </trans-unit>
+      <trans-unit id="cydhnYq" resname="Conference">
+        <source>Conference</source>
+        <target>Congres</target>
       </trans-unit>
       <trans-unit id="stB18m_" resname="Confidential Contact Person (CCP)">
         <source>Confidential Contact Person (CCP)</source>
@@ -304,6 +320,10 @@
       <trans-unit id="BGi6GGx" resname="Create Activity">
         <source>Create Activity</source>
         <target state="translated">Activiteit maken</target>
+      </trans-unit>
+      <trans-unit id="EMb_Fre" resname="Cultural">
+        <source>Cultural</source>
+        <target>Cultureel</target>
       </trans-unit>
       <trans-unit id="ukaFrcB" resname="Current password">
         <source>Current password</source>
@@ -633,6 +653,14 @@
         <source>Install an authenticator app such as Ente Auth or 2FAS on your phone.</source>
         <target state="translated">Installeer een authenticatie-app zoals Ente Auth of 2FAS op je telefoon.</target>
       </trans-unit>
+      <trans-unit id="aIlBisN" resname="Interest list">
+        <source>Interest list</source>
+        <target>Interesselijst</target>
+      </trans-unit>
+      <trans-unit id="jhj4D5a" resname="Interest meeting">
+        <source>Interest meeting</source>
+        <target>Interessebijeenkomst</target>
+      </trans-unit>
       <trans-unit id="j3ZMNbB" resname="Interim">
         <source>Interim</source>
         <target state="translated">Tussentijdse toets</target>
@@ -752,6 +780,10 @@
       <trans-unit id="Vuyl_8H" resname="Mail address">
         <source>Mail address</source>
         <target state="translated">Postadres</target>
+      </trans-unit>
+      <trans-unit id="dQZZmIL" resname="Meeting">
+        <source>Meeting</source>
+        <target>Vergadering</target>
       </trans-unit>
       <trans-unit id="Cg3S2oo" resname="Member">
         <source>Member</source>
@@ -905,6 +937,10 @@
         <source>Pagination</source>
         <target state="translated">Paginering</target>
       </trans-unit>
+      <trans-unit id="eI1dGQ5" resname="Party">
+        <source>Party</source>
+        <target>Feest</target>
+      </trans-unit>
       <trans-unit id="GqmFSHc" resname="Password">
         <source>Password</source>
         <target state="translated">Wachtwoord</target>
@@ -941,6 +977,10 @@
         <source>Privacy Policy</source>
         <target state="translated">Privacybeleid</target>
       </trans-unit>
+      <trans-unit id="M8W_jVO" resname="Promo &amp; merchandise">
+        <source>Promo &amp; merchandise</source>
+        <target><![CDATA[Promo & merchandise]]></target>
+      </trans-unit>
       <trans-unit id="YRI5E0j" resname="QR code">
         <source>QR code</source>
         <target state="translated">QR-code</target>
@@ -948,6 +988,10 @@
       <trans-unit id="9Iuz1j8" resname="Reality collapsed. Please go back before the singularity spreads.">
         <source>Reality collapsed. Please go back before the singularity spreads.</source>
         <target state="translated">De werkelijkheid stortte in. Ga alsjeblieft terug voordat de singulariteit zich verspreidt.</target>
+      </trans-unit>
+      <trans-unit id="3BS.OCQ" resname="Recreational">
+        <source>Recreational</source>
+        <target>Recreatief</target>
       </trans-unit>
       <trans-unit id="wtanMIv" resname="Regenerate backup codes">
         <source>Regenerate backup codes</source>
@@ -992,6 +1036,10 @@
       <trans-unit id="aq2eM8Q" resname="Roles">
         <source>Roles</source>
         <target state="translated">Rollen</target>
+      </trans-unit>
+      <trans-unit id="Nj16X3T" resname="Save the date">
+        <source>Save the date</source>
+        <target>Save the date</target>
       </trans-unit>
       <trans-unit id="2Fymdn1" resname="Save them now: write them down, print this page, or store them in a secure place. Each code can be used once if you lose access to your authenticator app. When you regenerate, all previous codes are invalidated.">
         <source>Save them now: write them down, print this page, or store them in a secure place. Each code can be used once if you lose access to your authenticator app. When you regenerate, all previous codes are invalidated.</source>
@@ -1052,6 +1100,14 @@
       <trans-unit id="lIY1Kot" resname="Signed in %date%">
         <source>Signed in %date%</source>
         <target state="translated">Ingelogd op %date%</target>
+      </trans-unit>
+      <trans-unit id="e9EhDeS" resname="Social drink">
+        <source>Social drink</source>
+        <target>Borrel</target>
+      </trans-unit>
+      <trans-unit id="U_RKQ4r" resname="Sports">
+        <source>Sports</source>
+        <target>Sport</target>
       </trans-unit>
       <trans-unit id="oBphsD9" resname="Stale">
         <source>Stale</source>
@@ -1189,6 +1245,10 @@
         <source>Treasurer</source>
         <target>Penningmeester</target>
       </trans-unit>
+      <trans-unit id="UryytzR" resname="Uncategorised">
+        <source>Uncategorised</source>
+        <target>Niet gecategoriseerd</target>
+      </trans-unit>
       <trans-unit id="7ZQ9oWO" resname="Unknown device">
         <source>Unknown device</source>
         <target state="translated">Onbekend apparaat</target>
@@ -1253,6 +1313,10 @@
         <source>We found a pointer to &lt;code&gt;NULL&lt;/code&gt; instead of this page</source>
         <target state="translated"><![CDATA[We hebben een verwijzing naar <code>NULL</code> gevonden in plaats van deze pagina]]></target>
       </trans-unit>
+      <trans-unit id="jUNxBhp" resname="Weekend">
+        <source>Weekend</source>
+        <target>Weekend</target>
+      </trans-unit>
       <trans-unit id="qLp0Jrc" resname="Welcome to the website of study association GEWIS, the study association of the department of Mathematics &amp; Computer Science at Eindhoven University of Technology.">
         <source>Welcome to the website of study association GEWIS, the study association of the department of Mathematics &amp; Computer Science at Eindhoven University of Technology.</source>
         <target state="translated"><![CDATA[Welkom op de website van studievereniging GEWIS, de studievereniging van de faculteit Wiskunde & Informatica aan de Technische Universiteit Eindhoven.]]></target>
@@ -1264,6 +1328,10 @@
       <trans-unit id="klYLh_k" resname="Which is basically the same thing.">
         <source>Which is basically the same thing.</source>
         <target state="translated">Wat in feite hetzelfde is.</target>
+      </trans-unit>
+      <trans-unit id="4EUNMUa" resname="Workshop">
+        <source>Workshop</source>
+        <target>Workshop</target>
       </trans-unit>
       <trans-unit id="vIs6CbG" resname="You are about to reset multi-factor authentication for:">
         <source>You are about to reset multi-factor authentication for:</source>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Introduce an `ActivityCategories` enum and make it a mandatory column on `Activity`, replacing the `isMyFuture` boolean. The new `career` category takes its place (as agreed with the external affairs officer).

A migration backfills existing activities: `isMyFuture = 1` becomes `career` and every other row becomes `uncategorised`, a value that exists only to satisfy the not-null constraint on legacy data and MUST be excluded from the activity creation form so it can never be chosen for new activities.

The upcoming-activities query and the seeder are updated to use the category, and English/Dutch translations for every label are provided.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Closes GH-2052.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
