### PR TITLE
feat(activity): overview of upcoming/archived activities and generic view

### DIFF
--- a/assets/controllers/activity_item_controller.js
+++ b/assets/controllers/activity_item_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Makes an entire activity list item navigate to the activity, while leaving real links and buttons inside it
+ * (the title link, Markdown links, the "Show more" toggle) working on their own.
+ */
+export default class extends Controller {
+    static values = { url: String };
+
+    open(event) {
+        if (event.target.closest('a, button')) {
+            return;
+        }
+
+        window.location.assign(this.urlValue);
+    }
+}

--- a/assets/controllers/description_toggle_controller.js
+++ b/assets/controllers/description_toggle_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Reveals/hides the full activity description. The content is line-clamped by CSS; this only shows the toggle button
+ * when the content actually overflows, and swaps its label between "Show more" and "Show less".
+ */
+export default class extends Controller {
+    static targets = ['content', 'button'];
+    static values = { more: String, less: String };
+
+    connect() {
+        if (!this.hasContentTarget || !this.hasButtonTarget) {
+            return;
+        }
+
+        // Wait for layout so clientHeight/scrollHeight are accurate, then reveal the button only when clamped.
+        requestAnimationFrame(() => {
+            if (this.contentTarget.scrollHeight > this.contentTarget.clientHeight + 1) {
+                this.buttonTarget.classList.remove('d-none');
+            }
+        });
+    }
+
+    toggle() {
+        const expanded = this.contentTarget.classList.toggle('expanded');
+        this.buttonTarget.textContent = expanded ? this.lessValue : this.moreValue;
+    }
+}

--- a/assets/controllers/infinite_scroll_controller.js
+++ b/assets/controllers/infinite_scroll_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Auto-loads the next batch of a live-component list when a sentinel scrolls into view, by clicking the (always
+ * rendered) "Load more" button. Degrades gracefully: without IntersectionObserver the button stays usable on its own.
+ * A short cooldown prevents firing a burst of requests while the sentinel remains visible.
+ */
+export default class extends Controller {
+    static targets = ['sentinel', 'button'];
+
+    connect() {
+        if (!('IntersectionObserver' in window) || !this.hasSentinelTarget) {
+            return;
+        }
+
+        this.cooldown = false;
+        this.observer = new IntersectionObserver((entries) => {
+            const visible = entries.some((entry) => entry.isIntersecting);
+            if (!visible || this.cooldown || !this.hasButtonTarget) {
+                return;
+            }
+
+            this.cooldown = true;
+            this.buttonTarget.click();
+            window.setTimeout(() => {
+                this.cooldown = false;
+            }, 800);
+        });
+        this.observer.observe(this.sentinelTarget);
+    }
+
+    disconnect() {
+        if (this.observer) {
+            this.observer.disconnect();
+        }
+    }
+}

--- a/assets/stimulus_bootstrap.js
+++ b/assets/stimulus_bootstrap.js
@@ -1,9 +1,15 @@
 import { startStimulusApp } from '@symfony/stimulus-bundle';
+import ActivityItemController from './controllers/activity_item_controller.js';
+import DescriptionToggleController from './controllers/description_toggle_controller.js';
+import InfiniteScrollController from './controllers/infinite_scroll_controller.js';
 import ModalFormTargetController from './controllers/modal_form_target_controller.js';
 import ParticipantsTableController from './controllers/activity/participants-table_controller.ts';
 import PrintController from './controllers/print_controller.js';
 
 const app = startStimulusApp();
+app.register('activity-item', ActivityItemController);
+app.register('description-toggle', DescriptionToggleController);
+app.register('infinite-scroll', InfiniteScrollController);
 app.register('modal-form-target', ModalFormTargetController);
 app.register('participants-table', ParticipantsTableController);
 app.register('print', PrintController);

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -51,6 +51,7 @@ $enable-negative-margins: true;
 
 // Custom styling
 // Components
+@import 'components/activity';
 @import 'components/balloons';
 @import 'components/breadcrumb';
 @import 'components/buttons';

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -27,6 +27,7 @@ $enable-negative-margins: true;
 @import '../../vendor/twbs/bootstrap/scss/alert';
 @import '../../vendor/twbs/bootstrap/scss/badge';
 @import '../../vendor/twbs/bootstrap/scss/buttons';
+@import '../../vendor/twbs/bootstrap/scss/button-group';
 @import '../../vendor/twbs/bootstrap/scss/breadcrumb';
 @import '../../vendor/twbs/bootstrap/scss/close';
 @import '../../vendor/twbs/bootstrap/scss/containers';

--- a/assets/styles/components/_activity.scss
+++ b/assets/styles/components/_activity.scss
@@ -3,6 +3,16 @@
     cursor: pointer;
 }
 
+// Sign-up list accordion on the activity view page: rotate the chevron when its section is expanded.
+.signup-list-chevron {
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+}
+
+.signup-list-heading:not(.collapsed) .signup-list-chevron {
+    transform: rotate(180deg);
+}
+
 // Clamp the (rendered Markdown) activity description on overview pages until the user expands it.
 .activity-description-content {
     display: -webkit-box;

--- a/assets/styles/components/_activity.scss
+++ b/assets/styles/components/_activity.scss
@@ -1,0 +1,24 @@
+// The whole activity list item is clickable (see activity_item_controller.js).
+.activity-list-item {
+    cursor: pointer;
+}
+
+// Clamp the (rendered Markdown) activity description on overview pages until the user expands it.
+.activity-description-content {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+
+    &.expanded {
+        display: block;
+        overflow: visible;
+        -webkit-line-clamp: none;
+        line-clamp: none;
+    }
+
+    > :last-child {
+        margin-bottom: 0;
+    }
+}

--- a/assets/styles/components/_badge.scss
+++ b/assets/styles/components/_badge.scss
@@ -1,9 +1,5 @@
-// Colour variants — generated from $theme-colors using the same CSS custom
-// properties the alert component uses (`--bs-{state}-bg-subtle`,
-// `--bs-{state}-text-emphasis`, `--bs-{state}-border-subtle`). Because those
-// tokens are redefined under `color-mode(gewis-night, true)` in `_root.scss`,
-// these badges automatically swap colour in dark mode — no extra
-// `color-mode()` block needed here.
+// Badges are like alerts, they use the same CSS custom properties (`--bs-{state}-bg-subtle`,
+// `--bs-{state}-text-emphasis`, `--bs-{state}-border-subtle`).
 @each $state, $value in $theme-colors {
     .badge-#{$state} {
         --#{$prefix}badge-color: var(--#{$prefix}#{$state}-text-emphasis);
@@ -13,14 +9,22 @@
     }
 }
 
-// Outlined: transparent fill, coloured border + text from the paired
-// `.badge-{state}` variant. Use as `class="badge badge-secondary badge-outlined"`.
+// Neutral badge variant. Built from the surface colours instead of the state colours, so it is subtle in both
+// `gewis-day` and `gewis-night`.
+.badge-tag {
+    --#{$prefix}badge-color: var(--#{$prefix}body-color);
+    background-color: var(--#{$prefix}secondary-bg);
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style)
+            var(--#{$prefix}border-color);
+}
+
+// Outlined: transparent fill, coloured border + text from the paired `.badge-{state}` variant. Use as
+// `class="badge badge-secondary badge-outlined"`.
 .badge-outlined {
     background-color: transparent;
 }
 
-// Selectable: hidden input + label.badge pattern, mirroring Bootstrap's
-// `btn-check`. CSS-only — no JS needed.
+// Selectable: hidden input + label.badge pattern, mirroring Bootstrap's `btn-check`.
 //
 // Usage:
 //   <input type="checkbox" class="badge-check" id="tag-1" autocomplete="off">
@@ -43,26 +47,4 @@
 label.badge {
     cursor: pointer;
     user-select: none;
-}
-
-// Dismissible: layout modifier that makes room for an inner `.btn-close`.
-// The actual removal behaviour is left to the consumer — most use cases want
-// to update state (filter / form / etc.) rather than just hide the DOM node.
-//
-// Usage:
-//   <span class="badge badge-info badge-dismissible">
-//     Filter
-//     <button type="button" class="btn-close" aria-label="Close"></button>
-//   </span>
-.badge-dismissible {
-    padding-inline-end: 1.75rem;
-    position: relative;
-
-    .btn-close {
-        position: absolute;
-        inset-block-start: 0;
-        inset-inline-end: 0;
-        padding: 0.5em 0.625em;
-        font-size: 0.5em;
-    }
 }

--- a/assets/styles/components/_panel.scss
+++ b/assets/styles/components/_panel.scss
@@ -37,10 +37,6 @@
             &:first-child {
                 padding-top: 0;
             }
-
-            &:last-child {
-                padding-bottom: 0;
-            }
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "symfony/string": "8.0.*",
         "symfony/translation": "8.0.*",
         "symfony/twig-bundle": "8.0.*",
+        "symfony/ux-calendar-link": "3.x-dev",
         "symfony/ux-live-component": "^3.0.0",
         "symfony/validator": "8.0.*",
         "symfony/web-link": "8.0.*",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "dragonmantank/cron-expression": "^3.6",
         "endroid/qr-code-bundle": "^7.0.1",
         "fortawesome/font-awesome": "^7.2.0",
+        "league/commonmark": "^2.8",
         "matomo/device-detector": "^6.5.1",
         "nelmio/cors-bundle": "^2.6.1",
         "nelmio/security-bundle": "^3.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d034d7728c1794251310ecb434252c23",
+    "content-hash": "85a9c1d0d458053a3261ec86080c26a9",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -1537,6 +1537,81 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
+            "name": "dflydev/dot-access-data",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dflydev\\DotAccessData\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "support": {
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
+            },
+            "time": "2024-07-08T12:26:09+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -3210,6 +3285,195 @@
             "time": "2025-10-17T11:30:53+00:00"
         },
         {
+            "name": "league/commonmark",
+            "version": "2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/commonmark.git",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "league/config": "^1.1.1",
+                "php": "^7.4 || ^8.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "require-dev": {
+                "cebe/markdown": "^1.0",
+                "commonmark/cmark": "0.31.1",
+                "commonmark/commonmark.js": "0.31.1",
+                "composer/package-versions-deprecated": "^1.8",
+                "embed/embed": "^4.4",
+                "erusev/parsedown": "^1.0",
+                "ext-json": "*",
+                "github/gfm": "0.29.0",
+                "michelf/php-markdown": "^1.4 || ^2.0",
+                "nyholm/psr7": "^1.5",
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "scrutinizer/ocular": "^1.8.1",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
+                "unleashedtech/php-coding-standard": "^3.1.1",
+                "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
+            },
+            "suggest": {
+                "symfony/yaml": "v2.3+ required if using the Front Matter extension"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\CommonMark\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and GitHub-Flavored Markdown (GFM)",
+            "homepage": "https://commonmark.thephpleague.com",
+            "keywords": [
+                "commonmark",
+                "flavored",
+                "gfm",
+                "github",
+                "github-flavored",
+                "markdown",
+                "md",
+                "parser"
+            ],
+            "support": {
+                "docs": "https://commonmark.thephpleague.com/",
+                "forum": "https://github.com/thephpleague/commonmark/discussions",
+                "issues": "https://github.com/thephpleague/commonmark/issues",
+                "rss": "https://github.com/thephpleague/commonmark/releases.atom",
+                "source": "https://github.com/thephpleague/commonmark"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/commonmark",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-19T13:16:38+00:00"
+        },
+        {
+            "name": "league/config",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/config.git",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^3.0.1",
+                "nette/schema": "^1.2",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Define configuration arrays with strict schemas and access values with dot notation",
+            "homepage": "https://config.thephpleague.com",
+            "keywords": [
+                "array",
+                "config",
+                "configuration",
+                "dot",
+                "dot-access",
+                "nested",
+                "schema"
+            ],
+            "support": {
+                "docs": "https://config.thephpleague.com/",
+                "issues": "https://github.com/thephpleague/config/issues",
+                "rss": "https://github.com/thephpleague/config/releases.atom",
+                "source": "https://github.com/thephpleague/config"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
             "name": "matomo/device-detector",
             "version": "6.5.1",
             "source": {
@@ -3573,6 +3837,164 @@
                 "source": "https://github.com/nelmio/NelmioSecurityBundle/tree/v3.9.0"
             },
             "time": "2026-02-23T10:58:33+00:00"
+        },
+        {
+            "name": "nette/schema",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/schema.git",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^4.0",
+                "php": "8.1 - 8.5"
+            },
+            "require-dev": {
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
+                "tracy/tracy": "^2.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/schema/issues",
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
+            },
+            "time": "2026-02-23T03:47:12+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.2 - 8.5"
+            },
+            "conflict": {
+                "nette/finder": "<3",
+                "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.5",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
+                "tracy/tracy": "^2.9"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
+            },
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85a9c1d0d458053a3261ec86080c26a9",
+    "content-hash": "6fe5672eead65c4ea5551a51cbd02132",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -11063,6 +11063,93 @@
             "time": "2026-04-30T16:10:06+00:00"
         },
         {
+            "name": "symfony/ux-calendar-link",
+            "version": "3.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/ux-calendar-link.git",
+                "reference": "6a56e575c4f35730144626dca8a1a2efb61184b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/ux-calendar-link/zipball/6a56e575c4f35730144626dca8a1a2efb61184b8",
+                "reference": "6a56e575c4f35730144626dca8a1a2efb61184b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/twig-bundle": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0"
+            },
+            "conflict": {
+                "symfony/flex": "<1.13"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.1|^12.0"
+            },
+            "default-branch": true,
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/ux",
+                    "name": "symfony/ux"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\CalendarLink\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Imad ZAIRIG",
+                    "email": "imadzairig@gmail.com"
+                },
+                {
+                    "name": "Hugo Alliaume",
+                    "email": "hugo@alliau.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generates 'Add to calendar' links for Google, Outlook, Office 365 and iCalendar (.ics) in Twig templates.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "calendar",
+                "ics",
+                "symfony-ux"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/ux-calendar-link/tree/3.x"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-22T05:04:55+00:00"
+        },
+        {
             "name": "symfony/ux-live-component",
             "version": "v3.0.0",
             "source": {
@@ -17798,7 +17885,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "symfony/ux-calendar-link": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,64 +1,29 @@
 <?php
 
-declare(strict_types=1);
-
-use Ambta\DoctrineEncryptBundle\AmbtaDoctrineEncryptBundle;
-use ApiPlatform\Symfony\Bundle\ApiPlatformBundle;
-use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
-use Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle;
-use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
-use Endroid\QrCodeBundle\EndroidQrCodeBundle;
-use IgorPhp\IgorBundle\IgorPhpBundle;
-use Nelmio\CorsBundle\NelmioCorsBundle;
-use Nelmio\SecurityBundle\NelmioSecurityBundle;
-use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
-use Sensiolabs\TypeScriptBundle\SensiolabsTypeScriptBundle;
-use Symfony\Bundle\DebugBundle\DebugBundle;
-use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
-use Symfony\Bundle\MakerBundle\MakerBundle;
-use Symfony\Bundle\MercureBundle\MercureBundle;
-use Symfony\Bundle\MonologBundle\MonologBundle;
-use Symfony\Bundle\SecurityBundle\SecurityBundle;
-use Symfony\Bundle\TwigBundle\TwigBundle;
-use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
-use Symfony\UX\LiveComponent\LiveComponentBundle;
-use Symfony\UX\StimulusBundle\StimulusBundle;
-use Symfony\UX\TwigComponent\TwigComponentBundle;
-use Symfonycasts\SassBundle\SymfonycastsSassBundle;
-use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
-
 return [
-    FrameworkBundle::class => ['all' => true],
-    DoctrineBundle::class => ['all' => true],
-    DoctrineMigrationsBundle::class => ['all' => true],
-    DebugBundle::class => ['dev' => true],
-    TwigBundle::class => ['all' => true],
-    WebProfilerBundle::class => [
-        'dev' => true,
-        'test' => true,
-    ],
-    TwigExtraBundle::class => ['all' => true],
-    SecurityBundle::class => ['all' => true],
-    MonologBundle::class => ['all' => true],
-    MakerBundle::class => ['dev' => true],
-    SymfonycastsSassBundle::class => ['all' => true],
-    NelmioCorsBundle::class => ['all' => true],
-    ApiPlatformBundle::class => ['all' => true],
-    DoctrineFixturesBundle::class => [
-        'dev' => true,
-        'test' => true,
-    ],
-    MercureBundle::class => ['all' => true],
-    NelmioSecurityBundle::class => ['all' => true],
-    StimulusBundle::class => ['all' => true],
-    TwigComponentBundle::class => ['all' => true],
-    LiveComponentBundle::class => ['all' => true],
-    SensiolabsTypeScriptBundle::class => ['all' => true],
-    IgorPhpBundle::class => [
-        'dev' => true,
-        'test' => true,
-    ],
-    SchebTwoFactorBundle::class => ['all' => true],
-    EndroidQrCodeBundle::class => ['all' => true],
-    AmbtaDoctrineEncryptBundle::class => ['all' => true],
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
+    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
+    Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
+    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
+    Symfonycasts\SassBundle\SymfonycastsSassBundle::class => ['all' => true],
+    Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
+    ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+    Symfony\Bundle\MercureBundle\MercureBundle::class => ['all' => true],
+    Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
+    Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
+    Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
+    Symfony\UX\LiveComponent\LiveComponentBundle::class => ['all' => true],
+    Sensiolabs\TypeScriptBundle\SensiolabsTypeScriptBundle::class => ['all' => true],
+    IgorPhp\IgorBundle\IgorPhpBundle::class => ['dev' => true, 'test' => true],
+    Scheb\TwoFactorBundle\SchebTwoFactorBundle::class => ['all' => true],
+    Endroid\QrCodeBundle\EndroidQrCodeBundle::class => ['all' => true],
+    Ambta\DoctrineEncryptBundle\AmbtaDoctrineEncryptBundle::class => ['all' => true],
+    Symfony\UX\CalendarLink\UXCalendarLinkBundle::class => ['all' => true],
 ];

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,29 +1,66 @@
 <?php
 
+declare(strict_types=1);
+
+use Ambta\DoctrineEncryptBundle\AmbtaDoctrineEncryptBundle;
+use ApiPlatform\Symfony\Bundle\ApiPlatformBundle;
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle;
+use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
+use Endroid\QrCodeBundle\EndroidQrCodeBundle;
+use IgorPhp\IgorBundle\IgorPhpBundle;
+use Nelmio\CorsBundle\NelmioCorsBundle;
+use Nelmio\SecurityBundle\NelmioSecurityBundle;
+use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
+use Sensiolabs\TypeScriptBundle\SensiolabsTypeScriptBundle;
+use Symfony\Bundle\DebugBundle\DebugBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MakerBundle\MakerBundle;
+use Symfony\Bundle\MercureBundle\MercureBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
+use Symfony\UX\CalendarLink\UXCalendarLinkBundle;
+use Symfony\UX\LiveComponent\LiveComponentBundle;
+use Symfony\UX\StimulusBundle\StimulusBundle;
+use Symfony\UX\TwigComponent\TwigComponentBundle;
+use Symfonycasts\SassBundle\SymfonycastsSassBundle;
+use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
+
 return [
-    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
-    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
-    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
-    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
-    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
-    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
-    Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
-    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
-    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
-    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
-    Symfonycasts\SassBundle\SymfonycastsSassBundle::class => ['all' => true],
-    Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
-    ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
-    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
-    Symfony\Bundle\MercureBundle\MercureBundle::class => ['all' => true],
-    Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
-    Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
-    Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
-    Symfony\UX\LiveComponent\LiveComponentBundle::class => ['all' => true],
-    Sensiolabs\TypeScriptBundle\SensiolabsTypeScriptBundle::class => ['all' => true],
-    IgorPhp\IgorBundle\IgorPhpBundle::class => ['dev' => true, 'test' => true],
-    Scheb\TwoFactorBundle\SchebTwoFactorBundle::class => ['all' => true],
-    Endroid\QrCodeBundle\EndroidQrCodeBundle::class => ['all' => true],
-    Ambta\DoctrineEncryptBundle\AmbtaDoctrineEncryptBundle::class => ['all' => true],
-    Symfony\UX\CalendarLink\UXCalendarLinkBundle::class => ['all' => true],
+    FrameworkBundle::class => ['all' => true],
+    DoctrineBundle::class => ['all' => true],
+    DoctrineMigrationsBundle::class => ['all' => true],
+    DebugBundle::class => ['dev' => true],
+    TwigBundle::class => ['all' => true],
+    WebProfilerBundle::class => [
+        'dev' => true,
+        'test' => true,
+    ],
+    TwigExtraBundle::class => ['all' => true],
+    SecurityBundle::class => ['all' => true],
+    MonologBundle::class => ['all' => true],
+    MakerBundle::class => ['dev' => true],
+    SymfonycastsSassBundle::class => ['all' => true],
+    NelmioCorsBundle::class => ['all' => true],
+    ApiPlatformBundle::class => ['all' => true],
+    DoctrineFixturesBundle::class => [
+        'dev' => true,
+        'test' => true,
+    ],
+    MercureBundle::class => ['all' => true],
+    NelmioSecurityBundle::class => ['all' => true],
+    StimulusBundle::class => ['all' => true],
+    TwigComponentBundle::class => ['all' => true],
+    LiveComponentBundle::class => ['all' => true],
+    SensiolabsTypeScriptBundle::class => ['all' => true],
+    IgorPhpBundle::class => [
+        'dev' => true,
+        'test' => true,
+    ],
+    SchebTwoFactorBundle::class => ['all' => true],
+    EndroidQrCodeBundle::class => ['all' => true],
+    AmbtaDoctrineEncryptBundle::class => ['all' => true],
+    UXCalendarLinkBundle::class => ['all' => true],
 ];

--- a/config/reference.php
+++ b/config/reference.php
@@ -1808,8 +1808,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/src/CommonMark/NoImage/NoImageExtension.php
+++ b/src/CommonMark/NoImage/NoImageExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CommonMark\NoImage;
+
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
+use League\CommonMark\Extension\ExtensionInterface;
+use Override;
+
+/**
+ * Renders Markdown images as their literal source text instead of `<img>` tags, so user-authored content cannot embed
+ * arbitrary remote images.
+ */
+class NoImageExtension implements ExtensionInterface
+{
+    #[Override]
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $environment->addRenderer(
+            Image::class,
+            new NoImageRenderer(),
+            10,
+        );
+    }
+}

--- a/src/CommonMark/NoImage/NoImageRenderer.php
+++ b/src/CommonMark/NoImage/NoImageRenderer.php
@@ -8,6 +8,7 @@ use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\Xml;
 use Override;
 
 use function sprintf;
@@ -24,10 +25,12 @@ class NoImageRenderer implements NodeRendererInterface
         // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable
         /** @var Image $node */
 
+        // Escape the title and URL: this renderer writes them straight into the HTML output, so unescaped
+        // metacharacters would otherwise allow HTML injection (the view page renders the full, un-stripped result).
         return sprintf(
             '![%s](%s)',
-            $node->getTitle() ?? '',
-            $node->getUrl(),
+            Xml::escape($node->getTitle() ?? ''),
+            Xml::escape($node->getUrl()),
         );
     }
 }

