### PR TITLE
 chore: resolve deprecation notices and clear fixable baseline entries

### DIFF
--- a/config/packages/web_profiler.yaml
+++ b/config/packages/web_profiler.yaml
@@ -5,10 +5,9 @@ when@dev:
 
     framework:
         profiler:
-            collect_serializer_data: true
+            enabled: true
 
 when@test:
     framework:
         profiler:
             collect: false
-            collect_serializer_data: true

--- a/config/reference.php
+++ b/config/reference.php
@@ -1834,8 +1834,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -211,10 +211,16 @@ parameters:
 			path: src/Entity/Decision/SubDecision/Reappointment.php
 
 		-
-			message: '#^Property App\\Entity\\User\\ExternalApp\:\:\$claims type mapping mismatch\: database can contain list\<App\\Entity\\User\\Enums\\JWTClaims\>\|null but property expects array\<App\\Entity\\User\\Enums\\JWTClaims\>\.$#'
-			identifier: doctrine.columnType
+			message: '#^Property App\\Entity\\Photo\\MemberTag\:\:\$member type mapping mismatch\: database can contain App\\Entity\\Decision\\Member\|null but property expects App\\Entity\\Decision\\Member\.$#'
+			identifier: doctrine.associationType
 			count: 1
-			path: src/Entity/User/ExternalApp.php
+			path: src/Entity/Photo/MemberTag.php
+
+		-
+			message: '#^Property App\\Entity\\Photo\\OrganTag\:\:\$organ type mapping mismatch\: database can contain App\\Entity\\Decision\\Organ\|null but property expects App\\Entity\\Decision\\Organ\.$#'
+			identifier: doctrine.associationType
+			count: 1
+			path: src/Entity/Photo/OrganTag.php
 
 		-
 			message: '#^Property App\\Entity\\User\\CompanyUser\:\:\$company is never written, only read\.$#'
@@ -229,6 +235,12 @@ parameters:
 			path: src/Entity/User/CompanyUser.php
 
 		-
+			message: '#^Property App\\Entity\\User\\ExternalApp\:\:\$claims type mapping mismatch\: database can contain list\<App\\Entity\\User\\Enums\\JWTClaims\>\|null but property expects array\<App\\Entity\\User\\Enums\\JWTClaims\>\.$#'
+			identifier: doctrine.columnType
+			count: 1
+			path: src/Entity/User/ExternalApp.php
+
+		-
 			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
@@ -239,21 +251,3 @@ parameters:
 			identifier: instanceof.alwaysTrue
 			count: 1
 			path: src/MessageHandler/User/PasswordResetRequestEmailHandler.php
-
-		-
-			message: '#^QueryBuilder\: \[Semantical Error\] line 0, col 87 near ''member \= \:me''\: Error\: Class App\\Entity\\Decision\\SubDecision has no field or association named member$#'
-			identifier: doctrine.dql
-			count: 1
-			path: src/Repository/Decision/SubDecisionRepository.php
-
-		-
-			message: '#^Property App\\Entity\\Photo\\MemberTag\:\:\$member type mapping mismatch\: database can contain App\\Entity\\Decision\\Member\|null but property expects App\\Entity\\Decision\\Member\.$#'
-			identifier: doctrine.associationType
-			count: 1
-			path: src/Entity/Photo/MemberTag.php
-
-		-
-			message: '#^Property App\\Entity\\Photo\\OrganTag\:\:\$organ type mapping mismatch\: database can contain App\\Entity\\Decision\\Organ\|null but property expects App\\Entity\\Decision\\Organ\.$#'
-			identifier: doctrine.associationType
-			count: 1
-			path: src/Entity/Photo/OrganTag.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
-  <file src="src/Controller/Frontpage/PageController.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$request->getLocale()]]></code>
-    </ArgumentTypeCoercion>
-  </file>
-  <file src="src/Entity/Application/Enums/Languages.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[explode('_', $locale)[0]]]></code>
-    </ArgumentTypeCoercion>
-  </file>
   <file src="src/Repository/Photo/PhotoRepository.php">
     <QueryBuilderSetParameter>
       <code><![CDATA[$album]]></code>

--- a/src/Controller/Activity/AdminApprovalController.php
+++ b/src/Controller/Activity/AdminApprovalController.php
@@ -22,6 +22,7 @@ use App\Service\Application\EditLockService;
 use App\Util\Activity\PastActivityRule;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
@@ -58,6 +59,7 @@ class AdminApprovalController extends AbstractController
         private readonly ActivityRevisionCommentRepository $commentRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly TranslatorInterface $translator,
+        #[Target('revisionStateMachine')]
         private readonly WorkflowInterface $revisionStateMachine,
         private readonly SignupListMigrator $signupListMigrator,
         private readonly DraftDiscarder $draftDiscarder,

