### PR TITLE
feat: cross-year search and year navigation on the activity/album overviews

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -1815,8 +1815,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/config/reference.php
+++ b/config/reference.php
@@ -1815,8 +1815,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/src/Controller/Activity/ActivityController.php
+++ b/src/Controller/Activity/ActivityController.php
@@ -37,7 +37,10 @@ class ActivityController extends AbstractController
     )]
     public function index(): Response
     {
-        return $this->render('activity/index.html.twig');
+        return $this->render(
+            'activity/index.html.twig',
+            ['years' => $this->activityRepository->getApprovedActivityYears()],
+        );
     }
 
     #[Route(
@@ -45,18 +48,31 @@ class ActivityController extends AbstractController
         name: 'my',
     )]
     #[IsGranted(UserRoles::User->value)]
-    public function my(): Response
+    public function my(
+        #[CurrentUser]
+        User $user,
+    ): Response {
+        return $this->render(
+            'activity/my.html.twig',
+            ['years' => $this->activityRepository->getSubscribedAssociationYears($user->getMember())],
+        );
+    }
+
+    #[Route(
+        path: '/search',
+        name: 'search',
+    )]
+    public function search(): Response
     {
-        return $this->render('activity/my.html.twig');
+        return $this->render('activity/search.html.twig');
     }
 
     #[Route(
         path: '/archive/{year}',
         name: 'archive',
         requirements: ['year' => '\d{4}'],
-        defaults: ['year' => null],
     )]
-    public function archive(?int $year = null): Response
+    public function archive(int $year): Response
     {
         return $this->render(
             'activity/archive.html.twig',
@@ -71,13 +87,12 @@ class ActivityController extends AbstractController
         path: '/archive/my/{year}',
         name: 'archive/my',
         requirements: ['year' => '\d{4}'],
-        defaults: ['year' => null],
     )]
     #[IsGranted(UserRoles::User->value)]
     public function myArchive(
         #[CurrentUser]
         User $user,
-        ?int $year = null,
+        int $year,
     ): Response {
         return $this->render(
             'activity/archive-my.html.twig',

--- a/src/Controller/Photo/PhotoController.php
+++ b/src/Controller/Photo/PhotoController.php
@@ -100,6 +100,15 @@ class PhotoController extends AbstractController
     }
 
     #[Route(
+        path: '/search',
+        name: 'search',
+    )]
+    public function search(): Response
+    {
+        return $this->render('photo/search.html.twig');
+    }
+
+    #[Route(
         path: '/weekly',
         name: 'weekly',
     )]

--- a/src/Repository/Activity/ActivityRepository.php
+++ b/src/Repository/Activity/ActivityRepository.php
@@ -186,8 +186,9 @@ class ActivityRepository extends ServiceEntityRepository
     }
 
     /**
-     * The association years (first calendar year) that have at least one live (approved), past activity, newest first,
-     * for the activity archive year switcher.
+     * The association years (first calendar year) that have at least one live (approved), finished activity, newest
+     * first, for the overview year switcher. Each year links to its archive, which lists that year's finished
+     * activities only, so a year with nothing finished yet (the current year early on) is not offered.
      *
      * @return int[]
      */
@@ -201,7 +202,7 @@ class ActivityRepository extends ServiceEntityRepository
                 'lr',
             )
             ->where('lr.endTime < :now')