--- a/src/CommonMark/NoImage/NoImageRenderer.php
+++ b/src/CommonMark/NoImage/NoImageRenderer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CommonMark\NoImage;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use Override;
+
+use function sprintf;
+
+class NoImageRenderer implements NodeRendererInterface
+{
+    #[Override]
+    public function render(
+        Node $node,
+        ChildNodeRendererInterface $childRenderer,
+    ): string {
+        Image::assertInstanceOf($node);
+
+        // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable
+        /** @var Image $node */
+
+        return sprintf(
+            '![%s](%s)',
+            $node->getTitle() ?? '',
+            $node->getUrl(),
+        );
+    }
+}

--- a/src/Controller/Activity/ActivityController.php
+++ b/src/Controller/Activity/ActivityController.php
@@ -11,6 +11,7 @@ use App\Entity\User\Enums\UserRoles;
 use App\Entity\User\User;
 use App\Repository\Activity\ActivityRepository;
 use App\View\Activity\SignupListView;
+use DateTime;
 use Locale;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,6 +20,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\UX\CalendarLink\CalendarEvent;
+
+use function range;
 
 #[Route(
     path: '/activities',
@@ -32,24 +35,38 @@ class ActivityController extends AbstractController
     ) {
     }
 
+    /**
+     * The association years (first calendar year) that have activities, newest first, for the archive year switcher.
+     *
+     * @return int[]
+     */
+    private function archiveYears(): array
+    {
+        $oldest = $this->activityRepository->getOldestActivity();
+        if (null === $oldest) {
+            return [];
+        }
+
+        $oldestYear = AssociationYear::fromDate($oldest->getBeginTime())->getYear();
+        $currentYear = AssociationYear::fromDate(new DateTime())->getYear();
+
+        if ($currentYear < $oldestYear) {
+            return [];
+        }
+
+        return range(
+            $currentYear,
+            $oldestYear,
+        );
+    }
+
     #[Route(
         path: '',
         name: 'index',
     )]
-    #[Route(
-        path: '/{category}',
-        name: 'category',
-        requirements: ['category' => '[a-z][0-9a-z\_\-]{2,31}'],
-        defaults: ['category' => null],
-        // Lower priority so static routes such as `/my` are not captured by this catch-all single-segment route.
-        priority: -10,
-    )]
-    public function index(?string $category = null): Response
+    public function index(): Response
     {
-        return $this->render(
-            'activity/index.html.twig',
-            ['initialCategory' => $category],
-        );
+        return $this->render('activity/index.html.twig');
     }
 
     #[Route(
@@ -70,20 +87,11 @@ class ActivityController extends AbstractController
     )]
     public function archive(?int $year = null): Response
     {
-        $yearStart = null;
-        $yearEnd = null;
-
-        if (null !== $year) {
-            $associationYear = AssociationYear::fromYear($year);
-            $yearStart = $associationYear->getStartDate()->format('Y-m-d');
-            $yearEnd = $associationYear->getEndDate()->format('Y-m-d');
-        }
-
         return $this->render(
             'activity/archive.html.twig',
             [
-                'yearStart' => $yearStart,
-                'yearEnd' => $yearEnd,
+                'year' => $year,
+                'years' => $this->archiveYears(),
             ],
         );
     }

--- a/src/Controller/Activity/ActivityController.php
+++ b/src/Controller/Activity/ActivityController.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Controller\Activity;
 
+use App\Entity\Decision\AssociationYear;
+use App\Entity\User\Enums\UserRoles;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(
     path: '/activities',
@@ -23,16 +26,22 @@ class ActivityController extends AbstractController
         name: 'category',
         requirements: ['category' => '[a-z][0-9a-z\_\-]{2,31}'],
         defaults: ['category' => null],
+        // Lower priority so static routes such as `/my` are not captured by this catch-all single-segment route.
+        priority: -10,
     )]
     public function index(?string $category = null): Response
     {
-        return $this->render('activity/index.html.twig');
+        return $this->render(
+            'activity/index.html.twig',
+            ['initialCategory' => $category],
+        );
     }
 
     #[Route(
         path: '/my',
         name: 'my',
     )]
+    #[IsGranted(UserRoles::User->value)]
     public function my(): Response
     {
         return $this->render('activity/my.html.twig');
@@ -46,7 +55,32 @@ class ActivityController extends AbstractController
     )]
     public function archive(?int $year = null): Response
     {
-        return $this->render('activity/archive.html.twig');
+        $yearStart = null;
+        $yearEnd = null;
+
+        if (null !== $year) {
+            $associationYear = AssociationYear::fromYear($year);
+            $yearStart = $associationYear->getStartDate()->format('Y-m-d');
+            $yearEnd = $associationYear->getEndDate()->format('Y-m-d');
+        }
+
+        return $this->render(
+            'activity/archive.html.twig',
+            [
+                'yearStart' => $yearStart,
+                'yearEnd' => $yearEnd,
+            ],
+        );
+    }
+
+    #[Route(
+        path: '/archive/my',
+        name: 'archive/my',
+    )]
+    #[IsGranted(UserRoles::User->value)]
+    public function myArchive(): Response
+    {
+        return $this->render('activity/archive-my.html.twig');
     }
 
     #[Route(

--- a/src/Controller/Activity/ActivityController.php
+++ b/src/Controller/Activity/ActivityController.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace App\Controller\Activity;
 
+use App\Entity\Activity\Activity;
+use App\Entity\Application\Enums\Languages;
 use App\Entity\Decision\AssociationYear;
 use App\Entity\User\Enums\UserRoles;
+use App\Entity\User\User;
+use App\Repository\Activity\ActivityRepository;
+use App\View\Activity\SignupListView;
+use Locale;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\UX\CalendarLink\CalendarEvent;
 
 #[Route(
     path: '/activities',
@@ -17,6 +26,12 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 )]
 class ActivityController extends AbstractController
 {
+    public function __construct(
+        private readonly ActivityRepository $activityRepository,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
     #[Route(
         path: '',
         name: 'index',
@@ -90,6 +105,53 @@ class ActivityController extends AbstractController
     )]
     public function view(int $activity): Response
     {
-        return $this->render('activity/view.html.twig');
+        $entity = $this->activityRepository->find($activity);
+        if (
+            null === $entity
+            || Activity::STATUS_APPROVED !== $entity->getStatus()
+        ) {
+            throw $this->createNotFoundException();
+        }
+
+        $canViewDetails = $this->isGranted(UserRoles::User->value);
+        $user = $this->getUser();
+        $viewerLidnr = $user instanceof User
+            ? $user->getMember()->getLidnr()
+            : null;
+
+        $signupListViews = [];
+        foreach ($entity->getSignupLists() as $signupList) {
+            $signupListViews[] = SignupListView::fromSignupList(
+                $signupList,
+                $canViewDetails,
+                $viewerLidnr,
+                $this->translator,
+            );
+        }
+
+        $language = 'nl' === Locale::getDefault()
+            ? Languages::Dutch
+            : Languages::English;
+
+        $calendarEvent = new CalendarEvent(
+            title: $entity->getName()->getText($language) ?? '',
+            start: $entity->getBeginTime(),
+            end: $entity->getEndTime(),
+            location: $entity->getLocation()->getText($language),
+            url: $this->generateUrl(
+                'activity/view',
+                ['activity' => $entity->getId()],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            ),
+        );
+
+        return $this->render(
+            'activity/view.html.twig',
+            [
+                'activity' => $entity,
+                'signupListViews' => $signupListViews,
+                'calendarEvent' => $calendarEvent,
+            ],
+        );
     }
 }

--- a/src/Controller/Activity/ActivityController.php
+++ b/src/Controller/Activity/ActivityController.php
@@ -6,22 +6,19 @@ namespace App\Controller\Activity;
 
 use App\Entity\Activity\Activity;
 use App\Entity\Application\Enums\Languages;
-use App\Entity\Decision\AssociationYear;
 use App\Entity\User\Enums\UserRoles;
 use App\Entity\User\User;
 use App\Repository\Activity\ActivityRepository;
 use App\View\Activity\SignupListView;
-use DateTime;
 use Locale;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\UX\CalendarLink\CalendarEvent;
-
-use function range;
 
 #[Route(
     path: '/activities',
@@ -33,31 +30,6 @@ class ActivityController extends AbstractController
         private readonly ActivityRepository $activityRepository,
         private readonly TranslatorInterface $translator,
     ) {
-    }
-
-    /**
-     * The association years (first calendar year) that have activities, newest first, for the archive year switcher.
-     *
-     * @return int[]
-     */
-    private function archiveYears(): array
-    {
-        $oldest = $this->activityRepository->getOldestActivity();
-        if (null === $oldest) {
-            return [];
-        }
-
-        $oldestYear = AssociationYear::fromDate($oldest->getBeginTime())->getYear();
-        $currentYear = AssociationYear::fromDate(new DateTime())->getYear();
-
-        if ($currentYear < $oldestYear) {
-            return [];
-        }
-
-        return range(
-            $currentYear,
-            $oldestYear,
-        );
     }
 
     #[Route(
@@ -91,19 +63,30 @@ class ActivityController extends AbstractController
             'activity/archive.html.twig',
             [
                 'year' => $year,
-                'years' => $this->archiveYears(),
+                'years' => $this->activityRepository->getApprovedActivityYears(),
             ],
         );
     }
 
     #[Route(
-        path: '/archive/my',
+        path: '/archive/my/{year}',
         name: 'archive/my',
+        requirements: ['year' => '\d{4}'],
+        defaults: ['year' => null],
     )]
     #[IsGranted(UserRoles::User->value)]
-    public function myArchive(): Response
-    {
-        return $this->render('activity/archive-my.html.twig');
+    public function myArchive(
+        #[CurrentUser]
+        User $user,
+        ?int $year = null,
+    ): Response {
+        return $this->render(
+            'activity/archive-my.html.twig',
+            [
+                'year' => $year,
+                'years' => $this->activityRepository->getSubscribedAssociationYears($user->getMember()),
+            ],
+        );
     }
 
     #[Route(

--- a/src/DataFixtures/Activity/ActivityFixture.php
+++ b/src/DataFixtures/Activity/ActivityFixture.php
@@ -10,6 +10,7 @@ use App\Entity\Activity\ActivityLabel;
 use App\Entity\Activity\ActivityLocalisedText;
 use App\Entity\Activity\Enums\ActivityCategories;
 use App\Entity\Activity\SignupList;
+use App\Entity\Activity\UserSignup;
 use App\Entity\Decision\Member;
 use DateTime;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -366,6 +367,12 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                         'onlyGEWIS' => true,
                         'displaySubscribedNumber' => true,
                         'limitedCapacity' => true,
+                        'subscribers' => [
+                            8005,
+                            8006,
+                            8007,
+                            8008,
+                        ],
                     ],
                 ],
             ],
@@ -580,6 +587,13 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 $signupList = $this->createSignupList($signupListData);
                 $activity->addSignupList($signupList);
                 $manager->persist($signupList);
+
+                foreach ($signupListData['subscribers'] ?? [] as $lidnr) {
+                    $signup = new UserSignup();
+                    $signup->setSignupList($signupList);
+                    $signup->setUser($this->getReference('member-' . $lidnr, Member::class));
+                    $manager->persist($signup);
+                }
             }
         }
 
@@ -597,6 +611,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
      *     limitedCapacity: bool,
      *     promoted?: bool,
      *     presenceTaken?: bool,
+     *     subscribers?: list<int>,
      * } $data
      */
     private function createSignupList(array $data): SignupList

--- a/src/DataFixtures/Activity/ActivityFixture.php
+++ b/src/DataFixtures/Activity/ActivityFixture.php
@@ -24,6 +24,78 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
     {
         // Ordered chronologically by begin time so the rows are inserted (and auto-incremented) in that order.
         $activities = [
+            // Past, two association years ago (AY 2023-2024) — appears under that heading in the archive and
+            // exercises the same-day, past-year date format.
+            [
+                'creator' => 8020,
+                'status' => Activity::STATUS_APPROVED,
+                'beginTime' => '2024-02-20 19:00',
+                'endTime' => '2024-02-20 22:00',
+                'category' => ActivityCategories::Cultural,
+                'requireGEFLITST' => false,
+                'requireZettle' => false,
+                'name' => [
+                    'en' => 'Museum Visit',
+                    'nl' => 'Museumbezoek',
+                ],
+                'location' => [
+                    'en' => 'Van Abbemuseum',
+                    'nl' => 'Van Abbemuseum',
+                ],
+                'costs' => [
+                    'en' => '5 euro',
+                    'nl' => '5 euro',
+                ],
+                'description' => [
+                    'en' => 'A guided evening tour of the modern art collection.',
+                    'nl' => 'Een rondleiding langs de moderne kunstcollectie.',
+                ],
+            ],
+            // Past, multi-day, in a previous calendar year (fixed dates) — exercises the multi-day + year date format.
+            [
+                'creator' => 8024,
+                'status' => Activity::STATUS_APPROVED,
+                'beginTime' => '2025-12-12 17:00',
+                'endTime' => '2025-12-14 12:00',
+                'category' => ActivityCategories::Weekend,
+                'requireGEFLITST' => false,
+                'requireZettle' => false,
+                'name' => [
+                    'en' => 'Winter Weekend',
+                    'nl' => 'Winterweekend',
+                ],
+                'location' => [
+                    'en' => 'Ardennes',
+                    'nl' => 'Ardennen',
+                ],
+                'costs' => [
+                    'en' => '75 euro',
+                    'nl' => '75 euro',
+                ],
+                'description' => [
+                    'en' => 'A three-day winter getaway in the Ardennes with hikes, board games, and plenty of '
+                        . '**hot chocolate**. Cabins are shared; transport is arranged together by carpool.',
+                    'nl' => 'Een driedaags winterweekend in de Ardennen met wandelingen, bordspellen en volop '
+                        . '**warme chocolademelk**. De huisjes worden gedeeld; vervoer regelen we samen via carpool.',
+                ],
+                'labels' => [
+                    ActivityLabelFixture::REFERENCE_DUTCH_ONLY,
+                ],
+                'signupLists' => [
+                    [
+                        'name' => [
+                            'en' => 'Attendance',
+                            'nl' => 'Aanwezigheid',
+                        ],
+                        'openDate' => '2025-11-01 12:00',
+                        'closeDate' => '2025-12-01 12:00',
+                        'onlyGEWIS' => true,
+                        'displaySubscribedNumber' => true,
+                        'limitedCapacity' => true,
+                        'presenceTaken' => true,
+                    ],
+                ],
+            ],
             // Past (already happened), approved, organised by a discharged member.
             [
                 'creator' => 8021,
@@ -46,8 +118,16 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                     'nl' => 'Gratis',
                 ],
                 'description' => [
-                    'en' => 'An evening of films and popcorn.',
-                    'nl' => 'Een avond vol films en popcorn.',
+                    'en' => "Grab a seat and a blanket for a cosy **movie night** at the association.\n\n"
+                        . 'We screen two films back to back, with a short break for free popcorn and drinks in '
+                        . "between. The theme changes every month and is decided by a poll among members.\n\n"
+                        . 'No sign-up needed for the second film — just show up. Expect the evening to run until '
+                        . 'well past midnight, so bring something comfortable to sit on.',
+                    'nl' => "Pak een stoel en een dekentje voor een gezellige **filmavond** bij de vereniging.\n\n"
+                        . 'We vertonen twee films achter elkaar, met een korte pauze voor gratis popcorn en drankjes '
+                        . "ertussen. Het thema wisselt elke maand en wordt bepaald via een poll onder leden.\n\n"
+                        . 'Voor de tweede film is geen aanmelding nodig — kom gewoon langs. De avond loopt door tot '
+                        . 'ruim na middernacht, dus neem iets comfortabels mee om op te zitten.',
                 ],
                 'labels' => [
                     ActivityLabelFixture::REFERENCE_DUTCH_ONLY,
@@ -113,6 +193,73 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                     ],
                 ],
             ],
+            // Ongoing right now (began earlier, ends later) — exercises the "ongoing for %duration%" note. A drop-in
+            // borrel has no sign-up: a sign-up list can never still be open once the activity has started.
+            [
+                'creator' => 8012,
+                'status' => Activity::STATUS_APPROVED,
+                'beginTime' => '-1 hour',
+                'endTime' => '+3 hours',
+                'category' => ActivityCategories::SocialDrink,
+                'requireGEFLITST' => false,
+                'requireZettle' => false,
+                'name' => [
+                    'en' => 'Open Borrel',
+                    'nl' => 'Open Borrel',
+                ],
+                'location' => [
+                    'en' => 'Association Room',
+                    'nl' => 'Verenigingskamer',
+                ],
+                'costs' => [
+                    'en' => 'Free',
+                    'nl' => 'Gratis',
+                ],
+                'description' => [
+                    'en' => 'Drop by the association room for a drink — we are open right now.',
+                    'nl' => 'Kom langs in de verenigingskamer voor een drankje — we zijn nu open.',
+                ],
+            ],
+            // Upcoming, with a sign-up that closes within a day — exercises the imminent-deadline colour (text-danger)
+            // on an activity that has not started yet, so its sign-up can legitimately still be open.
+            [
+                'creator' => 8013,
+                'status' => Activity::STATUS_APPROVED,
+                'beginTime' => '+2 days 20:00',
+                'endTime' => '+2 days 23:00',
+                'category' => ActivityCategories::Recreational,
+                'requireGEFLITST' => false,
+                'requireZettle' => false,
+                'name' => [
+                    'en' => 'Pub Quiz',
+                    'nl' => 'Pubquiz',
+                ],
+                'location' => [
+                    'en' => 'Common Room',
+                    'nl' => 'Huiskamer',
+                ],
+                'costs' => [
+                    'en' => '2 euro',
+                    'nl' => '2 euro',
+                ],
+                'description' => [
+                    'en' => 'Test your trivia knowledge in teams. Sign up soon — registration closes within a day!',
+                    'nl' => 'Test je kennis in teams. Schrijf je snel in — de inschrijving sluit binnen een dag!',
+                ],
+                'signupLists' => [
+                    [
+                        'name' => [
+                            'en' => 'Teams',
+                            'nl' => 'Teams',
+                        ],
+                        'openDate' => '-2 days 12:00',
+                        'closeDate' => '+12 hours',
+                        'onlyGEWIS' => true,
+                        'displaySubscribedNumber' => true,
+                        'limitedCapacity' => true,
+                    ],
+                ],
+            ],
             // Upcoming, approved, organised by a board member.
             [
                 'creator' => 8025,
@@ -137,6 +284,19 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 'description' => [
                     'en' => 'Join us for the monthly drink.',
                     'nl' => 'Kom langs op de maandelijkse borrel.',
+                ],
+                'signupLists' => [
+                    [
+                        'name' => [
+                            'en' => 'Attendance',
+                            'nl' => 'Aanwezigheid',
+                        ],
+                        'openDate' => '-2 days 12:00',
+                        'closeDate' => '+4 days 18:00',
+                        'onlyGEWIS' => true,
+                        'displaySubscribedNumber' => true,
+                        'limitedCapacity' => false,
+                    ],
                 ],
             ],
             // Upcoming, awaiting approval, organised by an active (external) member.