--- a/src/Controller/Frontpage/PageController.php
+++ b/src/Controller/Frontpage/PageController.php
@@ -7,7 +7,6 @@ namespace App\Controller\Frontpage;
 use App\Entity\Application\Enums\Languages;
 use App\Service\Frontpage\PageService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class PageController extends AbstractController
@@ -17,12 +16,11 @@ class PageController extends AbstractController
     }
 
     public function index(
-        Request $request,
         string $category,
         ?string $subCategory = null,
         ?string $name = null,
     ): Response {
-        $lang = Languages::fromLangParam($request->getLocale());
+        $lang = Languages::current();
         $page = $this->pageService->getPage(
             $lang,
             $category,

--- a/src/Entity/Application/Enums/Languages.php
+++ b/src/Entity/Application/Enums/Languages.php
@@ -9,7 +9,6 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 use function array_map;
 use function array_merge;
-use function explode;
 
 /**
  * This enum contains the different languages that are supported by the website.
@@ -65,16 +64,6 @@ enum Languages: string
             'en' => self::English,
             'nl' => self::Dutch,
         };
-    }
-
-    /**
-     * Get the language from a locale ('en_GB', 'nl_NL')
-     *
-     * @param Locale $locale
-     */
-    public static function fromLocale(string $locale): Languages
-    {
-        return self::fromLangParam(explode('_', $locale)[0]);
     }
 
     /**

--- a/src/Entity/User/UserSettings.php
+++ b/src/Entity/User/UserSettings.php
@@ -46,7 +46,6 @@ class UserSettings
     #[JoinColumn(
         name: 'lidnr',
         referencedColumnName: 'lidnr',
-        nullable: false,
         onDelete: 'CASCADE',
     )]
     private User $user;

--- a/src/MessageHandler/User/PasswordResetRequestEmailHandler.php
+++ b/src/MessageHandler/User/PasswordResetRequestEmailHandler.php
@@ -130,6 +130,8 @@ class PasswordResetRequestEmailHandler
             $recipientEmail = $member->getEmail();
             $fullName = $member->getFullName();
         } else {
+            // PHPStan narrows $companyUser from the both-null guard above and calls this assert redundant (baselined),
+            // but Psalm does not, so it stays.
             assert($companyUser instanceof CompanyUser);
             $recipientEmail = $companyUser->getCompany()->getRepresentativeEmail();
             $fullName = $companyUser->getCompany()->getRepresentativeName();

--- a/src/Repository/Decision/SubDecisionRepository.php
+++ b/src/Repository/Decision/SubDecisionRepository.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace App\Repository\Decision;
 
-use App\Entity\Decision\Member;
 use App\Entity\Decision\SubDecision;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
-
-use function addcslashes;
 
 /**
  * @extends ServiceEntityRepository<SubDecision>
@@ -22,32 +19,5 @@ class SubDecisionRepository extends ServiceEntityRepository
             $registry,
             SubDecision::class,
         );
-    }
-
-    /**
-     * Search sub-decisions.
-     *
-     * @return SubDecision[]
-     */
-    public function findByMember(Member $member): array
-    {
-        $qb = $this->createQueryBuilder('s');
-        $qb->where('s.contentNL LIKE :full_name')
-            ->orWhere('s.member = :member');
-
-        $qb->setParameter(
-            'full_name',
-            '%' . addcslashes(
-                $member->getFullName(),
-                '%_',
-            ) . '%',
-        )
-            ->setParameter(
-                'member',
-                $member,
-                Member::class,
-            );
-
-        return $qb->getQuery()->getResult();
     }
 }

--- a/src/Service/Application/FileStorage.php
+++ b/src/Service/Application/FileStorage.php
@@ -7,6 +7,7 @@ namespace App\Service\Application;
 use App\Entity\Application\Enums\StorageNamespace;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\Mime\MimeTypes;
 
 use function fclose;
@@ -33,6 +34,7 @@ use function sprintf;
 final readonly class FileStorage
 {
     public function __construct(
+        #[Target('defaultStorage')]
         private FilesystemOperator $defaultStorage,
         /** @var iterable<FileReferenceProviderInterface> */
         #[AutowireIterator('app.file_reference_provider')]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Resolves the Symfony 8.1 and Doctrine deprecation notices that come from our own
code, using `#[Target]` for the two named autowiring aliases and an explicit
`enabled: true` for the profiler, which was previously switched on as a side effect
of the deprecated option. Also clears the four baselined analysis findings that
turned out to be real, the largest being a `SubDecisionRepository` method whose DQL
filtered on a field `SubDecision` does not have.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

The deprecation notices surfaced after the dependency bump in GH-2137.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [X] Other _(please specify)_