-            // Unpublished activities are hidden from the public archive, so they must not contribute a year either.
+            // Unpublished activities are hidden from the public overview, so they must not contribute a year either.
             ->andWhere('a.unpublishedAt IS NULL')
             ->setParameter(
                 'now',
@@ -216,7 +217,7 @@ class ActivityRepository extends ServiceEntityRepository
 
     /**
      * The association years (first calendar year) in which the given member has at least one sign-up for a live
-     * (approved), past activity, newest first, for the "My past activities" year switcher.
+     * (approved), finished activity, newest first, for the "My Activities" year switcher (archive years only).
      *
      * @return int[]
      */
@@ -246,7 +247,7 @@ class ActivityRepository extends ServiceEntityRepository
             ->where('IDENTITY(su.user) = :subscriber')
             ->andWhere('r.endTime < :now')
             ->andWhere('IDENTITY(a.liveRevision) = r.id')
-            // Unpublished activities are hidden from the public/"my" archive, so they must not contribute a year.
+            // Unpublished activities are hidden from the public/"my" overview, so they must not contribute a year.
             ->andWhere('a.unpublishedAt IS NULL')
             ->setParameter(
                 'subscriber',
@@ -290,7 +291,8 @@ class ActivityRepository extends ServiceEntityRepository
      * from that live revision. Correlated EXISTS sub-queries keep the result at one row per activity, so the
      * Paginator counts correctly without a collection fetch-join.
      *
-     * @param bool        $past         false: upcoming (endTime > now, ASC); true: past (endTime < now, DESC)
+     * @param bool|null   $past         false: upcoming (endTime > now, ASC); true: past (endTime < now, DESC);
+     *                                  null: all time (no now filter, newest first) for the cross-year search page
      * @param Member|null $subscribedBy when set, only activities this member has a (user) signup for
      * @param string      $locale       'nl' searches the Dutch name, anything else the English name
      * @param int[]       $labelIds     match activities having ANY of these labels
@@ -299,7 +301,7 @@ class ActivityRepository extends ServiceEntityRepository
      * @return Paginator<Activity>
      */
     public function findForOverview(
-        bool $past,
+        ?bool $past,
         ?Member $subscribedBy,
         string $search,
         string $locale,
@@ -345,25 +347,38 @@ class ActivityRepository extends ServiceEntityRepository
             )
             // An unpublished activity is taken out of public view entirely, listings included. (A cancelled one still
             // shows, with a notice, so it is deliberately not filtered here.)
-            ->andWhere('a.unpublishedAt IS NULL')
-            ->setParameter(
+            ->andWhere('a.unpublishedAt IS NULL');
+
+        // `:now` is referenced by the past/upcoming window and by the open-sign-up filter, but not by the cross-year
+        // (all-time) search, so it is only bound when a clause actually uses it.
+        if (
+            null !== $past
+            || $openSignupOnly
+        ) {
+            $qb->setParameter(
                 'now',
                 new DateTime(),
                 Types::DATETIME_MUTABLE,
             );
+        }
 
-        if ($past) {
+        if (true === $past) {
             $qb->andWhere('lr.endTime < :now')
                 ->orderBy(
                     'lr.beginTime',
                     'DESC',
                 );
-        } else {
+        } elseif (false === $past) {
             $qb->andWhere('lr.endTime > :now')
                 ->orderBy(
                     'lr.beginTime',
                     'ASC',
                 );
+        } else {
+            $qb->orderBy(
+                'lr.beginTime',
+                'DESC',
+            );
         }
 
         $search = trim($search);

--- a/src/Repository/Photo/AlbumRepository.php
+++ b/src/Repository/Photo/AlbumRepository.php
@@ -64,10 +64,43 @@ class AlbumRepository extends ServiceEntityRepository
     }
 
     /**
-     * Albums matching a name fragment, for the admin move-photos picker. Unlike {@see self::search} (the public
-     * gallery) this is not restricted to published, dated, root albums: a photo can be moved into any album, drafts
-     * and sub-albums included. The parent is fetch-joined for a disambiguating label, and the result is capped so the
-     * typeahead stays light.
+     * Root albums whose name matches a fragment, across every association year, for the public cross-year search. Only
+     * published, dated albums are returned (the album voter still runs per result for the graduate rule). Newest first,
+     * and capped so the per-album voter pass stays bounded.
+     *
+     * @return Album[]
+     */
+    public function searchPublishedAlbums(
+        string $query,
+        int $limit = 25,
+    ): array {
+        return $this->createQueryBuilder('a')
+            ->where('a.parent IS NULL')
+            ->andWhere('a.published = TRUE')
+            ->andWhere('a.startDateTime IS NOT NULL')
+            ->andWhere('a.endDateTime IS NOT NULL')
+            ->andWhere('a.name LIKE :query')
+            ->setParameter(
+                'query',
+                '%' . addcslashes(
+                    $query,
+                    '%_',
+                ) . '%',
+            )
+            ->orderBy(
+                'a.startDateTime',
+                'DESC',
+            )
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Albums matching a name fragment, for the admin move-photos picker. Unlike the public cross-year search
+     * ({@see self::searchPublishedAlbums}) this is not restricted to published, dated, root albums: a photo can be
+     * moved into any album, drafts and sub-albums included. The parent is fetch-joined for a disambiguating label, and
+     * the result is capped so the typeahead stays light.
      *
      * @return Album[]
      */

--- a/src/Service/Photo/AlbumService.php
+++ b/src/Service/Photo/AlbumService.php
@@ -90,6 +90,41 @@ final readonly class AlbumService
             $associationYear->getEndDate(),
         );
 
+        return $this->bucketViewableAlbumsByMonth(
+            $albums,
+            $search,
+        );
+    }
+
+    /**
+     * The viewable root albums whose name matches the search, across every association year, grouped by month (keyed
+     * 'Y-m', most recent month first) for the cross-year album search page. The repository restricts to published,
+     * dated, root albums; the voter still runs per album for the graduate rule.
+     *
+     * @return array<string, Album[]>
+     */
+    public function searchViewableAlbums(string $search): array
+    {
+        // The name match already ran in SQL, so no further search filter is applied while bucketing.
+        return $this->bucketViewableAlbumsByMonth(
+            $this->albumRepository->searchPublishedAlbums($search),
+            null,
+        );
+    }
+
+    /**
+     * Keep only the albums the current user may view (published, plus the graduate rule via {@see AlbumVoter}),
+     * optionally narrowing to those whose name contains $search, and bucket them by month (keyed 'Y-m') preserving the
+     * given order.
+     *
+     * @param Album[] $albums
+     *
+     * @return array<string, Album[]>
+     */
+    private function bucketViewableAlbumsByMonth(
+        array $albums,
+        ?string $search,
+    ): array {
         $grouped = [];
         foreach ($albums as $album) {
             $start = $album->getStartDateTime();

--- a/src/Twig/Components/Activity/ActivityOverview.php
+++ b/src/Twig/Components/Activity/ActivityOverview.php
@@ -34,8 +34,9 @@ use function strval;
 use function trim;
 
 /**
- * Backs the four activity overview pages: upcoming/archive × public/subscribed. The page fixes `subscribed` and `past`
- * at mount time; everything else is a live filter. Infinite scroll grows `limit` via the loadMore action.
+ * Backs the activity overview pages: the upcoming overview, a single association-year archive, the cross-year search
+ * page, and their subscribed ("my") variants. The page fixes `subscribed`, `year` and `crossYear` at mount time;
+ * everything else is a live filter. Infinite scroll grows `limit` via the loadMore action.
  */
 #[AsLiveComponent(
     name: 'Activity:ActivityOverview',
@@ -51,7 +52,7 @@ final class ActivityOverview
     public bool $subscribed = false;
 
     #[LiveProp]
-    public bool $past = false;
+    public bool $crossYear = false;
 
     // All the filters mirror themselves into the query string via the History API, so the state survives a reload and
     // the address bar is itself a shareable link (the copy button just yields the same URL in one click).
@@ -196,6 +197,11 @@ final class ActivityOverview
         return $grouped;
     }
 
+    public function isGrouped(): bool
+    {
+        return $this->crossYear || null !== $this->year;
+    }
+
     public function getTotalCount(): int
     {
         if (!$this->canQuery()) {
@@ -251,7 +257,7 @@ final class ActivityOverview
     private function getPaginator(): Paginator
     {
         return $this->paginator ??= $this->activityRepository->findForOverview(
-            past: $this->past,
+            past: $this->timePast(),
             subscribedBy: $this->subscribed ? $this->currentMember() : null,
             search: $this->search,
             locale: $this->requestStack->getCurrentRequest()?->getLocale() ?? 'en',
@@ -296,6 +302,20 @@ final class ActivityOverview
                 static fn (int $id): bool => $id > 0,
             ),
         );
+    }
+
+    /**
+     * The time-window mode for {@see ActivityRepository::findForOverview()}: false on the default upcoming overview
+     * (future only), true on a selected association-year archive (past only, so the current year's archive excludes its
+     * still-upcoming activities), and null on the cross-year search page (past and upcoming, every year).
+     */
+    private function timePast(): ?bool
+    {
+        if ($this->crossYear) {
+            return null;
+        }
+
+        return null !== $this->year;
     }
 
     /**

--- a/src/Twig/Components/Photo/AlbumOverview.php
+++ b/src/Twig/Components/Photo/AlbumOverview.php
@@ -14,8 +14,9 @@ use function array_merge;
 use function array_values;
 
 /**
- * The albums of one association year on the photo landing page, grouped into months. The year is chosen by the page
- * (the year-switcher navigates here with a fresh year), and search filters the albums by name without a page reload.
+ * The albums shown on the photo landing page and the cross-year search page, grouped into months. On the landing page
+ * the year is chosen by the page and search filters within it; on the search page (`crossYear`) the query searches
+ * every year's albums by name. Filtering happens without a page reload.
  */
 #[AsLiveComponent(
     name: 'Photo:AlbumOverview',
@@ -28,6 +29,10 @@ final class AlbumOverview
     #[LiveProp]
     public ?int $year = null;
 
+    #[LiveProp]
+    public bool $crossYear = false;
+
+    // Not URL-synced: on the landing page the year is a query param, and syncing search could drop it on reload.
     #[LiveProp(writable: true)]
     public string $search = '';
 
@@ -46,6 +51,13 @@ final class AlbumOverview
     {
         if (null !== $this->albumsByMonth) {
             return $this->albumsByMonth;
+        }
+
+        if ($this->crossYear) {
+            // Wait for a query before searching: the whole photo archive is too large to list at once.
+            return $this->albumsByMonth = '' === $this->search
+                ? []
+                : $this->albumService->searchViewableAlbums($this->search);
         }
 
         if (null === $this->year) {

--- a/templates/activity/archive-my.html.twig
+++ b/templates/activity/archive-my.html.twig
@@ -1,29 +1,24 @@
 {% extends 'layout.html.twig' %}
 
-{% block page_title %}{{ 'My past activities'|trans|page_title }}{{ parent() }}{% endblock %}
+{% block page_title %}{{ 'My Activities'|trans|page_title }}{{ parent() }}{% endblock %}
 
 {% block contents %}
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
-        <h1 class="mb-0">{{ 'My past activities'|trans }}</h1>
+        <h1 class="mb-0">{{ 'My Activities'|trans }}</h1>
 
-        <div class="btn-toolbar gap-2" role="toolbar">
+        <div class="d-flex flex-wrap align-items-center gap-2">
             {% include 'partials/filter-toggle.html.twig' with { target: 'activity-filters' } only %}
-
-            <a class="btn btn-outline-secondary" href="{{ path('activity/my') }}">
-                <span class="fas fa-chevron-left"></span> {{ 'My upcoming activities'|trans }}
-            </a>
 
             {% include 'partials/year-switcher.html.twig' with {
                 route: 'activity/archive/my',
+                upcoming_route: 'activity/my',
+                upcoming: true,
                 year: year,
                 years: years,
+                all_years: false,
             } only %}
         </div>
     </div>
 
-    {{ component('Activity:ActivityOverview', {
-        subscribed: true,
-        past: true,
-        year: year,
-    }) }}
+    {{ component('Activity:ActivityOverview', { subscribed: true, year: year }) }}
 {% endblock %}

--- a/templates/activity/archive.html.twig
+++ b/templates/activity/archive.html.twig
@@ -1,24 +1,26 @@
 {% extends 'layout.html.twig' %}
 
-{% block page_title %}{{ 'Activity Archive'|trans|page_title }}{{ parent() }}{% endblock %}
+{% block page_title %}{{ 'Activities'|trans|page_title }}{{ parent() }}{% endblock %}
 
 {% block contents %}
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
-        <h1 class="mb-0">{{ 'Activity Archive'|trans }}</h1>
+        <h1 class="mb-0">{{ 'Activities'|trans }}</h1>
 
         <div class="d-flex flex-wrap align-items-center gap-2">
             {% include 'partials/filter-toggle.html.twig' with { target: 'activity-filters' } only %}
 
+            {% include 'partials/search-toggle.html.twig' with { route: 'activity/search' } only %}
+
             {% include 'partials/year-switcher.html.twig' with {
                 route: 'activity/archive',
+                upcoming_route: 'activity/index',
+                upcoming: true,
                 year: year,
                 years: years,
+                all_years: false,
             } only %}
         </div>
     </div>
 
-    {{ component('Activity:ActivityOverview', {
-        past: true,
-        year: year,
-    }) }}
+    {{ component('Activity:ActivityOverview', { year: year }) }}
 {% endblock %}

--- a/templates/activity/index.html.twig
+++ b/templates/activity/index.html.twig
@@ -6,7 +6,20 @@
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
         <h1 class="mb-0">{{ 'Activities'|trans }}</h1>
 
-        {% include 'partials/filter-toggle.html.twig' with { target: 'activity-filters' } only %}
+        <div class="d-flex flex-wrap align-items-center gap-2">
+            {% include 'partials/filter-toggle.html.twig' with { target: 'activity-filters' } only %}
+
+            {% include 'partials/search-toggle.html.twig' with { route: 'activity/search' } only %}
+
+            {% include 'partials/year-switcher.html.twig' with {
+                route: 'activity/archive',
+                upcoming_route: 'activity/index',
+                upcoming: true,
+                year: null,
+                years: years,
+                all_years: false,
+            } only %}
+        </div>
     </div>
 
     {{ component('Activity:ActivityOverview') }}

--- a/templates/activity/my.html.twig
+++ b/templates/activity/my.html.twig
@@ -4,14 +4,19 @@
 
 {% block contents %}
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
-        <h1 class="mb-0">{{ 'My upcoming activities'|trans }}</h1>
+        <h1 class="mb-0">{{ 'My Activities'|trans }}</h1>
 
-        <div class="d-flex flex-wrap gap-2">
+        <div class="d-flex flex-wrap align-items-center gap-2">
             {% include 'partials/filter-toggle.html.twig' with { target: 'activity-filters' } only %}
 
-            <a class="btn btn-outline-secondary" href="{{ path('activity/archive/my') }}">
-                {{ 'My past activities'|trans }} <span class="fas fa-chevron-right"></span>
-            </a>
+            {% include 'partials/year-switcher.html.twig' with {
+                route: 'activity/archive/my',
+                upcoming_route: 'activity/my',
+                upcoming: true,
+                year: null,
+                years: years,
+                all_years: false,
+            } only %}
         </div>
     </div>
 

--- a/templates/activity/search.html.twig
+++ b/templates/activity/search.html.twig
@@ -1,0 +1,19 @@
+{% extends 'layout.html.twig' %}
+
+{% block page_title %}{{ 'Search activities'|trans|page_title }}{{ parent() }}{% endblock %}
+
+{% block contents %}
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+        <h1 class="mb-0">{{ 'Search activities'|trans }}</h1>
+
+        <div class="d-flex flex-wrap align-items-center gap-2">
+            {% include 'partials/filter-toggle.html.twig' with { target: 'activity-filters', expanded: true } only %}
+
+            {% include 'partials/search-toggle.html.twig' with { route: 'activity/search', active: true } only %}
+        </div>
+    </div>
+
+    <p class="text-muted">{{ 'Find any activity across every association year.'|trans }}</p>
+
+    {{ component('Activity:ActivityOverview', { crossYear: true }) }}
+{% endblock %}

--- a/templates/activity/view.html.twig
+++ b/templates/activity/view.html.twig
@@ -30,6 +30,7 @@
 {% endblock %}
 
 {% block contents %}
+    {% set isCareer = activity.getCategory.value == 'career' %}
     {% if activity.isCancelled %}
         <div class="alert alert-danger" role="alert">
             <strong>{{ 'This activity has been cancelled.'|trans }}</strong>
@@ -93,7 +94,7 @@
                             </p>
                         </div>
                     {% endif %}
-                    {% if activity.getCategory.value == 'career' %}
+                    {% if isCareer %}
                         <a class="list-group-item list-group-item-action" href="https://myfuture.tue.nl/"
                            target="_blank" rel="noopener">
                             <img class="img-fluid" style="max-width: 125px;"
@@ -120,11 +121,26 @@
         </aside>
     </div>
 
+    {% set organ = activity.getOrgan %}
+    {% set organInformation = organ is not null ? organ.getApprovedOrganInformation : null %}
+    {% set organEmail = organInformation is not null ? organInformation.getEmail : null %}
+    {# Obfuscate the @ so the addresses are not trivially scraped from the public page. #}
+    {% set atSeparator = ' ' ~ '[at]'|trans ~ ' ' %}
+    {% set boardEmail = ((isCareer ? 'ceb' : 'cib') ~ '@gewis.nl')|replace({'@': atSeparator}) %}
     <p class="text-muted small mt-3">
-        {{ 'Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!'|trans({
-            '%organizer%': activity.getOrgan is not null ? activity.getOrgan.getName : 'the organising party'|trans,
-            '%email%': 'cib@gewis.nl',
-        }) }}
+        {% if organ is null %}
+            {{ 'Please contact the board (%email%) with any questions or concerns. Have fun!'|trans({
+                '%email%': boardEmail,
+            }) }}
+        {% else %}
+            {% set organizer = organEmail is not empty
+                ? organ.getAbbr ~ ' (' ~ organEmail|replace({'@': atSeparator}) ~ ')'
+                : organ.getAbbr %}
+            {{ 'Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!'|trans({
+                '%organizer%': organizer,
+                '%email%': boardEmail,
+            }) }}
+        {% endif %}
     </p>
 
     {% if signupListViews is not empty %}

--- a/templates/activity/view.html.twig
+++ b/templates/activity/view.html.twig
@@ -93,6 +93,13 @@
                             </p>
                         </div>
                     {% endif %}
+                    {% if activity.getCategory.value == 'career' %}
+                        <a class="list-group-item list-group-item-action" href="https://myfuture.tue.nl/"
+                           target="_blank" rel="noopener">
+                            <img class="img-fluid" style="max-width: 125px;"
+                                 src="{{ asset('images/myfuture.png') }}" alt="MyFuture">
+                        </a>
+                    {% endif %}
                 </div>
                 <div class="panel-footer dropdown">
                     <button type="button" class="panel-footer-link btn btn-link p-0 dropdown-toggle"

--- a/templates/components/Activity/ActivityOverview.html.twig
+++ b/templates/components/Activity/ActivityOverview.html.twig
@@ -1,6 +1,6 @@
 <div {{ attributes }}>
     {# data-live-ignore: keeps the injected label chips intact across re-renders. #}
-    <div class="collapse mb-3" id="activity-filters" data-live-ignore>
+    <div class="collapse mb-3{{ this.crossYear ? ' show' }}" id="activity-filters" data-live-ignore>
         <div class="panel my-0">
             <div class="panel-body">
                 <div class="row g-3 align-items-end">
@@ -9,7 +9,8 @@
                     <input type="search" class="form-control" id="activity-overview-search"
                            placeholder="{{ 'Search by activity name'|trans }}"
                            data-model="debounce(300)|search"
-                           value="{{ this.search }}">
+                           value="{{ this.search }}"
+                           {{ this.crossYear ? 'autofocus' }}>
                 </div>
                 <div class="col-md-4">
                     <label class="form-label" for="activity-overview-category">{{ 'Category'|trans }}</label>
@@ -75,7 +76,7 @@
         </div>
     </div>
 
-    {% if this.past %}
+    {% if this.isGrouped %}
         <div class="mb-2">
             {% for activities in this.activitiesByAssociationYear %}
                 {% set currentMonth = null %}

--- a/templates/components/Photo/AlbumOverview.html.twig
+++ b/templates/components/Photo/AlbumOverview.html.twig
@@ -1,19 +1,22 @@
 <div {{ attributes }}>
     {# data-live-ignore keeps the panel (and the focused search field) stable across live re-renders. #}
-    <div class="collapse mb-3" id="photo-filters" data-live-ignore>
+    <div class="collapse mb-3{{ this.crossYear ? ' show' }}" id="photo-filters" data-live-ignore>
         <div class="panel my-0">
             <div class="panel-body">
                 <label class="form-label" for="photo-overview-search">{{ 'Search'|trans }}</label>
                 <input type="search" class="form-control" id="photo-overview-search"
                        placeholder="{{ 'Search by album name'|trans }}"
                        data-model="debounce(300)|search"
-                       value="{{ this.search }}">
+                       value="{{ this.search }}"
+                       {{ this.crossYear ? 'autofocus' }}>
             </div>
         </div>
     </div>
 
     {% set albumsByMonth = this.albumsByMonth %}
-    {% if albumsByMonth is empty %}
+    {% if this.crossYear and this.search is empty %}
+        <p class="text-muted text-center py-4">{{ 'Type to search for albums across every year.'|trans }}</p>
+    {% elseif albumsByMonth is empty %}
         <p class="text-muted text-center py-4">{{ 'There are no albums to show.'|trans }}</p>
     {% else %}
         {% set cardCounts = this.cardCounts %}

--- a/templates/partials/application/main-nav.html.twig
+++ b/templates/partials/application/main-nav.html.twig
@@ -242,11 +242,6 @@
                                     {{ 'Overview'|trans }}
                                 </a>
                             </li>
-                            <li>
-                                <a href="{{ path('activity/archive') }}" class="dropdown-item">
-                                    {{ 'Archive'|trans }}
-                                </a>
-                            </li>
                             {% if is_granted('ROLE_USER') %}
                                 <li>
                                     <hr class="dropdown-divider">

--- a/templates/partials/filter-toggle.html.twig
+++ b/templates/partials/filter-toggle.html.twig
@@ -1,6 +1,6 @@
 {# `target` is the id (without #) of the collapsible filter panel this button toggles. #}
 <button type="button" class="btn btn-outline-secondary"
         data-bs-toggle="collapse" data-bs-target="#{{ target }}"
-        aria-expanded="false" aria-controls="{{ target }}">
+        aria-expanded="{{ (expanded ?? false) ? 'true' : 'false' }}" aria-controls="{{ target }}">
     <span class="fas fa-sliders"></span> {{ 'Filters'|trans }}
 </button>

--- a/templates/partials/search-toggle.html.twig
+++ b/templates/partials/search-toggle.html.twig
@@ -1,0 +1,3 @@
+<a class="btn btn-outline-secondary {{ (active ?? false) ? 'active' }}" href="{{ path(route) }}">
+    <span class="fas fa-magnifying-glass"></span> {{ 'Search'|trans }}
+</a>

--- a/templates/partials/year-switcher.html.twig
+++ b/templates/partials/year-switcher.html.twig
@@ -1,5 +1,6 @@
-{# `all_years` (default true) shows the "All years" entry; pass false where a specific year must always be selected. #}
 {% set all_years = all_years ?? true %}
+{% set upcoming = upcoming ?? false %}
+{% set upcoming_route = upcoming_route ?? route %}
 {% if years is not empty %}
     {% set query = app.request.query.all %}
     {% set newer_years = year is not null ? years|filter(y => y > year) : [] %}
@@ -16,10 +17,21 @@
             <button type="button" class="btn btn-outline-secondary dropdown-toggle"
                     data-bs-toggle="dropdown" aria-expanded="false">
                 {# Year 0 is the "undated" bucket (albums without a start date), so it is labelled instead of "0 - 1". #}
-                {{ year is null ? 'All years'|trans : (year > 0 ? (year ~ ' - ' ~ (year + 1)) : 'Undated'|trans) }}
+                {% if year is null %}
+                    {{ upcoming ? 'Upcoming'|trans : 'All years'|trans }}
+                {% else %}
+                    {{ year > 0 ? (year ~ ' - ' ~ (year + 1)) : 'Undated'|trans }}
+                {% endif %}
             </button>
             <ul class="dropdown-menu">
-                {% if all_years %}
+                {% if upcoming %}
+                    <li>
+                        <a class="dropdown-item {{ year is null ? 'active' }}" href="{{ path(upcoming_route, query) }}">
+                            {{ 'Upcoming'|trans }}
+                        </a>
+                    </li>
+                    <li><hr class="dropdown-divider"></li>
+                {% elseif all_years %}
                     <li>
                         <a class="dropdown-item {{ year is null ? 'active' }}" href="{{ path(route, query) }}">
                             {{ 'All years'|trans }}

--- a/templates/photo/index.html.twig
+++ b/templates/photo/index.html.twig
@@ -10,6 +10,8 @@
             <div class="d-flex flex-wrap align-items-center gap-2">
                 {% include 'partials/filter-toggle.html.twig' with { target: 'photo-filters' } only %}
 
+                {% include 'partials/search-toggle.html.twig' with { route: 'photo/search' } only %}
+
                 {% include 'partials/year-switcher.html.twig' with {
                     route: 'photo/index',
                     year: year,

--- a/templates/photo/search.html.twig
+++ b/templates/photo/search.html.twig
@@ -1,0 +1,19 @@
+{% extends 'layout.html.twig' %}
+
+{% block page_title %}{{ 'Search albums'|trans|page_title }}{{ parent() }}{% endblock %}
+
+{% block contents %}
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+        <h1 class="mb-0">{{ 'Search albums'|trans }}</h1>
+
+        <div class="d-flex flex-wrap align-items-center gap-2">
+            {% include 'partials/filter-toggle.html.twig' with { target: 'photo-filters', expanded: true } only %}
+
+            {% include 'partials/search-toggle.html.twig' with { route: 'photo/search', active: true } only %}
+        </div>
+    </div>
+
+    <p class="text-muted">{{ 'Find any album across every association year.'|trans }}</p>
+
+    {{ component('Photo:AlbumOverview', { crossYear: true }) }}
+{% endblock %}

--- a/tests/Integration/Controller/Activity/ActivityControllerTest.php
+++ b/tests/Integration/Controller/Activity/ActivityControllerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Controller\Activity;
 
 use App\Controller\Activity\ActivityController;
+use App\Entity\Activity\Activity;
+use App\Entity\Activity\Enums\ActivityCategories;
 use App\Entity\Decision\AssociationYear;
 use App\Tests\Integration\DatabaseTestCase;
 use DateTime;
@@ -57,9 +59,69 @@ final class ActivityControllerTest extends DatabaseTestCase
         );
     }
 
+    public function testViewShowsTheMyFutureLogoForCareerActivities(): void
+    {
+        $this->pushRequest();
+
+        $response = $this->controller()->view($this->approvedActivityId(true));
+
+        self::assertSame(
+            Response::HTTP_OK,
+            $response->getStatusCode(),
+        );
+        self::assertStringContainsString(
+            'myfuture.tue.nl',
+            (string) $response->getContent(),
+        );
+    }
+
+    public function testViewOmitsTheMyFutureLogoForOtherCategories(): void
+    {
+        $this->pushRequest();
+
+        self::assertStringNotContainsString(
+            'myfuture.tue.nl',
+            (string) $this->controller()->view($this->approvedActivityId(false))->getContent(),
+        );
+    }
+
     private function controller(): ActivityController
     {
         return self::getContainer()->get(ActivityController::class);
+    }
+
+    private function approvedActivityId(bool $career): int
+    {
+        $queryBuilder = $this->entityManager->createQueryBuilder()
+            ->select('a')
+            ->from(
+                Activity::class,
+                'a',
+            )
+            ->join(
+                'a.liveRevision',
+                'lr',
+            )
+            ->andWhere('a.unpublishedAt IS NULL')
+            ->setParameter(
+                'career',
+                ActivityCategories::Career->value,
+            )
+            ->setMaxResults(1);
+
+        $queryBuilder->andWhere(
+            $career
+                ? 'lr.category = :career'
+                : 'lr.category != :career',
+        );
+
+        $activity = $queryBuilder->getQuery()->getOneOrNullResult();
+        self::assertInstanceOf(
+            Activity::class,
+            $activity,
+        );
+
+        return (int) $activity->getId();
     }
 
     private function pushRequest(): void

--- a/tests/Integration/Controller/Activity/ActivityControllerTest.php
+++ b/tests/Integration/Controller/Activity/ActivityControllerTest.php
@@ -85,6 +85,33 @@ final class ActivityControllerTest extends DatabaseTestCase
         );
     }
 
+    public function testViewObfuscatesTheBoardContactEmail(): void
+    {
+        $this->pushRequest();
+
+        $career = (string) $this->controller()->view($this->approvedActivityId(true))->getContent();
+        $other = (string) $this->controller()->view($this->approvedActivityId(false))->getContent();
+
+        // Career activities use the external-relations board (ceb), others the internal board (cib); neither renders a
+        // plain, scrapable address.
+        self::assertMatchesRegularExpression(
+            '/ceb \[[^\]]+\] gewis\.nl/',
+            $career,
+        );
+        self::assertMatchesRegularExpression(
+            '/cib \[[^\]]+\] gewis\.nl/',
+            $other,
+        );
+        self::assertStringNotContainsString(
+            '@gewis.nl',
+            $career,
+        );
+        self::assertStringNotContainsString(
+            '@gewis.nl',
+            $other,
+        );
+    }
+
     private function controller(): ActivityController
     {
         return self::getContainer()->get(ActivityController::class);

--- a/tests/Integration/Controller/Activity/ActivityControllerTest.php
+++ b/tests/Integration/Controller/Activity/ActivityControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Controller\Activity;
+
+use App\Controller\Activity\ActivityController;
+use App\Entity\Decision\AssociationYear;
+use App\Tests\Integration\DatabaseTestCase;
+use DateTime;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
+
+/**
+ * The public activity pages, invoked directly (the codebase has no WebTestCase). The archive folds into the overview
+ * via a required year, and the cross-year search is its own page reusing the overview component.
+ */
+final class ActivityControllerTest extends DatabaseTestCase
+{
+    public function testIndexRendersTheUpcomingOverview(): void
+    {
+        $this->pushRequest();
+
+        self::assertSame(
+            Response::HTTP_OK,
+            $this->controller()->index()->getStatusCode(),
+        );
+    }
+
+    public function testArchiveRendersForTheCurrentAssociationYear(): void
+    {
+        $this->pushRequest();
+
+        // The current year's archive lists finished activities only (past-only), but the page still renders.
+        $year = AssociationYear::fromDate(new DateTime())->getYear();
+
+        self::assertSame(
+            Response::HTTP_OK,
+            $this->controller()->archive($year)->getStatusCode(),
+        );
+    }
+
+    public function testSearchRendersTheCrossYearSearchPage(): void
+    {
+        $this->pushRequest();
+
+        $response = $this->controller()->search();
+
+        self::assertSame(
+            Response::HTTP_OK,
+            $response->getStatusCode(),
+        );
+        self::assertStringContainsString(
+            'activity-overview-search',
+            (string) $response->getContent(),
+        );
+    }
+
+    private function controller(): ActivityController
+    {
+        return self::getContainer()->get(ActivityController::class);
+    }
+
+    private function pushRequest(): void
+    {
+        $session = self::getContainer()->get('session.factory')->createSession();
+        self::assertInstanceOf(
+            FlashBagAwareSessionInterface::class,
+            $session,
+        );
+
+        $request = new Request();
+        $request->setSession($session);
+        self::getContainer()->get('request_stack')->push($request);
+    }
+}

--- a/tests/Integration/Repository/Activity/ActivityOverviewQueryTest.php
+++ b/tests/Integration/Repository/Activity/ActivityOverviewQueryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository\Activity;
+
+use App\Entity\Activity\Activity;
+use App\Entity\Decision\AssociationYear;
+use App\Repository\Activity\ActivityRepository;
+use App\Tests\Integration\DatabaseTestCase;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function iterator_to_array;
+
+/**
+ * The overview query has three time modes: the default upcoming feed (past = false), a single association-year window,
+ * and the cross-year search (past = null) that drops the now-window entirely. These pin the cross-year mode against the
+ * seed, and pin the year list that feeds the switcher (which now includes upcoming years).
+ */
+final class ActivityOverviewQueryTest extends DatabaseTestCase
+{
+    public function testCrossYearModeReturnsUpcomingAndPastTogetherNewestFirst(): void
+    {
+        $all = $this->overview(null);
+        $allIds = $this->ids($all);
+        $upcomingIds = $this->ids($this->overview(false));
+        $pastIds = $this->ids($this->overview(true));
+
+        // The seed always has upcoming approved activities; past may be empty, but the union must hold exactly.
+        self::assertNotEmpty($upcomingIds);
+        self::assertEqualsCanonicalizing(
+            array_unique(array_merge(
+                $upcomingIds,
+                $pastIds,
+            )),
+            $allIds,
+        );
+
+        // Newest first: begin times are non-increasing.
+        $activities = iterator_to_array(
+            $all->getIterator(),
+            false,
+        );
+        $previous = null;
+        foreach ($activities as $activity) {
+            $begin = $activity->getBeginTime();
+            if (null !== $previous) {
+                self::assertGreaterThanOrEqual(
+                    $begin->getTimestamp(),
+                    $previous->getTimestamp(),
+                    'The cross-year search must list activities newest first.',
+                );
+            }
+
+            $previous = $begin;
+        }
+    }
+
+    public function testYearArchiveExcludesThatYearsUpcomingActivities(): void
+    {
+        // A known upcoming activity from the seed: its own association-year archive must not list it, because an
+        // archive is past only, even for the current year.
+        $upcoming = iterator_to_array(
+            $this->overview(false)->getIterator(),
+            false,
+        );
+        self::assertNotEmpty($upcoming);
+
+        $activity = $upcoming[0];
+        $window = AssociationYear::fromYear(AssociationYear::fromDate($activity->getBeginTime())->getYear());
+
+        $archiveIds = $this->ids($this->repository()->findForOverview(
+            true,
+            null,
+            '',
+            'en',
+            null,
+            [],
+            null,
+            false,
+            $window->getStartDate(),
+            $window->getEndDate(),
+            200,
+            0,
+        ));
+
+        self::assertNotContains(
+            (int) $activity->getId(),
+            $archiveIds,
+        );
+    }
+
+    /**
+     * @return Paginator<Activity>
+     */
+    private function overview(?bool $past): Paginator
+    {
+        return $this->repository()->findForOverview(
+            $past,
+            null,
+            '',
+            'en',
+            null,
+            [],
+            null,
+            false,
+            null,
+            null,
+            200,
+            0,
+        );
+    }
+
+    /**
+     * @param Paginator<Activity> $paginator
+     *
+     * @return int[]
+     */
+    private function ids(Paginator $paginator): array
+    {
+        return array_map(
+            static fn (Activity $activity): int => (int) $activity->getId(),
+            iterator_to_array(
+                $paginator->getIterator(),
+                false,
+            ),
+        );
+    }
+
+    private function repository(): ActivityRepository
+    {
+        return $this->entityManager->getRepository(Activity::class);
+    }
+}

--- a/tests/Integration/Repository/Photo/AlbumRepositoryTest.php
+++ b/tests/Integration/Repository/Photo/AlbumRepositoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository\Photo;
+
+use App\Entity\Photo\Album;
+use App\Repository\Photo\AlbumRepository;
+use App\Tests\Integration\DatabaseTestCase;
+
+use function array_map;
+
+/**
+ * The public cross-year album search: a name LIKE across every association year, restricted to published, dated, root
+ * albums (the graduate rule runs later, per result, in the service). Pins the query against the seed.
+ */
+final class AlbumRepositoryTest extends DatabaseTestCase
+{
+    public function testSearchPublishedAlbumsMatchesNameAcrossYears(): void
+    {
+        $results = $this->repository()->searchPublishedAlbums('Trip');
+
+        self::assertContains(
+            'Trip 2024',
+            array_map(
+                static fn (Album $album): string => $album->getName(),
+                $results,
+            ),
+        );
+
+        // Every result is a published, dated, root album; the voter/graduate rule is applied later, in the service.
+        foreach ($results as $album) {
+            self::assertNull($album->getParent());
+            self::assertNotNull($album->getStartDateTime());
+        }
+    }
+
+    public function testSearchPublishedAlbumsExcludesDrafts(): void
+    {
+        $draft = $this->repository()->findOneBy(['published' => false]);
+        self::assertInstanceOf(
+            Album::class,
+            $draft,
+            'The seed is expected to contain an unpublished album.',
+        );
+
+        $ids = array_map(
+            static fn (Album $album): int => (int) $album->getId(),
+            $this->repository()->searchPublishedAlbums($draft->getName()),
+        );
+
+        self::assertNotContains(
+            (int) $draft->getId(),
+            $ids,
+        );
+    }
+
+    private function repository(): AlbumRepository
+    {
+        return self::getContainer()->get(AlbumRepository::class);
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2189,6 +2189,10 @@
         <source>Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!</source>
         <target>Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!</target>
       </trans-unit>
+      <trans-unit id="7NVRAYy" resname="Please contact the board (%email%) with any questions or concerns. Have fun!">
+        <source>Please contact the board (%email%) with any questions or concerns. Have fun!</source>
+        <target>Please contact the board (%email%) with any questions or concerns. Have fun!</target>
+      </trans-unit>
       <trans-unit id="lwY.3Bl" resname="Please provide both a subject and a message.">
         <source>Please provide both a subject and a message.</source>
         <target>Please provide both a subject and a message.</target>
@@ -3617,6 +3621,10 @@
         <source>[CANCELLED]</source>
         <target>[CANCELLED]</target>
       </trans-unit>
+      <trans-unit id="NTb776I" resname="[at]">
+        <source>[at]</source>
+        <target>[at]</target>
+      </trans-unit>
       <trans-unit id="mC5UFtS" resname="and">
         <source>and</source>
         <target>and</target>
@@ -3700,10 +3708,6 @@
       <trans-unit id="GzaHa85" resname="sub-albums">
         <source>sub-albums</source>
         <target>sub-albums</target>
-      </trans-unit>
-      <trans-unit id="CqfqdkM" resname="the organising party">
-        <source>the organising party</source>
-        <target>the organising party</target>
       </trans-unit>
       <trans-unit id="q7soSeR" resname="the secretary of GEWIS">
         <source>the secretary of GEWIS</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -117,10 +117,6 @@
         <source>Activities awaiting review</source>
         <target state="translated">Activities awaiting review</target>
       </trans-unit>
-      <trans-unit id="BFqzH5q" resname="Activity Archive">
-        <source>Activity Archive</source>
-        <target state="translated">Activity Archive</target>
-      </trans-unit>
       <trans-unit id="YwgVFXF" resname="Activity Policy">
         <source>Activity Policy</source>
         <target>Activity Policy</target>
@@ -341,10 +337,6 @@
         <source>Approximate solutions welcome.</source>
         <target state="translated">Approximate solutions welcome.</target>
       </trans-unit>
-      <trans-unit id="YrS2U1U" resname="Archive">
-        <source>Archive</source>
-        <target state="translated">Archive</target>
-      </trans-unit>
       <trans-unit id="VTuuaXb" resname="Are you sure you want to delete the selected photos? This cannot be undone.">
         <source>Are you sure you want to delete the selected photos? This cannot be undone.</source>
         <target state="translated">Are you sure you want to delete the selected photos? This cannot be undone.</target>
@@ -388,6 +380,10 @@
       <trans-unit id="cfsy_RA" resname="Auto">
         <source>Auto</source>
         <target state="translated">Auto</target>
+      </trans-unit>
+      <trans-unit id="4h60eT0" resname="Avoid RS512 for new applications.">
+        <source>Avoid RS512 for new applications.</source>
+        <target>Avoid RS512 for new applications.</target>
       </trans-unit>
       <trans-unit id="z1eSmfk" resname="BM">
         <source>BM</source>
@@ -909,6 +905,14 @@
         <source>Dutch</source>
         <target state="translated">Dutch</target>
       </trans-unit>
+      <trans-unit id="Q0nHBMn" resname="ES512">
+        <source>ES512</source>
+        <target>ES512</target>
+      </trans-unit>
+      <trans-unit id="SovLeQu" resname="EdDSA (recommended)">
+        <source>EdDSA (recommended)</source>
+        <target>EdDSA (recommended)</target>
+      </trans-unit>
       <trans-unit id="M.l1CPU" resname="Edit">
         <source>Edit</source>
         <target state="translated">Edit</target>
@@ -1128,6 +1132,14 @@
       <trans-unit id="LoKQJVt" resname="Financial Audit Committees">
         <source>Financial Audit Committees</source>
         <target state="translated">Financial Audit Committees</target>
+      </trans-unit>
+      <trans-unit id="wTcft_z" resname="Find any activity across every association year.">
+        <source>Find any activity across every association year.</source>
+        <target>Find any activity across every association year.</target>
+      </trans-unit>
+      <trans-unit id="Q_Zc.PZ" resname="Find any album across every association year.">
+        <source>Find any album across every association year.</source>
+        <target>Find any album across every association year.</target>
       </trans-unit>
       <trans-unit id="h6eEHVD" resname="First name">
         <source>First name</source>
@@ -1509,6 +1521,10 @@
         <source>It is pointing somewhere. Just not here.</source>
         <target state="translated">It is pointing somewhere. Just not here.</target>
       </trans-unit>
+      <trans-unit id="7gJgnyX" resname="It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.">
+        <source>It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.</source>
+        <target>It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.</target>
+      </trans-unit>
       <trans-unit id="ZMKVhSD" resname="It was declared, but never initialised.">
         <source>It was declared, but never initialised.</source>
         <target state="translated">It was declared, but never initialised.</target>
@@ -1733,10 +1749,6 @@
         <source>Modern applications require the URL fragment.</source>
         <target>Modern applications require the URL fragment.</target>
       </trans-unit>
-      <trans-unit id="NpQ8GYT" resname="Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.">
-        <source>Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.</source>
-        <target>Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.</target>
-      </trans-unit>
       <trans-unit id="wHBscUb" resname="More of my photos">
         <source>More of my photos</source>
         <target>More of my photos</target>
@@ -1792,14 +1804,6 @@
       <trans-unit id="Y4A_lV7" resname="My Photos">
         <source>My Photos</source>
         <target state="translated">My Photos</target>
-      </trans-unit>
-      <trans-unit id="2xos6Ug" resname="My past activities">
-        <source>My past activities</source>
-        <target>My past activities</target>
-      </trans-unit>
-      <trans-unit id="rbP4ntw" resname="My upcoming activities">
-        <source>My upcoming activities</source>
-        <target>My upcoming activities</target>
       </trans-unit>
       <trans-unit id="btbbZiF" resname="N/A">
         <source>N/A</source>
@@ -2081,6 +2085,10 @@
         <source>PR Officer</source>
         <target state="translated">PR Officer</target>
       </trans-unit>
+      <trans-unit id="GUcjJPC" resname="PS512">
+        <source>PS512</source>
+        <target>PS512</target>
+      </trans-unit>
       <trans-unit id="zvMpy.G" resname="Page %page% of %totalPages% (%totalCount% records)">
         <source>Page %page% of %totalPages% (%totalCount% records)</source>
         <target state="translated">Page %page% of %totalPages% (%totalCount% records)</target>
@@ -2156,6 +2164,10 @@
       <trans-unit id="C_d4kR9" resname="Pick a long, unique password - at least 16 characters and not found in any known data breach.">
         <source>Pick a long, unique password - at least 16 characters and not found in any known data breach.</source>
         <target state="translated">Pick a long, unique password - at least 16 characters and not found in any known data breach.</target>
+      </trans-unit>
+      <trans-unit id="NpQ8GYT" resname="Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.">
+        <source>Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.</source>
+        <target>Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.</target>
       </trans-unit>
       <trans-unit id="u7c4pso" resname="Place on photo">
         <source>Place on photo</source>
@@ -2480,6 +2492,14 @@
       <trans-unit id="SdNWA5t" resname="Search">
         <source>Search</source>
         <target state="translated">Search</target>
+      </trans-unit>
+      <trans-unit id="i.thJTY" resname="Search activities">
+        <source>Search activities</source>
+        <target>Search activities</target>
+      </trans-unit>
+      <trans-unit id=".eUwBmk" resname="Search albums">
+        <source>Search albums</source>
+        <target>Search albums</target>
       </trans-unit>
       <trans-unit id="y7lUoQr" resname="Search bodies">
         <source>Search bodies</source>
@@ -3201,6 +3221,10 @@
         <source>Type</source>
         <target state="translated">Type</target>
       </trans-unit>
+      <trans-unit id="6ZlqFUZ" resname="Type to search for albums across every year.">
+        <source>Type to search for albums across every year.</source>
+        <target>Type to search for albums across every year.</target>
+      </trans-unit>
       <trans-unit id="uHprCpr" resname="URL fragment (#token=)">
         <source>URL fragment (#token=)</source>
         <target>URL fragment (#token=)</target>
@@ -3264,6 +3288,10 @@
       <trans-unit id="DoLVTva" resname="Until %date%">
         <source>Until %date%</source>
         <target>Until %date%</target>
+      </trans-unit>
+      <trans-unit id="itsx4Eu" resname="Upcoming">
+        <source>Upcoming</source>
+        <target>Upcoming</target>
       </trans-unit>
       <trans-unit id="ZOvPU2x" resname="Upload exams">
         <source>Upload exams</source>
@@ -3692,26 +3720,6 @@
       <trans-unit id="AdY3YcR" resname="¹ Fields marked with this symbol are only shared with the board and the organiser of the activity.">
         <source>¹ Fields marked with this symbol are only shared with the board and the organiser of the activity.</source>
         <target>¹ Fields marked with this symbol are only shared with the board and the organiser of the activity.</target>
-      </trans-unit>
-      <trans-unit id="4h60eT0" resname="Avoid RS512 for new applications.">
-        <source>Avoid RS512 for new applications.</source>
-        <target>Avoid RS512 for new applications.</target>
-      </trans-unit>
-      <trans-unit id="SovLeQu" resname="EdDSA (recommended)">
-        <source>EdDSA (recommended)</source>
-        <target>EdDSA (recommended)</target>
-      </trans-unit>
-      <trans-unit id="Q0nHBMn" resname="ES512">
-        <source>ES512</source>
-        <target>ES512</target>
-      </trans-unit>
-      <trans-unit id="7gJgnyX" resname="It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.">
-        <source>It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.</source>
-        <target>It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.</target>
-      </trans-unit>
-      <trans-unit id="GUcjJPC" resname="PS512">
-        <source>PS512</source>
-        <target>PS512</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -117,10 +117,6 @@
         <source>Activities awaiting review</source>
         <target state="translated">Activiteiten die wachten op beoordeling</target>
       </trans-unit>
-      <trans-unit id="BFqzH5q" resname="Activity Archive">
-        <source>Activity Archive</source>
-        <target state="translated">Activiteitenarchief</target>
-      </trans-unit>
       <trans-unit id="YwgVFXF" resname="Activity Policy">
         <source>Activity Policy</source>
         <target>Activiteitenbeleid</target>
@@ -341,10 +337,6 @@
         <source>Approximate solutions welcome.</source>
         <target state="translated">Benaderende oplossingen zijn welkom.</target>
       </trans-unit>
-      <trans-unit id="YrS2U1U" resname="Archive">
-        <source>Archive</source>
-        <target>Archief</target>
-      </trans-unit>
       <trans-unit id="VTuuaXb" resname="Are you sure you want to delete the selected photos? This cannot be undone.">
         <source>Are you sure you want to delete the selected photos? This cannot be undone.</source>
         <target state="translated">Weet je zeker dat je de geselecteerde foto's wilt verwijderen? Dit kan niet ongedaan worden gemaakt.</target>
@@ -388,6 +380,10 @@
       <trans-unit id="cfsy_RA" resname="Auto">
         <source>Auto</source>
         <target>Auto</target>
+      </trans-unit>
+      <trans-unit id="4h60eT0" resname="Avoid RS512 for new applications.">
+        <source>Avoid RS512 for new applications.</source>
+        <target>Vermijd RS512 voor nieuwe applicaties.</target>
       </trans-unit>
       <trans-unit id="z1eSmfk" resname="BM">
         <source>BM</source>
@@ -909,6 +905,14 @@
         <source>Dutch</source>
         <target>Nederlands</target>
       </trans-unit>
+      <trans-unit id="Q0nHBMn" resname="ES512">
+        <source>ES512</source>
+        <target>ES512</target>
+      </trans-unit>
+      <trans-unit id="SovLeQu" resname="EdDSA (recommended)">
+        <source>EdDSA (recommended)</source>
+        <target>EdDSA (aanbevolen)</target>
+      </trans-unit>
       <trans-unit id="M.l1CPU" resname="Edit">
         <source>Edit</source>
         <target state="translated">Bewerken</target>
@@ -1128,6 +1132,14 @@
       <trans-unit id="LoKQJVt" resname="Financial Audit Committees">
         <source>Financial Audit Committees</source>
         <target state="translated">Kas Controle Commissies</target>
+      </trans-unit>
+      <trans-unit id="wTcft_z" resname="Find any activity across every association year.">
+        <source>Find any activity across every association year.</source>
+        <target>Vind een activiteit uit alle verenigingsjaren.</target>
+      </trans-unit>
+      <trans-unit id="Q_Zc.PZ" resname="Find any album across every association year.">
+        <source>Find any album across every association year.</source>
+        <target>Vind een album uit alle verenigingsjaren.</target>
       </trans-unit>
       <trans-unit id="h6eEHVD" resname="First name">
         <source>First name</source>
@@ -1509,6 +1521,10 @@
         <source>It is pointing somewhere. Just not here.</source>
         <target state="translated">Het verwijst ergens naar. Alleen niet hier.</target>
       </trans-unit>
+      <trans-unit id="7gJgnyX" resname="It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.">
+        <source>It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.</source>
+        <target>Het ondertekent met PKCS#1 v1.5 en blijft alleen behouden voor applicaties die niets sterkers kunnen verifiëren. Kies bij voorkeur EdDSA, ES512 of PS512 wanneer de applicatie dit ondersteunt.</target>
+      </trans-unit>
       <trans-unit id="ZMKVhSD" resname="It was declared, but never initialised.">
         <source>It was declared, but never initialised.</source>
         <target state="translated">Het werd gedeclareerd, maar nooit geïnitialiseerd.</target>
@@ -1733,10 +1749,6 @@
         <source>Modern applications require the URL fragment.</source>
         <target>Moderne applicaties vereisen het URL-fragment.</target>
       </trans-unit>
-      <trans-unit id="NpQ8GYT" resname="Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.">
-        <source>Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.</source>
-        <target>Kies het sterkste algoritme dat de applicatie ondersteunt. Moderne profielen worden geverifieerd via het JWKS-eindpunt.</target>
-      </trans-unit>
       <trans-unit id="wHBscUb" resname="More of my photos">
         <source>More of my photos</source>
         <target>Meer van mijn foto's</target>
@@ -1792,14 +1804,6 @@
       <trans-unit id="Y4A_lV7" resname="My Photos">
         <source>My Photos</source>
         <target state="translated">Mijn foto's</target>
-      </trans-unit>
-      <trans-unit id="2xos6Ug" resname="My past activities">
-        <source>My past activities</source>
-        <target>Mijn afgelopen activiteiten</target>
-      </trans-unit>
-      <trans-unit id="rbP4ntw" resname="My upcoming activities">
-        <source>My upcoming activities</source>
-        <target>Mijn aankomende activiteiten</target>
       </trans-unit>
       <trans-unit id="btbbZiF" resname="N/A">
         <source>N/A</source>
@@ -2081,6 +2085,10 @@
         <source>PR Officer</source>
         <target state="translated">PR-Functionaris</target>
       </trans-unit>
+      <trans-unit id="GUcjJPC" resname="PS512">
+        <source>PS512</source>
+        <target>PS512</target>
+      </trans-unit>
       <trans-unit id="zvMpy.G" resname="Page %page% of %totalPages% (%totalCount% records)">
         <source>Page %page% of %totalPages% (%totalCount% records)</source>
         <target state="translated">Pagina %page% van %totalPages% (%totalCount% records)</target>
@@ -2156,6 +2164,10 @@
       <trans-unit id="C_d4kR9" resname="Pick a long, unique password - at least 16 characters and not found in any known data breach.">
         <source>Pick a long, unique password - at least 16 characters and not found in any known data breach.</source>
         <target state="translated">Kies een lang, uniek wachtwoord - minimaal 16 tekens lang en niet voorkomend in bekende datalekken.</target>
+      </trans-unit>
+      <trans-unit id="NpQ8GYT" resname="Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.">
+        <source>Pick the strongest algorithm the application supports. Modern profiles are verified through the JWKS endpoint.</source>
+        <target>Kies het sterkste algoritme dat de applicatie ondersteunt. Moderne profielen worden geverifieerd via het JWKS-eindpunt.</target>
       </trans-unit>
       <trans-unit id="u7c4pso" resname="Place on photo">
         <source>Place on photo</source>
@@ -2480,6 +2492,14 @@
       <trans-unit id="SdNWA5t" resname="Search">
         <source>Search</source>
         <target state="translated">Zoeken</target>
+      </trans-unit>
+      <trans-unit id="i.thJTY" resname="Search activities">
+        <source>Search activities</source>
+        <target>Activiteiten zoeken</target>
+      </trans-unit>
+      <trans-unit id=".eUwBmk" resname="Search albums">
+        <source>Search albums</source>
+        <target>Albums zoeken</target>
       </trans-unit>
       <trans-unit id="y7lUoQr" resname="Search bodies">
         <source>Search bodies</source>
@@ -3201,6 +3221,10 @@
         <source>Type</source>
         <target state="translated">Type</target>
       </trans-unit>
+      <trans-unit id="6ZlqFUZ" resname="Type to search for albums across every year.">
+        <source>Type to search for albums across every year.</source>
+        <target>Typ om albums uit alle verenigingsjaren te zoeken.</target>
+      </trans-unit>
       <trans-unit id="uHprCpr" resname="URL fragment (#token=)">
         <source>URL fragment (#token=)</source>
         <target>URL-fragment (#token=)</target>
@@ -3264,6 +3288,10 @@
       <trans-unit id="DoLVTva" resname="Until %date%">
         <source>Until %date%</source>
         <target>Tot %date%</target>
+      </trans-unit>
+      <trans-unit id="itsx4Eu" resname="Upcoming">
+        <source>Upcoming</source>
+        <target>Aankomend</target>
       </trans-unit>
       <trans-unit id="ZOvPU2x" resname="Upload exams">
         <source>Upload exams</source>
@@ -3692,26 +3720,6 @@
       <trans-unit id="AdY3YcR" resname="¹ Fields marked with this symbol are only shared with the board and the organiser of the activity.">
         <source>¹ Fields marked with this symbol are only shared with the board and the organiser of the activity.</source>
         <target>¹ Velden met dit symbool worden alleen gedeeld met het bestuur en de organisator van de activiteit.</target>
-      </trans-unit>
-      <trans-unit id="4h60eT0" resname="Avoid RS512 for new applications.">
-        <source>Avoid RS512 for new applications.</source>
-        <target>Vermijd RS512 voor nieuwe applicaties.</target>
-      </trans-unit>
-      <trans-unit id="SovLeQu" resname="EdDSA (recommended)">
-        <source>EdDSA (recommended)</source>
-        <target>EdDSA (aanbevolen)</target>
-      </trans-unit>
-      <trans-unit id="Q0nHBMn" resname="ES512">
-        <source>ES512</source>
-        <target>ES512</target>
-      </trans-unit>
-      <trans-unit id="7gJgnyX" resname="It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.">
-        <source>It signs with PKCS#1 v1.5, kept only for applications that cannot verify anything stronger. Prefer EdDSA, ES512, or PS512 whenever the application supports them.</source>
-        <target>Het ondertekent met PKCS#1 v1.5 en blijft alleen behouden voor applicaties die niets sterkers kunnen verifiëren. Kies bij voorkeur EdDSA, ES512 of PS512 wanneer de applicatie dit ondersteunt.</target>
-      </trans-unit>
-      <trans-unit id="GUcjJPC" resname="PS512">
-        <source>PS512</source>
-        <target>PS512</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -2189,6 +2189,10 @@
         <source>Please contact %organizer% or the board (%email%) with any questions or concerns. Have fun!</source>
         <target>Neem contact op met %organizer% of het bestuur (%email%) bij vragen of opmerkingen. Veel plezier!</target>
       </trans-unit>
+      <trans-unit id="7NVRAYy" resname="Please contact the board (%email%) with any questions or concerns. Have fun!">
+        <source>Please contact the board (%email%) with any questions or concerns. Have fun!</source>
+        <target>Neem contact op met het bestuur (%email%) bij vragen of opmerkingen. Veel plezier!</target>
+      </trans-unit>
       <trans-unit id="lwY.3Bl" resname="Please provide both a subject and a message.">
         <source>Please provide both a subject and a message.</source>
         <target>Geef zowel een onderwerp als een bericht op.</target>
@@ -3617,6 +3621,10 @@
         <source>[CANCELLED]</source>
         <target state="translated">[GEANNULEERD]</target>
       </trans-unit>
+      <trans-unit id="NTb776I" resname="[at]">
+        <source>[at]</source>
+        <target>[apenstaartje]</target>
+      </trans-unit>
       <trans-unit id="mC5UFtS" resname="and">
         <source>and</source>
         <target>en</target>
@@ -3700,10 +3708,6 @@
       <trans-unit id="GzaHa85" resname="sub-albums">
         <source>sub-albums</source>
         <target>subalbums</target>
-      </trans-unit>
-      <trans-unit id="CqfqdkM" resname="the organising party">
-        <source>the organising party</source>
-        <target>de organiserende partij</target>
       </trans-unit>
       <trans-unit id="q7soSeR" resname="the secretary of GEWIS">
         <source>the secretary of GEWIS</source>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Both the activity and photo overviews get a 'Search' button between the filters
and the assocation year selector. It opens a page that looks across every
association year instead of the single year the selector is bound to, the way
album search worked on the old website. Activities and albums both match on
name, results are grouped by year, and album search still respects who may see
each album.

The activity overview also gains that year selector, which replaces the separate
archive page. It still opens on upcoming activities.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Closes GH-2112.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