@@ -231,8 +391,26 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                     'nl' => 'Gratis',
                 ],
                 'description' => [
-                    'en' => 'A day full of talks, followed by dinner.',
-                    'nl' => 'Een dag vol lezingen, gevolgd door een diner.',
+                    'en' => "## Programme\n\n"
+                        . 'The annual **GEWIS Symposium** brings together students, alumni, and companies for a full '
+                        . "day of talks on the latest in computer science and mathematics.\n\n"
+                        . "The day is split into several tracks:\n\n"
+                        . "- Morning keynotes by leading researchers\n"
+                        . "- Hands-on afternoon workshops\n"
+                        . "- An evening dinner with drinks to close the day\n\n"
+                        . 'Whether you are a first-year or a seasoned PhD candidate, there is something for everyone. '
+                        . 'Doors open at 09:00; check the [programme booklet](https://gewis.nl) for the full schedule '
+                        . 'and come prepared to learn something new.',
+                    'nl' => "## Programma\n\n"
+                        . 'Het jaarlijkse **GEWIS Symposium** brengt studenten, alumni en bedrijven samen voor een dag '
+                        . "vol lezingen over de nieuwste ontwikkelingen in informatica en wiskunde.\n\n"
+                        . "De dag bestaat uit verschillende tracks:\n\n"
+                        . "- Ochtendkeynotes door vooraanstaande onderzoekers\n"
+                        . "- Praktische workshops in de middag\n"
+                        . "- Een diner met borrel als afsluiting\n\n"
+                        . 'Of je nu eerstejaars of een ervaren promovendus bent, er is voor ieder wat wils. '
+                        . 'De deuren openen om 09:00; bekijk het [programmaboekje](https://gewis.nl) voor het '
+                        . 'volledige schema en kom klaar om iets nieuws te leren.',
                 ],
                 'labels' => [
                     ActivityLabelFixture::REFERENCE_MASTER,
@@ -288,8 +466,24 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                     'nl' => 'Gratis',
                 ],
                 'description' => [
-                    'en' => 'Meet companies and explore your future career.',
-                    'nl' => 'Ontmoet bedrijven en verken je toekomstige carrière.',
+                    'en' => "Curious about life **after** your studies? The Career Day is the place to be.\n\n"
+                        . 'Dozens of companies — from fast-growing start-ups to established multinationals — will be '
+                        . "present to tell you about internships, graduation projects, and full-time positions.\n\n"
+                        . "What to expect:\n\n"
+                        . "- One-on-one chats at company stands\n"
+                        . "- Short company pitches throughout the day\n"
+                        . "- Free lunch and an informal closing drink\n\n"
+                        . 'Bring a few copies of your CV and dress to impress. Pre-registration is appreciated but '
+                        . 'walk-ins are always welcome.',
+                    'nl' => "Benieuwd naar het leven **na** je studie? Dan is de Carrièredag dé plek om te zijn.\n\n"
+                        . 'Tientallen bedrijven — van snelgroeiende start-ups tot gevestigde multinationals — zijn '
+                        . "aanwezig om te vertellen over stages, afstudeerprojecten en vaste banen.\n\n"
+                        . "Wat je kunt verwachten:\n\n"
+                        . "- Persoonlijke gesprekken bij bedrijfsstands\n"
+                        . "- Korte bedrijfspitches gedurende de dag\n"
+                        . "- Gratis lunch en een informele afsluitende borrel\n\n"
+                        . 'Neem een paar exemplaren van je cv mee en kleed je netjes. Aanmelden vooraf wordt '
+                        . 'gewaardeerd, maar je bent ook zonder aanmelding van harte welkom.',
                 ],
                 'labels' => [
                     ActivityLabelFixture::REFERENCE_FIRST_YEAR,
@@ -307,6 +501,51 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                         'onlyGEWIS' => false,
                         'displaySubscribedNumber' => true,
                         'limitedCapacity' => false,
+                    ],
+                ],
+            ],
+            // Upcoming, multi-day (spans several days) — exercises the multi-day date format for future activities.
+            [
+                'creator' => 8027,
+                'status' => Activity::STATUS_APPROVED,
+                'beginTime' => '+7 weeks 09:00',
+                'endTime' => '+7 weeks +2 days 17:00',
+                'category' => ActivityCategories::Conference,
+                'requireGEFLITST' => true,
+                'requireZettle' => true,
+                'name' => [
+                    'en' => 'Study Conference',
+                    'nl' => 'Studiecongres',
+                ],
+                'location' => [
+                    'en' => 'Conference Centre',
+                    'nl' => 'Congrescentrum',
+                ],
+                'costs' => [
+                    'en' => '40 euro',
+                    'nl' => '40 euro',
+                ],
+                'description' => [
+                    'en' => 'A three-day conference packed with lectures, workshops, and excursions. Accommodation '
+                        . 'and most meals are included; have a look at the schedule before you sign up.',
+                    'nl' => 'Een driedaags congres vol lezingen, workshops en excursies. Overnachting en de meeste '
+                        . 'maaltijden zijn inbegrepen; bekijk het programma voordat je je inschrijft.',
+                ],
+                'labels' => [
+                    ActivityLabelFixture::REFERENCE_MASTER,
+                    ActivityLabelFixture::REFERENCE_PHD,
+                ],
+                'signupLists' => [
+                    [
+                        'name' => [
+                            'en' => 'Attendance',
+                            'nl' => 'Aanwezigheid',
+                        ],
+                        'openDate' => '-1 week 12:00',
+                        'closeDate' => '+5 weeks 12:00',
+                        'onlyGEWIS' => true,
+                        'displaySubscribedNumber' => true,
+                        'limitedCapacity' => true,
                     ],
                 ],
             ],

--- a/src/Entity/Activity/Activity.php
+++ b/src/Entity/Activity/Activity.php
@@ -401,6 +401,58 @@ class Activity
         return $this->signupLists;
     }
 
+    /**
+     * The next sign-up list whose deadline is relevant to surface on overviews (see GH-2082): among the lists that have
+     * not yet closed, the currently-open one closing soonest, otherwise the one opening soonest. Null when all closed.
+     */
+    public function getRelevantSignupList(): ?SignupList
+    {
+        $now = new DateTime('now');
+        $open = null;
+        $upcoming = null;
+
+        foreach ($this->signupLists as $signupList) {
+            if ($signupList->getCloseDate() <= $now) {
+                continue;
+            }
+
+            if ($signupList->getOpenDate() <= $now) {
+                if (
+                    null === $open
+                    || $signupList->getCloseDate() < $open->getCloseDate()
+                ) {
+                    $open = $signupList;
+                }
+            } elseif (
+                null === $upcoming
+                || $signupList->getOpenDate() < $upcoming->getOpenDate()
+            ) {
+                $upcoming = $signupList;
+            }
+        }
+
+        return $open ?? $upcoming;
+    }
+
+    /**
+     * The number of sign-up lists that have not yet closed, i.e. that still have a relevant deadline.
+     */
+    public function countPendingSignupLists(): int
+    {
+        $now = new DateTime('now');
+        $count = 0;
+
+        foreach ($this->signupLists as $signupList) {
+            if ($signupList->getCloseDate() <= $now) {
+                continue;
+            }
+
+            ++$count;
+        }
+
+        return $count;
+    }
+
     public function getName(): ActivityLocalisedText
     {
         return $this->name;

--- a/src/Entity/Activity/Enums/ActivityCategories.php
+++ b/src/Entity/Activity/Enums/ActivityCategories.php
@@ -8,6 +8,8 @@ use Override;
 use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+use function array_filter;
+
 /**
  * Enum for the (single, mandatory) category of an activity.
  */
@@ -36,6 +38,19 @@ enum ActivityCategories: string implements TranslatableInterface
 
     // Only ever assigned to legacy activities by a migration; it must never be selectable for new activities.
     case Uncategorised = 'uncategorised';
+
+    /**
+     * All cases except the migration-only {@see self::Uncategorised}, for category selection and filtering.
+     *
+     * @return self[]
+     */
+    public static function selectableCases(): array
+    {
+        return array_filter(
+            self::cases(),
+            static fn (self $case): bool => self::Uncategorised !== $case,
+        );
+    }
 
     #[Override]
     public function trans(

--- a/src/Repository/Activity/ActivityRepository.php
+++ b/src/Repository/Activity/ActivityRepository.php
@@ -601,13 +601,13 @@ class ActivityRepository extends ServiceEntityRepository
                     'sl_sub',
                 )
                 ->where('sl_sub.activity = a')
-                ->andWhere('su.user = :subscriber');
+                ->andWhere('IDENTITY(su.user) = :subscriber');
 
             $qb->andWhere($qb->expr()->exists($subscriberSubquery->getDQL()))
                 ->setParameter(
                     'subscriber',
-                    $subscribedBy,
-                    Member::class,
+                    $subscribedBy->getLidnr(),
+                    Types::INTEGER,
                 );
         }
 

--- a/src/Repository/Activity/ActivityRepository.php
+++ b/src/Repository/Activity/ActivityRepository.php
@@ -18,9 +18,13 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
+use function addcslashes;
 use function array_key_exists;
+use function array_map;
 use function array_merge;
 use function count;
+use function mb_strtolower;
+use function trim;
 use function usort;
 
 /**
@@ -435,6 +439,238 @@ class ActivityRepository extends ServiceEntityRepository
             );
 
         return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Flexible query backing the activity overview pages (upcoming/archive, public/subscribed) with searching and
+     * filtering. Only approved activities are ever returned. Correlated EXISTS sub-queries keep the result at one row
+     * per activity, so the Paginator counts correctly without a collection fetch-join.
+     *
+     * @param bool        $past         false: upcoming (endTime > now, ASC); true: past (endTime < now, DESC)
+     * @param Member|null $subscribedBy when set, only activities this member has a (user) signup for
+     * @param string      $locale       'nl' searches the Dutch name, anything else the English name
+     * @param int[]       $labelIds     match activities having ANY of these labels
+     * @param int|null    $organId      identifier of the organising organ to filter on
+     *
+     * @return Paginator<Activity>
+     */
+    public function findForOverview(
+        bool $past,
+        ?Member $subscribedBy,
+        string $search,
+        string $locale,
+        ?ActivityCategories $category,
+        array $labelIds,
+        ?int $organId,
+        bool $openSignupOnly,
+        ?DateTime $from,
+        ?DateTime $until,
+        int $limit,
+        int $offset,
+    ): Paginator {
+        $qb = $this->createQueryBuilder('a');
+        // Fetch-join the to-one localised texts so they are hydrated in this single query instead of one lazy
+        // `SELECT ... FROM ActivityLocalisedText WHERE id = ?` per field per activity (N+1). These are to-one, so they
+        // do not multiply rows and the paginator's LIMIT keeps working.
+        $qb->addSelect(
+            'n',
+            'loc',
+            'cost',
+            'descr',
+        )
+            ->join(
+                'a.name',
+                'n',
+            )
+            ->join(
+                'a.location',
+                'loc',
+            )
+            ->join(
+                'a.costs',
+                'cost',
+            )
+            ->join(
+                'a.description',
+                'descr',
+            )
+            ->where('a.status = :status')
+            ->setParameter(
+                'status',
+                Activity::STATUS_APPROVED,
+            )
+            ->setParameter(
+                'now',
+                new DateTime(),
+                Types::DATETIME_MUTABLE,
+            );
+
+        if ($past) {
+            $qb->andWhere('a.endTime < :now')
+                ->orderBy(
+                    'a.beginTime',
+                    'DESC',
+                );
+        } else {
+            $qb->andWhere('a.endTime > :now')
+                ->orderBy(
+                    'a.beginTime',
+                    'ASC',
+                );
+        }
+
+        $search = trim($search);
+        if ('' !== $search) {
+            $column = 'nl' === $locale
+                ? 'n.valueNL'
+                : 'n.valueEN';
+            // Escape the LIKE wildcards (`%` and `_`) in user input so they are matched literally instead of acting as
+            // wildcards (see DecisionRepository::search). $column is a fixed internal field name, never user input.
+            $qb->andWhere('LOWER(' . $column . ') LIKE :needle')
+                ->setParameter(
+                    'needle',
+                    '%' . addcslashes(
+                        mb_strtolower($search),
+                        '%_',
+                    ) . '%',
+                );
+        }
+
+        if (null !== $category) {
+            $qb->andWhere('a.category = :category')
+                ->setParameter(
+                    'category',
+                    $category->value,
+                );
+        }
+
+        if (null !== $organId) {
+            $qb->andWhere('IDENTITY(a.organ) = :organId')
+                ->setParameter(
+                    'organId',
+                    $organId,
+                );
+        }
+
+        $entityManager = $this->getEntityManager();
+
+        if ([] !== $labelIds) {
+            $labelSubquery = $entityManager->createQueryBuilder()
+                ->select('1')
+                ->from(
+                    Activity::class,
+                    'a_lbl',
+                )
+                ->join(
+                    'a_lbl.labels',
+                    'lbl',
+                )
+                ->where('a_lbl = a')
+                ->andWhere('lbl.id IN (:labelIds)');
+
+            $qb->andWhere($qb->expr()->exists($labelSubquery->getDQL()))
+                ->setParameter(
+                    'labelIds',
+                    $labelIds,
+                );
+        }
+
+        if ($openSignupOnly) {
+            $openSignupSubquery = $entityManager->createQueryBuilder()
+                ->select('1')
+                ->from(
+                    SignupList::class,
+                    'sl_open',
+                )
+                ->where('sl_open.activity = a')
+                ->andWhere('sl_open.openDate <= :now')
+                ->andWhere('sl_open.closeDate > :now');
+
+            $qb->andWhere($qb->expr()->exists($openSignupSubquery->getDQL()));
+        }
+
+        if (null !== $subscribedBy) {
+            $subscriberSubquery = $entityManager->createQueryBuilder()
+                ->select('1')
+                ->from(
+                    UserSignup::class,
+                    'su',
+                )
+                ->join(
+                    'su.signupList',
+                    'sl_sub',
+                )
+                ->where('sl_sub.activity = a')
+                ->andWhere('su.user = :subscriber');
+
+            $qb->andWhere($qb->expr()->exists($subscriberSubquery->getDQL()))
+                ->setParameter(
+                    'subscriber',
+                    $subscribedBy,
+                    Member::class,
+                );
+        }
+
+        if (null !== $from) {
+            $qb->andWhere('a.beginTime >= :from')
+                ->setParameter(
+                    'from',
+                    $from,
+                    Types::DATETIME_MUTABLE,
+                );
+        }
+
+        if (null !== $until) {
+            $qb->andWhere('a.beginTime <= :until')
+                ->setParameter(
+                    'until',
+                    $until,
+                    Types::DATETIME_MUTABLE,
+                );
+        }
+
+        $paginator = new Paginator(
+            $qb,
+            false,
+        );
+        $paginator->getQuery()
+            ->setFirstResult($offset)
+            ->setMaxResults($limit);
+
+        return $paginator;
+    }
+
+    /**
+     * Returns the distinct organs that organise at least one approved activity, for the overview's organ filter.
+     *
+     * @return Organ[]
+     */
+    public function findOrganisingOrgans(): array
+    {
+        $rows = $this->createQueryBuilder('a')
+            ->select('DISTINCT IDENTITY(a.organ) AS organId')
+            ->where('a.status = :status')
+            ->setParameter(
+                'status',
+                Activity::STATUS_APPROVED,
+            )
+            ->andWhere('a.organ IS NOT NULL')
+            ->getQuery()
+            ->getScalarResult();
+
+        $organIds = array_map(
+            static fn (array $row): int => (int) $row['organId'],
+            $rows,
+        );
+
+        if ([] === $organIds) {
+            return [];
+        }
+
+        return $this->getEntityManager()->getRepository(Organ::class)->findBy(
+            ['id' => $organIds],
+            ['abbr' => 'ASC'],
+        );
     }
 
     /**

--- a/src/Repository/Activity/ActivityRepository.php
+++ b/src/Repository/Activity/ActivityRepository.php
@@ -8,6 +8,7 @@ use App\Entity\Activity\Activity;
 use App\Entity\Activity\Enums\ActivityCategories;
 use App\Entity\Activity\SignupList;
 use App\Entity\Activity\UserSignup;
+use App\Entity\Decision\AssociationYear;
 use App\Entity\Decision\Member;
 use App\Entity\Decision\Organ;
 use DateTime;
@@ -20,10 +21,12 @@ use Doctrine\Persistence\ManagerRegistry;
 
 use function addcslashes;
 use function array_key_exists;
+use function array_keys;
 use function array_map;
 use function array_merge;
 use function count;
 use function mb_strtolower;
+use function rsort;
 use function trim;
 use function usort;
 
@@ -382,6 +385,100 @@ class ActivityRepository extends ServiceEntityRepository
             ->setMaxResults($limit);
 
         return $paginator;
+    }
+
+    /**
+     * The association years (first calendar year) that have at least one approved, past activity, newest first, for
+     * the activity archive year switcher.
+     *
+     * @return int[]
+     */
+    public function getApprovedActivityYears(): array
+    {
+        /** @var list<array{beginTime: DateTime}> $rows */
+        $rows = $this->createQueryBuilder('a')
+            ->select('a.beginTime')
+            ->where('a.status = :status')
+            ->andWhere('a.endTime < :now')
+            ->setParameter(
+                'status',
+                Activity::STATUS_APPROVED,
+            )
+            ->setParameter(
+                'now',
+                new DateTime(),
+                Types::DATETIME_MUTABLE,
+            )
+            ->getQuery()
+            ->getResult();
+
+        return $this->associationYears($rows);
+    }
+
+    /**
+     * The association years (first calendar year) in which the given member has at least one sign-up for an approved,
+     * past activity, newest first, for the "My past activities" year switcher.
+     *
+     * @return int[]
+     */
+    public function getSubscribedAssociationYears(Member $member): array
+    {
+        /** @var list<array{beginTime: DateTime}> $rows */
+        $rows = $this->getEntityManager()->createQueryBuilder()
+            ->select('a.beginTime')
+            ->from(
+                UserSignup::class,
+                'su',
+            )
+            ->join(
+                'su.signupList',
+                'sl',
+            )
+            ->join(
+                'sl.activity',
+                'a',
+            )
+            ->where('IDENTITY(su.user) = :subscriber')
+            ->andWhere('a.status = :status')
+            ->andWhere('a.endTime < :now')
+            ->setParameter(
+                'subscriber',
+                $member->getLidnr(),
+                Types::INTEGER,
+            )
+            ->setParameter(
+                'status',
+                Activity::STATUS_APPROVED,
+            )
+            ->setParameter(
+                'now',
+                new DateTime(),
+                Types::DATETIME_MUTABLE,
+            )
+            ->getQuery()
+            ->getResult();
+
+        return $this->associationYears($rows);
+    }
+
+    /**
+     * Maps a list of activity begin times to their distinct association years (first calendar year), newest first.
+     *
+     * @param list<array{beginTime: DateTime}> $rows
+     *
+     * @return int[]
+     */
+    private function associationYears(array $rows): array
+    {
+        $years = [];
+        foreach ($rows as $row) {
+            $years[AssociationYear::fromDate($row['beginTime'])->getYear()] = true;
+        }
+
+        $years = array_keys($years);
+        rsort($years);
+
+        return $years;
     }
 
     /**

--- a/src/Repository/Activity/ActivityRepository.php
+++ b/src/Repository/Activity/ActivityRepository.php
@@ -738,6 +738,37 @@ class ActivityRepository extends ServiceEntityRepository
     }
 
     /**
+     * Eager-loads the sign-up lists for the given activities in a single query, hydrating each activity's (otherwise
+     * lazy) `signupLists` collection. This avoids the N+1 that the overview's per-activity accessors
+     * ({@see Activity::getRelevantSignupList()}, {@see Activity::countPendingSignupLists()}) would otherwise trigger.
+     *
+     * @param Activity[] $activities
+     */
+    public function primeSignupLists(array $activities): void
+    {
+        if ([] === $activities) {
+            return;
+        }
+
+        $this->createQueryBuilder('a')
+            ->select(
+                'a',
+                'sl',
+            )
+            ->leftJoin(
+                'a.signupLists',
+                'sl',
+            )
+            ->where('a IN (:activities)')
+            ->setParameter(
+                'activities',
+                $activities,
+            )
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Returns the distinct organs that organise at least one approved activity, for the overview's organ filter.
      *
      * @return Organ[]

--- a/src/Twig/Components/Activity/ActivityOverview.php
+++ b/src/Twig/Components/Activity/ActivityOverview.php
@@ -21,6 +21,7 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
+use Symfony\UX\LiveComponent\Metadata\UrlMapping;
 
 use function array_filter;
 use function array_map;
@@ -49,28 +50,56 @@ final class ActivityOverview
     #[LiveProp]
     public bool $past = false;
 
-    #[LiveProp(writable: true)]
+    // All the filters mirror themselves into the query string via the History API, so the state survives a reload and
+    // the address bar is itself a shareable link (the copy button just yields the same URL in one click).
+    #[LiveProp(
+        writable: true,
+        url: true,
+    )]
+    public ?string $category = null;
+
+    // The association year is part of the page path (/archive/{year}), set at mount time; not a live filter.
+    #[LiveProp]
+    public ?int $year = null;
+
+    #[LiveProp(
+        writable: true,
+        url: true,
+    )]
     public string $search = '';
 
-    #[LiveProp(writable: true)]
-    public ?string $categoryFilter = null;
-
     /** @var int[] */
-    #[LiveProp(writable: true)]
+    #[LiveProp(
+        writable: true,
+        url: new UrlMapping(as: 'labels'),
+    )]
     public array $labelFilters = [];
 
-    #[LiveProp(writable: true)]
+    #[LiveProp(
+        writable: true,
+        url: new UrlMapping(as: 'organ'),
+    )]
     public ?int $organFilter = null;
 
-    #[LiveProp(writable: true)]
+    #[LiveProp(
+        writable: true,
+        url: new UrlMapping(as: 'openSignup'),
+    )]
     public bool $openSignupOnly = false;
 
-    #[LiveProp(writable: true)]
+    #[LiveProp(
+        writable: true,
+        url: new UrlMapping(as: 'from'),
+    )]
     public ?string $fromDate = null;
 
-    #[LiveProp(writable: true)]
+    #[LiveProp(
+        writable: true,
+        url: new UrlMapping(as: 'until'),
+    )]
     public ?string $untilDate = null;
 
+    // Pagination state, deliberately not URL-synced.
     #[LiveProp(writable: true)]
     public int $limit = self::PAGE_SIZE;
 
