### PR TITLE
feat(activity): reorder sign-up fields/options and mark a default choice option

### DIFF
--- a/assets/controllers/activity/signup_field_controller.ts
+++ b/assets/controllers/activity/signup_field_controller.ts
@@ -3,24 +3,28 @@ import { Controller } from '@hotwired/stimulus';
 /**
  * One custom sign-up field: only a "number" field shows the min/max bounds and only a "choice" field shows the options
  * collection. Switching to "choice" seeds one empty option (so the editor is not left with an empty choice); switching
- * away clears the options again. Bound to the type `<select>`.
+ * away clears the options again. Bound to the type `<select>`. It also keeps the choice options' "default" checkboxes
+ * mutually exclusive, so at most one option per field is preselected on the public sign-up form.
  *
  * ```
  * <div data-controller="signup-field">
  *     <select data-signup-field-target="type" data-action="change->signup-field#typeChanged">...</select>
  *     <div data-signup-field-target="number">...min/max...</div>
- *     <div data-signup-field-target="choice">...options collection (form-collection)...</div>
+ *     <div data-signup-field-target="choice">...options collection, each with
+ *         <input type="checkbox" data-signup-field-target="defaultOption"
+ *                data-action="change->signup-field#defaultChanged">...</div>
  * </div>
  * ```
  */
 export default class extends Controller {
-    static targets = ['type', 'number', 'choice'];
+    static targets = ['type', 'number', 'choice', 'defaultOption'];
 
     declare readonly typeTarget: HTMLSelectElement;
     declare readonly hasNumberTarget: boolean;
     declare readonly numberTarget: HTMLElement;
     declare readonly hasChoiceTarget: boolean;
     declare readonly choiceTarget: HTMLElement;
+    declare readonly defaultOptionTargets: HTMLInputElement[];
 
     connect(): void {
         // Only set visibility on connect (an existing field keeps its saved options); seeding/clearing is user-driven.
@@ -49,6 +53,28 @@ export default class extends Controller {
         if (this.hasChoiceTarget) {
             this.choiceTarget.hidden = 'choice' !== type;
         }
+    }
+
+    /**
+     * The "default" checkboxes act as a radio group across this field's options: checking one clears the rest, so at
+     * most one option is preselected (none is allowed). Dynamically added options register as targets automatically.
+     */
+    defaultChanged(event: Event): void {
+        const changed = event.target;
+        if (
+            !(changed instanceof HTMLInputElement)
+            || !changed.checked
+        ) {
+            return;
+        }
+
+        this.defaultOptionTargets.forEach((checkbox) => {
+            if (checkbox === changed) {
+                return;
+            }
+
+            checkbox.checked = false;
+        });
     }
 
     optionEntries(): HTMLElement[] {

--- a/assets/controllers/application/sortable_controller.ts
+++ b/assets/controllers/application/sortable_controller.ts
@@ -1,0 +1,132 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Reorders the entries of a Symfony CollectionType by dragging, persisting the new order through the surrounding form.
+ *
+ * Each entry carries a drag handle (`draggable`, firing `dragStart`/`dragEnd`) and a hidden `position` input
+ * (`data-sortable-target="position"`); the entries wrapper (`data-sortable-target="entries"`) receives
+ * `dragOver`/`drop`. On drop the dragged entry is moved in the DOM and every entry's position input is rewritten to its
+ * new index. A capture-phase submit listener reindexes once more so entries added after the last drag (whose prototype
+ * position is 0) are numbered too. Only DIRECT entries of this controller's wrapper are considered, so a nested
+ * collection (a choice field's options inside a question) reorders independently -- Stimulus binds each `position`
+ * target to its nearest `sortable` controller.
+ *
+ * ```
+ * <div data-controller="form-collection sortable">
+ *     <div data-form-collection-target="entries" data-sortable-target="entries"
+ *          data-action="dragover->sortable#dragOver drop->sortable#drop">
+ *         <div data-form-collection-target="entry">
+ *             <span draggable="true" data-action="dragstart->sortable#dragStart dragend->sortable#dragEnd">...</span>
+ *             <input type="hidden" data-sortable-target="position">
+ *         </div>
+ *     </div>
+ * </div>
+ * ```
+ */
+export default class extends Controller {
+    static targets = ['entries', 'position'];
+
+    declare readonly entriesTarget: HTMLElement;
+    declare readonly positionTargets: HTMLInputElement[];
+
+    private dragging: HTMLElement | null = null;
+    private form: HTMLFormElement | null = null;
+    private readonly reindexOnSubmit = (): void => this.reindex();
+
+    connect(): void {
+        // Reindex right before the form serializes, so newly added entries (never dragged) also get their order.
+        this.form = this.element.closest('form');
+        this.form?.addEventListener('submit', this.reindexOnSubmit, true);
+    }
+
+    disconnect(): void {
+        this.form?.removeEventListener('submit', this.reindexOnSubmit, true);
+    }
+
+    dragStart(event: DragEvent): void {
+        const handle = event.currentTarget as HTMLElement;
+        const entry = handle.closest<HTMLElement>('[data-form-collection-target="entry"]');
+        // Only reorder entries that belong directly to this collection, never a nested one.
+        if (null === entry || entry.parentElement !== this.entriesTarget) {
+            return;
+        }
+
+        this.dragging = entry;
+        entry.classList.add('dragging');
+
+        if (null !== event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            // Firefox only starts a drag once some data is set; the value itself is unused.
+            event.dataTransfer.setData('text/plain', '');
+            event.dataTransfer.setDragImage(entry, 0, 0);
+        }
+    }
+
+    dragEnd(): void {
+        if (null !== this.dragging) {
+            this.dragging.classList.remove('dragging');
+            this.dragging = null;
+        }
+
+        this.reindex();
+    }
+
+    dragOver(event: DragEvent): void {
+        if (null === this.dragging) {
+            return;
+        }
+
+        // Allow dropping here and live-preview the move by slotting the dragged entry before the entry under the cursor.
+        event.preventDefault();
+
+        const after = this.entryAfter(event.clientY);
+        if (null === after) {
+            this.entriesTarget.appendChild(this.dragging);
+        } else if (after !== this.dragging) {
+            this.entriesTarget.insertBefore(this.dragging, after);
+        }
+    }
+
+    drop(event: DragEvent): void {
+        event.preventDefault();
+        this.reindex();
+    }
+
+    /**
+     * The first direct entry whose vertical midpoint is below the cursor (the entry the dragged one should sit before),
+     * or null to append at the end.
+     */
+    private entryAfter(y: number): HTMLElement | null {
+        let closestOffset = Number.NEGATIVE_INFINITY;
+        let closest: HTMLElement | null = null;
+
+        for (const entry of this.directEntries()) {
+            if (entry === this.dragging) {
+                continue;
+            }
+
+            const box = entry.getBoundingClientRect();
+            const offset = y - box.top - box.height / 2;
+            if (offset < 0 && offset > closestOffset) {
+                closestOffset = offset;
+                closest = entry;
+            }
+        }
+
+        return closest;
+    }
+
+    private directEntries(): HTMLElement[] {
+        return Array.from(
+            this.entriesTarget.querySelectorAll<HTMLElement>(':scope > [data-form-collection-target="entry"]'),
+        );
+    }
+
+    private reindex(): void {
+        // positionTargets are in document (i.e. entry) order, one per direct entry -- nested collections' position
+        // inputs bind to their own inner sortable controller, not this one.
+        this.positionTargets.forEach((input, index) => {
+            input.value = String(index);
+        });
+    }
+}

--- a/assets/stimulus_bootstrap.js
+++ b/assets/stimulus_bootstrap.js
@@ -14,6 +14,7 @@ import ModalCloseController from './controllers/application/modal_close_controll
 import ModalFormTargetController from './controllers/application/modal_form_target_controller.ts';
 import NavDropdownController from './controllers/application/nav_dropdown_controller.ts';
 import PrintController from './controllers/application/print_controller.ts';
+import SortableController from './controllers/application/sortable_controller.ts';
 
 // Activity-specific controllers.
 import ActivityItemController from './controllers/activity/activity_item_controller.ts';
@@ -42,6 +43,7 @@ app.register('modal-close', ModalCloseController);
 app.register('modal-form-target', ModalFormTargetController);
 app.register('nav-dropdown', NavDropdownController);
 app.register('print', PrintController);
+app.register('sortable', SortableController);
 
 app.register('activity-item', ActivityItemController);
 app.register('signup-field', SignupFieldController);

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -68,6 +68,7 @@ $enable-negative-margins: true;
 @import 'components/navbar';
 @import 'components/panel';
 @import 'components/privacy-widget';
+@import 'components/sortable';
 @import 'components/special-notice';
 @import 'components/table';
 @import 'components/toast';

--- a/assets/styles/components/_sortable.scss
+++ b/assets/styles/components/_sortable.scss
@@ -1,0 +1,14 @@
+// Drag handle and dragging state for the reusable `sortable` Stimulus controller, which reorders the entries of a
+// (form) collection by dragging. The dragged entry is dimmed while it is moved.
+.sortable-handle {
+    cursor: grab;
+    color: var(--#{$prefix}secondary-color);
+
+    &:active {
+        cursor: grabbing;
+    }
+}
+
+[data-form-collection-target="entry"].dragging {
+    opacity: 0.5;
+}

--- a/config/reference.php
+++ b/config/reference.php
@@ -2111,6 +2111,138 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         api_key?: scalar|Param|null, // Your sentinel client api key
  *     },
  * }
+ * @psalm-type FlysystemConfig = array{
+ *     storages?: array<string, array{ // Default: []
+ *         adapter?: scalar|Param|null, // DEPRECATED: Use the new config format instead (e.g. "local:" instead of "adapter: local")
+ *         options?: list<mixed>,
+ *         asyncaws?: array{
+ *             client?: scalar|Param|null, // The AsyncAws S3 client service name
+ *             bucket?: scalar|Param|null, // The name of the AWS S3 bucket
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *         },
+ *         aws?: array{
+ *             client?: scalar|Param|null, // The AWS S3 client service name
+ *             bucket?: scalar|Param|null, // The name of the AWS S3 bucket
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *             options?: list<mixed>,
+ *             streamReads?: bool|Param, // Whether to use streaming for file reads // Default: true
+ *         },
+ *         azure?: array{
+ *             client?: scalar|Param|null, // The Azure Blob Storage client service name
+ *             container?: scalar|Param|null, // The name of the Azure Blob Storage container
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all blob names // Default: ""
+ *         },
+ *         ftp?: array{
+ *             host?: scalar|Param|null, // FTP host
+ *             username?: scalar|Param|null, // FTP username
+ *             password?: scalar|Param|null, // FTP password
+ *             port?: int|Param, // FTP port number // Default: 21
+ *             root?: scalar|Param|null, // FTP root directory // Default: ""
+ *             passive?: bool|Param, // Use passive mode // Default: true
+ *             ssl?: bool|Param, // Use SSL/TLS encryption // Default: false
+ *             timeout?: int|Param, // Connection timeout in seconds // Default: 90
+ *             ignore_passive_address?: scalar|Param|null, // Ignore passive address // Default: null
+ *             utf8?: bool|Param, // Enable UTF8 mode // Default: false
+ *             transfer_mode?: scalar|Param|null, // Transfer mode (FTP_ASCII or FTP_BINARY constante on ftp extension) // Default: null
+ *             system_type?: null|"windows"|"unix"|Param, // FTP system type // Default: null
+ *             timestamps_on_unix_listings_enabled?: bool|Param, // Enable timestamps on Unix listings // Default: false
+ *             recurse_manually?: bool|Param, // Recurse directories manually // Default: true
+ *             use_raw_list_options?: bool|Param|null, // Use raw list options // Default: null
+ *             connectivityChecker?: scalar|Param|null, // Connectivity checker service name // Default: null
+ *             permissions?: array{ // Unix permissions configuration for files and directories
+ *                 file?: array{ // File permissions
+ *                     public?: int|Param, // Public file permissions // Default: 420
+ *                     private?: int|Param, // Private file permissions // Default: 384
+ *                 },
+ *                 dir?: array{ // Directory permissions
+ *                     public?: int|Param, // Public directory permissions // Default: 493
+ *                     private?: int|Param, // Private directory permissions // Default: 448
+ *                 },
+ *             },
+ *         },
+ *         gcloud?: array{
+ *             client?: scalar|Param|null, // The Google Cloud Storage client service name
+ *             bucket?: scalar|Param|null, // The name of the Google Cloud Storage bucket
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *             visibility_handler?: scalar|Param|null, // Optional visibility handler service name // Default: null
+ *             streamReads?: bool|Param, // Whether to use streaming for file reads // Default: false
+ *         },
+ *         gridfs?: array{
+ *             bucket?: scalar|Param|null, // GridFS bucket service name (if using an existing bucket service) // Default: null
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all file names // Default: ""
+ *             database?: scalar|Param|null, // MongoDB database name // Default: null
+ *             doctrine_connection?: scalar|Param|null, // Doctrine MongoDB connection name (mutually exclusive with mongodb_uri)
+ *             mongodb_uri?: scalar|Param|null, // MongoDB connection URI (mutually exclusive with doctrine_connection)
+ *             mongodb_uri_options?: list<mixed>,
+ *             mongodb_driver_options?: list<mixed>,
+ *         },
+ *         lazy?: array{ // Lazy adapter for runtime storage selection
+ *             source?: scalar|Param|null, // The service name of the storage to use at runtime
+ *         },
+ *         local?: array{
+ *             directory?: scalar|Param|null, // Directory path for local storage
+ *             lock?: int|Param, // Lock flags for file operations // Default: 0
+ *             skip_links?: bool|Param, // Whether to skip symbolic links // Default: false
+ *             lazy_root_creation?: bool|Param, // Whether to create the root directory lazily // Default: false
+ *             permissions?: array{ // Unix permissions configuration for files and directories
+ *                 file?: array{ // File permissions
+ *                     public?: int|Param, // Public file permissions // Default: 420
+ *                     private?: int|Param, // Private file permissions // Default: 384
+ *                 },
+ *                 dir?: array{ // Directory permissions
+ *                     public?: int|Param, // Public directory permissions // Default: 493
+ *                     private?: int|Param, // Private directory permissions // Default: 448
+ *                 },
+ *             },
+ *         },
+ *         memory?: array<mixed>,
+ *         sftp?: array{
+ *             host?: scalar|Param|null, // SFTP host
+ *             username?: scalar|Param|null, // SFTP username
+ *             password?: scalar|Param|null, // SFTP password (optional if using private key) // Default: null
+ *             privateKey?: scalar|Param|null, // Path to private key file or private key content // Default: null
+ *             passphrase?: scalar|Param|null, // Private key passphrase // Default: null
+ *             port?: int|Param, // SFTP port number // Default: 22
+ *             timeout?: int|Param, // Connection timeout in seconds // Default: 90
+ *             hostFingerprint?: scalar|Param|null, // Host fingerprint for verification // Default: null
+ *             connectivityChecker?: scalar|Param|null, // Connectivity checker service name // Default: null
+ *             preferredAlgorithms?: list<mixed>,
+ *             root?: scalar|Param|null, // SFTP root directory // Default: ""
+ *             permissions?: array{ // Unix permissions configuration for files and directories
+ *                 file?: array{ // File permissions
+ *                     public?: int|Param, // Public file permissions // Default: 420
+ *                     private?: int|Param, // Private file permissions // Default: 384
+ *                 },
+ *                 dir?: array{ // Directory permissions
+ *                     public?: int|Param, // Public directory permissions // Default: 493
+ *                     private?: int|Param, // Private directory permissions // Default: 448
+ *                 },
+ *             },
+ *         },
+ *         webdav?: array{
+ *             client?: scalar|Param|null, // The WebDAV client service name
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all paths // Default: ""
+ *             visibility_handling?: "throw"|"ignore"|Param, // How to handle visibility operations // Default: "throw"
+ *             manual_copy?: bool|Param, // Whether to handle copy operations manually // Default: false
+ *             manual_move?: bool|Param, // Whether to handle move operations manually // Default: false
+ *         },
+ *         bunnycdn?: array{
+ *             client?: scalar|Param|null, // The BunnyCDN client service name
+ *             pull_zone?: scalar|Param|null, // The BunnyCDN pull zone name // Default: ""
+ *         },
+ *         service?: scalar|Param|null, // Reference to a custom adapter service (alternative to registered adapter types)
+ *         visibility?: scalar|Param|null, // Default visibility for files // Default: null
+ *         directory_visibility?: scalar|Param|null, // Default visibility for directories // Default: null
+ *         retain_visibility?: scalar|Param|null, // Keeps the original file visibility (public/private) when copying or moving. // Default: null
+ *         case_sensitive?: bool|Param, // Deprecated: The "case_sensitive" option is deprecated and will be removed in 4.0. // Default: true
+ *         disable_asserts?: bool|Param, // Deprecated: The "disable_asserts" option is deprecated and will be removed in 4.0. // Default: false
+ *         public_url?: list<scalar|Param|null>,
+ *         path_normalizer?: scalar|Param|null, // Path normalizer service name (should implement League\Flysystem\PathNormalizer) // Default: null
+ *         public_url_generator?: scalar|Param|null, // For adapter that do not provide public URLs or override adapter capabilities and public_url option, a public URL generator service name can be configured in the main Filesystem configuration (should implement League\Flysystem\PublicUrlGenerator) // Default: null
+ *         temporary_url_generator?: scalar|Param|null, // For adapter that do not provide public URLs or override adapter capabilities, a temporary URL generator service name can be configured in the main Filesystem configuration (should implement League\Flysystem\TemporaryUrlGenerator) // Default: null
+ *         read_only?: bool|Param, // Converts a file system to read-only // Default: false
+ *     }>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -2135,6 +2267,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     endroid_qr_code?: EndroidQrCodeConfig,
  *     ambta_doctrine_encrypt?: AmbtaDoctrineEncryptConfig,
  *     altcha?: AltchaConfig,
+ *     flysystem?: FlysystemConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -2162,6 +2295,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         endroid_qr_code?: EndroidQrCodeConfig,
  *         ambta_doctrine_encrypt?: AmbtaDoctrineEncryptConfig,
  *         altcha?: AltchaConfig,
+ *         flysystem?: FlysystemConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -2187,6 +2321,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         endroid_qr_code?: EndroidQrCodeConfig,
  *         ambta_doctrine_encrypt?: AmbtaDoctrineEncryptConfig,
  *         altcha?: AltchaConfig,
+ *         flysystem?: FlysystemConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -2214,6 +2349,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         endroid_qr_code?: EndroidQrCodeConfig,
  *         ambta_doctrine_encrypt?: AmbtaDoctrineEncryptConfig,
  *         altcha?: AltchaConfig,
+ *         flysystem?: FlysystemConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/migrations/Version20260715140922.php
+++ b/migrations/Version20260715140922.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ * phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
+ */
+final class Version20260715140922 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add a display position to sign-up fields and options (reorderable in the editor) and a default marker to choice options; GH-2036, GH-2106.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // GH-2036: the organiser reorders the questions and (choice) options by dragging; a 0-based position (lower
+        // first) fixes the order. Existing rows default to 0 and keep their relative order via the id tiebreaker.
+        $this->addSql('ALTER TABLE SignupField ADD position INT DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE SignupOption ADD position INT DEFAULT 0 NOT NULL');
+
+        // GH-2106: a choice option can be marked as the default preselected value. Add it like the other booleans:
+        // nullable first so existing rows can be backfilled to false, then make it mandatory.
+        $this->addSql('ALTER TABLE SignupOption ADD isDefault TINYINT DEFAULT NULL');
+        $this->addSql('UPDATE SignupOption SET isDefault = 0');
+        $this->addSql('ALTER TABLE SignupOption CHANGE isDefault isDefault TINYINT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE SignupField DROP position');
+        $this->addSql('ALTER TABLE SignupOption DROP position, DROP isDefault');
+    }
+}

--- a/src/DataFixtures/Activity/ActivityFixture.php
+++ b/src/DataFixtures/Activity/ActivityFixture.php
@@ -240,6 +240,7 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                                     [
                                         'en' => 'M',
                                         'nl' => 'M',
+                                        'default' => true,
                                     ],
                                     [
                                         'en' => 'L',
@@ -878,16 +879,19 @@ class ActivityFixture extends Fixture implements DependentFixtureInterface
                 // Sign-up fields (and their options for Choice fields), keyed by English name so a subscriber's
                 // answers can reference them. Fields/options cascade-persist through the list.
                 $fields = [];
-                foreach ($signupListData['fields'] ?? [] as $fieldData) {
+                foreach ($signupListData['fields'] ?? [] as $fieldIndex => $fieldData) {
                     $field = new SignupField();
                     $field->setName(new ActivityLocalisedText($fieldData['name']['en'], $fieldData['name']['nl']));
                     $field->setType($fieldData['type']);
+                    $field->setPosition($fieldIndex);
                     $signupList->addField($field);
 
                     $options = [];
-                    foreach ($fieldData['options'] ?? [] as $optionData) {
+                    foreach ($fieldData['options'] ?? [] as $optionIndex => $optionData) {
                         $option = new SignupOption();
                         $option->setValue(new ActivityLocalisedText($optionData['en'], $optionData['nl']));
+                        $option->setPosition($optionIndex);
+                        $option->setIsDefault($optionData['default'] ?? false);
                         $field->addOption($option);
                         $options[$optionData['en']] = $option;
                     }

--- a/src/Entity/Activity/SignupField.php
+++ b/src/Entity/Activity/SignupField.php
@@ -118,6 +118,17 @@ class SignupField
     private ?int $maximumValue = null;
 
     /**
+     * The position of this field among the sign-up list's fields; the organiser reorders them in the editor and this
+     * fixes the display order (lower first) everywhere the fields are listed. The id is the tiebreaker (see the
+     * ``SignupList::$fields'' ordering) so pre-existing fields keep their relative order.
+     */
+    #[Column(
+        type: Types::INTEGER,
+        options: ['default' => 0],
+    )]
+    private int $position = 0;
+
+    /**
      * The allowed options for the SignupField of the ``option'' type.
      *
      * @var Collection<array-key, SignupOption>
@@ -131,7 +142,10 @@ class SignupField
         ],
         orphanRemoval: true,
     )]
-    #[OrderBy(['id' => 'ASC'])]
+    #[OrderBy([
+        'position' => 'ASC',
+        'id' => 'ASC',
+    ])]
     private Collection $options;
 
     public function __construct()
@@ -222,6 +236,16 @@ class SignupField
     public function setMaximumValue(?int $maximumValue): void
     {
         $this->maximumValue = $maximumValue;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
     }
 
     /**

--- a/src/Entity/Activity/SignupList.php
+++ b/src/Entity/Activity/SignupList.php
@@ -275,7 +275,10 @@ class SignupList
         ],
         orphanRemoval: true,
     )]
-    #[OrderBy(['id' => 'ASC'])]
+    #[OrderBy([
+        'position' => 'ASC',
+        'id' => 'ASC',
+    ])]
     private Collection $fields;
 
     /**

--- a/src/Entity/Activity/SignupOption.php
+++ b/src/Entity/Activity/SignupOption.php
@@ -7,6 +7,8 @@ namespace App\Entity\Activity;
 use App\Entity\Application\LocalisedText as LocalisedTextModel;
 use App\Entity\Application\Traits\IdentifiableTrait;
 use App\Repository\Activity\SignupOptionRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
@@ -60,6 +62,25 @@ class SignupOption
     )]
     private ActivityLocalisedText $value;
 
+    /**
+     * The position of this option among its field's options; the organiser reorders them in the editor and this fixes
+     * the order they are offered in (lower first). The id is the tiebreaker (see the ``SignupField::$options''
+     * ordering) so pre-existing options keep their relative order.
+     */
+    #[Column(
+        type: Types::INTEGER,
+        options: ['default' => 0],
+    )]
+    private int $position = 0;
+
+    /**
+     * Whether this option is preselected as the default answer on the public sign-up form. At most one option per
+     * field may be the default; it only sets the initial value for a new sign-up and never overrides an existing
+     * answer.
+     */
+    #[Column(type: Types::BOOLEAN)]
+    private bool $isDefault = false;
+
     public function __construct()
     {
         // Form-ready default; Doctrine bypasses the constructor when hydrating existing rows.
@@ -90,6 +111,26 @@ class SignupOption
     public function setValue(ActivityLocalisedText $value): void
     {
         $this->value = $value;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function setIsDefault(bool $isDefault): void
+    {
+        $this->isDefault = $isDefault;
     }
 
     /**

--- a/src/Form/Activity/ActivityType.php
+++ b/src/Form/Activity/ActivityType.php
@@ -225,13 +225,34 @@ class ActivityType extends AbstractType
                     continue;
                 }
 
+                // A choice field may preselect at most one option as its default. The editor enforces this client-side
+                // (the checkboxes are mutually exclusive), so this only guards a tampered submission.
+                $defaultCount = 0;
                 foreach ($fieldForm->get('options') as $optionForm) {
                     $this->requireLocalised(
                         $optionForm->get('value'),
                         $dutchOn,
                         $englishOn,
                     );
+
+                    if (true !== $optionForm->get('isDefault')->getData()) {
+                        continue;
+                    }
+
+                    ++$defaultCount;
                 }
+
+                if ($defaultCount <= 1) {
+                    continue;
+                }
+
+                $fieldForm->addError(new FormError(
+                    $this->translator->trans(
+                        'Only one option can be preselected as the default.',
+                        [],
+                        'validators',
+                    ),
+                ));
             }
         }
     }

--- a/src/Form/Activity/SignupFieldType.php
+++ b/src/Form/Activity/SignupFieldType.php
@@ -9,13 +9,16 @@ use App\Entity\Activity\SignupField;
 use App\Form\Application\LocalisedTextType;
 use Override;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+use function strval;
 use function Symfony\Component\Translation\t;
 
 /**
@@ -81,8 +84,24 @@ class SignupFieldType extends AbstractType
                     'by_reference' => false,
                     'prototype' => true,
                     'prototype_name' => '__option__',
+                    'block_prefix' => 'signup_option_collection',
                 ],
             );
+
+        // The organiser reorders the questions by dragging (see the sortable Stimulus controller); the new order is
+        // written into this hidden input per entry and mapped onto the position column. HiddenType keeps the value as
+        // a string, so transform it to/from the entity's int property.
+        $builder->add(
+            'position',
+            HiddenType::class,
+            [
+                'attr' => ['data-sortable-target' => 'position'],
+            ],
+        );
+        $builder->get('position')->addModelTransformer(new CallbackTransformer(
+            static fn (?int $value): string => strval($value ?? 0),
+            static fn (?string $value): int => (int) $value,
+        ));
     }
 
     #[Override]

--- a/src/Form/Activity/SignupOptionType.php
+++ b/src/Form/Activity/SignupOptionType.php
@@ -8,9 +8,13 @@ use App\Entity\Activity\SignupOption;
 use App\Form\Application\LocalisedTextType;
 use Override;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+use function strval;
 use function Symfony\Component\Translation\t;
 
 /**
@@ -25,11 +29,40 @@ class SignupOptionType extends AbstractType
         FormBuilderInterface $builder,
         array $options,
     ): void {
+        $builder
+            ->add(
+                'value',
+                LocalisedTextType::class,
+                ['label' => t('Option')],
+            )
+            ->add(
+                'isDefault',
+                CheckboxType::class,
+                [
+                    'label' => t('Default'),
+                    'required' => false,
+                    // Rendered as a checkbox but made mutually exclusive per field by the signup-field controller
+                    // (checking one clears the others), so at most one option is the default.
+                    'attr' => [
+                        'data-signup-field-target' => 'defaultOption',
+                        'data-action' => 'change->signup-field#defaultChanged',
+                    ],
+                ],
+            );
+
+        // Options are reorderable too (see the sortable Stimulus controller); carry the dragged order in a hidden
+        // input, transformed to/from the entity's int position like the field's own position.
         $builder->add(
-            'value',
-            LocalisedTextType::class,
-            ['label' => t('Option')],
+            'position',
+            HiddenType::class,
+            [
+                'attr' => ['data-sortable-target' => 'position'],
+            ],
         );
+        $builder->get('position')->addModelTransformer(new CallbackTransformer(
+            static fn (?int $value): string => strval($value ?? 0),
+            static fn (?string $value): int => (int) $value,
+        ));
     }
 
     #[Override]

--- a/src/Form/Activity/SignupType.php
+++ b/src/Form/Activity/SignupType.php
@@ -17,6 +17,8 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\IsTrue;
@@ -291,6 +293,8 @@ class SignupType extends AbstractType
                     $labelsById[$optionId] = $option->getValue()->getText($language) ?? '';
                 }
 
+                $defaultOptionId = self::defaultOptionId($field);
+
                 $builder->add(
                     $name,
                     ChoiceType::class,
@@ -299,13 +303,46 @@ class SignupType extends AbstractType
                         'choices' => $optionIds,
                         'choice_label' => static fn (int $id): string => $labelsById[$id] ?? '',
                         'choice_translation_domain' => false,
-                        'placeholder' => $this->translator->trans('Choose an option'),
+                        // With a default option, drop the empty placeholder so a real option is always selected.
+                        'placeholder' => null !== $defaultOptionId
+                            ? false
+                            : $this->translator->trans('Choose an option'),
                         'constraints' => [new NotNull(message: 'This field is required.')],
                     ],
                 );
 
+                // Preselect the default for a NEW sign-up only. PRE_SET_DATA fires with the value mapped from the
+                // form's data, so an existing answer (non-null) is kept and only an unanswered field falls back to the
+                // default. Setting the ChoiceType's ``data'' option instead would override the saved answer on edit.
+                if (null !== $defaultOptionId) {
+                    $builder->get($name)->addEventListener(
+                        FormEvents::PRE_SET_DATA,
+                        static function (FormEvent $event) use ($defaultOptionId): void {
+                            if (null !== $event->getData()) {
+                                return;
+                            }
+
+                            $event->setData($defaultOptionId);
+                        },
+                    );
+                }
+
                 break;
         }
+    }
+
+    /**
+     * The id of the option marked as the default for a choice field, or null if none is.
+     */
+    private static function defaultOptionId(SignupField $field): ?int
+    {
+        foreach ($field->getOptions() as $option) {
+            if ($option->isDefault()) {
+                return $option->getId();
+            }
+        }
+
+        return null;
     }
 
     #[Override]

--- a/src/Service/Activity/ActivityRevisionCloner.php
+++ b/src/Service/Activity/ActivityRevisionCloner.php
@@ -133,6 +133,8 @@ final readonly class ActivityRevisionCloner extends AbstractRevisionCloner
         $field->setIsSensitive($source->isSensitive());
         $field->setMinimumValue($source->getMinimumValue());
         $field->setMaximumValue($source->getMaximumValue());
+        // Carry the display order forward, otherwise a reordered list would revert to id order on the next draft.
+        $field->setPosition($source->getPosition());
 
         foreach ($source->getOptions() as $option) {
             $field->addOption($this->copySignupOption($option));
@@ -145,6 +147,9 @@ final readonly class ActivityRevisionCloner extends AbstractRevisionCloner
     {
         $option = new SignupOption();
         $option->setValue($source->getValue()->copy());
+        // Carry the display order and the default marker forward, like the field's own position.
+        $option->setPosition($source->getPosition());
+        $option->setIsDefault($source->isDefault());
 
         return $option;
     }

--- a/templates/form/signup_list_collection.html.twig
+++ b/templates/form/signup_list_collection.html.twig
@@ -103,13 +103,25 @@
 {# --- Custom field (question) ---------------------------------------------------------------------------------- #}
 {% macro signup_field_panel(child, collapse_id, remove_label) %}
     <div class="panel mb-3" data-form-collection-target="entry">
-        <button type="button"
-                class="panel-heading signup-list-heading d-flex justify-content-between align-items-center gap-2 w-100 border-0 bg-transparent text-start"
-                data-bs-toggle="collapse" data-bs-target="#{{ collapse_id }}"
-                aria-expanded="true" aria-controls="{{ collapse_id }}">
-            <span class="h6 mb-0">{{ 'Question'|trans }} <span class="signup-field-number"></span></span>
-            <i class="fas fa-chevron-down signup-list-chevron"></i>
-        </button>
+        {# The drag handle is a sibling of (never nested in) the collapse button: a nested interactive element would
+           fight `data-bs-toggle` and swallow text selection. Only the handle is draggable, and it is offered only when
+           the fields collection is editable (a frozen list ignores its submissions, so reordering could not persist). #}
+        <div class="panel-heading d-flex align-items-center gap-2">
+            {% if not child.vars.disabled %}
+                <span class="sortable-handle" draggable="true"
+                      data-action="dragstart->sortable#dragStart dragend->sortable#dragEnd"
+                      role="button" aria-label="{{ 'Reorder question'|trans }}">
+                    <i class="fas fa-arrows-up-down"></i>
+                </span>
+            {% endif %}
+            <button type="button"
+                    class="signup-list-heading d-flex justify-content-between align-items-center gap-2 w-100 border-0 bg-transparent text-start p-0"
+                    data-bs-toggle="collapse" data-bs-target="#{{ collapse_id }}"
+                    aria-expanded="true" aria-controls="{{ collapse_id }}">
+                <span class="h6 mb-0">{{ 'Question'|trans }} <span class="signup-field-number"></span></span>
+                <i class="fas fa-chevron-down signup-list-chevron"></i>
+            </button>
+        </div>
         <div class="collapse show" id="{{ collapse_id }}">
             {# signup-field shows the min/max bounds only for a "number" field and the options only for a "choice"
                field, seeding/clearing the options as the type changes. #}
@@ -149,13 +161,16 @@
     {% set has_prototype = allow_add and prototype is defined and prototype is not null %}
     {% set placeholder = has_prototype ? (prototype.vars.name|split('[')|last|trim(']')) : '__field__' %}
     {% set remove_label = 'Remove question'|trans %}
+    {# `sortable` (added only when the collection is editable) turns the drag handles into a reorder: it moves the
+       question panels and writes their new order into each panel's hidden position input. #}
     <div id="{{ id }}" class="signup-field-collection"
-         data-controller="form-collection"
+         data-controller="form-collection{% if not disabled %} sortable{% endif %}"
          data-form-collection-prototype-name-value="{{ placeholder }}"
          {% if has_prototype %}
              data-form-collection-prototype-value="{{ helper.signup_field_panel(prototype, prototype.vars.id ~ '-collapse', remove_label)|e('html_attr') }}"
          {% endif %}>
-        <div data-form-collection-target="entries">
+        <div data-form-collection-target="entries" data-sortable-target="entries"
+             data-action="dragover->sortable#dragOver drop->sortable#drop">
             {% for child in form %}
                 {{ helper.signup_field_panel(child, child.vars.id ~ '-collapse', remove_label) }}
             {% endfor %}
@@ -164,6 +179,60 @@
         {% if allow_add and not disabled %}
             <button type="button" class="btn btn-sm btn-outline-secondary" data-action="form-collection#add">
                 <i class="fas fa-plus"></i> {{ 'Add a question'|trans }}
+            </button>
+        {% endif %}
+    </div>
+{% endblock %}
+
+{# --- Choice option -------------------------------------------------------------------------------------------- #}
+{# The options of a "choice" question. Like the questions themselves these are draggable to reorder (the `sortable`
+   controller writes the new order into each option's hidden position input) and each carries an "is default" checkbox;
+   the signup-field controller keeps at most one default checked per question. This mirrors the generic `collection`
+   form theme but adds the handle, the default checkbox and the position input. #}
+{% macro signup_option_entry(child, remove_label) %}
+    <div class="d-flex align-items-start gap-2 border rounded p-3 mb-2" data-form-collection-target="entry">
+        {% if not child.vars.disabled %}
+            <span class="sortable-handle mt-2" draggable="true"
+                  data-action="dragstart->sortable#dragStart dragend->sortable#dragEnd"
+                  role="button" aria-label="{{ 'Reorder option'|trans }}">
+                <i class="fas fa-arrows-up-down"></i>
+            </span>
+        {% endif %}
+        <div class="flex-grow-1">
+            {{ form_row(child.value) }}
+            {{ form_row(child.isDefault) }}
+            {{ form_rest(child) }}
+            {% if not child.vars.disabled %}
+                <button type="button" class="btn btn-sm btn-outline-gewis-primary mt-2"
+                        data-action="form-collection#remove">
+                    <i class="fas fa-trash"></i> {{ remove_label }}
+                </button>
+            {% endif %}
+        </div>
+    </div>
+{% endmacro %}
+
+{% block signup_option_collection_widget %}
+    {% import _self as helper %}
+    {% set has_prototype = allow_add and prototype is defined and prototype is not null %}
+    {% set placeholder = has_prototype ? (prototype.vars.name|split('[')|last|trim(']')) : '__option__' %}
+    {% set add_label = add_label|default('Add option'|trans) %}
+    {% set remove_label = remove_label|default('Remove option'|trans) %}
+    <div id="{{ id }}" class="signup-option-collection"
+         data-controller="form-collection{% if not disabled %} sortable{% endif %}"
+         data-form-collection-prototype-name-value="{{ placeholder }}"
+         {% if has_prototype %}
+             data-form-collection-prototype-value="{{ helper.signup_option_entry(prototype, remove_label)|e('html_attr') }}"
+         {% endif %}>
+        <div data-form-collection-target="entries" data-sortable-target="entries"
+             data-action="dragover->sortable#dragOver drop->sortable#drop">
+            {% for child in form %}
+                {{ helper.signup_option_entry(child, remove_label) }}
+            {% endfor %}
+        </div>
+        {% if allow_add and not disabled %}
+            <button type="button" class="btn btn-sm btn-outline-secondary mt-2" data-action="form-collection#add">
+                <i class="fas fa-plus"></i> {{ add_label }}
             </button>
         {% endif %}
     </div>

--- a/tests/Form/Activity/SignupListTypeTest.php
+++ b/tests/Form/Activity/SignupListTypeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Form\Activity;
 
 use App\Entity\Activity\ActivityLocalisedText;
+use App\Entity\Activity\Enums\SignupFieldTypes;
 use App\Entity\Activity\ExternalSignup;
 use App\Entity\Activity\SignupList;
 use App\Form\Activity\SignupFieldType;
@@ -123,6 +124,74 @@ final class SignupListTypeTest extends TypeTestCase
             ),
             'A list without sign-ups must keep its allocation method editable.',
         );
+    }
+
+    public function testSubmittedFieldAndOptionOrderAndDefaultAreMappedOntoTheEntities(): void
+    {
+        $list = $this->list();
+        $form = $this->factory->create(
+            SignupListType::class,
+            $list,
+        );
+
+        // Submit only the fields collection (clearMissing = false keeps the list's other values); the hidden position
+        // inputs carry the dragged order as strings and the default marker is a checkbox on one option.
+        $form->submit(
+            [
+                'fields' => [
+                    [
+                        'name' => [
+                            'valueNL' => 'Vraag',
+                            'valueEN' => 'Question',
+                        ],
+                        'type' => SignupFieldTypes::Choice->value,
+                        'position' => '2',
+                        'options' => [
+                            [
+                                'value' => [
+                                    'valueNL' => 'A',
+                                    'valueEN' => 'A',
+                                ],
+                                'position' => '5',
+                                'isDefault' => '1',
+                            ],
+                            [
+                                'value' => [
+                                    'valueNL' => 'B',
+                                    'valueEN' => 'B',
+                                ],
+                                'position' => '3',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            false,
+        );
+
+        $fields = $list->getFields()->getValues();
+        self::assertCount(
+            1,
+            $fields,
+        );
+        // The string position round-trips to the entity's int property (the HiddenType model transformer).
+        self::assertSame(
+            2,
+            $fields[0]->getPosition(),
+        );
+
+        $options = $fields[0]->getOptions()->getValues();
+        self::assertSame(
+            5,
+            $options[0]->getPosition(),
+        );
+        self::assertTrue($options[0]->isDefault());
+        self::assertSame(
+            3,
+            $options[1]->getPosition(),
+        );
+        // An unchecked "default" checkbox is simply absent from the submission and maps to false.
+        self::assertFalse($options[1]->isDefault());
     }
 
     private function listWithSignUp(): SignupList

--- a/tests/Form/Activity/SignupTypeTest.php
+++ b/tests/Form/Activity/SignupTypeTest.php
@@ -91,6 +91,135 @@ final class SignupTypeTest extends TypeTestCase
         );
     }
 
+    public function testDefaultOptionIsPreselectedForANewSignupAndDropsThePlaceholder(): void
+    {
+        $list = new SignupList();
+        $list->addField($this->choiceField(
+            100,
+            [
+                201 => false,
+                202 => true,
+                203 => false,
+            ],
+        ));
+
+        // A brand-new sign-up: no prefill data, so the field-level default takes effect.
+        $form = $this->factory->create(
+            SignupType::class,
+            null,
+            [
+                'signupList' => $list,
+                'mode' => SignupType::MODE_MEMBER,
+            ],
+        );
+
+        $choice = $form->get(SignupType::fieldKey(100));
+
+        // The flagged option is preselected...
+        self::assertSame(
+            202,
+            $choice->getData(),
+        );
+        // ...and the empty placeholder is dropped (ChoiceType normalises `false` to null), so a real option is always
+        // selected.
+        self::assertNull($choice->getConfig()->getOption('placeholder'));
+    }
+
+    public function testAnExistingAnswerOverridesTheDefaultOption(): void
+    {
+        $list = new SignupList();
+        $list->addField($this->choiceField(
+            100,
+            [
+                201 => false,
+                202 => true,
+                203 => false,
+            ],
+        ));
+
+        // Editing an existing sign-up whose saved answer is a non-default option; the prefill data must win.
+        $form = $this->factory->create(
+            SignupType::class,
+            [SignupType::fieldKey(100) => 203],
+            [
+                'signupList' => $list,
+                'mode' => SignupType::MODE_MEMBER,
+            ],
+        );
+
+        self::assertSame(
+            203,
+            $form->get(SignupType::fieldKey(100))->getData(),
+        );
+    }
+
+    public function testWithoutADefaultTheChoiceKeepsItsPlaceholderAndNoPreselection(): void
+    {
+        $list = new SignupList();
+        $list->addField($this->choiceField(
+            100,
+            [
+                201 => false,
+                202 => false,
+            ],
+        ));
+
+        $form = $this->factory->create(
+            SignupType::class,
+            null,
+            [
+                'signupList' => $list,
+                'mode' => SignupType::MODE_MEMBER,
+            ],
+        );
+
+        $choice = $form->get(SignupType::fieldKey(100));
+
+        self::assertNull($choice->getData());
+        // The stub translator echoes the message key, so the placeholder is present (not dropped).
+        self::assertSame(
+            'Choose an option',
+            $choice->getConfig()->getOption('placeholder'),
+        );
+    }
+
+    /**
+     * A choice field with the given options, each flagged (or not) as the default.
+     *
+     * @param array<int, bool> $options option id => whether it is the default
+     */
+    private function choiceField(
+        int $fieldId,
+        array $options,
+    ): SignupField {
+        $field = new SignupField();
+        $this->setId(
+            $field,
+            $fieldId,
+        );
+        $field->setName(new ActivityLocalisedText(
+            'Kleur',
+            'Colour',
+        ));
+        $field->setType(SignupFieldTypes::Choice);
+
+        foreach ($options as $optionId => $isDefault) {
+            $option = new SignupOption();
+            $this->setId(
+                $option,
+                $optionId,
+            );
+            $option->setValue(new ActivityLocalisedText(
+                'Waarde ' . $optionId,
+                'Value ' . $optionId,
+            ));
+            $option->setIsDefault($isDefault);
+            $field->addOption($option);
+        }
+
+        return $field;
+    }
+
     private function choiceFieldWithDuplicateLabels(): SignupField
     {
         $field = new SignupField();

--- a/tests/Service/Activity/ActivityRevisionClonerTest.php
+++ b/tests/Service/Activity/ActivityRevisionClonerTest.php
@@ -251,6 +251,18 @@ final class ActivityRevisionClonerTest extends TestCase
             $sourceOption->getValue(),
             $draftOption->getValue(),
         );
+
+        // The reorder position and the default marker are carried forward too, else a reordered list or a chosen
+        // default would silently revert to id order / no default on the next draft.
+        self::assertSame(
+            2,
+            $draftField->getPosition(),
+        );
+        self::assertSame(
+            3,
+            $draftOption->getPosition(),
+        );
+        self::assertTrue($draftOption->isDefault());
     }
 
     private function assertCopiedNotShared(
@@ -335,12 +347,15 @@ final class ActivityRevisionClonerTest extends TestCase
             'Kleur',
         ));
         $field->setType(SignupFieldTypes::Choice);
+        $field->setPosition(2);
 
         $option = new SignupOption();
         $option->setValue($this->text(
             'Red',
             'Rood',
         ));
+        $option->setPosition(3);
+        $option->setIsDefault(true);
         $field->addOption($option);
         $list->addField($field);
 

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -661,6 +661,10 @@
         <source>Date/time</source>
         <target>Date/time</target>
       </trans-unit>
+      <trans-unit id="NR4FjXR" resname="Default">
+        <source>Default</source>
+        <target state="translated">Default</target>
+      </trans-unit>
       <trans-unit id="nooMqa8" resname="Delete album">
         <source>Delete album</source>
         <target state="translated">Delete album</target>
@@ -1992,6 +1996,14 @@
       <trans-unit id="avQ46Ou" resname="Reopen">
         <source>Reopen</source>
         <target state="translated">Reopen</target>
+      </trans-unit>
+      <trans-unit id="YGNXLoq" resname="Reorder option">
+        <source>Reorder option</source>
+        <target state="translated">Reorder option</target>
+      </trans-unit>
+      <trans-unit id=".ibmqP1" resname="Reorder question">
+        <source>Reorder question</source>
+        <target state="translated">Reorder question</target>
       </trans-unit>
       <trans-unit id="0GpRD.b" resname="Repeat password">
         <source>Repeat password</source>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -661,6 +661,10 @@
         <source>Date/time</source>
         <target>Datum/tijd</target>
       </trans-unit>
+      <trans-unit id="NR4FjXR" resname="Default">
+        <source>Default</source>
+        <target state="translated">Standaard</target>
+      </trans-unit>
       <trans-unit id="nooMqa8" resname="Delete album">
         <source>Delete album</source>
         <target state="translated">Album verwijderen</target>
@@ -1992,6 +1996,14 @@
       <trans-unit id="avQ46Ou" resname="Reopen">
         <source>Reopen</source>
         <target state="translated">Heropenen</target>
+      </trans-unit>
+      <trans-unit id="YGNXLoq" resname="Reorder option">
+        <source>Reorder option</source>
+        <target state="translated">Optie verplaatsen</target>
+      </trans-unit>
+      <trans-unit id=".ibmqP1" resname="Reorder question">
+        <source>Reorder question</source>
+        <target state="translated">Vraag verplaatsen</target>
       </trans-unit>
       <trans-unit id="0GpRD.b" resname="Repeat password">
         <source>Repeat password</source>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -73,6 +73,10 @@
         <source>Fill in the English text.</source>
         <target state="translated">Fill in the English text.</target>
       </trans-unit>
+      <trans-unit id="Dtm28Py" resname="Only one option can be preselected as the default.">
+        <source>Only one option can be preselected as the default.</source>
+        <target state="translated">Only one option can be preselected as the default.</target>
+      </trans-unit>
       <trans-unit id="0wZ1438" resname="Please enter a password.">
         <source>Please enter a password.</source>
         <target state="translated">Please enter a password.</target>

--- a/translations/validators.nl.xlf
+++ b/translations/validators.nl.xlf
@@ -73,6 +73,10 @@
         <source>Fill in the English text.</source>
         <target state="translated">Vul de Engelse tekst in.</target>
       </trans-unit>
+      <trans-unit id="Dtm28Py" resname="Only one option can be preselected as the default.">
+        <source>Only one option can be preselected as the default.</source>
+        <target state="translated">Er kan slechts één optie als standaard worden voorgeselecteerd.</target>
+      </trans-unit>
       <trans-unit id="0wZ1438" resname="Please enter a password.">
         <source>Please enter a password.</source>
         <target state="translated">Voer een wachtwoord in.</target>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

An organiser can now drag the questions, and the options of a choice question, into their desired order.

A choice option can also be marked as the default. It is a checkbox on each option that the editor keeps mutually exclusive, and the server rejects a submission that marks more than one. On the public sign-up form the default is preselected for a new sign-up and the empty placeholder is removed, while an existing answer is kept as it is when someone edits their sign-up.


## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Closes GH-2036.
Closes GH-2106.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
