### PR TITLE
fix(assets): compile TypeScript from the top-level assets/ directory

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -102,8 +102,7 @@ jobs:
                 # Font Awesome fonts/sprites and Bootstrap bundle (copied out of vendor/ by assets:update), the
                 # importmap's vendored JS such as the live-component CSS (importmap:install), and the sass/TypeScript
                 # compiled to var/sass and var/typescript. None of that is committed and composer ran with
-                # --no-scripts, so it is all built here. swc writes the controllers to var/typescript/controllers,
-                # while the compiler reads them from var/typescript/assets/controllers, so they are copied across.
+                # --no-scripts, so it is all built here.
                 run: |
                     composer run-script assets:update
                     bin/console importmap:install
@@ -111,8 +110,6 @@ jobs:
                     sudo chmod +x /usr/local/bin/swc
                     bin/console sass:build
                     bin/console typescript:build
-                    mkdir -p var/typescript/assets/controllers
-                    cp -r var/typescript/controllers/. var/typescript/assets/controllers/
 
             -   name: Run PHPUnit
                 run: bin/phpunit

--- a/config/packages/asset_mapper.yaml
+++ b/config/packages/asset_mapper.yaml
@@ -10,8 +10,15 @@ framework:
         missing_import_mode: strict
 
 sensiolabs_typescript:
+    # This must stay the top-level assets/ directory, not assets/controllers. swc writes its output
+    # to var/typescript/<basename of source_dir>/..., while the bundle's compiler reads it back from
+    # var/typescript/<source path relative to the project root>/.... Those only line up when the
+    # source_dir sits directly under the project root, so pointing it at the nested assets/controllers
+    # drops the assets/ segment and the compiler can no longer find the compiled JavaScript. Only
+    # assets/controllers holds TypeScript; the rest of assets/ is plain/vendored JavaScript that swc
+    # harmlessly (if needlessly) transpiles into var/typescript, where nothing reads it.
     source_dir:
-        - '%kernel.project_dir%/assets/controllers'
+        - '%kernel.project_dir%/assets'
     swc_binary: /usr/local/bin/swc
     swc_config_file: '%kernel.project_dir%/.swcrc'
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
`swc` writes its output to `var/typescript/<basename of source_dir>/...`, while the `sensiolabs/typescript-bundle` compiler reads it back from `var/typescript/<source path relative to the project root>/...`. These only line up when `source_dir` sits directly under the project root, so the nested `assets/controllers` dropped the `assets/` segment and `asset-map:compile` failed on a fresh clone with
"`file_get_contents(.../assets/controllers/.../*.js)`: No such file or directory".

Fixed by pointing the `source_dir` at `assets/` so `swc` writes to the paths the compiler reads.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-2114

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