@@ -139,14 +168,6 @@ final class ActivityOverview
     }
 
     /**
-     * @return ActivityCategories[]
-     */
-    public function getCategories(): array
-    {
-        return ActivityCategories::cases();
-    }
-
-    /**
      * @return ActivityLabel[]
      */
     public function getLabels(): array
@@ -163,6 +184,14 @@ final class ActivityOverview
     public function getOrgans(): array
     {
         return $this->activityRepository->findOrganisingOrgans();
+    }
+
+    /**
+     * @return ActivityCategories[]
+     */
+    public function getCategories(): array
+    {
+        return ActivityCategories::selectableCases();
     }
 
     /**
@@ -183,28 +212,64 @@ final class ActivityOverview
             subscribedBy: $this->subscribed ? $this->currentMember() : null,
             search: $this->search,
             locale: $this->requestStack->getCurrentRequest()?->getLocale() ?? 'en',
-            category: null !== $this->categoryFilter
-                ? ActivityCategories::tryFrom($this->categoryFilter)
+            category: null !== $this->category
+                ? ActivityCategories::tryFrom($this->category)
                 : null,
-            labelIds: array_values(
-                array_filter(
-                    array_map(
-                        'intval',
-                        $this->labelFilters,
-                    ),
-                    static fn (int $id): bool => $id > 0,
-                ),
-            ),
+            labelIds: $this->selectedLabelIds(),
             organId: $this->organFilter,
             openSignupOnly: $this->openSignupOnly,
-            from: $this->parseDate($this->fromDate),
-            until: $this->parseDate(
-                $this->untilDate,
-                true,
-            ),
+            from: $this->effectiveFrom(),
+            until: $this->effectiveUntil(),
             limit: $this->limit,
             offset: 0,
         );
+    }
+
+    /**
+     * @return int[]
+     */
+    private function selectedLabelIds(): array
+    {
+        return array_values(
+            array_filter(
+                array_map(
+                    'intval',
+                    $this->labelFilters,
+                ),
+                static fn (int $id): bool => $id > 0,
+            ),
+        );
+    }
+
+    /**
+     * The effective start of the time window: an explicit "from" filter, otherwise the start of the selected
+     * association year (archive), otherwise unbounded.
+     */
+    private function effectiveFrom(): ?DateTime
+    {
+        $explicit = $this->parseDate($this->fromDate);
+        if (null !== $explicit) {
+            return $explicit;
+        }
+
+        return null !== $this->year
+            ? AssociationYear::fromYear($this->year)->getStartDate()
+            : null;
+    }
+
+    private function effectiveUntil(): ?DateTime
+    {
+        $explicit = $this->parseDate(
+            $this->untilDate,
+            true,
+        );
+        if (null !== $explicit) {
+            return $explicit;
+        }
+
+        return null !== $this->year
+            ? AssociationYear::fromYear($this->year)->getEndDate()
+            : null;
     }
 
     private function currentMember(): ?Member

--- a/src/Twig/Components/Activity/ActivityOverview.php
+++ b/src/Twig/Components/Activity/ActivityOverview.php
@@ -107,6 +107,9 @@ final class ActivityOverview
     /** @var Paginator<Activity>|null */
     private ?Paginator $paginator = null;
 
+    /** @var Activity[]|null */
+    private ?array $activities = null;
+
     private bool $memberResolved = false;
     private ?Member $member = null;
 
@@ -129,14 +132,23 @@ final class ActivityOverview
      */
     public function getActivities(): array
     {
-        if (!$this->canQuery()) {
-            return [];
+        if (null !== $this->activities) {
+            return $this->activities;
         }
 
-        return iterator_to_array(
+        if (!$this->canQuery()) {
+            return $this->activities = [];
+        }
+
+        $activities = iterator_to_array(
             $this->getPaginator()->getIterator(),
             false,
         );
+
+        // Hydrate the sign-up lists for the whole page in one query so the per-item accessors do not N+1.
+        $this->activityRepository->primeSignupLists($activities);
+
+        return $this->activities = $activities;
     }
 
     /**

--- a/src/Twig/Components/Activity/ActivityOverview.php
+++ b/src/Twig/Components/Activity/ActivityOverview.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components\Activity;
+
+use App\Entity\Activity\Activity;
+use App\Entity\Activity\ActivityLabel;
+use App\Entity\Activity\Enums\ActivityCategories;
+use App\Entity\Decision\AssociationYear;
+use App\Entity\Decision\Member;
+use App\Entity\Decision\Organ;
+use App\Entity\User\User;
+use App\Repository\Activity\ActivityLabelRepository;
+use App\Repository\Activity\ActivityRepository;
+use DateTime;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function count;
+use function iterator_to_array;
+use function trim;
+
+/**
+ * Backs the four activity overview pages: upcoming/archive × public/subscribed. The page fixes `subscribed` and `past`
+ * at mount time; everything else is a live filter. Infinite scroll grows `limit` via the loadMore action.
+ */
+#[AsLiveComponent(
+    name: 'Activity:ActivityOverview',
+    template: 'components/Activity/ActivityOverview.html.twig',
+)]
+final class ActivityOverview
+{
+    use DefaultActionTrait;
+
+    public const int PAGE_SIZE = 20;
+
+    #[LiveProp]
+    public bool $subscribed = false;
+
+    #[LiveProp]
+    public bool $past = false;
+
+    #[LiveProp(writable: true)]
+    public string $search = '';
+
+    #[LiveProp(writable: true)]
+    public ?string $categoryFilter = null;
+
+    /** @var int[] */
+    #[LiveProp(writable: true)]
+    public array $labelFilters = [];
+
+    #[LiveProp(writable: true)]
+    public ?int $organFilter = null;
+
+    #[LiveProp(writable: true)]
+    public bool $openSignupOnly = false;
+
+    #[LiveProp(writable: true)]
+    public ?string $fromDate = null;
+
+    #[LiveProp(writable: true)]
+    public ?string $untilDate = null;
+
+    #[LiveProp(writable: true)]
+    public int $limit = self::PAGE_SIZE;
+
+    /** @var Paginator<Activity>|null */
+    private ?Paginator $paginator = null;
+
+    private bool $memberResolved = false;
+    private ?Member $member = null;
+
+    public function __construct(
+        private readonly ActivityRepository $activityRepository,
+        private readonly ActivityLabelRepository $activityLabelRepository,
+        private readonly Security $security,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    #[LiveAction]
+    public function loadMore(): void
+    {
+        $this->limit += self::PAGE_SIZE;
+    }
+
+    /**
+     * @return Activity[]
+     */
+    public function getActivities(): array
+    {
+        if (!$this->canQuery()) {
+            return [];
+        }
+
+        return iterator_to_array(
+            $this->getPaginator()->getIterator(),
+            false,
+        );
+    }
+
+    /**
+     * The activities grouped by association-year string (e.g. '2025-2026'), preserving the DESC order — for archives.
+     *
+     * @return array<string, Activity[]>
+     */
+    public function getActivitiesByAssociationYear(): array
+    {
+        $grouped = [];
+        foreach ($this->getActivities() as $activity) {
+            $grouped[AssociationYear::fromDate($activity->getBeginTime())->getYearString()][] = $activity;
+        }
+
+        return $grouped;
+    }
+
+    public function getTotalCount(): int
+    {
+        if (!$this->canQuery()) {
+            return 0;
+        }
+
+        return $this->getPaginator()->count();
+    }
+
+    public function hasMore(): bool
+    {
+        return $this->getTotalCount() > count($this->getActivities());
+    }
+
+    /**
+     * @return ActivityCategories[]
+     */
+    public function getCategories(): array
+    {
+        return ActivityCategories::cases();
+    }
+
+    /**
+     * @return ActivityLabel[]
+     */
+    public function getLabels(): array
+    {
+        return $this->activityLabelRepository->findBy(
+            [],
+            ['id' => 'ASC'],
+        );
+    }
+
+    /**
+     * @return Organ[]
+     */
+    public function getOrgans(): array
+    {
+        return $this->activityRepository->findOrganisingOrgans();
+    }
+
+    /**
+     * Whether a query should run at all: the subscribed pages need an authenticated member.
+     */
+    private function canQuery(): bool
+    {
+        return !$this->subscribed || null !== $this->currentMember();
+    }
+
+    /**
+     * @return Paginator<Activity>
+     */
+    private function getPaginator(): Paginator
+    {
+        return $this->paginator ??= $this->activityRepository->findForOverview(
+            past: $this->past,
+            subscribedBy: $this->subscribed ? $this->currentMember() : null,
+            search: $this->search,
+            locale: $this->requestStack->getCurrentRequest()?->getLocale() ?? 'en',
+            category: null !== $this->categoryFilter
+                ? ActivityCategories::tryFrom($this->categoryFilter)
+                : null,
+            labelIds: array_values(
+                array_filter(
+                    array_map(
+                        'intval',
+                        $this->labelFilters,
+                    ),
+                    static fn (int $id): bool => $id > 0,
+                ),
+            ),
+            organId: $this->organFilter,
+            openSignupOnly: $this->openSignupOnly,
+            from: $this->parseDate($this->fromDate),
+            until: $this->parseDate(
+                $this->untilDate,
+                true,
+            ),
+            limit: $this->limit,
+            offset: 0,
+        );
+    }
+
+    private function currentMember(): ?Member
+    {
+        if (!$this->memberResolved) {
+            $this->memberResolved = true;
+            $user = $this->security->getUser();
+            $this->member = $user instanceof User
+                ? $user->getMember()
+                : null;
+        }
+
+        return $this->member;
+    }
+
+    private function parseDate(
+        ?string $value,
+        bool $endOfDay = false,
+    ): ?DateTime {
+        if (
+            null === $value
+            || '' === trim($value)
+        ) {
+            return null;
+        }
+
+        $date = DateTime::createFromFormat(
+            'Y-m-d',
+            $value,
+        );
+
+        if (false === $date) {
+            return null;
+        }
+
+        return $endOfDay
+            ? $date->setTime(
+                23,
+                59,
+                59,
+            )
+            : $date->setTime(
+                0,
+                0,
+            );
+    }
+}

--- a/src/Twig/Components/Activity/ActivityOverview.php
+++ b/src/Twig/Components/Activity/ActivityOverview.php
@@ -42,7 +42,7 @@ final class ActivityOverview
 {
     use DefaultActionTrait;
 
-    public const int PAGE_SIZE = 20;
+    public const int PAGE_SIZE = 15;
 
     #[LiveProp]
     public bool $subscribed = false;
@@ -99,8 +99,9 @@ final class ActivityOverview
     )]
     public ?string $untilDate = null;
 
-    // Pagination state, deliberately not URL-synced.
-    #[LiveProp(writable: true)]
+    // Pagination state: not URL-synced and not client-writable. Only the `loadMore` action grows it server-side, so a
+    // crafted request cannot ask for an arbitrarily large page.
+    #[LiveProp]
     public int $limit = self::PAGE_SIZE;
 
     /** @var Paginator<Activity>|null */
@@ -139,7 +140,7 @@ final class ActivityOverview
     }
 
     /**
-     * The activities grouped by association-year string (e.g. '2025-2026'), preserving the DESC order — for archives.
+     * The activities grouped by association-year string (e.g. '2025-2026'), preserving the `DESC` order for archives.
      *
      * @return array<string, Activity[]>
      */

--- a/src/Twig/Extensions/ActivityDateRangeExtension.php
+++ b/src/Twig/Extensions/ActivityDateRangeExtension.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Extensions;
+
+use DateTime;
+use DateTimeInterface;
+use IntlDateFormatter;
+use Locale;
+use Override;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+use function sprintf;
+use function ucfirst;
+
+/**
+ * Formats an activity's begin/end as a single locale-aware range string, mirroring the previous GEWIS overview:
+ *  - single day:   "Thursday 28 May. 12:40 - 13:20"
+ *  - multiple days: "Sun. 17 May. (00:00) - Sun. 21 Jun. (23:59)"
+ * A side that falls in a different calendar year than today also shows its year (e.g. "… 14 Dec. 2026 …").
+ */
+class ActivityDateRangeExtension extends AbstractExtension
+{
+    /**
+     * @return TwigFunction[]
+     */
+    #[Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'activity_date_range',
+                $this->activityDateRange(...),
+            ),
+        ];
+    }
+
+    public function activityDateRange(
+        DateTimeInterface $begin,
+        DateTimeInterface $end,
+    ): string {
+        $locale = Locale::getDefault();
+        $currentYear = new DateTime()->format('Y');
+        $sameDay = $begin->format('Y-m-d') === $end->format('Y-m-d');
+
+        if ($sameDay) {
+            $beginPattern = $begin->format('Y') === $currentYear
+                ? 'EEEE d MMM. HH:mm'
+                : 'EEEE d MMM. yyyy HH:mm';
+
+            $rendered = sprintf(
+                '%s - %s',
+                $this->format(
+                    $begin,
+                    $beginPattern,
+                    $locale,
+                ),
+                $this->format(
+                    $end,
+                    'HH:mm',
+                    $locale,
+                ),
+            );
+        } else {
+            $beginPattern = $begin->format('Y') === $currentYear
+                ? 'EEE. d MMM. (HH:mm)'
+                : 'EEE. d MMM. yyyy (HH:mm)';
+            $endPattern = $end->format('Y') === $currentYear
+                ? 'EEE. d MMM. (HH:mm)'
+                : 'EEE. d MMM. yyyy (HH:mm)';
+
+            $rendered = sprintf(
+                '%s - %s',
+                $this->format(
+                    $begin,
+                    $beginPattern,
+                    $locale,
+                ),
+                $this->format(
+                    $end,
+                    $endPattern,
+                    $locale,
+                ),
+            );
+        }
+
+        return ucfirst($rendered);
+    }
+
+    private function format(
+        DateTimeInterface $date,
+        string $pattern,
+        string $locale,
+    ): string {
+        $formatter = new IntlDateFormatter(
+            $locale,
+            IntlDateFormatter::FULL,
+            IntlDateFormatter::FULL,
+            $date->getTimezone(),
+            IntlDateFormatter::GREGORIAN,
+            $pattern,
+        );
+
+        $result = $formatter->format($date);
+
+        return false === $result
+            ? ''
+            : $result;
+    }
+}

--- a/src/Twig/Extensions/MarkdownExtension.php
+++ b/src/Twig/Extensions/MarkdownExtension.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Extensions;
+
+use App\CommonMark\NoImage\NoImageExtension;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\Autolink\AutolinkExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
+use League\CommonMark\MarkdownConverter;
+use Override;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+use function strip_tags;
+
+/**
+ * Renders Markdown to safe HTML, mirroring the configuration GEWIS used previously: raw HTML is escaped, unsafe links
+ * are dropped, external links open safely in a new window, and images are not emitted (see {@link NoImageExtension}).
+ */
+final class MarkdownExtension extends AbstractExtension
+{
+    private ?MarkdownConverter $converter = null;
+
+    /**
+     * @return TwigFilter[]
+     */
+    #[Override]
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter(
+                'markdown',
+                $this->markdown(...),
+                ['is_safe' => ['html']],
+            ),
+        ];
+    }
+
+    /**
+     * Render Markdown to safe HTML. When $allowedTags is given (bare tag names, e.g. ['p', 'em', 'strong', 'a']),
+     * every other tag is stripped from the output — used on the overview to keep descriptions to inline formatting;
+     * pass nothing on the single activity page for the full rendering.
+     *
+     * @param string[]|null $allowedTags
+     */
+    public function markdown(
+        ?string $text,
+        ?array $allowedTags = null,
+    ): string {
+        if (
+            null === $text
+            || '' === $text
+        ) {
+            return '';
+        }
+
+        $html = $this->getConverter()->convert($text)->getContent();
+
+        if (null !== $allowedTags) {
+            $html = strip_tags(
+                $html,
+                $allowedTags,
+            );
+        }
+
+        return $html;
+    }
+
+    private function getConverter(): MarkdownConverter
+    {
+        if (null !== $this->converter) {
+            return $this->converter;
+        }
+
+        $environment = new Environment([
+            'html_input' => 'escape',
+            'allow_unsafe_links' => false,
+            'max_nesting_level' => 100,
+            'renderer' => ['soft_break' => '<br>'],
+            'commonmark' => [
+                'enable_em' => true,
+                'enable_strong' => true,
+                'use_asterisk' => true,
+                'use_underscore' => true,
+                'unordered_list_markers' => [
+                    '-',
+                    '*',
+                    '+',
+                ],
+            ],
+            'external_link' => [
+                'internal_hosts' => 'gewis.nl',
+                'open_in_new_window' => true,
+                'html_class' => 'external-link',
+                'nofollow' => '',
+                'noopener' => 'external',
+                'noreferrer' => 'external',
+            ],
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new AutolinkExtension());
+        $environment->addExtension(new ExternalLinkExtension());
+        $environment->addExtension(new NoImageExtension());
+
+        return $this->converter = new MarkdownConverter($environment);
+    }
+}

--- a/src/Twig/Extensions/MarkdownExtension.php
+++ b/src/Twig/Extensions/MarkdownExtension.php
@@ -17,8 +17,8 @@ use Twig\TwigFilter;
 use function strip_tags;
 
 /**
- * Renders Markdown to safe HTML, mirroring the configuration GEWIS used previously: raw HTML is escaped, unsafe links
- * are dropped, external links open safely in a new window, and images are not emitted (see {@link NoImageExtension}).
+ * Renders Markdown to safe HTML: raw HTML is escaped, unsafe links are dropped, external links open safely in a new
+ * window, and images are not allowed (see {@link NoImageExtension}).
  */
 final class MarkdownExtension extends AbstractExtension
 {

--- a/src/Twig/Extensions/RelativeTimeExtension.php
+++ b/src/Twig/Extensions/RelativeTimeExtension.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Extensions;
+
+use DateTimeInterface;
+use Override;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+use function intdiv;
+
+/**
+ * Produces a short, localised "coarse" duration between two moments (largest non-zero unit), e.g. "3 weeks",
+ * "2 days", "5 hours". Used by the overview to phrase how long until an activity starts / a sign-up closes, and how
+ * long an ongoing activity still runs. The caller wraps it (e.g. "in %duration%", "ongoing for %duration%").
+ */
+class RelativeTimeExtension extends AbstractExtension
+{
+    public function __construct(private readonly TranslatorInterface $translator)
+    {
+    }
+
+    /**
+     * @return TwigFunction[]
+     */
+    #[Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'human_time_diff',
+                $this->humanTimeDiff(...),
+            ),
+        ];
+    }
+
+    public function humanTimeDiff(
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+    ): string {
+        $interval = $from->diff($to);
+        $days = $interval->days;
+
+        if ($days >= 7) {
+            return $this->translator->trans(
+                '%count% week|%count% weeks',
+                [
+                    '%count%' => intdiv(
+                        $days,
+                        7,
+                    ),
+                ],
+            );
+        }
+
+        if ($days >= 1) {
+            return $this->translator->trans(
+                '%count% day|%count% days',
+                ['%count%' => $days],
+            );
+        }
+
+        if ($interval->h >= 1) {
+            return $this->translator->trans(
+                '%count% hour|%count% hours',
+                ['%count%' => $interval->h],
+            );
+        }
+
+        if ($interval->i >= 1) {
+            return $this->translator->trans(
+                '%count% minute|%count% minutes',
+                ['%count%' => $interval->i],
+            );
+        }
+
+        return $this->translator->trans('less than a minute');
+    }
+}

--- a/src/View/Activity/SignupListView.php
+++ b/src/View/Activity/SignupListView.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Read-model of a {@see SignupList} for the activity view page. Pre-computes the localised name, the sign-up window,
- * the subscriber count and — when the viewer may see details — the subscriber rows, so the Twig stays declarative and
+ * the subscriber count and when the viewer may see details also the subscriber rows, so the Twig stays declarative and
  * free of permission/sensitivity/`instanceof` logic.
  */
 final readonly class SignupListView

--- a/src/View/Activity/SignupListView.php
+++ b/src/View/Activity/SignupListView.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Activity;
+
+use App\Entity\Activity\Signup;
+use App\Entity\Activity\SignupField;
+use App\Entity\Activity\SignupList;
+use App\Entity\Activity\UserSignup;
+use App\Entity\Application\Enums\Languages;
+use DateTime;
+use Locale;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Read-model of a {@see SignupList} for the activity view page. Pre-computes the localised name, the sign-up window,
+ * the subscriber count and — when the viewer may see details — the subscriber rows, so the Twig stays declarative and
+ * free of permission/sensitivity/`instanceof` logic.
+ */
+final readonly class SignupListView
+{
+    /**
+     * @param string[]    $fieldNames column headers (localised), one per sign-up field
+     * @param SignupRow[] $rows       populated only when $canViewDetails
+     */
+    public function __construct(
+        public string $name,
+        public DateTime $openDate,
+        public DateTime $closeDate,
+        public bool $limitedCapacity,
+        public bool $onlyGEWIS,
+        public bool $displaySubscribedNumber,
+        public bool $promoted,
+        public bool $isOpen,
+        public bool $isClosed,
+        public int $subscriberCount,
+        public bool $canViewDetails,
+        public array $fieldNames,
+        public array $rows,
+    ) {
+    }
+
+    public static function fromSignupList(
+        SignupList $signupList,
+        bool $canViewDetails,
+        ?int $viewerLidnr,
+        TranslatorInterface $translator,
+    ): self {
+        $language = 'nl' === Locale::getDefault()
+            ? Languages::Dutch
+            : Languages::English;
+
+        $fields = $signupList->getFields()->toArray();
+        $fieldNames = [];
+        foreach ($fields as $field) {
+            $fieldNames[] = $field->getName()->getText($language) ?? '';
+        }
+
+        $rows = [];
+        if ($canViewDetails) {
+            $position = 1;
+            foreach ($signupList->getSignUps() as $signup) {
+                $isOwn = $signup instanceof UserSignup
+                    && null !== $viewerLidnr
+                    && $viewerLidnr === $signup->getUser()->getLidnr();
+
+                $cells = [];
+                foreach ($fields as $field) {
+                    if (
+                        $field->isSensitive()
+                        && !$isOwn
+                    ) {
+                        $cells[] = [
+                            'hidden' => true,
+                            'value' => '',
+                        ];
+
+                        continue;
+                    }
+
+                    $cells[] = [
+                        'hidden' => false,
+                        'value' => self::formatFieldValue(
+                            $field,
+                            $signup,
+                            $translator,
+                            $language,
+                        ),
+                    ];
+                }
+
+                $rows[] = new SignupRow(
+                    $position++,
+                    $signup->getFullName(),
+                    $cells,
+                );
+            }
+        }
+
+        return new self(
+            name: $signupList->getName()->getText($language) ?? '',
+            openDate: $signupList->getOpenDate(),
+            closeDate: $signupList->getCloseDate(),
+            limitedCapacity: $signupList->getLimitedCapacity(),
+            onlyGEWIS: $signupList->getOnlyGEWIS(),
+            displaySubscribedNumber: $signupList->getDisplaySubscribedNumber(),
+            promoted: $signupList->isPromoted(),
+            isOpen: $signupList->isOpen(),
+            isClosed: $signupList->getCloseDate() < new DateTime('now'),
+            subscriberCount: $signupList->getSignUps()->count(),
+            canViewDetails: $canViewDetails,
+            fieldNames: $fieldNames,
+            rows: $rows,
+        );
+    }
+
+    /**
+     * Formats a sign-up field value by its type: 0 = text, 1 = yes/no (translated), 2 = number, 3 = option (localised).
+     */
+    private static function formatFieldValue(
+        SignupField $field,
+        Signup $signup,
+        TranslatorInterface $translator,
+        Languages $language,
+    ): string {
+        foreach ($signup->getFieldValues() as $fieldValue) {
+            if ($fieldValue->getField()->getId() !== $field->getId()) {
+                continue;
+            }
+
+            return match ($field->getType()) {
+                1 => $translator->trans($fieldValue->getValue() ?? ''),
+                3 => $fieldValue->getOption()?->getValue()->getText($language) ?? '',
+                default => $fieldValue->getValue() ?? '',
+            };
+        }
+
+        return '';
+    }
+}

--- a/src/View/Activity/SignupRow.php
+++ b/src/View/Activity/SignupRow.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Activity;
+
+/**
+ * A single row in the read-only "current subscriptions" table of a sign-up list.
+ */
+final readonly class SignupRow
+{
+    /**
+     * @param list<array{hidden: bool, value: string}> $cells one cell per sign-up field, already formatted; `hidden`
+     *                                                         marks a sensitive field that is not the viewer's own
+     */
+    public function __construct(
+        public int $position,
+        public string $fullName,
+        public array $cells,
+    ) {
+    }
+}

--- a/src/View/Activity/SignupRow.php
+++ b/src/View/Activity/SignupRow.php
@@ -11,7 +11,7 @@ final readonly class SignupRow
 {
     /**
      * @param list<array{hidden: bool, value: string}> $cells one cell per sign-up field, already formatted; `hidden`
-     *                                                         marks a sensitive field that is not the viewer's own
+     * marks a sensitive field that is not the viewer's own
      */
     public function __construct(
         public int $position,

--- a/symfony.lock
+++ b/symfony.lock
@@ -420,6 +420,9 @@
             "ref": "0df5844274d871b37fc3816c57a768ffc60a43a5"
         }
     },
+    "symfony/ux-calendar-link": {
+        "version": "3.x-dev"
+    },
     "symfony/ux-live-component": {
         "version": "2.32",
         "recipe": {

--- a/templates/activity/archive-my.html.twig
+++ b/templates/activity/archive-my.html.twig
@@ -4,5 +4,8 @@
 
 {% block contents %}
     <h1>{{ 'My past activities'|trans }}</h1>
-    {{ component('Activity:ActivityOverview', { subscribed: true, past: true }) }}
+    {{ component('Activity:ActivityOverview', {
+        subscribed: true,
+        past: true,
+    }) }}
 {% endblock %}

--- a/templates/activity/archive-my.html.twig
+++ b/templates/activity/archive-my.html.twig
@@ -3,9 +3,25 @@
 {% block page_title %}{{ 'My past activities'|trans|page_title }}{{ parent() }}{% endblock %}
 
 {% block contents %}
-    <h1>{{ 'My past activities'|trans }}</h1>
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <h1 class="mb-0">{{ 'My past activities'|trans }}</h1>
+
+        <div class="btn-toolbar gap-2" role="toolbar">
+            <a class="btn btn-outline-secondary" href="{{ path('activity/my') }}">
+                <i class="fas fa-chevron-left"></i> {{ 'My upcoming activities'|trans }}
+            </a>
+
+            {% include 'partials/activity/year-switcher.html.twig' with {
+                route: 'activity/archive/my',
+                year: year,
+                years: years,
+            } only %}
+        </div>
+    </div>
+
     {{ component('Activity:ActivityOverview', {
         subscribed: true,
         past: true,
+        year: year,
     }) }}
 {% endblock %}

--- a/templates/activity/archive-my.html.twig
+++ b/templates/activity/archive-my.html.twig
@@ -1,0 +1,8 @@
+{% extends 'layout.html.twig' %}
+
+{% block page_title %}{{ 'My past activities'|trans|page_title }}{{ parent() }}{% endblock %}
+
+{% block contents %}
+    <h1>{{ 'My past activities'|trans }}</h1>
+    {{ component('Activity:ActivityOverview', { subscribed: true, past: true }) }}
+{% endblock %}

--- a/templates/activity/archive.html.twig
+++ b/templates/activity/archive.html.twig
@@ -6,48 +6,11 @@
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
         <h1 class="mb-0">{{ 'Activity Archive'|trans }}</h1>
 
-        {% if years is not empty %}
-            {# Preserve the active filters (e.g. ?category=…) when switching years by carrying the current query string. #}
-            {% set query = app.request.query.all %}
-            {% set newer_url = year is not null and year < years|first
-                ? path('activity/archive', query|merge({ year: year + 1 })) : null %}
-            {% set older_url = year is not null and year > years|last
-                ? path('activity/archive', query|merge({ year: year - 1 })) : null %}
-
-            <div class="btn-group">
-                <a class="btn btn-outline-secondary {{ newer_url is null ? 'disabled' }}"
-                   href="{{ newer_url ?? '#' }}" aria-label="{{ 'Newer'|trans }}">
-                    <i class="fas fa-chevron-left"></i>
-                </a>
-                <div class="btn-group">
-                    <button type="button" class="btn btn-outline-secondary dropdown-toggle"
-                            data-bs-toggle="dropdown" aria-expanded="false">
-                        {{ year is not null ? (year ~ ' - ' ~ (year + 1)) : 'All years'|trans }}
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li>
-                            <a class="dropdown-item {{ year is null ? 'active' }}"
-                               href="{{ path('activity/archive', query) }}">
-                                {{ 'All years'|trans }}
-                            </a>
-                        </li>
-                        <li><hr class="dropdown-divider"></li>
-                        {% for y in years %}
-                            <li>
-                                <a class="dropdown-item {{ year == y ? 'active' }}"
-                                   href="{{ path('activity/archive', query|merge({ year: y })) }}">
-                                    {{ y }} - {{ y + 1 }}
-                                </a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-                <a class="btn btn-outline-secondary {{ older_url is null ? 'disabled' }}"
-                   href="{{ older_url ?? '#' }}" aria-label="{{ 'Older'|trans }}">
-                    <i class="fas fa-chevron-right"></i>
-                </a>
-            </div>
-        {% endif %}
+        {% include 'partials/activity/year-switcher.html.twig' with {
+            route: 'activity/archive',
+            year: year,
+            years: years,
+        } only %}
     </div>
 
     {{ component('Activity:ActivityOverview', {

--- a/templates/activity/archive.html.twig
+++ b/templates/activity/archive.html.twig
@@ -3,4 +3,6 @@
 {% block page_title %}{{ 'Activity Archive'|trans|page_title }}{{ parent() }}{% endblock %}
 
 {% block contents %}
+    <h1>{{ 'Activity Archive'|trans }}</h1>
+    {{ component('Activity:ActivityOverview', { past: true, fromDate: yearStart, untilDate: yearEnd }) }}
 {% endblock %}

--- a/templates/activity/archive.html.twig
+++ b/templates/activity/archive.html.twig
@@ -3,6 +3,55 @@
 {% block page_title %}{{ 'Activity Archive'|trans|page_title }}{{ parent() }}{% endblock %}
 
 {% block contents %}
-    <h1>{{ 'Activity Archive'|trans }}</h1>
-    {{ component('Activity:ActivityOverview', { past: true, fromDate: yearStart, untilDate: yearEnd }) }}
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <h1 class="mb-0">{{ 'Activity Archive'|trans }}</h1>
+
+        {% if years is not empty %}
+            {# Preserve the active filters (e.g. ?category=…) when switching years by carrying the current query string. #}
+            {% set query = app.request.query.all %}
+            {% set newer_url = year is not null and year < years|first
+                ? path('activity/archive', query|merge({ year: year + 1 })) : null %}
+            {% set older_url = year is not null and year > years|last
+                ? path('activity/archive', query|merge({ year: year - 1 })) : null %}
+
+            <div class="btn-group">
+                <a class="btn btn-outline-secondary {{ newer_url is null ? 'disabled' }}"
+                   href="{{ newer_url ?? '#' }}" aria-label="{{ 'Newer'|trans }}">
+                    <i class="fas fa-chevron-left"></i>
+                </a>
+                <div class="btn-group">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle"
+                            data-bs-toggle="dropdown" aria-expanded="false">
+                        {{ year is not null ? (year ~ ' - ' ~ (year + 1)) : 'All years'|trans }}
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li>
+                            <a class="dropdown-item {{ year is null ? 'active' }}"
+                               href="{{ path('activity/archive', query) }}">
+                                {{ 'All years'|trans }}
+                            </a>
+                        </li>
+                        <li><hr class="dropdown-divider"></li>
+                        {% for y in years %}
+                            <li>
+                                <a class="dropdown-item {{ year == y ? 'active' }}"
+                                   href="{{ path('activity/archive', query|merge({ year: y })) }}">
+                                    {{ y }} - {{ y + 1 }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                <a class="btn btn-outline-secondary {{ older_url is null ? 'disabled' }}"
+                   href="{{ older_url ?? '#' }}" aria-label="{{ 'Older'|trans }}">
+                    <i class="fas fa-chevron-right"></i>
+                </a>
+            </div>
+        {% endif %}
+    </div>
+
+    {{ component('Activity:ActivityOverview', {
+        past: true,
+        year: year,
+    }) }}
 {% endblock %}

--- a/templates/activity/index.html.twig
+++ b/templates/activity/index.html.twig
@@ -3,4 +3,6 @@
 {% block page_title %}{{ 'Activities'|trans|page_title }}{{ parent() }}{% endblock %}
 
 {% block contents %}
+    <h1>{{ 'Activities'|trans }}</h1>
+    {{ component('Activity:ActivityOverview', { categoryFilter: initialCategory }) }}
 {% endblock %}

--- a/templates/activity/index.html.twig
+++ b/templates/activity/index.html.twig
@@ -4,5 +4,6 @@
 
 {% block contents %}
     <h1>{{ 'Activities'|trans }}</h1>
-    {{ component('Activity:ActivityOverview', { categoryFilter: initialCategory }) }}
+
+    {{ component('Activity:ActivityOverview') }}
 {% endblock %}

--- a/templates/activity/my.html.twig
+++ b/templates/activity/my.html.twig
@@ -3,4 +3,6 @@
 {% block page_title %}{{ 'My Activities'|trans|page_title }}{{ parent() }}{% endblock %}
 
 {% block contents %}
+    <h1>{{ 'My upcoming activities'|trans }}</h1>
+    {{ component('Activity:ActivityOverview', { subscribed: true }) }}
 {% endblock %}

--- a/templates/activity/my.html.twig
+++ b/templates/activity/my.html.twig
@@ -3,6 +3,13 @@
 {% block page_title %}{{ 'My Activities'|trans|page_title }}{{ parent() }}{% endblock %}
 
 {% block contents %}
-    <h1>{{ 'My upcoming activities'|trans }}</h1>
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <h1 class="mb-0">{{ 'My upcoming activities'|trans }}</h1>
+
+        <a class="btn btn-outline-secondary" href="{{ path('activity/archive/my') }}">
+            {{ 'My past activities'|trans }} <i class="fas fa-chevron-right"></i>
+        </a>
+    </div>
+
     {{ component('Activity:ActivityOverview', { subscribed: true }) }}
 {% endblock %}

--- a/templates/activity/view.html.twig
+++ b/templates/activity/view.html.twig
@@ -2,5 +2,146 @@
 
 {% block page_title %}{{ activity.getName|localise_text|page_title }}{{ parent() }}{% endblock %}
 
+{% block structured_data %}
+    {% set organizerName = activity.getOrgan is not null
+        ? activity.getOrgan.getName
+        : (activity.getCompany is not null ? activity.getCompany.getName : 'Study Association GEWIS'|trans) %}
+    <script type="application/ld+json">
+        {{ {
+            '@context': 'https://schema.org',
+            '@type': 'Event',
+            'name': activity.getName|localise_text,
+            'startDate': activity.getBeginTime|date('c'),
+            'endDate': activity.getEndTime|date('c'),
+            'eventStatus': 'https://schema.org/EventScheduled',
+            'eventAttendanceMode': 'https://schema.org/OfflineEventAttendanceMode',
+            'location': {
+                '@type': 'Place',
+                'name': activity.getLocation|localise_text,
+            },
+            'organizer': {
+                '@type': 'Organization',
+                'name': organizerName,
+            },
+            'description': activity.getDescription|localise_text|markdown|striptags,
+            'url': url('activity/view', {'activity': activity.getId}),
+        }|json_encode|raw }}
+    </script>
+{% endblock %}
+
 {% block contents %}
+    <div class="row">
+        <main class="col-md-8">
+            <h1 class="mb-2">{{ activity.getName|localise_text }}</h1>
+            <div class="d-flex flex-wrap gap-1 mb-3">
+                {% if activity.getCategory.value not in ['other', 'uncategorised'] %}
+                    <span class="badge badge-info">{{ activity.getCategory|trans }}</span>
+                {% endif %}
+                {% for label in activity.getLabels %}
+                    <span class="badge badge-secondary">{{ label.getName|localise_text }}</span>
+                {% endfor %}
+            </div>
+            <div class="markdown">
+                {{ activity.getDescription|localise_text|markdown }}
+            </div>
+        </main>
+        <aside class="col-md-4">
+            <div class="panel">
+                <div class="panel-heading">
+                    <h3>{{ 'Details'|trans }}</h3>
+                </div>
+                <div class="list-group list-group-flush">
+                    <div class="list-group-item">
+                        <h3 class="h6 mb-1">{{ 'Start'|trans }}</h3>
+                        <p class="text-muted small mb-0">
+                            {% set start = activity.getBeginTime|format_datetime(pattern: 'EEEE d MMMM yyyy HH:mm', locale: app.request.locale) %}
+                            {{ start|first|upper ~ start|slice(1) }}
+                        </p>
+                    </div>
+                    <div class="list-group-item">
+                        <h3 class="h6 mb-1">{{ 'End'|trans }}</h3>
+                        <p class="text-muted small mb-0">
+                            {% set end = activity.getEndTime|format_datetime(pattern: 'EEEE d MMMM yyyy HH:mm', locale: app.request.locale) %}
+                            {{ end|first|upper ~ end|slice(1) }}
+                        </p>
+                    </div>
+                    {% set location = activity.getLocation|localise_text %}
+                    {% if location is not empty %}
+                        <div class="list-group-item">
+                            <h3 class="h6 mb-1">{{ 'Location'|trans }}</h3>
+                            <p class="text-muted small mb-0">{{ location }}</p>
+                        </div>
+                    {% endif %}
+                    {% set costs = activity.getCosts|localise_text %}
+                    {% if costs is not empty %}
+                        <div class="list-group-item">
+                            <h3 class="h6 mb-1">{{ 'Costs'|trans }}</h3>
+                            <p class="text-muted small mb-0">{{ costs }}</p>
+                        </div>
+                    {% endif %}
+                    {% if activity.getOrgan is not null or activity.getCompany is not null %}
+                        <div class="list-group-item">
+                            <h3 class="h6 mb-1">{{ 'Organised by'|trans }}</h3>
+                            <p class="text-muted small mb-0">
+                                {{ activity.getOrgan is not null ? activity.getOrgan.getName : activity.getCompany.getName }}
+                            </p>
+                        </div>
+                    {% endif %}
+                </div>
+                <div class="panel-footer dropdown">
+                    <button type="button" class="panel-footer-link btn btn-link p-0 dropdown-toggle"
+                            data-bs-toggle="dropdown" aria-expanded="false">
+                        <i class="fas fa-calendar-plus"></i> {{ 'Add to calendar'|trans }}
+                    </button>
+                    <ul class="dropdown-menu">
+                        {% for link in ux_calendar_links(calendarEvent) %}
+                            <li>
+                                <a class="dropdown-item" href="{{ link.url }}" target="_blank" rel="noopener">
+                                    {{ link.label }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </aside>
+    </div>
+
+    <p class="text-muted small mt-3">
+        {{ 'Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!'|trans({
+            '%organizer%': activity.getOrgan is not null ? activity.getOrgan.getName : 'the organising party'|trans,
+            '%email%': 'cib@gewis.nl',
+        }) }}
+    </p>
+
+    {% if signupListViews is not empty %}
+        {% set activeLists = signupListViews|filter(list => not list.isClosed) %}
+        {% set closedLists = signupListViews|filter(list => list.isClosed) %}
+
+        {% if activeLists is not empty %}
+            <h2 class="h4 mt-4">{{ 'Sign-up lists'|trans }}</h2>
+            {# Auto-open the first list that is still open for sign-up; leave the rest collapsed. #}
+            {% set openedFirst = false %}
+            {% for list in activeLists %}
+                {% set autoOpen = not openedFirst and list.isOpen %}
+                {% if autoOpen %}{% set openedFirst = true %}{% endif %}
+                {% include 'partials/activity/signup-list.html.twig' with {
+                    'list': list,
+                    'collapseId': 'signup-list-active-' ~ loop.index,
+                    'open': autoOpen,
+                } only %}
+            {% endfor %}
+        {% endif %}
+
+        {% if closedLists is not empty %}
+            <h2 class="h4 mt-4 text-muted">{{ 'Closed sign-up lists'|trans }}</h2>
+            {% for list in closedLists %}
+                {% include 'partials/activity/signup-list.html.twig' with {
+                    'list': list,
+                    'collapseId': 'signup-list-closed-' ~ loop.index,
+                    'open': false,
+                } only %}
+            {% endfor %}
+        {% endif %}
+    {% endif %}
 {% endblock %}

--- a/templates/activity/view.html.twig
+++ b/templates/activity/view.html.twig
@@ -25,7 +25,7 @@
             },
             'description': activity.getDescription|localise_text|markdown|striptags,
             'url': url('activity/view', {'activity': activity.getId}),
-        }|json_encode|raw }}
+        }|json_encode(constant('JSON_HEX_TAG') b-or constant('JSON_HEX_AMP') b-or constant('JSON_HEX_APOS') b-or constant('JSON_HEX_QUOT'))|raw }}
     </script>
 {% endblock %}
 

--- a/templates/activity/view.html.twig
+++ b/templates/activity/view.html.twig
@@ -38,7 +38,7 @@
                     <span class="badge badge-info">{{ activity.getCategory|trans }}</span>
                 {% endif %}
                 {% for label in activity.getLabels %}
-                    <span class="badge badge-secondary">{{ label.getName|localise_text }}</span>
+                    <span class="badge badge-tag">{{ label.getName|localise_text }}</span>
                 {% endfor %}
             </div>
             <div class="markdown">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -55,6 +55,7 @@
             _paq.push(['setSiteId', '1']);
         </script>
         <script src="{{ matomo_domain }}/matomo.js" nonce="{{ csp_nonce('script') }}" async defer></script>
+        {% block structured_data %}{% endblock %}
     </head>
     <body class="d-flex flex-column h-100">
         {% include 'partials/application/main-nav.html.twig' %}

--- a/templates/components/Activity/ActivityOverview.html.twig
+++ b/templates/components/Activity/ActivityOverview.html.twig
@@ -1,0 +1,110 @@
+<div {{ attributes }}>
+    <div class="panel mb-3" data-live-ignore>
+        <button type="button"
+                class="panel-heading d-flex justify-content-between align-items-center w-100 border-0 bg-transparent text-start collapsed"
+                data-bs-toggle="collapse" data-bs-target="#activity-filters"
+                aria-expanded="false" aria-controls="activity-filters">
+            <span class="h6 mb-0">{{ 'Filters'|trans }}</span>
+            <i class="fas fa-sliders"></i>
+        </button>
+        <div class="collapse" id="activity-filters">
+            <div class="panel-body">
+                <div class="row g-3 align-items-end">
+                <div class="col-md-6">
+                    <label class="form-label" for="activity-overview-search">{{ 'Search'|trans }}</label>
+                    <input type="search" class="form-control" id="activity-overview-search"
+                           placeholder="{{ 'Search by activity name'|trans }}"
+                           data-model="debounce(300)|search"
+                           value="{{ this.search }}">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label" for="activity-overview-category">{{ 'Category'|trans }}</label>
+                    <select class="form-select" id="activity-overview-category" data-model="categoryFilter">
+                        <option value="">{{ 'Any'|trans }}</option>
+                        {% for category in this.categories %}
+                            <option value="{{ category.value }}" {% if this.categoryFilter == category.value %}selected{% endif %}>
+                                {{ category|trans }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label" for="activity-overview-organ">{{ 'Organising party'|trans }}</label>
+                    <select class="form-select" id="activity-overview-organ" data-model="organFilter">
+                        <option value="">{{ 'Any'|trans }}</option>
+                        {% for organ in this.organs %}
+                            <option value="{{ organ.id }}" {% if this.organFilter == organ.id %}selected{% endif %}>
+                                {{ organ.abbr }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="activity-overview-from">{{ 'From'|trans }}</label>
+                    <input type="date" class="form-control" id="activity-overview-from"
+                           data-model="fromDate" value="{{ this.fromDate }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="activity-overview-until">{{ 'Until'|trans }}</label>
+                    <input type="date" class="form-control" id="activity-overview-until"
+                           data-model="untilDate" value="{{ this.untilDate }}">
+                </div>
+                <div class="col-md-4 d-flex align-items-end">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="activity-overview-open-signup"
+                               data-model="openSignupOnly" {% if this.openSignupOnly %}checked{% endif %}>
+                        <label class="form-check-label" for="activity-overview-open-signup">{{ 'Only with open sign-up'|trans }}</label>
+                    </div>
+                </div>
+                {% if this.labels is not empty %}
+                    <div class="col-12">
+                        <label class="form-label">{{ 'Labels'|trans }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                            {% for label in this.labels %}
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="activity-overview-label-{{ label.id }}"
+                                           data-model="labelFilters" value="{{ label.id }}"
+                                           {% if label.id in this.labelFilters %}checked{% endif %}>
+                                    <label class="form-check-label" for="activity-overview-label-{{ label.id }}">{{ label.getName|localise_text }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if this.past %}
+        {% for year, activities in this.activitiesByAssociationYear %}
+            <h2 class="h4 mt-4 mb-2">{{ year }}</h2>
+            <div class="list-group mb-2">
+                {% for activity in activities %}
+                    {% include 'partials/activity/list-item.html.twig' with {'activity': activity} only %}
+                {% endfor %}
+            </div>
+        {% else %}
+            <p class="text-muted text-center py-4">{{ 'No activities match the current filters.'|trans }}</p>
+        {% endfor %}
+    {% else %}
+        <div class="list-group mb-2">
+            {% for activity in this.activities %}
+                {% include 'partials/activity/list-item.html.twig' with {'activity': activity} only %}
+            {% else %}
+                <p class="text-muted text-center py-4">{{ 'No activities match the current filters.'|trans }}</p>
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    {% if this.hasMore %}
+        <div data-controller="infinite-scroll" class="text-center py-3">
+            <button type="button" class="btn btn-outline-secondary"
+                    data-action="live#action" data-live-action-param="loadMore"
+                    data-infinite-scroll-target="button">
+                {{ 'Load more'|trans }}
+            </button>
+            <div data-infinite-scroll-target="sentinel" aria-hidden="true"></div>
+        </div>
+    {% endif %}
+</div>

--- a/templates/components/Activity/ActivityOverview.html.twig
+++ b/templates/components/Activity/ActivityOverview.html.twig
@@ -10,25 +10,25 @@
         <div class="collapse" id="activity-filters">
             <div class="panel-body">
                 <div class="row g-3 align-items-end">
-                <div class="col-md-6">
+                <div class="col-md-4">
                     <label class="form-label" for="activity-overview-search">{{ 'Search'|trans }}</label>
                     <input type="search" class="form-control" id="activity-overview-search"
                            placeholder="{{ 'Search by activity name'|trans }}"
                            data-model="debounce(300)|search"
                            value="{{ this.search }}">
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-4">
                     <label class="form-label" for="activity-overview-category">{{ 'Category'|trans }}</label>
-                    <select class="form-select" id="activity-overview-category" data-model="categoryFilter">
+                    <select class="form-select" id="activity-overview-category" data-model="category">
                         <option value="">{{ 'Any'|trans }}</option>
                         {% for category in this.categories %}
-                            <option value="{{ category.value }}" {% if this.categoryFilter == category.value %}selected{% endif %}>
+                            <option value="{{ category.value }}" {% if this.category == category.value %}selected{% endif %}>
                                 {{ category|trans }}
                             </option>
                         {% endfor %}
                     </select>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-4">
                     <label class="form-label" for="activity-overview-organ">{{ 'Organising party'|trans }}</label>
                     <select class="form-select" id="activity-overview-organ" data-model="organFilter">
                         <option value="">{{ 'Any'|trans }}</option>
@@ -78,8 +78,8 @@
 
     {% if this.past %}
         {% for year, activities in this.activitiesByAssociationYear %}
-            <h2 class="h4 mt-4 mb-2">{{ year }}</h2>
-            <div class="list-group mb-2">
+            <h2 class="h4 {{ loop.first ? 'mt-2' : 'mt-5' }} mb-3 pb-2 border-bottom">{{ year }}</h2>
+            <div class="mb-2">
                 {% for activity in activities %}
                     {% include 'partials/activity/list-item.html.twig' with {'activity': activity} only %}
                 {% endfor %}
@@ -88,7 +88,7 @@
             <p class="text-muted text-center py-4">{{ 'No activities match the current filters.'|trans }}</p>
         {% endfor %}
     {% else %}
-        <div class="list-group mb-2">
+        <div class="mb-2">
             {% for activity in this.activities %}
                 {% include 'partials/activity/list-item.html.twig' with {'activity': activity} only %}
             {% else %}

--- a/templates/partials/activity/list-item.html.twig
+++ b/templates/partials/activity/list-item.html.twig
@@ -1,83 +1,75 @@
 {% set now = date() %}
-<div class="list-group-item list-group-item-action activity-list-item" data-controller="activity-item"
+<div class="activity-list-item mb-4" data-controller="activity-item"
      data-activity-item-url-value="{{ path('activity/view', {'activity': activity.getId}) }}"
      data-action="click->activity-item#open">
-    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-start gap-1">
-        <h3 class="h5 mb-1">
-            <a href="{{ path('activity/view', {'activity': activity.getId}) }}">{{ activity.getName|localise_text }}</a>
-        </h3>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-start gap-1 mb-2">
+        <div>
+            <h3 class="h5 mb-2">
+                <a href="{{ path('activity/view', {'activity': activity.getId}) }}">{{ activity.getName|localise_text }}</a>
+            </h3>
+            <div class="d-flex flex-wrap gap-1">
+                {% if activity.getCategory.value not in ['other', 'uncategorised'] %}
+                    <span class="badge badge-info">{{ activity.getCategory|trans }}</span>
+                {% endif %}
+                {% for label in activity.getLabels %}
+                    <span class="badge badge-secondary">{{ label.getName|localise_text }}</span>
+                {% endfor %}
+            </div>
+        </div>
         <span class="text-muted small text-md-end">
             {{ activity_date_range(activity.getBeginTime, activity.getEndTime) }}
-        </span>
-    </div>
-
-    {% set location = activity.getLocation|localise_text %}
-    {% set costs = activity.getCosts|localise_text %}
-    <div class="d-flex flex-column flex-md-row justify-content-between text-muted small mb-1 gap-1">
-        <span>
-            {% if location is not empty %}
-                <span class="me-3"><i class="fas fa-location-dot"></i> {{ location }}</span>
-            {% endif %}
-            {% if costs is not empty %}
-                <span><i class="fas fa-tag"></i> {{ costs }}</span>
+            {% if now.timestamp >= activity.getBeginTime.timestamp and now.timestamp <= activity.getEndTime.timestamp %}
+                <br><span class="text-success">{{ 'ongoing for %duration%'|trans({'%duration%': human_time_diff(now, activity.getEndTime)}) }}</span>
+            {% elseif now.timestamp < activity.getBeginTime.timestamp %}
+                <br><span>{{ 'in %duration%'|trans({'%duration%': human_time_diff(now, activity.getBeginTime)}) }}</span>
             {% endif %}
         </span>
-        {% if now.timestamp >= activity.getBeginTime.timestamp and now.timestamp <= activity.getEndTime.timestamp %}
-            <span class="text-success text-md-end">{{ 'ongoing for %duration%'|trans({'%duration%': human_time_diff(now, activity.getEndTime)}) }}</span>
-        {% elseif now.timestamp < activity.getBeginTime.timestamp %}
-            <span class="text-md-end">{{ 'in %duration%'|trans({'%duration%': human_time_diff(now, activity.getBeginTime)}) }}</span>
-        {% endif %}
     </div>
 
-    {% set signupList = activity.getRelevantSignupList %}
-    {% if signupList is not null %}
-        {% if signupList.isOpen %}
-            {% set secondsLeft = signupList.getCloseDate.timestamp - now.timestamp %}
-            {% set urgency = secondsLeft < 86400 ? 'text-danger' : (secondsLeft < 604800 ? 'text-warning' : 'text-muted') %}
-            <p class="small mb-1 {{ urgency }}">
-                <i class="fas fa-clock"></i>
-                {{ 'Sign-up closes:'|trans }}
-                {{ signupList.getCloseDate|format_datetime(pattern: 'EEE d MMM. HH:mm', locale: app.request.locale) }}
-                ({{ 'in %duration%'|trans({'%duration%': human_time_diff(now, signupList.getCloseDate)}) }})
-                {% if activity.countPendingSignupLists > 1 %}
-                    <span class="text-muted">({{ 'more deadlines'|trans }})</span>
-                {% endif %}
-            </p>
-        {% else %}
-            <p class="small mb-1 text-muted">
-                <i class="fas fa-clock"></i>
-                {{ 'Sign-up opens:'|trans }}
-                {{ signupList.getOpenDate|format_datetime(pattern: 'EEE d MMM. HH:mm', locale: app.request.locale) }}
-                ({{ 'in %duration%'|trans({'%duration%': human_time_diff(now, signupList.getOpenDate)}) }})
-                {% if activity.countPendingSignupLists > 1 %}
-                    <span>({{ 'more deadlines'|trans }})</span>
-                {% endif %}
-            </p>
-        {% endif %}
-    {% endif %}
-
-    <div class="d-flex flex-wrap gap-1 mb-1">
-        {% if activity.getCategory.value not in ['other', 'uncategorised'] %}
-            <span class="badge badge-info">{{ activity.getCategory|trans }}</span>
-        {% endif %}
-        {% for label in activity.getLabels %}
-            <span class="badge badge-secondary">{{ label.getName|localise_text }}</span>
-        {% endfor %}
-    </div>
-
-    {% set description = activity.getDescription|localise_text %}
-    {% if description is not empty %}
-        <div class="activity-description" data-controller="description-toggle"
-             data-description-toggle-more-value="{{ 'Show more'|trans }}"
-             data-description-toggle-less-value="{{ 'Show less'|trans }}">
-            <div class="activity-description-content" data-description-toggle-target="content">
-                {{ description|markdown(['p', 'del', 'em', 'strong', 'a']) }}
-            </div>
-            <button type="button" class="btn btn-link btn-sm p-0 d-none"
-                    data-description-toggle-target="button"
-                    data-action="description-toggle#toggle">
-                {{ 'Show more'|trans }}
-            </button>
+    <div class="activity-description mb-2" data-controller="description-toggle"
+         data-description-toggle-more-value="{{ 'Show more'|trans }}"
+         data-description-toggle-less-value="{{ 'Show less'|trans }}">
+        <div class="activity-description-content" data-description-toggle-target="content">
+            {{ activity.getDescription|localise_text|markdown(['p', 'del', 'em', 'strong', 'a']) }}
         </div>
-    {% endif %}
+        <button type="button" class="btn btn-link btn-sm p-0 d-none"
+                data-description-toggle-target="button"
+                data-action="description-toggle#toggle">
+            {{ 'Show more'|trans }}
+        </button>
+    </div>
+
+    <hr class="my-1">
+
+    <div class="text-muted small">
+        <span class="me-3"><i class="fas fa-location-dot"></i> {{ activity.getLocation|localise_text }}</span>
+        <span class="me-3"><i class="fas fa-tag"></i> {{ activity.getCosts|localise_text }}</span>
+        {% set signupList = activity.getRelevantSignupList %}
+        {% if null !== signupList %}
+            {% if signupList.isOpen %}
+                {% set secondsLeft = signupList.getCloseDate.timestamp - now.timestamp %}
+                {% set urgency = secondsLeft < 86400 ? 'text-danger' : (secondsLeft < 604800 ? 'text-warning' : '') %}
+                <span>
+                    <i class="fas fa-ticket"></i>
+                    {{ 'Sign-up closes:'|trans }}
+                    <span class="{{ urgency }}">
+                        {{ signupList.getCloseDate|format_datetime(pattern: 'EEE d MMM. HH:mm', locale: app.request.locale) }} ({{ 'in %duration%'|trans({'%duration%': human_time_diff(now, signupList.getCloseDate)}) }})
+                    </span>
+                    {% if activity.countPendingSignupLists > 1 %}
+                        <span class="text-muted">({{ 'more deadlines'|trans }})</span>
+                    {% endif %}
+                </span>
+            {% else %}
+                <span>
+                    <i class="fas fa-ticket"></i>
+                    {{ 'Sign-up opens:'|trans }}
+                    {{ signupList.getOpenDate|format_datetime(pattern: 'EEE d MMM. HH:mm', locale: app.request.locale) }}
+                    ({{ 'in %duration%'|trans({'%duration%': human_time_diff(now, signupList.getOpenDate)}) }})
+                    {% if activity.countPendingSignupLists > 1 %}
+                        <span>({{ 'more deadlines'|trans }})</span>
+                    {% endif %}
+                </span>
+            {% endif %}
+        {% endif %}
+    </div>
 </div>

--- a/templates/partials/activity/list-item.html.twig
+++ b/templates/partials/activity/list-item.html.twig
@@ -1,0 +1,83 @@
+{% set now = date() %}
+<div class="list-group-item list-group-item-action activity-list-item" data-controller="activity-item"
+     data-activity-item-url-value="{{ path('activity/view', {'activity': activity.getId}) }}"
+     data-action="click->activity-item#open">
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-start gap-1">
+        <h3 class="h5 mb-1">
+            <a href="{{ path('activity/view', {'activity': activity.getId}) }}">{{ activity.getName|localise_text }}</a>
+        </h3>
+        <span class="text-muted small text-md-end">
+            {{ activity_date_range(activity.getBeginTime, activity.getEndTime) }}
+        </span>
+    </div>
+
+    {% set location = activity.getLocation|localise_text %}
+    {% set costs = activity.getCosts|localise_text %}
+    <div class="d-flex flex-column flex-md-row justify-content-between text-muted small mb-1 gap-1">
+        <span>
+            {% if location is not empty %}
+                <span class="me-3"><i class="fas fa-location-dot"></i> {{ location }}</span>
+            {% endif %}
+            {% if costs is not empty %}
+                <span><i class="fas fa-tag"></i> {{ costs }}</span>
+            {% endif %}
+        </span>
+        {% if now.timestamp >= activity.getBeginTime.timestamp and now.timestamp <= activity.getEndTime.timestamp %}
+            <span class="text-success text-md-end">{{ 'ongoing for %duration%'|trans({'%duration%': human_time_diff(now, activity.getEndTime)}) }}</span>
+        {% elseif now.timestamp < activity.getBeginTime.timestamp %}
+            <span class="text-md-end">{{ 'in %duration%'|trans({'%duration%': human_time_diff(now, activity.getBeginTime)}) }}</span>
+        {% endif %}
+    </div>
+
+    {% set signupList = activity.getRelevantSignupList %}
+    {% if signupList is not null %}
+        {% if signupList.isOpen %}
+            {% set secondsLeft = signupList.getCloseDate.timestamp - now.timestamp %}
+            {% set urgency = secondsLeft < 86400 ? 'text-danger' : (secondsLeft < 604800 ? 'text-warning' : 'text-muted') %}
+            <p class="small mb-1 {{ urgency }}">
+                <i class="fas fa-clock"></i>
+                {{ 'Sign-up closes:'|trans }}
+                {{ signupList.getCloseDate|format_datetime(pattern: 'EEE d MMM. HH:mm', locale: app.request.locale) }}
+                ({{ 'in %duration%'|trans({'%duration%': human_time_diff(now, signupList.getCloseDate)}) }})
+                {% if activity.countPendingSignupLists > 1 %}
+                    <span class="text-muted">({{ 'more deadlines'|trans }})</span>
+                {% endif %}
+            </p>
+        {% else %}
+            <p class="small mb-1 text-muted">
+                <i class="fas fa-clock"></i>
+                {{ 'Sign-up opens:'|trans }}
+                {{ signupList.getOpenDate|format_datetime(pattern: 'EEE d MMM. HH:mm', locale: app.request.locale) }}
+                ({{ 'in %duration%'|trans({'%duration%': human_time_diff(now, signupList.getOpenDate)}) }})
+                {% if activity.countPendingSignupLists > 1 %}
+                    <span>({{ 'more deadlines'|trans }})</span>
+                {% endif %}
+            </p>
+        {% endif %}
+    {% endif %}
+
+    <div class="d-flex flex-wrap gap-1 mb-1">
+        {% if activity.getCategory.value not in ['other', 'uncategorised'] %}
+            <span class="badge badge-info">{{ activity.getCategory|trans }}</span>
+        {% endif %}
+        {% for label in activity.getLabels %}
+            <span class="badge badge-secondary">{{ label.getName|localise_text }}</span>
+        {% endfor %}
+    </div>
+
+    {% set description = activity.getDescription|localise_text %}
+    {% if description is not empty %}
+        <div class="activity-description" data-controller="description-toggle"
+             data-description-toggle-more-value="{{ 'Show more'|trans }}"
+             data-description-toggle-less-value="{{ 'Show less'|trans }}">
+            <div class="activity-description-content" data-description-toggle-target="content">
+                {{ description|markdown(['p', 'del', 'em', 'strong', 'a']) }}
+            </div>
+            <button type="button" class="btn btn-link btn-sm p-0 d-none"
+                    data-description-toggle-target="button"
+                    data-action="description-toggle#toggle">
+                {{ 'Show more'|trans }}
+            </button>
+        </div>
+    {% endif %}
+</div>

--- a/templates/partials/activity/list-item.html.twig
+++ b/templates/partials/activity/list-item.html.twig
@@ -12,7 +12,7 @@
                     <span class="badge badge-info">{{ activity.getCategory|trans }}</span>
                 {% endif %}
                 {% for label in activity.getLabels %}
-                    <span class="badge badge-secondary">{{ label.getName|localise_text }}</span>
+                    <span class="badge badge-tag">{{ label.getName|localise_text }}</span>
                 {% endfor %}
             </div>
         </div>

--- a/templates/partials/activity/signup-list.html.twig
+++ b/templates/partials/activity/signup-list.html.twig
@@ -23,7 +23,7 @@
                     <span class="badge badge-warning">{{ 'Limited capacity'|trans }}</span>
                 {% endif %}
                 {% if list.onlyGEWIS %}
-                    <span class="badge badge-secondary">{{ 'GEWIS members only'|trans }}</span>
+                    <span class="badge badge-tag">{{ 'GEWIS members only'|trans }}</span>
                 {% endif %}
             </span>
             <small class="text-muted d-block mt-1">

--- a/templates/partials/activity/signup-list.html.twig
+++ b/templates/partials/activity/signup-list.html.twig
@@ -1,0 +1,85 @@
+{# Accordion panel for one sign-up list. Params: `list` (SignupListView), `collapseId` (string), `open` (bool). #}
+<div class="panel mb-3">
+    <button type="button"
+            class="panel-heading signup-list-heading d-flex justify-content-between align-items-start gap-2 w-100 border-0 bg-transparent text-start {% if not open %}collapsed{% endif %}"
+            data-bs-toggle="collapse" data-bs-target="#{{ collapseId }}"
+            aria-expanded="{{ open ? 'true' : 'false' }}" aria-controls="{{ collapseId }}">
+        <span>
+            <span class="d-flex flex-wrap align-items-center gap-1">
+                <span class="h5 mb-0">{{ list.name }}</span>
+                {% if list.promoted %}
+                    <i class="fas fa-star text-warning" title="{{ 'Promoted'|trans }}"></i>
+                {% endif %}
+            </span>
+            <span class="d-flex flex-wrap align-items-center gap-1 mt-1">
+                {% if list.isOpen %}
+                    <span class="badge badge-success">{{ 'Open'|trans }}</span>
+                {% elseif list.isClosed %}
+                    <span class="badge badge-secondary">{{ 'Closed'|trans }}</span>
+                {% else %}
+                    <span class="badge badge-info">{{ 'Not yet open'|trans }}</span>
+                {% endif %}
+                {% if list.limitedCapacity %}
+                    <span class="badge badge-warning">{{ 'Limited capacity'|trans }}</span>
+                {% endif %}
+                {% if list.onlyGEWIS %}
+                    <span class="badge badge-secondary">{{ 'GEWIS members only'|trans }}</span>
+                {% endif %}
+            </span>
+            <small class="text-muted d-block mt-1">
+                {{ 'Open from %open% until %close%.'|trans({
+                    '%open%': list.openDate|format_datetime(pattern: 'EEE d MMM. yyyy HH:mm', locale: app.request.locale),
+                    '%close%': list.closeDate|format_datetime(pattern: 'EEE d MMM. yyyy HH:mm', locale: app.request.locale),
+                }) }}
+            </small>
+        </span>
+        <i class="fas fa-chevron-down signup-list-chevron"></i>
+    </button>
+    <div class="collapse {% if open %}show{% endif %}" id="{{ collapseId }}">
+        <div class="panel-body">
+            {% if list.canViewDetails %}
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>{{ 'Name'|trans }}</th>
+                                {% for fieldName in list.fieldNames %}
+                                    <th>{{ fieldName }}</th>
+                                {% endfor %}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in list.rows %}
+                                <tr>
+                                    <td>{{ row.position }}</td>
+                                    <td>{{ row.fullName }}</td>
+                                    {% for cell in row.cells %}
+                                        <td>
+                                            {% if cell.hidden %}
+                                                <span class="text-muted fst-italic">{{ 'Hidden'|trans }}</span>
+                                            {% else %}
+                                                {{ cell.value }}
+                                            {% endif %}
+                                        </td>
+                                    {% endfor %}
+                                </tr>
+                            {% else %}
+                                <tr>
+                                    <td colspan="{{ 2 + list.fieldNames|length }}" class="text-center text-muted py-3">
+                                        {{ 'No subscriptions yet.'|trans }}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                {% if list.displaySubscribedNumber %}
+                    <p class="mb-1">{{ 'Number of subscriptions: %count%'|trans({'%count%': list.subscriberCount}) }}</p>
+                {% endif %}
+                <a href="{{ path('user_login') }}">{{ 'Log in to view the subscribers.'|trans }}</a>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/templates/partials/activity/signup-list.html.twig
+++ b/templates/partials/activity/signup-list.html.twig
@@ -15,7 +15,7 @@
                 {% if list.isOpen %}
                     <span class="badge badge-success">{{ 'Open'|trans }}</span>
                 {% elseif list.isClosed %}
-                    <span class="badge badge-secondary">{{ 'Closed'|trans }}</span>
+                    <span class="badge badge-danger">{{ 'Closed'|trans }}</span>
                 {% else %}
                     <span class="badge badge-info">{{ 'Not yet open'|trans }}</span>
                 {% endif %}

--- a/templates/partials/activity/year-switcher.html.twig
+++ b/templates/partials/activity/year-switcher.html.twig
@@ -1,0 +1,42 @@
+{# Association-year switcher (previous/next + dropdown). Params: route (route name), year (?int), years (int[]). Preserves the current query string so the active filters survive a year change. #}
+{% if years is not empty %}
+    {% set query = app.request.query.all %}
+    {# Jump to the nearest year actually present in the list, so gaps in a sparse list don't land on an empty year. #}
+    {% set newer_years = year is not null ? years|filter(y => y > year) : [] %}
+    {% set older_years = year is not null ? years|filter(y => y < year) : [] %}
+    {% set newer_url = newer_years is not empty ? path(route, query|merge({ year: min(newer_years) })) : null %}
+    {% set older_url = older_years is not empty ? path(route, query|merge({ year: max(older_years) })) : null %}
+
+    <div class="btn-group">
+        <a class="btn btn-outline-secondary {{ newer_url is null ? 'disabled' }}"
+           href="{{ newer_url ?? '#' }}" aria-label="{{ 'Newer'|trans }}">
+            <i class="fas fa-chevron-left"></i>
+        </a>
+        <div class="btn-group">
+            <button type="button" class="btn btn-outline-secondary dropdown-toggle"
+                    data-bs-toggle="dropdown" aria-expanded="false">
+                {{ year is not null ? (year ~ ' - ' ~ (year + 1)) : 'All years'|trans }}
+            </button>
+            <ul class="dropdown-menu">
+                <li>
+                    <a class="dropdown-item {{ year is null ? 'active' }}" href="{{ path(route, query) }}">
+                        {{ 'All years'|trans }}
+                    </a>
+                </li>
+                <li><hr class="dropdown-divider"></li>
+                {% for y in years %}
+                    <li>
+                        <a class="dropdown-item {{ year == y ? 'active' }}"
+                           href="{{ path(route, query|merge({ year: y })) }}">
+                            {{ y }} - {{ y + 1 }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+        <a class="btn btn-outline-secondary {{ older_url is null ? 'disabled' }}"
+           href="{{ older_url ?? '#' }}" aria-label="{{ 'Older'|trans }}">
+            <i class="fas fa-chevron-right"></i>
+        </a>
+    </div>
+{% endif %}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5,9 +5,25 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
+      <trans-unit id="E69bPZ6" resname="%count% day|%count% days">
+        <source>%count% day|%count% days</source>
+        <target>%count% day|%count% days</target>
+      </trans-unit>
+      <trans-unit id="H3jnVKg" resname="%count% hour|%count% hours">
+        <source>%count% hour|%count% hours</source>
+        <target>%count% hour|%count% hours</target>
+      </trans-unit>
+      <trans-unit id="30tji6_" resname="%count% minute|%count% minutes">
+        <source>%count% minute|%count% minutes</source>
+        <target>%count% minute|%count% minutes</target>
+      </trans-unit>
       <trans-unit id="Bp.9tYU" resname="%count% session(s) terminated.">
         <source>%count% session(s) terminated.</source>
         <target state="translated">%count% session(s) terminated.</target>
+      </trans-unit>
+      <trans-unit id="KJO8tlf" resname="%count% week|%count% weeks">
+        <source>%count% week|%count% weeks</source>
+        <target>%count% week|%count% weeks</target>
       </trans-unit>
       <trans-unit id="6e8o.wA" resname="API">
         <source>API</source>
@@ -220,6 +236,10 @@
       <trans-unit id="wmlL5M4" resname="Categories">
         <source>Categories</source>
         <target state="translated">Categories</target>
+      </trans-unit>
+      <trans-unit id="tceoGZr" resname="Category">
+        <source>Category</source>
+        <target>Category</target>
       </trans-unit>
       <trans-unit id="ROsdATY" resname="Chair">
         <source>Chair</source>
@@ -469,6 +489,10 @@
         <source>Featured</source>
         <target state="translated">Featured</target>
       </trans-unit>
+      <trans-unit id="jqwP5Ri" resname="Filters">
+        <source>Filters</source>
+        <target>Filters</target>
+      </trans-unit>
       <trans-unit id="2ul.IfN" resname="Final">
         <source>Final</source>
         <target state="translated">Final</target>
@@ -508,6 +532,10 @@
       <trans-unit id="TZOmMlF" resname="Fraternity">
         <source>Fraternity</source>
         <target state="translated">Fraternity</target>
+      </trans-unit>
+      <trans-unit id="Ll4aq_." resname="From">
+        <source>From</source>
+        <target>From</target>
       </trans-unit>
       <trans-unit id="kCLhNY7" resname="Frontpage">
         <source>Frontpage</source>
@@ -725,6 +753,10 @@
         <source>Links</source>
         <target state="translated">Links</target>
       </trans-unit>
+      <trans-unit id="uU838DK" resname="Load more">
+        <source>Load more</source>
+        <target>Load more</target>
+      </trans-unit>
       <trans-unit id="sRyfMnf" resname="Loading an infimum...">
         <source>Loading an infimum...</source>
         <target state="translated">Loading an infimum...</target>
@@ -853,6 +885,14 @@
         <source>My Photos</source>
         <target state="translated">My Photos</target>
       </trans-unit>
+      <trans-unit id="2xos6Ug" resname="My past activities">
+        <source>My past activities</source>
+        <target>My past activities</target>
+      </trans-unit>
+      <trans-unit id="rbP4ntw" resname="My upcoming activities">
+        <source>My upcoming activities</source>
+        <target>My upcoming activities</target>
+      </trans-unit>
       <trans-unit id="wbMeKOh" resname="Name">
         <source>Name</source>
         <target state="translated">Name</target>
@@ -877,6 +917,10 @@
         <source>No active sessions.</source>
         <target state="translated">No active sessions.</target>
       </trans-unit>
+      <trans-unit id="FeP0dTL" resname="No activities match the current filters.">
+        <source>No activities match the current filters.</source>
+        <target>No activities match the current filters.</target>
+      </trans-unit>
       <trans-unit id="VROC54W" resname="No company users match the current filters.">
         <source>No company users match the current filters.</source>
         <target state="translated">No company users match the current filters.</target>
@@ -897,6 +941,10 @@
         <source>On Thursdays, there is a %link_start%social drink%link_end% from 16.30 to 19.00.</source>
         <target state="translated">On Thursdays, there is a %link_start%social drink%link_end% from 16.30 to 19.00.</target>
       </trans-unit>
+      <trans-unit id="bnfrTZj" resname="Only with open sign-up">
+        <source>Only with open sign-up</source>
+        <target>Only with open sign-up</target>
+      </trans-unit>
       <trans-unit id="FJxCJQn" resname="Opperhoofd">
         <source>Opperhoofd</source>
         <target state="translated">Opperhoofd</target>
@@ -912,6 +960,10 @@
       <trans-unit id="ljfCRt6" resname="Ordinary">
         <source>Ordinary</source>
         <target state="translated">Ordinary</target>
+      </trans-unit>
+      <trans-unit id="zvvKAKp" resname="Organising party">
+        <source>Organising party</source>
+        <target>Organising party</target>
       </trans-unit>
       <trans-unit id="aiFSOsy" resname="Other">
         <source>Other</source>
@@ -1053,6 +1105,10 @@
         <source>Search</source>
         <target state="translated">Search</target>
       </trans-unit>
+      <trans-unit id="ZNQdihj" resname="Search by activity name">
+        <source>Search by activity name</source>
+        <target>Search by activity name</target>
+      </trans-unit>
       <trans-unit id="YWrWXBq" resname="Search by company, representative name, or email">
         <source>Search by company, representative name, or email</source>
         <target state="translated">Search by company, representative name, or email</target>
@@ -1093,9 +1149,25 @@
         <source>Settings</source>
         <target state="translated">Settings</target>
       </trans-unit>
+      <trans-unit id="WDBuc7a" resname="Show less">
+        <source>Show less</source>
+        <target>Show less</target>
+      </trans-unit>
+      <trans-unit id="Vlj9mPs" resname="Show more">
+        <source>Show more</source>
+        <target>Show more</target>
+      </trans-unit>
       <trans-unit id="pNIxNSX" resname="Sign in">
         <source>Sign in</source>
         <target state="translated">Sign in</target>
+      </trans-unit>
+      <trans-unit id="4ufAWYB" resname="Sign-up closes:">
+        <source>Sign-up closes:</source>
+        <target>Sign-up closes:</target>
+      </trans-unit>
+      <trans-unit id="C3eGQtZ" resname="Sign-up opens:">
+        <source>Sign-up opens:</source>
+        <target>Sign-up opens:</target>
       </trans-unit>
       <trans-unit id="lIY1Kot" resname="Signed in %date%">
         <source>Signed in %date%</source>
@@ -1253,6 +1325,10 @@
         <source>Unknown device</source>
         <target state="translated">Unknown device</target>
       </trans-unit>
+      <trans-unit id=".b394XX" resname="Until">
+        <source>Until</source>
+        <target>Until</target>
+      </trans-unit>
       <trans-unit id="ZOvPU2x" resname="Upload exams">
         <source>Upload exams</source>
         <target state="translated">Upload exams</target>
@@ -1405,13 +1481,29 @@
         <source>iCal</source>
         <target state="translated">iCal</target>
       </trans-unit>
+      <trans-unit id="Q384Ly2" resname="in %duration%">
+        <source>in %duration%</source>
+        <target>in %duration%</target>
+      </trans-unit>
       <trans-unit id="6.eCze3" resname="jane.doe@example.com">
         <source>jane.doe@example.com</source>
         <target state="translated">jane.doe@example.com</target>
       </trans-unit>
+      <trans-unit id="huWr6j7" resname="less than a minute">
+        <source>less than a minute</source>
+        <target>less than a minute</target>
+      </trans-unit>
+      <trans-unit id="CC4UZ2j" resname="more deadlines">
+        <source>more deadlines</source>
+        <target>more deadlines</target>
+      </trans-unit>
       <trans-unit id="edSu_p6" resname="on">
         <source>on</source>
         <target state="translated">on</target>
+      </trans-unit>
+      <trans-unit id="NpnxF2Z" resname="ongoing for %duration%">
+        <source>ongoing for %duration%</source>
+        <target>ongoing for %duration%</target>
       </trans-unit>
       <trans-unit id="W3MzJgn" resname="unavailable">
         <source>unavailable</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -85,6 +85,10 @@
         <source>Activity Archive</source>
         <target state="translated">Activity Archive</target>
       </trans-unit>
+      <trans-unit id="85z9UtL" resname="Add to calendar">
+        <source>Add to calendar</source>
+        <target>Add to calendar</target>
+      </trans-unit>
       <trans-unit id="kIqhHtP" resname="Admin">
         <source>Admin</source>
         <target state="translated">Admin</target>
@@ -257,6 +261,14 @@
         <source>Close</source>
         <target state="translated">Close</target>
       </trans-unit>
+      <trans-unit id="yRh1o7S" resname="Closed">
+        <source>Closed</source>
+        <target>Closed</target>
+      </trans-unit>
+      <trans-unit id="wt5TMsn" resname="Closed sign-up lists">
+        <source>Closed sign-up lists</source>
+        <target>Closed sign-up lists</target>
+      </trans-unit>
       <trans-unit id="c1Os74Z" resname="Commissaris Digitale Innovatie">
         <source>Commissaris Digitale Innovatie</source>
         <target state="translated">Digital Innovation Officer</target>
@@ -328,6 +340,10 @@
       <trans-unit id="Xj30MRg" resname="Continue">
         <source>Continue</source>
         <target state="translated">Continue</target>
+      </trans-unit>
+      <trans-unit id="LTGw.px" resname="Costs">
+        <source>Costs</source>
+        <target>Costs</target>
       </trans-unit>
       <trans-unit id="lmE8cjL" resname="Courses">
         <source>Courses</source>
@@ -424,6 +440,10 @@
       <trans-unit id="FdpiKgY" resname="Enabled">
         <source>Enabled</source>
         <target state="translated">Enabled</target>
+      </trans-unit>
+      <trans-unit id="kI3gFIV" resname="End">
+        <source>End</source>
+        <target>End</target>
       </trans-unit>
       <trans-unit id="_ujLe_1" resname="Ends">
         <source>Ends</source>
@@ -540,6 +560,10 @@
       <trans-unit id="kCLhNY7" resname="Frontpage">
         <source>Frontpage</source>
         <target state="translated">Frontpage</target>
+      </trans-unit>
+      <trans-unit id="ThCpIAB" resname="GEWIS members only">
+        <source>GEWIS members only</source>
+        <target>GEWIS members only</target>
       </trans-unit>
       <trans-unit id="gfAnVGd" resname="GEWIS room impression">
         <source>GEWIS room impression</source>
@@ -749,6 +773,10 @@
         <source>Light</source>
         <target state="translated">Light</target>
       </trans-unit>
+      <trans-unit id="JvvWrjE" resname="Limited capacity">
+        <source>Limited capacity</source>
+        <target>Limited capacity</target>
+      </trans-unit>
       <trans-unit id="Dz0Nyiu" resname="Links">
         <source>Links</source>
         <target state="translated">Links</target>
@@ -761,9 +789,17 @@
         <source>Loading an infimum...</source>
         <target state="translated">Loading an infimum...</target>
       </trans-unit>
+      <trans-unit id="nODxdW." resname="Location">
+        <source>Location</source>
+        <target>Location</target>
+      </trans-unit>
       <trans-unit id="RxIIlzy" resname="Log in">
         <source>Log in</source>
         <target state="translated">Log in</target>
+      </trans-unit>
+      <trans-unit id="oQ0iCjA" resname="Log in to view the subscribers.">
+        <source>Log in to view the subscribers.</source>
+        <target>Log in to view the subscribers.</target>
       </trans-unit>
       <trans-unit id="N_oO8pX" resname="Log out everywhere">
         <source>Log out everywhere</source>
@@ -929,9 +965,21 @@
         <source>No members match the current filters.</source>
         <target state="translated">No members match the current filters.</target>
       </trans-unit>
+      <trans-unit id="6I5cJhu" resname="No subscriptions yet.">
+        <source>No subscriptions yet.</source>
+        <target>No subscriptions yet.</target>
+      </trans-unit>
       <trans-unit id="5oWvzf3" resname="Not activated">
         <source>Not activated</source>
         <target state="translated">Not activated</target>
+      </trans-unit>
+      <trans-unit id="Q7CXr4n" resname="Not yet open">
+        <source>Not yet open</source>
+        <target>Not yet open</target>
+      </trans-unit>
+      <trans-unit id="ZV7YFQ7" resname="Number of subscriptions: %count%">
+        <source>Number of subscriptions: %count%</source>
+        <target>Number of subscriptions: %count%</target>
       </trans-unit>
       <trans-unit id="fm8k4L1" resname="Oh no! Something went wrong :(">
         <source>Oh no! Something went wrong :(</source>
@@ -944,6 +992,14 @@
       <trans-unit id="bnfrTZj" resname="Only with open sign-up">
         <source>Only with open sign-up</source>
         <target>Only with open sign-up</target>
+      </trans-unit>
+      <trans-unit id="_SqArFZ" resname="Open">
+        <source>Open</source>
+        <target>Open</target>
+      </trans-unit>
+      <trans-unit id="NYE98.0" resname="Open from %open% until %close%.">
+        <source>Open from %open% until %close%.</source>
+        <target>Open from %open% until %close%.</target>
       </trans-unit>
       <trans-unit id="FJxCJQn" resname="Opperhoofd">
         <source>Opperhoofd</source>
@@ -960,6 +1016,10 @@
       <trans-unit id="ljfCRt6" resname="Ordinary">
         <source>Ordinary</source>
         <target state="translated">Ordinary</target>
+      </trans-unit>
+      <trans-unit id="flkVGv3" resname="Organised by">
+        <source>Organised by</source>
+        <target>Organised by</target>
       </trans-unit>
       <trans-unit id="zvvKAKp" resname="Organising party">
         <source>Organising party</source>
@@ -1013,6 +1073,10 @@
         <source>Pick a long, unique password - at least 16 characters and not found in any known data breach.</source>
         <target state="translated">Pick a long, unique password - at least 16 characters and not found in any known data breach.</target>
       </trans-unit>
+      <trans-unit id="GqUZ23A" resname="Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!">
+        <source>Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!</source>
+        <target>Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!</target>
+      </trans-unit>
       <trans-unit id="qT565tK" resname="Polls">
         <source>Polls</source>
         <target state="translated">Polls</target>
@@ -1032,6 +1096,10 @@
       <trans-unit id="M8W_jVO" resname="Promo &amp; merchandise">
         <source>Promo &amp; merchandise</source>
         <target><![CDATA[Promo & merchandise]]></target>
+      </trans-unit>
+      <trans-unit id="R2eeY_o" resname="Promoted">
+        <source>Promoted</source>
+        <target>Promoted</target>
       </trans-unit>
       <trans-unit id="YRI5E0j" resname="QR code">
         <source>QR code</source>
@@ -1165,6 +1233,10 @@
         <source>Sign-up closes:</source>
         <target>Sign-up closes:</target>
       </trans-unit>
+      <trans-unit id="JiavS3V" resname="Sign-up lists">
+        <source>Sign-up lists</source>
+        <target>Sign-up lists</target>
+      </trans-unit>
       <trans-unit id="C3eGQtZ" resname="Sign-up opens:">
         <source>Sign-up opens:</source>
         <target>Sign-up opens:</target>
@@ -1184,6 +1256,10 @@
       <trans-unit id="oBphsD9" resname="Stale">
         <source>Stale</source>
         <target state="translated">Stale</target>
+      </trans-unit>
+      <trans-unit id="qpMwoA4" resname="Start">
+        <source>Start</source>
+        <target>Start</target>
       </trans-unit>
       <trans-unit id="6xCSWiZ" resname="Status">
         <source>Status</source>
@@ -1504,6 +1580,10 @@
       <trans-unit id="NpnxF2Z" resname="ongoing for %duration%">
         <source>ongoing for %duration%</source>
         <target>ongoing for %duration%</target>
+      </trans-unit>
+      <trans-unit id="CqfqdkM" resname="the organising party">
+        <source>the organising party</source>
+        <target>the organising party</target>
       </trans-unit>
       <trans-unit id="W3MzJgn" resname="unavailable">
         <source>unavailable</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -133,6 +133,10 @@
         <source>All sessions except this one will be signed out immediately.</source>
         <target state="translated">All sessions except this one will be signed out immediately.</target>
       </trans-unit>
+      <trans-unit id="CdVO0Gm" resname="All years">
+        <source>All years</source>
+        <target state="translated">All years</target>
+      </trans-unit>
       <trans-unit id="3eX.3WJ" resname="Analytics are currently">
         <source>Analytics are currently</source>
         <target state="translated">Analytics are currently</target>
@@ -243,7 +247,7 @@
       </trans-unit>
       <trans-unit id="tceoGZr" resname="Category">
         <source>Category</source>
-        <target>Category</target>
+        <target state="translated">Category</target>
       </trans-unit>
       <trans-unit id="ROsdATY" resname="Chair">
         <source>Chair</source>
@@ -941,6 +945,10 @@
         <source>New password</source>
         <target state="translated">New password</target>
       </trans-unit>
+      <trans-unit id="VXC5Ldf" resname="Newer">
+        <source>Newer</source>
+        <target state="translated">Newer</target>
+      </trans-unit>
       <trans-unit id="XUSTYpl" resname="News">
         <source>News</source>
         <target state="translated">News</target>
@@ -984,6 +992,10 @@
       <trans-unit id="fm8k4L1" resname="Oh no! Something went wrong :(">
         <source>Oh no! Something went wrong :(</source>
         <target state="translated">Oh no! Something went wrong :(</target>
+      </trans-unit>
+      <trans-unit id="AxXKYah" resname="Older">
+        <source>Older</source>
+        <target state="translated">Older</target>
       </trans-unit>
       <trans-unit id="svuF9zU" resname="On Thursdays, there is a %link_start%social drink%link_end% from 16.30 to 19.00.">
         <source>On Thursdays, there is a %link_start%social drink%link_end% from 16.30 to 19.00.</source>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -85,6 +85,10 @@
         <source>Activity Archive</source>
         <target state="translated">Activiteitenarchief</target>
       </trans-unit>
+      <trans-unit id="85z9UtL" resname="Add to calendar">
+        <source>Add to calendar</source>
+        <target>Toevoegen aan agenda</target>
+      </trans-unit>
       <trans-unit id="kIqhHtP" resname="Admin">
         <source>Admin</source>
         <target>Admin</target>
@@ -257,6 +261,14 @@
         <source>Close</source>
         <target>Sluiten</target>
       </trans-unit>
+      <trans-unit id="yRh1o7S" resname="Closed">
+        <source>Closed</source>
+        <target>Gesloten</target>
+      </trans-unit>
+      <trans-unit id="wt5TMsn" resname="Closed sign-up lists">
+        <source>Closed sign-up lists</source>
+        <target>Gesloten inschrijflijsten</target>
+      </trans-unit>
       <trans-unit id="c1Os74Z" resname="Commissaris Digitale Innovatie">
         <source>Commissaris Digitale Innovatie</source>
         <target state="translated">Commissaris Digitale Innovatie</target>
@@ -328,6 +340,10 @@
       <trans-unit id="Xj30MRg" resname="Continue">
         <source>Continue</source>
         <target state="translated">Doorgaan</target>
+      </trans-unit>
+      <trans-unit id="LTGw.px" resname="Costs">
+        <source>Costs</source>
+        <target>Kosten</target>
       </trans-unit>
       <trans-unit id="lmE8cjL" resname="Courses">
         <source>Courses</source>
@@ -424,6 +440,10 @@
       <trans-unit id="FdpiKgY" resname="Enabled">
         <source>Enabled</source>
         <target state="translated">Ingeschakeld</target>
+      </trans-unit>
+      <trans-unit id="kI3gFIV" resname="End">
+        <source>End</source>
+        <target>Einde</target>
       </trans-unit>
       <trans-unit id="_ujLe_1" resname="Ends">
         <source>Ends</source>
@@ -540,6 +560,10 @@
       <trans-unit id="kCLhNY7" resname="Frontpage">
         <source>Frontpage</source>
         <target state="translated">Voorpagina</target>
+      </trans-unit>
+      <trans-unit id="ThCpIAB" resname="GEWIS members only">
+        <source>GEWIS members only</source>
+        <target>Alleen GEWIS-leden</target>
       </trans-unit>
       <trans-unit id="gfAnVGd" resname="GEWIS room impression">
         <source>GEWIS room impression</source>
@@ -749,6 +773,10 @@
         <source>Light</source>
         <target state="translated">Licht</target>
       </trans-unit>
+      <trans-unit id="JvvWrjE" resname="Limited capacity">
+        <source>Limited capacity</source>
+        <target>Beperkte capaciteit</target>
+      </trans-unit>
       <trans-unit id="Dz0Nyiu" resname="Links">
         <source>Links</source>
         <target state="translated">Links</target>
@@ -761,9 +789,17 @@
         <source>Loading an infimum...</source>
         <target state="translated">Een infimum aan het laden...</target>
       </trans-unit>
+      <trans-unit id="nODxdW." resname="Location">
+        <source>Location</source>
+        <target>Locatie</target>
+      </trans-unit>
       <trans-unit id="RxIIlzy" resname="Log in">
         <source>Log in</source>
         <target state="translated">Inloggen</target>
+      </trans-unit>
+      <trans-unit id="oQ0iCjA" resname="Log in to view the subscribers.">
+        <source>Log in to view the subscribers.</source>
+        <target>Log in om de inschrijvingen te bekijken.</target>
       </trans-unit>
       <trans-unit id="N_oO8pX" resname="Log out everywhere">
         <source>Log out everywhere</source>
@@ -929,9 +965,21 @@
         <source>No members match the current filters.</source>
         <target state="translated">Geen leden voldoen aan de huidige filters.</target>
       </trans-unit>
+      <trans-unit id="6I5cJhu" resname="No subscriptions yet.">
+        <source>No subscriptions yet.</source>
+        <target>Nog geen inschrijvingen.</target>
+      </trans-unit>
       <trans-unit id="5oWvzf3" resname="Not activated">
         <source>Not activated</source>
         <target state="translated">Niet geactiveerd</target>
+      </trans-unit>
+      <trans-unit id="Q7CXr4n" resname="Not yet open">
+        <source>Not yet open</source>
+        <target>Nog niet open</target>
+      </trans-unit>
+      <trans-unit id="ZV7YFQ7" resname="Number of subscriptions: %count%">
+        <source>Number of subscriptions: %count%</source>
+        <target>Aantal inschrijvingen: %count%</target>
       </trans-unit>
       <trans-unit id="fm8k4L1" resname="Oh no! Something went wrong :(">
         <source>Oh no! Something went wrong :(</source>
@@ -944,6 +992,14 @@
       <trans-unit id="bnfrTZj" resname="Only with open sign-up">
         <source>Only with open sign-up</source>
         <target>Alleen met open inschrijving</target>
+      </trans-unit>
+      <trans-unit id="_SqArFZ" resname="Open">
+        <source>Open</source>
+        <target>Open</target>
+      </trans-unit>
+      <trans-unit id="NYE98.0" resname="Open from %open% until %close%.">
+        <source>Open from %open% until %close%.</source>
+        <target>Open van %open% tot %close%.</target>
       </trans-unit>
       <trans-unit id="FJxCJQn" resname="Opperhoofd">
         <source>Opperhoofd</source>
@@ -960,6 +1016,10 @@
       <trans-unit id="ljfCRt6" resname="Ordinary">
         <source>Ordinary</source>
         <target state="translated">Gewoon</target>
+      </trans-unit>
+      <trans-unit id="flkVGv3" resname="Organised by">
+        <source>Organised by</source>
+        <target>Georganiseerd door</target>
       </trans-unit>
       <trans-unit id="zvvKAKp" resname="Organising party">
         <source>Organising party</source>
@@ -1013,6 +1073,10 @@
         <source>Pick a long, unique password - at least 16 characters and not found in any known data breach.</source>
         <target state="translated">Kies een lang, uniek wachtwoord - minimaal 16 tekens lang en niet voorkomend in bekende datalekken.</target>
       </trans-unit>
+      <trans-unit id="GqUZ23A" resname="Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!">
+        <source>Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!</source>
+        <target>Neem contact op met %organizer% of het bestuur (%email%) bij vragen of opmerkingen. Veel plezier!</target>
+      </trans-unit>
       <trans-unit id="qT565tK" resname="Polls">
         <source>Polls</source>
         <target state="translated">Polls</target>
@@ -1032,6 +1096,10 @@
       <trans-unit id="M8W_jVO" resname="Promo &amp; merchandise">
         <source>Promo &amp; merchandise</source>
         <target><![CDATA[Promo & merchandise]]></target>
+      </trans-unit>
+      <trans-unit id="R2eeY_o" resname="Promoted">
+        <source>Promoted</source>
+        <target>Uitgelicht</target>
       </trans-unit>
       <trans-unit id="YRI5E0j" resname="QR code">
         <source>QR code</source>
@@ -1165,6 +1233,10 @@
         <source>Sign-up closes:</source>
         <target>Inschrijving sluit:</target>
       </trans-unit>
+      <trans-unit id="JiavS3V" resname="Sign-up lists">
+        <source>Sign-up lists</source>
+        <target>Inschrijflijsten</target>
+      </trans-unit>
       <trans-unit id="C3eGQtZ" resname="Sign-up opens:">
         <source>Sign-up opens:</source>
         <target>Inschrijving opent:</target>
@@ -1184,6 +1256,10 @@
       <trans-unit id="oBphsD9" resname="Stale">
         <source>Stale</source>
         <target state="translated">Verouderd</target>
+      </trans-unit>
+      <trans-unit id="qpMwoA4" resname="Start">
+        <source>Start</source>
+        <target>Start</target>
       </trans-unit>
       <trans-unit id="6xCSWiZ" resname="Status">
         <source>Status</source>
@@ -1504,6 +1580,10 @@
       <trans-unit id="NpnxF2Z" resname="ongoing for %duration%">
         <source>ongoing for %duration%</source>
         <target>nog %duration% bezig</target>
+      </trans-unit>
+      <trans-unit id="CqfqdkM" resname="the organising party">
+        <source>the organising party</source>
+        <target>de organiserende partij</target>
       </trans-unit>
       <trans-unit id="W3MzJgn" resname="unavailable">
         <source>unavailable</source>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -5,9 +5,25 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
+      <trans-unit id="E69bPZ6" resname="%count% day|%count% days">
+        <source>%count% day|%count% days</source>
+        <target>%count% dag|%count% dagen</target>
+      </trans-unit>
+      <trans-unit id="H3jnVKg" resname="%count% hour|%count% hours">
+        <source>%count% hour|%count% hours</source>
+        <target>%count% uur|%count% uur</target>
+      </trans-unit>
+      <trans-unit id="30tji6_" resname="%count% minute|%count% minutes">
+        <source>%count% minute|%count% minutes</source>
+        <target>%count% minuut|%count% minuten</target>
+      </trans-unit>
       <trans-unit id="Bp.9tYU" resname="%count% session(s) terminated.">
         <source>%count% session(s) terminated.</source>
         <target state="translated">%count% sessie(s) beëindigd.</target>
+      </trans-unit>
+      <trans-unit id="KJO8tlf" resname="%count% week|%count% weeks">
+        <source>%count% week|%count% weeks</source>
+        <target>%count% week|%count% weken</target>
       </trans-unit>
       <trans-unit id="6e8o.wA" resname="API">
         <source>API</source>
@@ -220,6 +236,10 @@
       <trans-unit id="wmlL5M4" resname="Categories">
         <source>Categories</source>
         <target state="translated">Categorieën</target>
+      </trans-unit>
+      <trans-unit id="tceoGZr" resname="Category">
+        <source>Category</source>
+        <target>Categorie</target>
       </trans-unit>
       <trans-unit id="ROsdATY" resname="Chair">
         <source>Chair</source>
@@ -469,6 +489,10 @@
         <source>Featured</source>
         <target state="translated">Uitgelicht</target>
       </trans-unit>
+      <trans-unit id="jqwP5Ri" resname="Filters">
+        <source>Filters</source>
+        <target>Filters</target>
+      </trans-unit>
       <trans-unit id="2ul.IfN" resname="Final">
         <source>Final</source>
         <target state="translated">Eindexamen</target>
@@ -508,6 +532,10 @@
       <trans-unit id="TZOmMlF" resname="Fraternity">
         <source>Fraternity</source>
         <target>Dispuut</target>
+      </trans-unit>
+      <trans-unit id="Ll4aq_." resname="From">
+        <source>From</source>
+        <target>Vanaf</target>
       </trans-unit>
       <trans-unit id="kCLhNY7" resname="Frontpage">
         <source>Frontpage</source>
@@ -725,6 +753,10 @@
         <source>Links</source>
         <target state="translated">Links</target>
       </trans-unit>
+      <trans-unit id="uU838DK" resname="Load more">
+        <source>Load more</source>
+        <target>Meer laden</target>
+      </trans-unit>
       <trans-unit id="sRyfMnf" resname="Loading an infimum...">
         <source>Loading an infimum...</source>
         <target state="translated">Een infimum aan het laden...</target>
@@ -853,6 +885,14 @@
         <source>My Photos</source>
         <target state="translated">Mijn foto's</target>
       </trans-unit>
+      <trans-unit id="2xos6Ug" resname="My past activities">
+        <source>My past activities</source>
+        <target>Mijn afgelopen activiteiten</target>
+      </trans-unit>
+      <trans-unit id="rbP4ntw" resname="My upcoming activities">
+        <source>My upcoming activities</source>
+        <target>Mijn aankomende activiteiten</target>
+      </trans-unit>
       <trans-unit id="wbMeKOh" resname="Name">
         <source>Name</source>
         <target state="translated">Naam</target>
@@ -877,6 +917,10 @@
         <source>No active sessions.</source>
         <target state="translated">Geen actieve sessies.</target>
       </trans-unit>
+      <trans-unit id="FeP0dTL" resname="No activities match the current filters.">
+        <source>No activities match the current filters.</source>
+        <target>Geen activiteiten voldoen aan de huidige filters.</target>
+      </trans-unit>
       <trans-unit id="VROC54W" resname="No company users match the current filters.">
         <source>No company users match the current filters.</source>
         <target state="translated">Geen bedrijfsgebruikers voldoen aan de huidige filters.</target>
@@ -897,6 +941,10 @@
         <source>On Thursdays, there is a %link_start%social drink%link_end% from 16.30 to 19.00.</source>
         <target state="translated">Donderdags is er een %link_start%borrel%link_end% van 16.30 tot 19.00.</target>
       </trans-unit>
+      <trans-unit id="bnfrTZj" resname="Only with open sign-up">
+        <source>Only with open sign-up</source>
+        <target>Alleen met open inschrijving</target>
+      </trans-unit>
       <trans-unit id="FJxCJQn" resname="Opperhoofd">
         <source>Opperhoofd</source>
         <target state="translated">Opperhoofd</target>
@@ -912,6 +960,10 @@
       <trans-unit id="ljfCRt6" resname="Ordinary">
         <source>Ordinary</source>
         <target state="translated">Gewoon</target>
+      </trans-unit>
+      <trans-unit id="zvvKAKp" resname="Organising party">
+        <source>Organising party</source>
+        <target>Organiserende partij</target>
       </trans-unit>
       <trans-unit id="aiFSOsy" resname="Other">
         <source>Other</source>
@@ -1053,6 +1105,10 @@
         <source>Search</source>
         <target state="translated">Zoeken</target>
       </trans-unit>
+      <trans-unit id="ZNQdihj" resname="Search by activity name">
+        <source>Search by activity name</source>
+        <target>Zoek op naam van activiteit</target>
+      </trans-unit>
       <trans-unit id="YWrWXBq" resname="Search by company, representative name, or email">
         <source>Search by company, representative name, or email</source>
         <target state="translated">Zoek op bedrijf, vertegenwoordiger of e-mail</target>
@@ -1093,9 +1149,25 @@
         <source>Settings</source>
         <target>Instellingen</target>
       </trans-unit>
+      <trans-unit id="WDBuc7a" resname="Show less">
+        <source>Show less</source>
+        <target>Toon minder</target>
+      </trans-unit>
+      <trans-unit id="Vlj9mPs" resname="Show more">
+        <source>Show more</source>
+        <target>Toon meer</target>
+      </trans-unit>
       <trans-unit id="pNIxNSX" resname="Sign in">
         <source>Sign in</source>
         <target state="translated">Inloggen</target>
+      </trans-unit>
+      <trans-unit id="4ufAWYB" resname="Sign-up closes:">
+        <source>Sign-up closes:</source>
+        <target>Inschrijving sluit:</target>
+      </trans-unit>
+      <trans-unit id="C3eGQtZ" resname="Sign-up opens:">
+        <source>Sign-up opens:</source>
+        <target>Inschrijving opent:</target>
       </trans-unit>
       <trans-unit id="lIY1Kot" resname="Signed in %date%">
         <source>Signed in %date%</source>
@@ -1253,6 +1325,10 @@
         <source>Unknown device</source>
         <target state="translated">Onbekend apparaat</target>
       </trans-unit>
+      <trans-unit id=".b394XX" resname="Until">
+        <source>Until</source>
+        <target>Tot</target>
+      </trans-unit>
       <trans-unit id="ZOvPU2x" resname="Upload exams">
         <source>Upload exams</source>
         <target state="translated">Upload tentamens</target>
@@ -1405,13 +1481,29 @@
         <source>iCal</source>
         <target state="translated">iCal</target>
       </trans-unit>
+      <trans-unit id="Q384Ly2" resname="in %duration%">
+        <source>in %duration%</source>
+        <target>over %duration%</target>
+      </trans-unit>
       <trans-unit id="6.eCze3" resname="jane.doe@example.com">
         <source>jane.doe@example.com</source>
         <target state="translated">janneke.jansen@example.nl</target>
       </trans-unit>
+      <trans-unit id="huWr6j7" resname="less than a minute">
+        <source>less than a minute</source>
+        <target>minder dan een minuut</target>
+      </trans-unit>
+      <trans-unit id="CC4UZ2j" resname="more deadlines">
+        <source>more deadlines</source>
+        <target>meer deadlines</target>
+      </trans-unit>
       <trans-unit id="edSu_p6" resname="on">
         <source>on</source>
         <target state="translated">op</target>
+      </trans-unit>
+      <trans-unit id="NpnxF2Z" resname="ongoing for %duration%">
+        <source>ongoing for %duration%</source>
+        <target>nog %duration% bezig</target>
       </trans-unit>
       <trans-unit id="W3MzJgn" resname="unavailable">
         <source>unavailable</source>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -133,6 +133,10 @@
         <source>All sessions except this one will be signed out immediately.</source>
         <target state="translated">Alle sessies, behalve deze, worden onmiddellijk beëindigd.</target>
       </trans-unit>
+      <trans-unit id="CdVO0Gm" resname="All years">
+        <source>All years</source>
+        <target state="translated">Alle jaren</target>
+      </trans-unit>
       <trans-unit id="3eX.3WJ" resname="Analytics are currently">
         <source>Analytics are currently</source>
         <target state="translated">Analytics zijn momenteel</target>
@@ -243,7 +247,7 @@
       </trans-unit>
       <trans-unit id="tceoGZr" resname="Category">
         <source>Category</source>
-        <target>Categorie</target>
+        <target state="translated">Categorie</target>
       </trans-unit>
       <trans-unit id="ROsdATY" resname="Chair">
         <source>Chair</source>
@@ -941,6 +945,10 @@
         <source>New password</source>
         <target state="translated">Nieuw wachtwoord</target>
       </trans-unit>
+      <trans-unit id="VXC5Ldf" resname="Newer">
+        <source>Newer</source>
+        <target state="translated">Nieuwer</target>
+      </trans-unit>
       <trans-unit id="XUSTYpl" resname="News">
         <source>News</source>
         <target state="translated">Nieuws</target>
@@ -984,6 +992,10 @@
       <trans-unit id="fm8k4L1" resname="Oh no! Something went wrong :(">
         <source>Oh no! Something went wrong :(</source>
         <target state="translated">Oh nee! Er is iets misgegaan :(</target>
+      </trans-unit>
+      <trans-unit id="AxXKYah" resname="Older">
+        <source>Older</source>
+        <target state="translated">Ouder</target>
       </trans-unit>
       <trans-unit id="svuF9zU" resname="On Thursdays, there is a %link_start%social drink%link_end% from 16.30 to 19.00.">
         <source>On Thursdays, there is a %link_start%social drink%link_end% from 16.30 to 19.00.</source>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Replace the empty activity overview stubs with live-component-driven pages: an upcoming overview (index), a per-association-year archive, and "my" (subscribed) variants of both. A single `ActivityOverview` live component powers all four.

Visitors can search activities by name (in the current language), and filter by category, labels (matching any), organising party, open sign-up, and a date range. The list loads more on scroll instead of paginating.

Each activity is shown compactly: a locale-aware 24-hour date range (single- or multi-day, with the year only when it differs from the current one), an "ongoing for ..." / "in ..." note, location and costs, category and label chips, a clamped and expandable Markdown description, and the next relevant sign-up deadline coloured by urgency. Markdown is rendered with `league/commonmark` using a safe configuration (escaped HTML, no images on the overview).

The sign-up deadline always shows the next list still to close, so deadlines no longer disappear once an earlier sign-up list has closed. The intentionally compact cards also give continuous and multi-day activities a short form.

---

The actual design went through several candidates; the final design closely replicates the current design instead of putting everything in a `.list-group` (too compact).

**Overview:**
<img width="2560" height="1355" alt="Screenshot 2026-05-29 at 11-24-41 Activities - Study Association GEWIS" src="https://github.com/user-attachments/assets/e60495a4-6e05-462d-a938-fa16fb1fd0cf" />

**Overview (filters expanded):**
<img width="2560" height="1355" alt="Screenshot 2026-05-29 at 11-24-51 Activities - Study Association GEWIS" src="https://github.com/user-attachments/assets/0079fc8a-0faa-4c5e-b2b4-9e07735cad7c" />

**Activity:**
<img width="2560" height="1355" alt="Screenshot 2026-05-29 at 11-25-35 Symposium - Study Association GEWIS" src="https://github.com/user-attachments/assets/9d9dd120-7954-4c41-9701-81f8fd0d9620" />

**My past activities:**
<img width="2560" height="1355" alt="Screenshot 2026-05-29 at 11-25-22 My past activities - Study Association GEWIS" src="https://github.com/user-attachments/assets/67b2864f-56ca-4941-8616-d1c278040e4c" />

**General past activities archive:**
<img width="2560" height="1355" alt="Screenshot 2026-05-29 at 11-25-04 Activity Archive - Study Association GEWIS" src="https://github.com/user-attachments/assets/78ccd0bd-166d-472d-ad15-7e700a4e1e58" />


## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-2082.
Closes GH-2072.
Closes GH-1817.
Closes GH-1804.
Closes GH-1761.
Closes GH-1723.
Closes GH-732.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
