### PR TITLE
feat(career): give a company two logos and shuffle the career overviews

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -30,6 +30,7 @@ $enable-negative-margins: true;
 @import '../../vendor/twbs/bootstrap/scss/button-group';
 @import '../../vendor/twbs/bootstrap/scss/breadcrumb';
 @import '../../vendor/twbs/bootstrap/scss/card';
+@import '../../vendor/twbs/bootstrap/scss/carousel';
 @import '../../vendor/twbs/bootstrap/scss/close';
 @import '../../vendor/twbs/bootstrap/scss/containers';
 @import '../../vendor/twbs/bootstrap/scss/dropdown';

--- a/assets/styles/modules/_career.scss
+++ b/assets/styles/modules/_career.scss
@@ -63,39 +63,6 @@
     white-space: nowrap;
 }
 
-.career-logo-xs {
-    flex: none;
-    width: 1.875rem;
-    height: 1.875rem;
-    border-radius: var(--#{$prefix}border-radius);
-    font-size: 0.8125rem;
-}
-
-.career-logo-lg {
-    flex: none;
-    width: 4rem;
-    height: 4rem;
-    border-radius: var(--#{$prefix}border-radius-lg);
-    font-size: 1.75rem;
-}
-
-// The featured company leads with whatever logo it has, on a tinted band.
-.career-featured-banner {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 7rem;
-    padding: 1rem;
-    border-bottom: var(--#{$prefix}border-width) solid var(--#{$prefix}border-color-translucent);
-    background-color: var(--#{$prefix}secondary-bg);
-
-    img {
-        max-width: 100%;
-        max-height: 100%;
-        object-fit: contain;
-    }
-}
-
 .career-featured-kicker {
     color: #{$gewis-red};
 }

--- a/assets/styles/modules/_company.scss
+++ b/assets/styles/modules/_company.scss
@@ -9,23 +9,53 @@
     }
 }
 
-// Monogram logo placeholder (until real logo serving exists): a centred initial on a muted square. `-sm` is the small
-// inline mark used on a vacancy card next to the title; the detail pages use a full-width banner variant inline.
 .career-logo {
     display: inline-flex;
+    flex: none;
     align-items: center;
     justify-content: center;
+    object-fit: contain;
+}
+
+.career-logo-monogram {
+    padding: 0.25rem;
+    border-radius: var(--#{$prefix}border-radius);
     font-weight: 700;
     color: var(--#{$prefix}secondary-color);
     background-color: var(--#{$prefix}secondary-bg);
 }
 
+.career-logo-xs {
+    width: 2.5rem;
+    height: 1.875rem;
+    font-size: 0.8125rem;
+}
+
 .career-logo-sm {
-    flex: none;
-    width: 2.75rem;
-    height: 2.75rem;
+    width: 3.5rem;
+    height: 2.625rem;
     font-size: 1.1rem;
-    border-radius: var(--#{$prefix}border-radius);
+}
+
+.career-logo-lg {
+    width: 6rem;
+    height: 4.5rem;
+    font-size: 2rem;
+}
+
+.career-logo-plate {
+    display: flex;
+    width: 100%;
+    max-height: 8rem;
+    padding: 0;
+    border-bottom: var(--#{$prefix}border-width) solid var(--#{$prefix}border-color-translucent);
+    border-radius: 0;
+    font-size: 2.5rem;
+
+    &.career-logo-monogram {
+        height: 8rem;
+        border-radius: 0;
+    }
 }
 
 // Clamp the (rendered Markdown) description teaser on a vacancy card, mirroring `.activity-description-content`.

--- a/assets/styles/modules/_company.scss
+++ b/assets/styles/modules/_company.scss
@@ -9,6 +9,10 @@
     }
 }
 
+.vacancy-card-highlighted {
+    --#{$prefix}card-border-color: #{$gewis-red};
+}
+
 .career-logo {
     display: inline-flex;
     flex: none;

--- a/migrations/Version20260810085618.php
+++ b/migrations/Version20260810085618.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ * phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
+ */
+final class Version20260810085618 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ask a company for two logos rather than one. The square mark is what fits beside a line of text and the wider one, the mark and the name together, is what leads a company card; one image could never sit well in both. The single logo a company already handed over becomes its square one, and the banner is empty until it uploads one.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE CompanyRevision
+              CHANGE logo squareLogo VARCHAR(255) DEFAULT NULL,
+              ADD bannerLogo VARCHAR(255) DEFAULT NULL
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE CompanyRevision
+              CHANGE squareLogo logo VARCHAR(255) DEFAULT NULL,
+              DROP bannerLogo
+            SQL);
+    }
+}

--- a/src/Command/Storage/MigrateStorageCommand.php
+++ b/src/Command/Storage/MigrateStorageCommand.php
@@ -706,7 +706,7 @@ final class MigrateStorageCommand extends Command
             ],
             [
                 'key' => self::KEY_COMPANY_LOGO,
-                'field' => 'logo',
+                'field' => 'squareLogo',
                 'namespace' => StorageNamespace::CompanyImage,
             ],
             [
@@ -764,7 +764,9 @@ final class MigrateStorageCommand extends Command
                 return $entity->getCoverPath();
 
             case $entity instanceof CompanyRevision:
-                return $entity->getLogo();
+                return 'bannerLogo' === $field
+                    ? $entity->getBannerLogo()
+                    : $entity->getSquareLogo();
 
             case $entity instanceof CompanyBannerPackage:
                 return $entity->getImage();
@@ -802,7 +804,11 @@ final class MigrateStorageCommand extends Command
                 return;
 
             case $entity instanceof CompanyRevision:
-                $entity->setLogo($value);
+                if ('bannerLogo' === $field) {
+                    $entity->setBannerLogo($value);
+                } else {
+                    $entity->setSquareLogo($value);
+                }
 
                 return;
 
@@ -864,7 +870,7 @@ final class MigrateStorageCommand extends Command
         return match ($key) {
             self::KEY_PHOTO => 'path',
             self::KEY_ALBUM_COVER => 'coverPath',
-            self::KEY_COMPANY_LOGO => 'logo',
+            self::KEY_COMPANY_LOGO => 'squareLogo',
             self::KEY_COMPANY_BANNER => 'image',
             self::KEY_ORGAN_COVER => 'coverPath',
             self::KEY_ORGAN_THUMBNAIL => 'thumbnailPath',

--- a/src/Controller/Career/AdminController.php
+++ b/src/Controller/Career/AdminController.php
@@ -24,6 +24,7 @@ use App\Service\Career\CompanyImageUploadService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -118,8 +119,8 @@ class AdminController extends AbstractController
         // Flushed before the logo so the company has an id, which is the directory its images are stored under.
         $this->entityManager->flush();
 
-        $this->storeLogo(
-            $form->get('currentRevision')->get('logoFile')->getData(),
+        $this->storeLogos(
+            $form,
             $company,
             $revision,
             $user,
@@ -248,8 +249,8 @@ class AdminController extends AbstractController
             );
         }
 
-        $this->storeLogo(
-            $form->get('currentRevision')->get('logoFile')->getData(),
+        $this->storeLogos(
+            $form,
             $company,
             $current,
             $user,
@@ -378,17 +379,49 @@ class AdminController extends AbstractController
     }
 
     /**
-     * Puts an uploaded logo on the revision being worked on, so it only reaches the public page once that revision
-     * does.
+     * A field left empty keeps the logo already on the revision.
+     *
+     * @param FormInterface<Company> $form
      */
-    private function storeLogo(
-        mixed $file,
+    private function storeLogos(
+        FormInterface $form,
         Company $company,
         CompanyRevision $revision,
         User $user,
     ): void {
-        if (!$file instanceof UploadedFile) {
+        $revisionForm = $form->get('currentRevision');
+
+        $square = $this->storeLogo(
+            $revisionForm->get('squareLogoFile')->getData(),
+            $company,
+            $user,
+        );
+        if (null !== $square) {
+            $revision->setSquareLogo($square);
+        }
+
+        $banner = $this->storeLogo(
+            $revisionForm->get('bannerLogoFile')->getData(),
+            $company,
+            $user,
+        );
+        if (null === $banner) {
             return;
+        }
+
+        $revision->setBannerLogo($banner);
+    }
+
+    /**
+     * @return string|null the stored path, or null when nothing was uploaded or it could not be stored
+     */
+    private function storeLogo(
+        mixed $file,
+        Company $company,
+        User $user,
+    ): ?string {
+        if (!$file instanceof UploadedFile) {
+            return null;
         }
 
         $path = $this->imageUploadService->uploadLogo(
@@ -402,15 +435,16 @@ class AdminController extends AbstractController
                 $this->translator->trans('The logo could not be stored, so the previous one is still in use.'),
             );
 
-            return;
+            return null;
         }
 
-        $revision->setLogo($path);
         $this->auditLogger->log(
             $company,
             $user,
             CompanyAuditVerbs::LogoUploaded,
         );
+
+        return $path;
     }
 
     private function backToCompany(Company $company): Response

--- a/src/Controller/Career/CareerController.php
+++ b/src/Controller/Career/CareerController.php
@@ -14,6 +14,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
+use function array_slice;
 use function shuffle;
 
 #[Route(
@@ -31,6 +32,11 @@ class CareerController extends AbstractController
      * How much of the landing page's taste of the vacancies is shown before it sends the reader on to the full list.
      */
     private const int LATEST_VACANCY_LIMIT = 4;
+
+    /**
+     * How many companies the landing page's strip shows before it sends the reader on to the full overview.
+     */
+    private const int COMPANY_STRIP_LIMIT = 9;
 
     public function __construct(
         private readonly CompanyRepository $companyRepository,
@@ -51,10 +57,17 @@ class CareerController extends AbstractController
     {
         $companies = $this->companyRepository->findAllPublic();
 
+        // Randomise before slicing, so the strip is not a standing showcase for whoever is early in the alphabet.
+        shuffle($companies);
+
         return $this->render(
             'career/index.html.twig',
             [
-                'companies' => $companies,
+                'companies' => array_slice(
+                    $companies,
+                    0,
+                    self::COMPANY_STRIP_LIMIT,
+                ),
                 'latestVacancies' => $this->vacancyRepository->findLatestForOverview(self::LATEST_VACANCY_LIMIT),
                 'events' => $this->activityRepository->findUpcoming(category: ActivityCategories::Career),
             ],
@@ -62,7 +75,8 @@ class CareerController extends AbstractController
     }
 
     /**
-     * Every company that is currently visible.
+     * Every company that is currently visible. The search, the random order and the paging are all handled by the
+     * {@see \App\Twig\Components\Career\CompanyOverview} live component.
      */
     #[Route(
         path: '/companies',
@@ -70,15 +84,7 @@ class CareerController extends AbstractController
     )]
     public function companies(): Response
     {
-        $companies = $this->companyRepository->findAllPublic();
-
-        // Randomise the order so no company is structurally favoured.
-        shuffle($companies);
-
-        return $this->render(
-            'career/companies.html.twig',
-            ['companies' => $companies],
-        );
+        return $this->render('career/companies.html.twig');
     }
 
     /**

--- a/src/Controller/Career/CompanyProfileController.php
+++ b/src/Controller/Career/CompanyProfileController.php
@@ -157,26 +157,24 @@ class CompanyProfileController extends AbstractRevisionReviewController
             );
         }
 
-        $file = $form->get('currentRevision')->get('logoFile')->getData();
-        if ($file instanceof UploadedFile) {
-            $path = $this->imageUploadService->uploadLogo(
-                $company,
-                $file,
-            );
+        $revisionForm = $form->get('currentRevision');
 
-            if (null === $path) {
-                $this->addFlash(
-                    AlertTypes::Warning->value,
-                    $this->translator->trans('The logo could not be stored, so the previous one is still in use.'),
-                );
-            } else {
-                $current->setLogo($path);
-                $this->auditLogger->log(
-                    $company,
-                    $companyUser,
-                    CompanyAuditVerbs::LogoUploaded,
-                );
-            }
+        $square = $this->storeLogo(
+            $revisionForm->get('squareLogoFile')->getData(),
+            $company,
+            $companyUser,
+        );
+        if (null !== $square) {
+            $current->setSquareLogo($square);
+        }
+
+        $banner = $this->storeLogo(
+            $revisionForm->get('bannerLogoFile')->getData(),
+            $company,
+            $companyUser,
+        );
+        if (null !== $banner) {
+            $current->setBannerLogo($banner);
         }
 
         $current->setLastEditedByCompanyUser($companyUser);
@@ -470,5 +468,40 @@ class CompanyProfileController extends AbstractRevisionReviewController
         }
 
         return $current;
+    }
+
+    /**
+     * @return string|null the stored path, or null when nothing was uploaded or it could not be stored
+     */
+    private function storeLogo(
+        mixed $file,
+        Company $company,
+        CompanyUser $companyUser,
+    ): ?string {
+        if (!$file instanceof UploadedFile) {
+            return null;
+        }
+
+        $path = $this->imageUploadService->uploadLogo(
+            $company,
+            $file,
+        );
+
+        if (null === $path) {
+            $this->addFlash(
+                AlertTypes::Warning->value,
+                $this->translator->trans('The logo could not be stored, so the previous one is still in use.'),
+            );
+
+            return null;
+        }
+
+        $this->auditLogger->log(
+            $company,
+            $companyUser,
+            CompanyAuditVerbs::LogoUploaded,
+        );
+
+        return $path;
     }
 }

--- a/src/DataFixtures/Career/CareerReviewFixture.php
+++ b/src/DataFixtures/Career/CareerReviewFixture.php
@@ -263,7 +263,8 @@ class CareerReviewFixture extends Fixture implements DependentFixtureInterface
         $draft->setSlogan($source->getSlogan()->copy());
         $draft->setWebsite($source->getWebsite()->copy());
         $draft->setDescription($source->getDescription()->copy());
-        $draft->setLogo($source->getLogo());
+        $draft->setSquareLogo($source->getSquareLogo());
+        $draft->setBannerLogo($source->getBannerLogo());
         $draft->setContactName($source->getContactName());
         $draft->setContactEmail($source->getContactEmail());
         $draft->setContactPhone($source->getContactPhone());

--- a/src/DataFixtures/Career/CareerReviewFixture.php
+++ b/src/DataFixtures/Career/CareerReviewFixture.php
@@ -38,6 +38,13 @@ use function random_bytes;
  */
 class CareerReviewFixture extends Fixture implements DependentFixtureInterface
 {
+    /** The slogan Orbit Analytics submitted, and the line on the banner they proposed alongside it. */
+    private const string SUBMITTED_SLOGAN = 'Turning data into decisions, faster';
+
+    public function __construct(private readonly CompanyImageGenerator $imageGenerator)
+    {
+    }
+
     #[Override]
     public function load(ObjectManager $manager): void
     {
@@ -104,7 +111,7 @@ class CareerReviewFixture extends Fixture implements DependentFixtureInterface
         $draft->setStatus(RevisionStatus::Submitted);
         $draft->setAuthorCompanyUser($author);
         $draft->setSlogan(new CareerLocalisedText(
-            'Turning data into decisions, faster',
+            self::SUBMITTED_SLOGAN,
             'Sneller van data naar beslissingen',
         ));
 
@@ -193,6 +200,10 @@ class CareerReviewFixture extends Fixture implements DependentFixtureInterface
         $manager->persist($reply);
     }
 
+    /**
+     * New artwork waiting for the committee next to the banner that is still running. It carries the slogan the
+     * company submitted along with it, which is the ordinary reason to redo a banner in the first place.
+     */
     private function proposeABanner(
         ObjectManager $manager,
         Company $company,
@@ -204,7 +215,11 @@ class CareerReviewFixture extends Fixture implements DependentFixtureInterface
             }
 
             $package->proposeImage(
-                'data/company/banner/orbit-analytics-proposed.png',
+                $this->imageGenerator->storeBanner(
+                    $company,
+                    $package->getFormat(),
+                    self::SUBMITTED_SLOGAN,
+                ),
                 $author,
             );
             $manager->persist($package);

--- a/src/DataFixtures/Career/CompanyFixture.php
+++ b/src/DataFixtures/Career/CompanyFixture.php
@@ -27,6 +27,9 @@ use Override;
  * Seeds a handful of publicly visible companies with active packages and vacancies across the vacancy categories, so
  * the career overview and the per-category vacancy listings have something to show.
  *
+ * Only some of them have a logo, because most real profiles do not: the pages fall back to a monogram, which needs
+ * seeding just as much as the case where an image is there.
+ *
  * @phpstan-type VacancyData = array{
  *     slug: string,
  *     category: VacancyCategories,
@@ -43,6 +46,10 @@ class CompanyFixture extends Fixture
 {
     /** @var array<string, VacancyLabel> */
     private array $labels = [];
+
+    public function __construct(private readonly CompanyImageGenerator $imageGenerator)
+    {
+    }
 
     #[Override]
     public function load(ObjectManager $manager): void
@@ -61,6 +68,11 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/nexunt',
             featured: true,
             bannerFormat: null,
+            // A large square logo, which is what the featured slot on the landing page shows at its biggest.
+            logoSize: [
+                800,
+                800,
+            ],
             highlight: true,
             vacancies: [
                 [
@@ -121,6 +133,8 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/orbit',
             featured: false,
             bannerFormat: CompanyBannerFormats::Leaderboard,
+            // No logo, so the company pages have to fall back to the monogram for a company that does have a banner.
+            logoSize: null,
             vacancies: [
                 [
                     'slug' => 'data-science-internship',
@@ -167,6 +181,11 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/delta',
             featured: false,
             bannerFormat: CompanyBannerFormats::Billboard,
+            // A wide logo, the other shape a company hands one over in, so the boxes it is fitted into are exercised.
+            logoSize: [
+                512,
+                256,
+            ],
             vacancies: [
                 [
                     'slug' => 'robotics-traineeship',
@@ -227,6 +246,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/halcyon',
             featured: false,
             bannerFormat: null,
+            logoSize: null,
             vacancies: [
                 [
                     'slug' => 'drivetrain-engineer',
@@ -239,6 +259,125 @@ class CompanyFixture extends Fixture
                 ],
             ],
             contractExpired: true,
+        );
+
+        $this->createCompany(
+            $manager,
+            slug: 'vantsel',
+            name: 'Vantsel',
+            sloganEn: 'Chemistry, scaled up',
+            sloganNl: 'Chemie, opgeschaald',
+            descriptionEn: 'Vantsel takes processes out of the laboratory and onto the production floor.',
+            descriptionNl: 'Vantsel haalt processen uit het laboratorium en zet ze op de productievloer.',
+            websiteEn: 'https://example.com/vantsel',
+            websiteNl: 'https://example.com/vantsel',
+            featured: false,
+            bannerFormat: null,
+            // The widest a real wordmark gets, which is what sets how much room the box has to leave on the sides.
+            logoSize: [
+                900,
+                300,
+            ],
+            vacancies: [
+                [
+                    'slug' => 'process-engineer',
+                    'category' => VacancyCategories::Jobs,
+                    'nameEn' => 'Process Engineer',
+                    'nameNl' => 'Procestechnoloog',
+                    'descriptionEn' => 'Take a process from a bench-scale proof to a line that runs every day.',
+                    'descriptionNl' => 'Breng een proces van labopstelling naar een lijn die elke dag draait.',
+                    'labels' => ['fulltime'],
+                ],
+            ],
+        );
+
+        $this->createCompany(
+            $manager,
+            slug: 'meridian-labs',
+            name: 'Meridian Labs',
+            sloganEn: 'Instruments for people who measure things',
+            sloganNl: 'Instrumenten voor wie dingen meet',
+            descriptionEn: 'Meridian Labs builds measurement instruments for university research groups.',
+            descriptionNl: 'Meridian Labs bouwt meetinstrumenten voor universitaire onderzoeksgroepen.',
+            websiteEn: 'https://example.com/meridian',
+            websiteNl: 'https://example.com/meridian',
+            featured: false,
+            bannerFormat: null,
+            // Barely wider than it is tall, the other end of what companies hand over.
+            logoSize: [
+                640,
+                540,
+            ],
+            vacancies: [
+                [
+                    'slug' => 'measurement-thesis',
+                    'category' => VacancyCategories::ThesisProjects,
+                    'nameEn' => 'Master Thesis: Sensor Calibration',
+                    'nameNl' => 'Afstudeerproject: Sensorkalibratie',
+                    'descriptionEn' => 'Work out how far our instruments drift, and what it would take to stop them.',
+                    'descriptionNl' => 'Zoek uit hoever onze instrumenten driften en wat nodig is om dat te stoppen.',
+                    'labels' => ['hybrid'],
+                ],
+            ],
+        );
+
+        $this->createCompany(
+            $manager,
+            slug: 'koda-interactive',
+            name: 'Koda Interactive',
+            sloganEn: 'Small studio, large worlds',
+            sloganNl: 'Kleine studio, grote werelden',
+            descriptionEn: 'Koda Interactive is a game studio of eleven people in the middle of Eindhoven.',
+            descriptionNl: 'Koda Interactive is een gamestudio van elf mensen midden in Eindhoven.',
+            websiteEn: 'https://example.com/koda',
+            websiteNl: 'https://example.com/koda',
+            featured: false,
+            bannerFormat: null,
+            // Barely larger than the smallest rendition, so nothing has anything to scale down from.
+            logoSize: [
+                160,
+                160,
+            ],
+            vacancies: [
+                [
+                    'slug' => 'gameplay-internship',
+                    'category' => VacancyCategories::Internships,
+                    'nameEn' => 'Gameplay Programming Internship',
+                    'nameNl' => 'Stage Gameplay Programmeren',
+                    'descriptionEn' => 'Ship a feature of your own in a team small enough that you will see it land.',
+                    'descriptionNl' => 'Lever een eigen feature op in een team klein genoeg om het te zien landen.',
+                    'labels' => ['fulltime'],
+                ],
+            ],
+        );
+
+        $this->createCompany(
+            $manager,
+            slug: 'brekhoff-groep',
+            name: 'Brekhoff Groep',
+            sloganEn: 'Building since 1924',
+            sloganNl: 'Bouwen sinds 1924',
+            descriptionEn: 'The Brekhoff Groep engineers the structures underneath large infrastructure projects.',
+            descriptionNl: 'De Brekhoff Groep ontwerpt de constructies onder grote infrastructuurprojecten.',
+            websiteEn: 'https://example.com/brekhoff',
+            websiteNl: 'https://example.com/brekhoff',
+            featured: false,
+            bannerFormat: null,
+            logoSize: null,
+            vacancies: [
+                [
+                    'slug' => 'structural-traineeship',
+                    'category' => VacancyCategories::Traineeships,
+                    'nameEn' => 'Structural Engineering Traineeship',
+                    'nameNl' => 'Traineeship Constructief Ontwerp',
+                    'descriptionEn' => 'Two years across our bridge, tunnel and foundation teams.',
+                    'descriptionNl' => 'Twee jaar langs onze brug-, tunnel- en funderingsteams.',
+                    'labels' => [
+                        'fulltime',
+                        'hybrid',
+                    ],
+                ],
+            ],
         );
 
         $manager->flush();
@@ -271,7 +410,8 @@ class CompanyFixture extends Fixture
     }
 
     /**
-     * @param VacancyData[] $vacancies
+     * @param VacancyData[]                          $vacancies
+     * @param array{positive-int, positive-int}|null $logoSize
      */
     private function createCompany(
         ObjectManager $manager,
@@ -285,6 +425,7 @@ class CompanyFixture extends Fixture
         string $websiteNl,
         bool $featured,
         ?CompanyBannerFormats $bannerFormat,
+        ?array $logoSize,
         array $vacancies,
         bool $highlight = false,
         bool $contractExpired = false,
@@ -340,6 +481,18 @@ class CompanyFixture extends Fixture
         $manager->persist($revision);
         $manager->persist($jobPackage);
 
+        // An image is stored under the id of the company it belongs to, so the company needs one before it can be
+        // given any artwork.
+        $manager->flush();
+
+        if (null !== $logoSize) {
+            $revision->setLogo($this->imageGenerator->storeLogo(
+                $company,
+                $logoSize[0],
+                $logoSize[1],
+            ));
+        }
+
         if (null !== $bannerFormat) {
             $bannerPackage = new CompanyBannerPackage();
             $this->configurePackage(
@@ -347,7 +500,11 @@ class CompanyFixture extends Fixture
                 $company,
             );
             $bannerPackage->setFormat($bannerFormat);
-            $bannerPackage->setImage('data/company/banner/' . $slug . '.png');
+            $bannerPackage->setImage($this->imageGenerator->storeBanner(
+                $company,
+                $bannerFormat,
+                $sloganEn,
+            ));
             $manager->persist($bannerPackage);
         }
 

--- a/src/DataFixtures/Career/CompanyFixture.php
+++ b/src/DataFixtures/Career/CompanyFixture.php
@@ -27,9 +27,6 @@ use Override;
  * Seeds a handful of publicly visible companies with active packages and vacancies across the vacancy categories, so
  * the career overview and the per-category vacancy listings have something to show.
  *
- * Only some of them have a logo, because most real profiles do not: the pages fall back to a monogram, which needs
- * seeding just as much as the case where an image is there.
- *
  * @phpstan-type VacancyData = array{
  *     slug: string,
  *     category: VacancyCategories,
@@ -68,11 +65,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/nexunt',
             featured: true,
             bannerFormat: null,
-            // A large square logo, which is what the featured slot on the landing page shows at its biggest.
-            logoSize: [
-                800,
-                800,
-            ],
+            logos: true,
             highlight: true,
             vacancies: [
                 [
@@ -133,8 +126,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/orbit',
             featured: false,
             bannerFormat: CompanyBannerFormats::Leaderboard,
-            // No logo, so the company pages have to fall back to the monogram for a company that does have a banner.
-            logoSize: null,
+            logos: true,
             vacancies: [
                 [
                     'slug' => 'data-science-internship',
@@ -181,11 +173,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/delta',
             featured: false,
             bannerFormat: CompanyBannerFormats::Billboard,
-            // A wide logo, the other shape a company hands one over in, so the boxes it is fitted into are exercised.
-            logoSize: [
-                512,
-                256,
-            ],
+            logos: true,
             vacancies: [
                 [
                     'slug' => 'robotics-traineeship',
@@ -246,7 +234,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/halcyon',
             featured: false,
             bannerFormat: null,
-            logoSize: null,
+            logos: false,
             vacancies: [
                 [
                     'slug' => 'drivetrain-engineer',
@@ -273,11 +261,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/vantsel',
             featured: false,
             bannerFormat: null,
-            // The widest a real wordmark gets, which is what sets how much room the box has to leave on the sides.
-            logoSize: [
-                900,
-                300,
-            ],
+            logos: true,
             vacancies: [
                 [
                     'slug' => 'process-engineer',
@@ -303,11 +287,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/meridian',
             featured: false,
             bannerFormat: null,
-            // Barely wider than it is tall, the other end of what companies hand over.
-            logoSize: [
-                640,
-                540,
-            ],
+            logos: true,
             vacancies: [
                 [
                     'slug' => 'measurement-thesis',
@@ -333,11 +313,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/koda',
             featured: false,
             bannerFormat: null,
-            // Barely larger than the smallest rendition, so nothing has anything to scale down from.
-            logoSize: [
-                160,
-                160,
-            ],
+            logos: true,
             vacancies: [
                 [
                     'slug' => 'gameplay-internship',
@@ -363,7 +339,7 @@ class CompanyFixture extends Fixture
             websiteNl: 'https://example.com/brekhoff',
             featured: false,
             bannerFormat: null,
-            logoSize: null,
+            logos: true,
             vacancies: [
                 [
                     'slug' => 'structural-traineeship',
@@ -410,8 +386,7 @@ class CompanyFixture extends Fixture
     }
 
     /**
-     * @param VacancyData[]                          $vacancies
-     * @param array{positive-int, positive-int}|null $logoSize
+     * @param VacancyData[] $vacancies
      */
     private function createCompany(
         ObjectManager $manager,
@@ -425,7 +400,7 @@ class CompanyFixture extends Fixture
         string $websiteNl,
         bool $featured,
         ?CompanyBannerFormats $bannerFormat,
-        ?array $logoSize,
+        bool $logos,
         array $vacancies,
         bool $highlight = false,
         bool $contractExpired = false,
@@ -485,12 +460,9 @@ class CompanyFixture extends Fixture
         // given any artwork.
         $manager->flush();
 
-        if (null !== $logoSize) {
-            $revision->setLogo($this->imageGenerator->storeLogo(
-                $company,
-                $logoSize[0],
-                $logoSize[1],
-            ));
+        if ($logos) {
+            $revision->setSquareLogo($this->imageGenerator->storeSquareLogo($company));
+            $revision->setBannerLogo($this->imageGenerator->storeBannerLogo($company));
         }
 
         if (null !== $bannerFormat) {

--- a/src/DataFixtures/Career/CompanyImageGenerator.php
+++ b/src/DataFixtures/Career/CompanyImageGenerator.php
@@ -1,0 +1,508 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures\Career;
+
+use App\Entity\Application\Enums\StorageNamespace;
+use App\Entity\Career\Company;
+use App\Entity\Career\Enums\CompanyBannerFormats;
+use App\Service\Application\FileStorage;
+use GdImage;
+use RuntimeException;
+
+use function abs;
+use function count;
+use function crc32;
+use function imagecolorallocate;
+use function imagecopyresampled;
+use function imagecreatetruecolor;
+use function imagefilledrectangle;
+use function imagefontheight;
+use function imagefontwidth;
+use function imagepng;
+use function imagestring;
+use function intdiv;
+use function max;
+use function mb_strtoupper;
+use function mb_substr;
+use function min;
+use function strlen;
+use function strval;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+/**
+ * Draws the artwork the career fixtures need, banner-package images and company logos, and stores it the way an upload
+ * would, so the career pages serve real files instead of pointing at paths nobody ever wrote anything to.
+ *
+ * Images are generated rather than committed to the repository, as the photo fixtures do. Only the original is stored:
+ * the renditions the pages ask for are generated the first time one is requested.
+ *
+ * A banner is drawn at twice the box its format is shown in, which is what a company hands over when it wants its
+ * artwork to survive a dense screen, and means both the ordinary and the retina rendition are real downscales.
+ */
+final readonly class CompanyImageGenerator
+{
+    /** The built-in font the captions are drawn in before being scaled up. */
+    private const int FONT = 5;
+
+    /** Background colours, picked per company so two of them are told apart at a glance. */
+    private const array PALETTE = [
+        [
+            21,
+            101,
+            192,
+        ],
+        [
+            46,
+            125,
+            50,
+        ],
+        [
+            106,
+            27,
+            154,
+        ],
+        [
+            191,
+            54,
+            12,
+        ],
+        [
+            0,
+            131,
+            143,
+        ],
+        [
+            55,
+            71,
+            79,
+        ],
+    ];
+
+    public function __construct(private FileStorage $fileStorage)
+    {
+    }
+
+    /**
+     * A banner carrying the company name and its slogan, which is what the format describes real artwork as. The
+     * slogan is also what tells two banners for the same company apart, so a banner proposed alongside a new slogan
+     * does not collapse onto the one it is meant to replace: stored files are content-addressed, and identical bytes
+     * are one file.
+     */
+    public function storeBanner(
+        Company $company,
+        CompanyBannerFormats $format,
+        string $slogan,
+    ): string {
+        $width = $format->width() * 2;
+        $height = $format->height() * 2;
+        $padding = intdiv(
+            $height,
+            10,
+        );
+
+        $image = $this->createCanvas(
+            $width,
+            $height,
+        );
+        $background = $this->colorFor($company->getName() . $slogan);
+        $this->fill(
+            $image,
+            $background,
+            0,
+            0,
+            $width,
+            $height,
+        );
+
+        // A square of flat colour on the left, where finished artwork would carry the company's own mark.
+        $accent = $this->lighten($background);
+        $this->fill(
+            $image,
+            $accent,
+            0,
+            0,
+            $height,
+            $height,
+        );
+        $this->drawText(
+            $image,
+            $this->monogram($company->getName()),
+            $accent,
+            intdiv(
+                $height,
+                2,
+            ),
+            intdiv(
+                $height,
+                2,
+            ),
+            intdiv(
+                $height,
+                2,
+            ),
+            intdiv(
+                $height,
+                2,
+            ),
+        );
+
+        $columnWidth = $width - $height - 2 * $padding;
+        $columnCentre = $height + $padding + intdiv(
+            $columnWidth,
+            2,
+        );
+        $this->drawText(
+            $image,
+            $company->getName(),
+            $background,
+            $columnCentre,
+            intdiv(
+                $height * 2,
+                5,
+            ),
+            $columnWidth,
+            intdiv(
+                $height,
+                3,
+            ),
+        );
+        $this->drawText(
+            $image,
+            $slogan,
+            $background,
+            $columnCentre,
+            intdiv(
+                $height * 7,
+                10,
+            ),
+            $columnWidth,
+            intdiv(
+                $height,
+                6,
+            ),
+        );
+
+        return $this->store(
+            $image,
+            $company,
+        );
+    }
+
+    /**
+     * A logo, at whatever size the company happened to hand one over at. Every page fits it into a box of its own, so
+     * the shape it arrives in is exactly the thing worth varying between companies.
+     *
+     * @param positive-int $width
+     * @param positive-int $height
+     */
+    public function storeLogo(
+        Company $company,
+        int $width,
+        int $height,
+    ): string {
+        $image = $this->createCanvas(
+            $width,
+            $height,
+        );
+        $background = $this->colorFor($company->getName());
+        $this->fill(
+            $image,
+            $background,
+            0,
+            0,
+            $width,
+            $height,
+        );
+
+        $this->drawText(
+            $image,
+            $this->monogram($company->getName()),
+            $background,
+            intdiv(
+                $width,
+                2,
+            ),
+            intdiv(
+                $height * 2,
+                5,
+            ),
+            intdiv(
+                $width * 3,
+                5,
+            ),
+            intdiv(
+                $height * 2,
+                5,
+            ),
+        );
+        $this->drawText(
+            $image,
+            $company->getName(),
+            $background,
+            intdiv(
+                $width,
+                2,
+            ),
+            intdiv(
+                $height * 4,
+                5,
+            ),
+            intdiv(
+                $width * 4,
+                5,
+            ),
+            intdiv(
+                $height,
+                6,
+            ),
+        );
+
+        return $this->store(
+            $image,
+            $company,
+        );
+    }
+
+    /**
+     * Draws a caption centred on a point, as large as the given box takes. GD's built-in fonts top out at fifteen
+     * pixels tall, which is lost on artwork this size, so the text is drawn small onto a strip of the colour it lands
+     * on and copied over enlarged. A strip that already carries its own background leaves no fringe around the letters
+     * when it is resampled.
+     *
+     * @param array{int<0, 255>, int<0, 255>, int<0, 255>} $background
+     */
+    private function drawText(
+        GdImage $target,
+        string $text,
+        array $background,
+        int $centreX,
+        int $centreY,
+        int $boxWidth,
+        int $boxHeight,
+    ): void {
+        $width = max(
+            1,
+            imagefontwidth(self::FONT) * strlen($text),
+        );
+        $height = max(
+            1,
+            imagefontheight(self::FONT),
+        );
+        $scale = max(
+            1,
+            min(
+                intdiv(
+                    $boxWidth,
+                    $width,
+                ),
+                intdiv(
+                    $boxHeight,
+                    $height,
+                ),
+            ),
+        );
+
+        $strip = $this->createCanvas(
+            $width,
+            $height,
+        );
+        $this->fill(
+            $strip,
+            $background,
+            0,
+            0,
+            $width,
+            $height,
+        );
+        imagestring(
+            $strip,
+            self::FONT,
+            0,
+            0,
+            $text,
+            $this->allocate(
+                $strip,
+                [
+                    255,
+                    255,
+                    255,
+                ],
+            ),
+        );
+
+        imagecopyresampled(
+            $target,
+            $strip,
+            $centreX - intdiv(
+                $width * $scale,
+                2,
+            ),
+            $centreY - intdiv(
+                $height * $scale,
+                2,
+            ),
+            0,
+            0,
+            $width * $scale,
+            $height * $scale,
+            $width,
+            $height,
+        );
+    }
+
+    /**
+     * Writes the drawing out and stores it against the company, which is what scopes the stored path, so the company
+     * must already have an id by the time this is called.
+     */
+    private function store(
+        GdImage $image,
+        Company $company,
+    ): string {
+        $temporaryFile = tempnam(
+            sys_get_temp_dir(),
+            'fixture-company-image-',
+        );
+
+        if (false === $temporaryFile) {
+            throw new RuntimeException('Could not create a temporary file for a fixture image.');
+        }
+
+        imagepng(
+            $image,
+            $temporaryFile,
+        );
+
+        try {
+            return $this->fileStorage->store(
+                StorageNamespace::CompanyImage,
+                $temporaryFile,
+                strval($company->getId()),
+            )->path;
+        } finally {
+            unlink($temporaryFile);
+        }
+    }
+
+    /**
+     * @param positive-int $width
+     * @param positive-int $height
+     */
+    private function createCanvas(
+        int $width,
+        int $height,
+    ): GdImage {
+        $image = imagecreatetruecolor(
+            $width,
+            $height,
+        );
+
+        if (false === $image) {
+            throw new RuntimeException('Cannot create a canvas for a fixture image.');
+        }
+
+        return $image;
+    }
+
+    /**
+     * @param array{int<0, 255>, int<0, 255>, int<0, 255>} $color
+     */
+    private function fill(
+        GdImage $image,
+        array $color,
+        int $left,
+        int $top,
+        int $right,
+        int $bottom,
+    ): void {
+        imagefilledrectangle(
+            $image,
+            $left,
+            $top,
+            $right,
+            $bottom,
+            $this->allocate(
+                $image,
+                $color,
+            ),
+        );
+    }
+
+    /**
+     * @param array{int<0, 255>, int<0, 255>, int<0, 255>} $color
+     */
+    private function allocate(
+        GdImage $image,
+        array $color,
+    ): int {
+        [
+            $red,
+            $green,
+            $blue,
+        ] = $color;
+
+        $allocated = imagecolorallocate(
+            $image,
+            $red,
+            $green,
+            $blue,
+        );
+
+        if (false === $allocated) {
+            throw new RuntimeException('Cannot allocate a colour for a fixture image.');
+        }
+
+        return $allocated;
+    }
+
+    /**
+     * The colour an image is drawn in, from the text it is drawn for, so a company keeps the same look everywhere.
+     *
+     * @return array{int<0, 255>, int<0, 255>, int<0, 255>}
+     */
+    private function colorFor(string $seed): array
+    {
+        return self::PALETTE[abs(crc32($seed)) % count(self::PALETTE)];
+    }
+
+    /**
+     * @param array{int<0, 255>, int<0, 255>, int<0, 255>} $color
+     *
+     * @return array{int<0, 255>, int<0, 255>, int<0, 255>}
+     */
+    private function lighten(array $color): array
+    {
+        [
+            $red,
+            $green,
+            $blue,
+        ] = $color;
+
+        return [
+            min(
+                255,
+                $red + 45,
+            ),
+            min(
+                255,
+                $green + 45,
+            ),
+            min(
+                255,
+                $blue + 45,
+            ),
+        ];
+    }
+
+    private function monogram(string $name): string
+    {
+        return mb_strtoupper(mb_substr(
+            $name,
+            0,
+            1,
+        ));
+    }
+}

--- a/src/DataFixtures/Career/CompanyImageGenerator.php
+++ b/src/DataFixtures/Career/CompanyImageGenerator.php
@@ -48,6 +48,10 @@ final readonly class CompanyImageGenerator
     /** The built-in font the captions are drawn in before being scaled up. */
     private const int FONT = 5;
 
+    private const int SQUARE_LOGO_SIZE = 512;
+
+    private const int BANNER_LOGO_HEIGHT = 320;
+
     /** Background colours, picked per company so two of them are told apart at a glance. */
     private const array PALETTE = [
         [
@@ -192,18 +196,55 @@ final readonly class CompanyImageGenerator
         );
     }
 
-    /**
-     * A logo, at whatever size the company happened to hand one over at. Every page fits it into a box of its own, so
-     * the shape it arrives in is exactly the thing worth varying between companies.
-     *
-     * @param positive-int $width
-     * @param positive-int $height
-     */
-    public function storeLogo(
-        Company $company,
-        int $width,
-        int $height,
-    ): string {
+    public function storeSquareLogo(Company $company): string
+    {
+        $size = self::SQUARE_LOGO_SIZE;
+        $image = $this->createCanvas(
+            $size,
+            $size,
+        );
+        $background = $this->colorFor($company->getName());
+        $this->fill(
+            $image,
+            $background,
+            0,
+            0,
+            $size,
+            $size,
+        );
+
+        $this->drawText(
+            $image,
+            $this->monogram($company->getName()),
+            $background,
+            intdiv(
+                $size,
+                2,
+            ),
+            intdiv(
+                $size,
+                2,
+            ),
+            intdiv(
+                $size * 3,
+                5,
+            ),
+            intdiv(
+                $size * 3,
+                5,
+            ),
+        );
+
+        return $this->store(
+            $image,
+            $company,
+        );
+    }
+
+    public function storeBannerLogo(Company $company): string
+    {
+        $height = self::BANNER_LOGO_HEIGHT;
+        $width = $height * (2 + abs(crc32($company->getName())) % 3);
         $image = $this->createCanvas(
             $width,
             $height,
@@ -218,46 +259,57 @@ final readonly class CompanyImageGenerator
             $height,
         );
 
+        $accent = $this->lighten($background);
+        $this->fill(
+            $image,
+            $accent,
+            0,
+            0,
+            $height,
+            $height,
+        );
         $this->drawText(
             $image,
             $this->monogram($company->getName()),
-            $background,
+            $accent,
             intdiv(
-                $width,
+                $height,
                 2,
             ),
             intdiv(
-                $height * 2,
+                $height,
+                2,
+            ),
+            intdiv(
+                $height * 3,
                 5,
             ),
             intdiv(
-                $width * 3,
-                5,
-            ),
-            intdiv(
-                $height * 2,
+                $height * 3,
                 5,
             ),
         );
+
+        $columnWidth = $width - $height;
         $this->drawText(
             $image,
             $company->getName(),
             $background,
-            intdiv(
-                $width,
+            $height + intdiv(
+                $columnWidth,
                 2,
             ),
             intdiv(
-                $height * 4,
-                5,
+                $height,
+                2,
             ),
-            intdiv(
-                $width * 4,
-                5,
+            $columnWidth - intdiv(
+                $height,
+                4,
             ),
             intdiv(
                 $height,
-                6,
+                3,
             ),
         );
 

--- a/src/Entity/Career/Company.php
+++ b/src/Entity/Career/Company.php
@@ -312,11 +312,19 @@ class Company implements RevisableInterface
     }
 
     /**
-     * Display proxy. Get the company's logo.
+     * Display proxy. Get the company's square logo.
      */
-    public function getLogo(): ?string
+    public function getSquareLogo(): ?string
     {
-        return $this->getDisplayRevision()->getLogo();
+        return $this->getDisplayRevision()->getSquareLogo();
+    }
+
+    /**
+     * Display proxy. Get the company's banner logo.
+     */
+    public function getBannerLogo(): ?string
+    {
+        return $this->getDisplayRevision()->getBannerLogo();
     }
 
     /**
@@ -576,7 +584,8 @@ class Company implements RevisableInterface
      * @return array{
      *     name: string,
      *     slugName: string,
-     *     logo: ?string,
+     *     squareLogo: ?string,
+     *     bannerLogo: ?string,
      *     contactName: ?string,
      *     contactEmail: ?string,
      *     contactAddress: ?string,
@@ -597,7 +606,8 @@ class Company implements RevisableInterface
         $arraycopy['name'] = $this->getName();
         $arraycopy['slugName'] = $this->getSlugName();
 
-        $arraycopy['logo'] = $this->getLogo();
+        $arraycopy['squareLogo'] = $this->getSquareLogo();
+        $arraycopy['bannerLogo'] = $this->getBannerLogo();
         $arraycopy['contactName'] = $this->getContactName();
         $arraycopy['contactEmail'] = $this->getContactEmail();
         $arraycopy['contactAddress'] = $this->getContactAddress();

--- a/src/Entity/Career/CompanyRevision.php
+++ b/src/Entity/Career/CompanyRevision.php
@@ -92,7 +92,13 @@ class CompanyRevision extends AbstractRevision
         type: Types::STRING,
         nullable: true,
     )]
-    private ?string $logo = null;
+    private ?string $squareLogo = null;
+
+    #[Column(
+        type: Types::STRING,
+        nullable: true,
+    )]
+    private ?string $bannerLogo = null;
 
     #[Column(
         type: Types::STRING,
@@ -202,14 +208,24 @@ class CompanyRevision extends AbstractRevision
         $this->website = $website;
     }
 
-    public function getLogo(): ?string
+    public function getSquareLogo(): ?string
     {
-        return $this->logo;
+        return $this->squareLogo;
     }
 
-    public function setLogo(?string $logo): void
+    public function setSquareLogo(?string $squareLogo): void
     {
-        $this->logo = $logo;
+        $this->squareLogo = $squareLogo;
+    }
+
+    public function getBannerLogo(): ?string
+    {
+        return $this->bannerLogo;
+    }
+
+    public function setBannerLogo(?string $bannerLogo): void
+    {
+        $this->bannerLogo = $bannerLogo;
     }
 
     public function getContactName(): ?string

--- a/src/Form/Career/CompanyRevisionType.php
+++ b/src/Form/Career/CompanyRevisionType.php
@@ -17,9 +17,11 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Email;
-use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotNull;
 
 use function Symfony\Component\Translation\t;
 use function trim;
@@ -37,6 +39,26 @@ use function trim;
  */
 class CompanyRevisionType extends AbstractType
 {
+    private const string MAXIMUM_SIZE = '8M';
+
+    private const array MIME_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+    ];
+
+    private const int SQUARE_MINIMUM = 320;
+
+    private const int BANNER_MINIMUM_WIDTH = 640;
+
+    private const float SQUARE_MINIMUM_RATIO = 0.9;
+
+    private const float SQUARE_MAXIMUM_RATIO = 1.1;
+
+    private const float BANNER_MINIMUM_RATIO = 1.5;
+
+    private const float BANNER_MAXIMUM_RATIO = 6.0;
+
     #[Override]
     public function buildForm(
         FormBuilderInterface $builder,
@@ -119,34 +141,94 @@ class CompanyRevisionType extends AbstractType
                     'required' => false,
                     'constraints' => [new Length(max: 255)],
                 ],
-            )
-            // Unmapped: the upload is stored by the controller, which puts the resulting path on the revision. Leaving
-            // it empty keeps whatever logo the revision already carries.
-            ->add(
-                'logoFile',
-                FileType::class,
-                [
-                    'label' => t('Logo'),
-                    'required' => false,
-                    'mapped' => false,
-                    'constraints' => [
-                        new File(
-                            maxSize: '8M',
-                            mimeTypes: [
-                                'image/jpeg',
-                                'image/png',
-                                'image/webp',
-                            ],
-                            mimeTypesMessage: 'Upload a JPEG, PNG or WebP image.',
-                        ),
-                    ],
-                ],
             );
 
         $builder->addEventListener(
             FormEvents::POST_SET_DATA,
             $this->primeLanguageToggles(...),
         );
+        $builder->addEventListener(
+            FormEvents::POST_SET_DATA,
+            $this->addLogoFields(...),
+        );
+    }
+
+    /**
+     * Unmapped: the controller stores the upload and puts the path on the revision. Each field is required until the
+     * revision carries that logo, which is why they can only be built once the revision is known.
+     */
+    private function addLogoFields(FormEvent $event): void
+    {
+        $revision = $event->getData();
+        $form = $event->getForm();
+
+        $form->add(
+            'squareLogoFile',
+            FileType::class,
+            [
+                'label' => t('Square logo'),
+                'help' => t(
+                    'Your mark on its own, square, at least %size% by %size% pixels.',
+                    ['%size%' => self::SQUARE_MINIMUM],
+                ),
+                'required' => null === $revision?->getSquareLogo(),
+                'mapped' => false,
+                'constraints' => $this->logoConstraints(
+                    $revision?->getSquareLogo(),
+                    new Image(
+                        maxSize: self::MAXIMUM_SIZE,
+                        mimeTypes: self::MIME_TYPES,
+                        mimeTypesMessage: 'Upload a JPEG, PNG or WebP image.',
+                        minWidth: self::SQUARE_MINIMUM,
+                        minHeight: self::SQUARE_MINIMUM,
+                        maxRatio: self::SQUARE_MAXIMUM_RATIO,
+                        minRatio: self::SQUARE_MINIMUM_RATIO,
+                    ),
+                ),
+            ],
+        );
+
+        $form->add(
+            'bannerLogoFile',
+            FileType::class,
+            [
+                'label' => t('Banner logo'),
+                'help' => t(
+                    'Your mark and name side by side, at least %width% pixels wide and wider than it is tall.',
+                    ['%width%' => self::BANNER_MINIMUM_WIDTH],
+                ),
+                'required' => null === $revision?->getBannerLogo(),
+                'mapped' => false,
+                'constraints' => $this->logoConstraints(
+                    $revision?->getBannerLogo(),
+                    new Image(
+                        maxSize: self::MAXIMUM_SIZE,
+                        mimeTypes: self::MIME_TYPES,
+                        mimeTypesMessage: 'Upload a JPEG, PNG or WebP image.',
+                        minWidth: self::BANNER_MINIMUM_WIDTH,
+                        maxRatio: self::BANNER_MAXIMUM_RATIO,
+                        minRatio: self::BANNER_MINIMUM_RATIO,
+                    ),
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return list<Constraint>
+     */
+    private function logoConstraints(
+        ?string $stored,
+        Image $image,
+    ): array {
+        if (null !== $stored) {
+            return [$image];
+        }
+
+        return [
+            new NotNull(message: 'Choose an image to upload.'),
+            $image,
+        ];
     }
 
     #[Override]

--- a/src/Repository/Career/CompanyRepository.php
+++ b/src/Repository/Career/CompanyRepository.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
+use function array_map;
 use function intval;
 use function mb_strtolower;
 use function trim;
@@ -20,6 +21,27 @@ use function trim;
  */
 class CompanyRepository extends ServiceEntityRepository
 {
+    private const string PUBLIC_SOURCE = <<<'QUERY'
+        FROM `Company` AS `t1`
+        LEFT JOIN (
+            SELECT `company_id`,
+                COUNT(`company_id`) AS `totalPackages`,
+                SUM(
+                    CASE WHEN `expires` <= CURRENT_TIMESTAMP
+                            OR `published` = 0
+                            OR `starts` > CURRENT_TIMESTAMP
+                        THEN 1
+                        ELSE 0
+                    END
+                ) AS `expiredHiddenOrNotStartedPackages`
+            FROM `CompanyPackage`
+            GROUP BY `company_id`
+        ) `CompanyPackages` ON `CompanyPackages`.`company_id` = `t1`.`id`
+        WHERE `t1`.`published` = 1
+        AND `t1`.`liveRevision_id` IS NOT NULL
+        AND `CompanyPackages`.`totalPackages` > `CompanyPackages`.`expiredHiddenOrNotStartedPackages`
+        QUERY;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct(
@@ -43,26 +65,10 @@ class CompanyRepository extends ServiceEntityRepository
         );
 
         $select = $rsmBuilder->generateSelectClause(['c' => 't1']);
+        $source = self::PUBLIC_SOURCE;
 
         $sql = <<<QUERY
-            SELECT {$select} FROM `Company` AS `t1`
-            LEFT JOIN (
-                SELECT `company_id`,
-                    COUNT(`company_id`) AS `totalPackages`,
-                    SUM(
-                        CASE WHEN `expires` <= CURRENT_TIMESTAMP
-                                OR `published` = 0
-                                OR `starts` > CURRENT_TIMESTAMP
-                            THEN 1
-                            ELSE 0
-                        END
-                    ) AS `expiredHiddenOrNotStartedPackages`
-                FROM `CompanyPackage`
-                GROUP BY `company_id`
-            ) `CompanyPackages` ON `CompanyPackages`.`company_id` = `t1`.`id`
-            WHERE `t1`.`published` = 1
-            AND `t1`.`liveRevision_id` IS NOT NULL
-            AND `CompanyPackages`.`totalPackages` > `CompanyPackages`.`expiredHiddenOrNotStartedPackages`
+            SELECT {$select} {$source}
             ORDER BY `t1`.`name` ASC
             QUERY;
 
@@ -81,33 +87,86 @@ class CompanyRepository extends ServiceEntityRepository
     }
 
     /**
+     * The ids of the public companies matching the overview's search box. The order is pinned rather than left to
+     * the database: the overview seeds a shuffle over this list and pages through it, which only holds together if the
+     * same seed always meets the same list.
+     *
+     * @return int[]
+     */
+    public function findPublicIds(string $search): array
+    {
+        $source = self::PUBLIC_SOURCE;
+        $parameters = [];
+
+        $search = trim($search);
+        if ('' !== $search) {
+            $source .= ' AND (LOWER(`t1`.`name`) LIKE :search OR LOWER(`t1`.`slugName`) LIKE :search)';
+            $parameters['search'] = '%' . mb_strtolower($search) . '%';
+        }
+
+        $sql = <<<QUERY
+            SELECT `t1`.`id` {$source}
+            ORDER BY `t1`.`name` ASC
+            QUERY;
+
+        return array_map(
+            'intval',
+            $this->getEntityManager()->getConnection()->fetchFirstColumn(
+                $sql,
+                $parameters,
+            ),
+        );
+    }
+
+    /**
+     * Hydrate the given companies, in the order they are asked for. Ids that no longer resolve to a company are
+     * left out.
+     *
+     * @param int[] $ids
+     *
+     * @return Company[]
+     */
+    public function findPublicByIds(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        $companies = $this->createQueryBuilder(
+            'c',
+            'c.id',
+        )
+            ->where('c.id IN (:ids)')
+            ->setParameter(
+                'ids',
+                $ids,
+            )
+            ->getQuery()
+            ->getResult();
+
+        $this->warmOverviewAssociations($companies);
+
+        $ordered = [];
+        foreach ($ids as $id) {
+            if (!isset($companies[$id])) {
+                continue;
+            }
+
+            $ordered[] = $companies[$id];
+        }
+
+        return $ordered;
+    }
+
+    /**
      * How many companies the public overview would list, for the count the navigation menu carries. The same three
      * conditions as {@see self::findAllPublic()}, counted rather than hydrated, since the menu is on every page.
      */
     public function countPublic(): int
     {
-        $sql = <<<'QUERY'
-            SELECT COUNT(*) FROM `Company` AS `t1`
-            LEFT JOIN (
-                SELECT `company_id`,
-                    COUNT(`company_id`) AS `totalPackages`,
-                    SUM(
-                        CASE WHEN `expires` <= CURRENT_TIMESTAMP
-                                OR `published` = 0
-                                OR `starts` > CURRENT_TIMESTAMP
-                            THEN 1
-                            ELSE 0
-                        END
-                    ) AS `expiredHiddenOrNotStartedPackages`
-                FROM `CompanyPackage`
-                GROUP BY `company_id`
-            ) `CompanyPackages` ON `CompanyPackages`.`company_id` = `t1`.`id`
-            WHERE `t1`.`published` = 1
-            AND `t1`.`liveRevision_id` IS NOT NULL
-            AND `CompanyPackages`.`totalPackages` > `CompanyPackages`.`expiredHiddenOrNotStartedPackages`
-            QUERY;
+        $source = self::PUBLIC_SOURCE;
 
-        return intval($this->getEntityManager()->getConnection()->fetchOne($sql));
+        return intval($this->getEntityManager()->getConnection()->fetchOne('SELECT COUNT(*) ' . $source));
     }
 
     /**

--- a/src/Repository/Career/VacancyRepository.php
+++ b/src/Repository/Career/VacancyRepository.php
@@ -17,6 +17,8 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
+use function array_column;
+use function array_map;
 use function intval;
 use function iterator_to_array;
 use function mb_strtolower;
@@ -161,26 +163,41 @@ class VacancyRepository extends ServiceEntityRepository
     }
 
     /**
-     * Find the publicly visible vacancies for the public overview, narrowed by the optional filters (category, owning
-     * company, assigned labels and a free-text search over the localised name).
+     * The ids of the publicly visible vacancies for the public overview, narrowed by the optional filters (category,
+     * owning company, assigned labels and a free-text search over the localised name), in a fixed order.
      *
-     * This expresses the full "active" predicate ({@see Vacancy::isActive()}) in the query so the filters apply at the
-     * database level: the vacancy and its package must be published and the package within its active window, and the
-     * owning company must be published with an approved revision (an active package implies the company has a
-     * non-expired one, so {@see \App\Entity\Career\Company::isHidden()} reduces to those two checks here). Every
-     * association the card renders is fetch-joined to keep the page free of per-item lazy loads.
+     * The order is pinned rather than left to the database: the overview seeds a shuffle over this list and pages
+     * through it, which only holds together if the same seed always meets the same list. The page that ends up on
+     * screen is hydrated afterwards by {@see self::findForOverviewByIds()}.
      *
      * @param int[] $labelIds
      *
-     * @return Vacancy[]
+     * @return int[]
      */
-    public function findForOverview(
+    public function findActiveIdsForOverview(
         ?VacancyCategories $category = null,
         ?string $companySlugName = null,
         array $labelIds = [],
         string $search = '',
     ): array {
-        $qb = $this->activeVacancyQueryBuilder()
+        $qb = $this->createQueryBuilder('j')
+            ->select('j.id')
+            ->join(
+                'j.package',
+                'p',
+            )
+            ->join(
+                'p.company',
+                'c',
+            )
+            ->join(
+                'j.liveRevision',
+                'lr',
+            )
+            ->join(
+                'lr.name',
+                'name',
+            )
             ->orderBy(
                 'c.name',
                 'ASC',
@@ -189,6 +206,8 @@ class VacancyRepository extends ServiceEntityRepository
                 'j.id',
                 'ASC',
             );
+
+        $this->applyActivePredicate($qb);
 
         if (null !== $category) {
             $qb->andWhere('lr.category = :category')
@@ -237,7 +256,53 @@ class VacancyRepository extends ServiceEntityRepository
                 );
         }
 
-        return $qb->getQuery()->getResult();
+        return array_map(
+            'intval',
+            array_column(
+                $qb->getQuery()->getArrayResult(),
+                'id',
+            ),
+        );
+    }
+
+    /**
+     * Hydrate the given vacancies, in the order they are asked for. The "active" predicate is applied again, so a
+     * vacancy whose package expired between picking the ids and rendering them drops out rather than appearing one
+     * last time.
+     *
+     * @param int[] $ids
+     *
+     * @return Vacancy[]
+     */
+    public function findForOverviewByIds(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        $vacancies = $this->activeVacancyQueryBuilder()
+            ->indexBy(
+                'j',
+                'j.id',
+            )
+            ->andWhere('j.id IN (:ids)')
+            ->setParameter(
+                'ids',
+                $ids,
+            )
+            ->getQuery()
+            ->getResult();
+
+        $ordered = [];
+        foreach ($ids as $id) {
+            if (!isset($vacancies[$id])) {
+                continue;
+            }
+
+            $ordered[] = $vacancies[$id];
+        }
+
+        return $ordered;
     }
 
     /**
@@ -281,9 +346,9 @@ class VacancyRepository extends ServiceEntityRepository
      */
     public function countActiveByCategory(): array
     {
-        // A lean copy of the "active" predicate rather than `activeVacancyQueryBuilder()`, which fetch-joins
-        // everything a card renders and would drag all of that into a query that only counts.
-        $rows = $this->createQueryBuilder('j')
+        // The joins the predicate needs, but none of the fetch joins `activeVacancyQueryBuilder()` adds for the cards:
+        // this query only counts.
+        $qb = $this->createQueryBuilder('j')
             ->select(
                 'lr.category AS category',
                 'COUNT(j.id) AS total',
@@ -300,25 +365,9 @@ class VacancyRepository extends ServiceEntityRepository
                 'j.liveRevision',
                 'lr',
             )
-            ->where('j.published = true')
-            ->andWhere('p.published = true')
-            ->andWhere('p.starts <= :now')
-            ->andWhere('p.expires > :now')
-            ->andWhere('c.published = true')
-            ->andWhere('c.liveRevision IS NOT NULL')
-            ->andWhere('lr.startDate IS NULL OR lr.startDate <= :today')
-            ->andWhere('lr.endDate >= :today')
-            ->setParameter(
-                'now',
-                new DateTime(),
-                Types::DATETIME_MUTABLE,
-            )
-            ->setParameter(
-                'today',
-                new DateTime('today'),
-                Types::DATE_MUTABLE,
-            )
-            ->groupBy('lr.category')
+            ->groupBy('lr.category');
+
+        $rows = $this->applyActivePredicate($qb)
             ->getQuery()
             ->getArrayResult();
 
@@ -349,31 +398,46 @@ class VacancyRepository extends ServiceEntityRepository
                 'ASC',
             );
 
-        // An EXISTS rather than a selected join, so a vacancy picked by two packages is still listed once.
-        $subQuery = $this->getEntityManager()->createQueryBuilder()
-            ->select('1')
-            ->from(
-                CompanyHighlightPackage::class,
-                'highlight',
-            )
-            ->join(
-                'highlight.vacancies',
-                'highlighted',
-            )
-            ->where('highlighted = j')
-            ->andWhere('highlight.published = true')
-            ->andWhere('highlight.starts <= :now')
-            ->andWhere('highlight.expires > :now');
-
-        return $qb->andWhere($qb->expr()->exists($subQuery->getDQL()))
+        return $this->applyHighlightedPredicate($qb)
             ->getQuery()
             ->getResult();
     }
 
     /**
+     * @return int[]
+     */
+    public function findHighlightedIds(): array
+    {
+        $qb = $this->createQueryBuilder('j')
+            ->select('j.id')
+            ->join(
+                'j.package',
+                'p',
+            )
+            ->join(
+                'p.company',
+                'c',
+            )
+            ->join(
+                'j.liveRevision',
+                'lr',
+            );
+
+        $this->applyActivePredicate($qb);
+
+        return array_map(
+            'intval',
+            array_column(
+                $this->applyHighlightedPredicate($qb)->getQuery()->getArrayResult(),
+                'id',
+            ),
+        );
+    }
+
+    /**
      * Find a single publicly visible vacancy by its company, category and slug (the tuple that identifies it in a URL),
      * or null when it does not exist or is not currently active. Shares the "active" predicate and the fetch joins with
-     * {@see self::findForOverview()}, so the detail page renders without lazy loads.
+     * {@see self::findForOverviewByIds()}, so the detail page renders without lazy loads.
      */
     public function findPublicVacancy(
         string $companySlugName,
@@ -404,14 +468,11 @@ class VacancyRepository extends ServiceEntityRepository
 
     /**
      * The base query for publicly visible ("active") vacancies, with every association the cards and the detail page
-     * render fetch-joined. Expresses {@see Vacancy::isActive()} at the database level: the vacancy and its package must
-     * be published and the package within its active window, and the owning company published with an approved revision
-     * (an active package implies a non-expired one, so {@see \App\Entity\Career\Company::isHidden()} reduces to those
-     * two checks here). Callers add their own filters and ordering.
+     * render fetch-joined. Callers add their own filters and ordering.
      */
     private function activeVacancyQueryBuilder(): QueryBuilder
     {
-        return $this->createQueryBuilder('j')
+        $qb = $this->createQueryBuilder('j')
             ->join(
                 'j.package',
                 'p',
@@ -463,8 +524,46 @@ class VacancyRepository extends ServiceEntityRepository
                 'label.name',
                 'labelName',
             )
-            ->addSelect('labelName')
-            ->where('j.published = true')
+            ->addSelect('labelName');
+
+        return $this->applyActivePredicate($qb);
+    }
+
+    /**
+     * Narrow to what companies with a running highlight package have put forward, on a query builder that has the
+     * vacancy as `j`. An EXISTS rather than a selected join, so a vacancy picked by two packages is still listed once.
+     * Reads the `:now` parameter {@see self::applyActivePredicate()} sets, so it is applied after that one.
+     */
+    private function applyHighlightedPredicate(QueryBuilder $qb): QueryBuilder
+    {
+        $subQuery = $this->getEntityManager()->createQueryBuilder()
+            ->select('1')
+            ->from(
+                CompanyHighlightPackage::class,
+                'highlight',
+            )
+            ->join(
+                'highlight.vacancies',
+                'highlighted',
+            )
+            ->where('highlighted = j')
+            ->andWhere('highlight.published = true')
+            ->andWhere('highlight.starts <= :now')
+            ->andWhere('highlight.expires > :now');
+
+        return $qb->andWhere($qb->expr()->exists($subQuery->getDQL()));
+    }
+
+    /**
+     * Express {@see Vacancy::isActive()} at the database level, on a query builder that has the vacancy as `j`, its
+     * package as `p`, the owning company as `c` and the live revision as `lr`: the vacancy and its package must be
+     * published and the package within its active window, and the owning company published with an approved revision
+     * (an active package implies a non-expired one, so {@see \App\Entity\Career\Company::isHidden()} reduces to those
+     * two checks here).
+     */
+    private function applyActivePredicate(QueryBuilder $qb): QueryBuilder
+    {
+        return $qb->andWhere('j.published = true')
             ->andWhere('p.published = true')
             ->andWhere('p.starts <= :now')
             ->andWhere('p.expires > :now')

--- a/src/Service/Career/CompanyLogoReferenceProvider.php
+++ b/src/Service/Career/CompanyLogoReferenceProvider.php
@@ -11,8 +11,8 @@ use Override;
 
 /**
  * Keeps a company logo alive while any revision, in any approval chain, still points at its content-addressed path.
- * Cloning a revision carries the logo path forward by value, so several revisions share one physical file; the file may
- * only be reclaimed once the last referencing revision is gone.
+ * Cloning a revision carries both logo paths forward by value, so several revisions share one physical file; the file
+ * may only be reclaimed once the last referencing revision is gone.
  */
 final readonly class CompanyLogoReferenceProvider implements FileReferenceProviderInterface
 {
@@ -30,7 +30,7 @@ final readonly class CompanyLogoReferenceProvider implements FileReferenceProvid
                 CompanyRevision::class,
                 'revision',
             )
-            ->where('revision.logo = :path')
+            ->where('revision.squareLogo = :path OR revision.bannerLogo = :path')
             ->setParameter(
                 'path',
                 $path,

--- a/src/Service/Career/CompanyRevisionCloner.php
+++ b/src/Service/Career/CompanyRevisionCloner.php
@@ -52,7 +52,8 @@ final readonly class CompanyRevisionCloner extends AbstractRevisionCloner
         $draft->setSlogan($source->getSlogan()->copy());
         $draft->setDescription($source->getDescription()->copy());
         $draft->setWebsite($source->getWebsite()->copy());
-        $draft->setLogo($source->getLogo());
+        $draft->setSquareLogo($source->getSquareLogo());
+        $draft->setBannerLogo($source->getBannerLogo());
         $draft->setContactName($source->getContactName());
         $draft->setContactAddress($source->getContactAddress());
         $draft->setContactEmail($source->getContactEmail());

--- a/src/Service/Career/CompanyRevisionDescriber.php
+++ b/src/Service/Career/CompanyRevisionDescriber.php
@@ -96,17 +96,29 @@ final class CompanyRevisionDescriber extends AbstractRevisionDescriber
                 ],
             ),
             new RevisionSection(
-                t('Logo'),
+                t('Logos'),
                 [
                     $this->field(
-                        t('Logo'),
+                        t('Square logo'),
                         RevisionFieldKind::Image,
-                        $previous?->getLogo(),
-                        $revision->getLogo(),
+                        $previous?->getSquareLogo(),
+                        $revision->getSquareLogo(),
                         $comparable,
                         [
                             'variant' => 'w320',
-                            'class' => 'career-logo-sm',
+                            'class' => 'career-logo-lg',
+                        ],
+                        emptyLabel: t('No logo.'),
+                    ),
+                    $this->field(
+                        t('Banner logo'),
+                        RevisionFieldKind::Image,
+                        $previous?->getBannerLogo(),
+                        $revision->getBannerLogo(),
+                        $comparable,
+                        [
+                            'variant' => 'w640',
+                            'class' => 'career-logo-plate',
                         ],
                         emptyLabel: t('No logo.'),
                     ),

--- a/src/Twig/Components/Career/CompanyOverview.php
+++ b/src/Twig/Components/Career/CompanyOverview.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components\Career;
+
+use App\Entity\Career\Company;
+use App\Repository\Career\CompanyRepository;
+use Random\Engine\Mt19937;
+use Random\Randomizer;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+use function array_slice;
+use function count;
+use function mt_getrandmax;
+use function random_int;
+
+/**
+ * Backs the public company overview: a free-text search that mirrors itself into the query string, and infinite scroll
+ * that grows `limit` through the loadMore action.
+ *
+ * The companies are listed in a random order, so that no company is structurally favoured by being early in the
+ * alphabet. Paging through a list that is reshuffled on every request would show some companies twice and others not
+ * at all, so the order is drawn once, at mount, and carried along as a seed for as long as the visitor stays on the
+ * page. Reloading it deals a new hand.
+ */
+#[AsLiveComponent(
+    name: 'Career:CompanyOverview',
+    template: 'components/Career/CompanyOverview.html.twig',
+)]
+final class CompanyOverview
+{
+    use DefaultActionTrait;
+
+    public const int PAGE_SIZE = 12;
+
+    #[LiveProp(
+        writable: true,
+        url: true,
+    )]
+    public string $search = '';
+
+    // Neither is client-writable: they travel in the signed props, so a crafted request can neither reshuffle the list
+    // mid-page nor ask for an arbitrarily large page. The seed's ceiling keeps it inside the range JavaScript
+    // represents exactly, since the props go through JSON.parse in the browser and a rounded seed fails the checksum.
+    #[LiveProp]
+    public int $seed = 0;
+
+    #[LiveProp]
+    public int $limit = self::PAGE_SIZE;
+
+    /** @var int[]|null */
+    private ?array $ids = null;
+
+    /** @var Company[]|null */
+    private ?array $companies = null;
+
+    public function __construct(private readonly CompanyRepository $companyRepository)
+    {
+    }
+
+    public function mount(): void
+    {
+        $this->seed = random_int(
+            0,
+            mt_getrandmax(),
+        );
+    }
+
+    #[LiveAction]
+    public function loadMore(): void
+    {
+        $this->limit += self::PAGE_SIZE;
+    }
+
+    /**
+     * @return Company[]
+     */
+    public function getCompanies(): array
+    {
+        return $this->companies ??= $this->companyRepository->findPublicByIds(
+            array_slice(
+                $this->shuffledIds(),
+                0,
+                $this->limit,
+            ),
+        );
+    }
+
+    public function getTotalCount(): int
+    {
+        return count($this->matchingIds());
+    }
+
+    public function hasMore(): bool
+    {
+        return $this->getTotalCount() > count($this->getCompanies());
+    }
+
+    /**
+     * The matching companies in this visitor's order. A seeded Mt19937 rather than the global generator, so drawing
+     * this hand leaves the rest of the request's randomness alone.
+     *
+     * @return int[]
+     */
+    private function shuffledIds(): array
+    {
+        return new Randomizer(new Mt19937($this->seed))->shuffleArray($this->matchingIds());
+    }
+
+    /**
+     * @return int[]
+     */
+    private function matchingIds(): array
+    {
+        return $this->ids ??= $this->companyRepository->findPublicIds($this->search);
+    }
+}

--- a/src/Twig/Components/Career/VacancyOverview.php
+++ b/src/Twig/Components/Career/VacancyOverview.php
@@ -11,23 +11,37 @@ use App\Entity\Career\VacancyLabel;
 use App\Repository\Career\CompanyRepository;
 use App\Repository\Career\VacancyLabelRepository;
 use App\Repository\Career\VacancyRepository;
+use Random\Engine\Mt19937;
+use Random\Randomizer;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\LiveComponent\Metadata\UrlMapping;
 
 use function array_filter;
+use function array_intersect;
 use function array_map;
+use function array_slice;
 use function array_values;
+use function count;
 use function explode;
 use function is_array;
+use function mt_getrandmax;
+use function random_int;
 use function strval;
 
 /**
  * Backs the public vacancies overview: the whole filter set (category, owning company, labels and a free-text search)
  * lives here and mirrors itself into the query string, so the address bar is a shareable, reload-safe link. A company
- * card's per-category link lands here with `?category=...&company=...` pre-applied.
+ * card's per-category link lands here with `?category=...&company=...` pre-applied. Infinite scroll grows `limit`
+ * through the loadMore action.
+ *
+ * As on the company overview, the vacancies are listed in a random order, so that a company is not structurally
+ * favoured by where its name falls in the alphabet. The order is drawn once, at mount, and carried along as a seed for
+ * as long as the visitor stays on the page; without that, every filter keystroke and every loaded page would reshuffle
+ * the list under the reader. Reloading the page deals a new hand.
  */
 #[AsLiveComponent(
     name: 'Career:VacancyOverview',
@@ -36,6 +50,8 @@ use function strval;
 final class VacancyOverview
 {
     use DefaultActionTrait;
+
+    public const int PAGE_SIZE = 16;
 
     #[LiveProp(
         writable: true,
@@ -62,8 +78,26 @@ final class VacancyOverview
     )]
     public array $labelFilters = [];
 
+    // Neither is client-writable: they travel in the signed props, so a crafted request can neither reshuffle the list
+    // mid-page nor ask for an arbitrarily large page. The seed's ceiling keeps it inside the range JavaScript
+    // represents exactly, since the props go through JSON.parse in the browser and a rounded seed fails the checksum.
+    #[LiveProp]
+    public int $seed = 0;
+
+    #[LiveProp]
+    public int $limit = self::PAGE_SIZE;
+
+    /** @var int[]|null */
+    private ?array $ids = null;
+
+    /** @var int[]|null */
+    private ?array $highlights = null;
+
     /** @var Vacancy[]|null */
     private ?array $vacancies = null;
+
+    /** @var Vacancy[]|null */
+    private ?array $highlighted = null;
 
     /** @var VacancyLabel[]|null */
     private ?array $labels = null;
@@ -77,13 +111,19 @@ final class VacancyOverview
     }
 
     /**
-     * Pre-select the label filter from the query string on a full page load. ux-live-component v3 hydrates scalar
-     * url-mapped props server-side but leaves an array prop ({@see $labelFilters}) empty, and the filter panel is
-     * `data-live-ignore`, so the client-side sync never re-checks the boxes. Reading the ids here makes a shared or
-     * reloaded `?labels=` URL pre-select them. Runs only on the initial render, not on live re-renders.
+     * Draw this visitor's order, and pre-select the label filter from the query string on a full page load.
+     * ux-live-component v3 hydrates scalar url-mapped props server-side but leaves an array prop
+     * ({@see $labelFilters}) empty, and the filter panel is `data-live-ignore`, so the client-side sync never re-checks
+     * the boxes. Reading the ids here makes a shared or reloaded `?labels=` URL pre-select them. Runs only on the
+     * initial render, not on live re-renders.
      */
     public function mount(): void
     {
+        $this->seed = random_int(
+            0,
+            mt_getrandmax(),
+        );
+
         $request = $this->requestStack->getCurrentRequest();
         if (
             null === $request
@@ -103,21 +143,60 @@ final class VacancyOverview
         $this->labelFilters = self::positiveIntIds($values);
     }
 
+    #[LiveAction]
+    public function loadMore(): void
+    {
+        $this->limit += self::PAGE_SIZE;
+    }
+
     /**
      * @return Vacancy[]
      */
     public function getVacancies(): array
     {
-        return $this->vacancies ??= $this->vacancyRepository->findForOverview(
-            category: null !== $this->category
-                ? VacancyCategories::tryFrom($this->category)
-                : null,
-            companySlugName: '' !== (string) $this->companyFilter
-                ? $this->companyFilter
-                : null,
-            labelIds: self::positiveIntIds($this->labelFilters),
-            search: $this->search,
+        return $this->vacancies ??= $this->vacancyRepository->findForOverviewByIds(
+            array_slice(
+                $this->shuffledIds(),
+                0,
+                $this->limit,
+            ),
         );
+    }
+
+    /**
+     * The highlighted vacancies among the current results, for the strip above the grid. Narrowed by the filters, so
+     * filtering down to internships does not leave a highlighted full-time job sitting on top.
+     *
+     * @return Vacancy[]
+     */
+    public function getHighlightedVacancies(): array
+    {
+        return $this->highlighted ??= $this->vacancyRepository->findForOverviewByIds(
+            array_values(
+                array_intersect(
+                    $this->shuffledIds(),
+                    $this->highlightedIds(),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getHighlightedIds(): array
+    {
+        return $this->highlightedIds();
+    }
+
+    public function getTotalCount(): int
+    {
+        return count($this->matchingIds());
+    }
+
+    public function hasMore(): bool
+    {
+        return $this->getTotalCount() > count($this->getVacancies());
     }
 
     /**
@@ -148,8 +227,44 @@ final class VacancyOverview
     }
 
     /**
+     * The matching vacancies in this visitor's order. A seeded Mt19937 rather than the global generator, so drawing
+     * this hand leaves the rest of the request's randomness alone.
+     *
+     * @return int[]
+     */
+    private function shuffledIds(): array
+    {
+        return new Randomizer(new Mt19937($this->seed))->shuffleArray($this->matchingIds());
+    }
+
+    /**
+     * @return int[]
+     */
+    private function highlightedIds(): array
+    {
+        return $this->highlights ??= $this->vacancyRepository->findHighlightedIds();
+    }
+
+    /**
+     * @return int[]
+     */
+    private function matchingIds(): array
+    {
+        return $this->ids ??= $this->vacancyRepository->findActiveIdsForOverview(
+            category: null !== $this->category
+                ? VacancyCategories::tryFrom($this->category)
+                : null,
+            companySlugName: '' !== (string) $this->companyFilter
+                ? $this->companyFilter
+                : null,
+            labelIds: self::positiveIntIds($this->labelFilters),
+            search: $this->search,
+        );
+    }
+
+    /**
      * Normalise a raw list of label-id values into a clean, re-indexed list of positive ints (dropping blanks, zero and
-     * negatives). Shared by mount() (query-string parsing) and getVacancies() (filtering) so the two can never drift.
+     * negatives). Shared by mount() (query-string parsing) and matchingIds() (filtering) so the two can never drift.
      *
      * @param array<mixed> $values
      *

--- a/src/Twig/Extensions/CareerExtension.php
+++ b/src/Twig/Extensions/CareerExtension.php
@@ -17,7 +17,9 @@ use Symfony\Contracts\Service\ResetInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+use function array_slice;
 use function array_sum;
+use function shuffle;
 
 /**
  * The navigation menu asks for the counts and the featured company on every page, and the career pages ask for the
@@ -124,11 +126,25 @@ class CareerExtension extends AbstractExtension implements ResetInterface
     /**
      * Everything companies with a running highlight package have chosen to put forward, and that is still showable.
      *
+     * Shuffled, and cut down to $limit where one is given: the space was sold to each of these companies alike, so
+     * neither the first slot nor making the cut at all may come down to the alphabet.
+     *
      * @return Vacancy[]
      */
-    public function getHighlightedVacancies(): array
+    public function getHighlightedVacancies(?int $limit = null): array
     {
-        return $this->vacancyRepository->findHighlighted();
+        $vacancies = $this->vacancyRepository->findHighlighted();
+        shuffle($vacancies);
+
+        if (null === $limit) {
+            return $vacancies;
+        }
+
+        return array_slice(
+            $vacancies,
+            0,
+            $limit,
+        );
     }
 
     /**

--- a/templates/career/companies.html.twig
+++ b/templates/career/companies.html.twig
@@ -18,15 +18,14 @@
         {% for company in companies %}
             <div class="col">
                 <div class="card company-card h-100">
-                    <a href="{{ path('career/company', {slug: company.getSlugName}) }}"
-                       class="card-img-top d-flex align-items-center justify-content-center bg-body-secondary text-decoration-none overflow-hidden"
-                       style="height: 8rem;">
-                        {% if company.getLogo %}
-                            <img class="w-100 h-100" style="object-fit: contain;" loading="lazy"
-                                 src="{{ image_url(company.getLogo, 'w640') }}" alt="{{ company.getName }}">
-                        {% else %}
-                            <span class="display-6 text-muted">{{ company.getName|slice(0, 1)|upper }}</span>
-                        {% endif %}
+                    <a class="card-img-top text-decoration-none"
+                       href="{{ path('career/company', {slug: company.getSlugName}) }}">
+                        {% include 'partials/career/logo.html.twig' with {
+                            'logo': company.getBannerLogo,
+                            'name': company.getName,
+                            'class': 'career-logo-plate',
+                            'alt': company.getName,
+                        } only %}
                     </a>
                     <div class="card-body">
                         <h5 class="card-title mb-1">

--- a/templates/career/companies.html.twig
+++ b/templates/career/companies.html.twig
@@ -8,53 +8,11 @@
 {% endblock %}
 
 {% block contents %}
-    <h2 class="mb-4">{{ 'Companies'|trans }}</h2>
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <h2 class="mb-0">{{ 'Companies'|trans }}</h2>
 
-    {% if companies is empty %}
-        <p class="text-muted">{{ 'There are currently no companies to display.'|trans }}</p>
-    {% endif %}
-
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4">
-        {% for company in companies %}
-            <div class="col">
-                <div class="card company-card h-100">
-                    <a class="card-img-top text-decoration-none"
-                       href="{{ path('career/company', {slug: company.getSlugName}) }}">
-                        {% include 'partials/career/logo.html.twig' with {
-                            'logo': company.getBannerLogo,
-                            'name': company.getName,
-                            'class': 'career-logo-plate',
-                            'alt': company.getName,
-                        } only %}
-                    </a>
-                    <div class="card-body">
-                        <h5 class="card-title mb-1">
-                            <a href="{{ path('career/company', {slug: company.getSlugName}) }}">
-                                {{ company.getName }}
-                            </a>
-                        </h5>
-                        {% set slogan = company.getSlogan|localise_text %}
-                        {% if slogan is not empty %}
-                            <h6 class="card-subtitle text-muted fw-normal mb-0">{{ slogan }}</h6>
-                        {% endif %}
-                    </div>
-                    <ul class="list-group list-group-flush">
-                        {% for category in vacancy_categories() %}
-                            {% set amount = company.getNumberOfActiveJobs(category) %}
-                            {% if amount > 0 %}
-                                <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
-                                   href="{{ path('career/vacancies', {category: category.value, company: company.getSlugName}) }}">
-                                    {{ (amount == 1 ? category.label : category.pluralLabel)|trans }}
-                                    <span class="badge badge-tag">{{ amount }}</span>
-                                </a>
-                            {% endif %}
-                        {% endfor %}
-                        {% if company.getNumberOfActiveJobs() == 0 %}
-                            <li class="list-group-item text-muted small">{{ 'No open vacancies'|trans }}</li>
-                        {% endif %}
-                    </ul>
-                </div>
-            </div>
-        {% endfor %}
+        {% include 'partials/filter-toggle.html.twig' with { target: 'company-filters' } only %}
     </div>
+
+    {{ component('Career:CompanyOverview') }}
 {% endblock %}

--- a/templates/career/company.html.twig
+++ b/templates/career/company.html.twig
@@ -14,15 +14,12 @@
     <div class="row g-4">
         <div class="col-lg-4 col-xl-3">
             <div class="card company-card mb-4">
-                <div class="card-img-top d-flex align-items-center justify-content-center bg-body-secondary overflow-hidden"
-                     style="height: 10rem;">
-                    {% if company.getLogo %}
-                        <img class="w-100 h-100" style="object-fit: contain;"
-                             src="{{ image_url(company.getLogo, 'w640') }}" alt="{{ company.getName }}">
-                    {% else %}
-                        <span class="display-5 text-muted">{{ company.getName|slice(0, 1)|upper }}</span>
-                    {% endif %}
-                </div>
+                {% include 'partials/career/logo.html.twig' with {
+                    'logo': company.getBannerLogo,
+                    'name': company.getName,
+                    'class': 'career-logo-plate',
+                    'alt': company.getName,
+                } only %}
                 {% if
                     company.getContactName is not null
                     or company.getContactAddress is not null

--- a/templates/career/company/profile.html.twig
+++ b/templates/career/company/profile.html.twig
@@ -59,8 +59,13 @@
                             {{ 'Nothing yet: your profile has not been approved, so your company is not shown on the website.'|trans }}
                         </p>
                     {% else %}
-                        {% if live.logo is not null %}
-                            <img class="career-logo-sm mb-3" style="object-fit: cover;" src="{{ image_url(live.logo, 'w320') }}" alt="">
+                        {% if live.squareLogo is not null %}
+                            <img class="career-logo career-logo-lg mb-3"
+                                 src="{{ image_url(live.squareLogo, 'w320') }}" alt="">
+                        {% endif %}
+                        {% if live.bannerLogo is not null %}
+                            <img class="career-logo career-logo-plate mb-3"
+                                 src="{{ image_url(live.bannerLogo, 'w640') }}" alt="">
                         {% endif %}
                         <dl class="row mb-0">
                             <dt class="col-sm-3">{{ 'Slogan'|trans }}</dt>

--- a/templates/career/index.html.twig
+++ b/templates/career/index.html.twig
@@ -62,6 +62,25 @@
 {% block contents %}
     <div class="row g-4">
         <div class="col-lg-8">
+            {% set highlighted = highlighted_vacancies(4) %}
+            {% if highlighted is not empty %}
+                <div class="d-flex flex-wrap justify-content-between align-items-baseline gap-2 mb-3">
+                    <h3 class="mb-0">
+                        <span class="fas fa-star career-featured-kicker small" aria-hidden="true"></span>
+                        {{ 'Highlighted vacancies'|trans }}
+                    </h3>
+                </div>
+
+                <div class="row row-cols-1 row-cols-md-2 g-3 mb-4">
+                    {% for vacancy in highlighted %}
+                        {% include 'partials/career/vacancy-card.html.twig' with {
+                            'vacancy': vacancy,
+                            'highlighted': true,
+                        } only %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+
             <div class="d-flex flex-wrap justify-content-between align-items-baseline gap-2 mb-3">
                 <h3 class="mb-0">{{ 'Latest vacancies'|trans }}</h3>
                 <a href="{{ path('career/vacancies') }}" class="fw-semibold">

--- a/templates/career/index.html.twig
+++ b/templates/career/index.html.twig
@@ -75,12 +75,11 @@
                     {% set company = vacancy.getCompany %}
                     <div class="panel panel-surface {{ loop.first ? 'mt-0' : '' }}">
                         <div class="panel-body d-flex gap-3">
-                            {% if company.getLogo %}
-                                <img class="career-logo-sm" style="object-fit: cover;" loading="lazy"
-                                     src="{{ image_url(company.getLogo, 'w320') }}" alt="">
-                            {% else %}
-                                <span class="career-logo career-logo-sm" aria-hidden="true">{{ company.getName|slice(0, 1)|upper }}</span>
-                            {% endif %}
+                            {% include 'partials/career/logo.html.twig' with {
+                                'logo': company.getSquareLogo,
+                                'name': company.getName,
+                                'class': 'career-logo-sm',
+                            } only %}
                             <div class="flex-grow-1 overflow-hidden">
                                 <h5 class="mb-0">
                                     <a class="stretched-link" href="{{ path('career/vacancy', {
@@ -128,12 +127,11 @@
                     <div class="col">
                         <div class="panel panel-surface h-100 my-0">
                             <div class="panel-body d-flex align-items-center gap-3">
-                                {% if company.getLogo %}
-                                    <img class="career-logo-xs" style="object-fit: cover;" loading="lazy"
-                                         src="{{ image_url(company.getLogo, 'w320') }}" alt="">
-                                {% else %}
-                                    <span class="career-logo career-logo-xs" aria-hidden="true">{{ company.getName|slice(0, 1)|upper }}</span>
-                                {% endif %}
+                                {% include 'partials/career/logo.html.twig' with {
+                                    'logo': company.getSquareLogo,
+                                    'name': company.getName,
+                                    'class': 'career-logo-xs',
+                                } only %}
                                 <div class="overflow-hidden">
                                     <span class="career-company-name">
                                         <a class="stretched-link text-body"
@@ -166,14 +164,12 @@
                 {% set featuredCompany = featuredPackage.getCompany %}
                 {% set featuredOpenings = featuredCompany.getNumberOfActiveJobs() %}
                 <div class="panel mt-0">
-                    <div class="career-featured-banner">
-                        {% if featuredCompany.getLogo %}
-                            <img loading="lazy" src="{{ image_url(featuredCompany.getLogo, 'w640') }}"
-                                 alt="{{ featuredCompany.getName }}">
-                        {% else %}
-                            <span class="career-logo career-logo-lg" aria-hidden="true">{{ featuredCompany.getName|slice(0, 1)|upper }}</span>
-                        {% endif %}
-                    </div>
+                    {% include 'partials/career/logo.html.twig' with {
+                        'logo': featuredCompany.getBannerLogo,
+                        'name': featuredCompany.getName,
+                        'class': 'career-logo-plate',
+                        'alt': featuredCompany.getName,
+                    } only %}
                     <div class="panel-body">
                         <span class="page-header-eyebrow career-featured-kicker">
                             <span class="fas fa-star" aria-hidden="true"></span> {{ 'Featured this month'|trans }}

--- a/templates/career/vacancy.html.twig
+++ b/templates/career/vacancy.html.twig
@@ -21,9 +21,12 @@
     <div class="row g-4">
         <div class="col-lg-4 col-xl-3">
             <div class="card company-card mb-4">
-                <div class="card-img-top d-flex align-items-center justify-content-center bg-body-secondary py-5">
-                    <span class="display-5 text-muted">{{ company.getName|slice(0, 1)|upper }}</span>
-                </div>
+                {% include 'partials/career/logo.html.twig' with {
+                    'logo': company.getBannerLogo,
+                    'name': company.getName,
+                    'class': 'career-logo-plate',
+                    'alt': company.getName,
+                } only %}
                 <div class="card-body">
                     <p class="mb-1">
                         <a href="{{ path('career/company', {slug: company.getSlugName}) }}">{{ company.getName }}</a>

--- a/templates/components/Career/CompanyOverview.html.twig
+++ b/templates/components/Career/CompanyOverview.html.twig
@@ -1,0 +1,80 @@
+<div {{ attributes }}>
+    <div class="collapse mb-3" id="company-filters">
+        <div class="panel my-0">
+            <div class="panel-body">
+                <div class="row g-3 align-items-end">
+                    <div class="col-md-4">
+                        <label class="form-label" for="company-overview-search">{{ 'Search'|trans }}</label>
+                        <input type="search" class="form-control" id="company-overview-search"
+                               placeholder="{{ 'Search by company name'|trans }}"
+                               data-model="debounce(300)|search"
+                               value="{{ this.search }}">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if this.companies is empty %}
+        {% if this.search is empty %}
+            <p class="text-muted text-center py-4">{{ 'There are currently no companies to display.'|trans }}</p>
+        {% else %}
+            <p class="text-muted text-center py-4">{{ 'No companies match the current search.'|trans }}</p>
+        {% endif %}
+    {% else %}
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4">
+            {% for company in this.companies %}
+                <div class="col">
+                    <div class="card company-card h-100">
+                        <a class="card-img-top text-decoration-none"
+                           href="{{ path('career/company', {slug: company.getSlugName}) }}">
+                            {% include 'partials/career/logo.html.twig' with {
+                                'logo': company.getBannerLogo,
+                                'name': company.getName,
+                                'class': 'career-logo-plate',
+                                'alt': company.getName,
+                            } only %}
+                        </a>
+                        <div class="card-body">
+                            <h5 class="card-title mb-1">
+                                <a href="{{ path('career/company', {slug: company.getSlugName}) }}">
+                                    {{ company.getName }}
+                                </a>
+                            </h5>
+                            {% set slogan = company.getSlogan|localise_text %}
+                            {% if slogan is not empty %}
+                                <h6 class="card-subtitle text-muted fw-normal mb-0">{{ slogan }}</h6>
+                            {% endif %}
+                        </div>
+                        <ul class="list-group list-group-flush">
+                            {% for category in vacancy_categories() %}
+                                {% set amount = company.getNumberOfActiveJobs(category) %}
+                                {% if amount > 0 %}
+                                    <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                                       href="{{ path('career/vacancies', {category: category.value, company: company.getSlugName}) }}">
+                                        {{ (amount == 1 ? category.label : category.pluralLabel)|trans }}
+                                        <span class="badge badge-tag">{{ amount }}</span>
+                                    </a>
+                                {% endif %}
+                            {% endfor %}
+                            {% if company.getNumberOfActiveJobs() == 0 %}
+                                <li class="list-group-item text-muted small">{{ 'No open vacancies'|trans }}</li>
+                            {% endif %}
+                        </ul>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    {% if this.hasMore %}
+        <div data-controller="infinite-scroll" class="text-center py-3">
+            <button type="button" class="btn btn-outline-secondary"
+                    data-action="live#action" data-live-action-param="loadMore"
+                    data-infinite-scroll-target="button">
+                {{ 'Load more'|trans }}
+            </button>
+            <div data-infinite-scroll-target="sentinel" aria-hidden="true"></div>
+        </div>
+    {% endif %}
+</div>

--- a/templates/components/Career/VacancyOverview.html.twig
+++ b/templates/components/Career/VacancyOverview.html.twig
@@ -54,13 +54,47 @@
         </div>
     </div>
 
+    {% set highlightedIds = this.highlightedIds %}
+
+    {% if this.highlightedVacancies is not empty %}
+        <h3 class="h5 mb-3">
+            <span class="fas fa-star career-featured-kicker small" aria-hidden="true"></span>
+            {{ 'Highlighted'|trans }}
+        </h3>
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4 mb-4">
+            {% for vacancy in this.highlightedVacancies %}
+                {% include 'partials/career/vacancy-card.html.twig' with {
+                    'vacancy': vacancy,
+                    'highlighted': true,
+                } only %}
+            {% endfor %}
+        </div>
+    {% endif %}
+
     {% if this.vacancies is empty %}
         <p class="text-muted text-center py-4">{{ 'No vacancies match the current filters.'|trans }}</p>
     {% else %}
+        {% if this.highlightedVacancies is not empty %}
+            <h3 class="h5 mb-3">{{ 'All vacancies'|trans }}</h3>
+        {% endif %}
         <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4">
             {% for vacancy in this.vacancies %}
-                {% include 'partials/career/vacancy-card.html.twig' with {'vacancy': vacancy} only %}
+                {% include 'partials/career/vacancy-card.html.twig' with {
+                    'vacancy': vacancy,
+                    'highlighted': vacancy.getId in highlightedIds,
+                } only %}
             {% endfor %}
+        </div>
+    {% endif %}
+
+    {% if this.hasMore %}
+        <div data-controller="infinite-scroll" class="text-center py-3">
+            <button type="button" class="btn btn-outline-secondary"
+                    data-action="live#action" data-live-action-param="loadMore"
+                    data-infinite-scroll-target="button">
+                {{ 'Load more'|trans }}
+            </button>
+            <div data-infinite-scroll-target="sentinel" aria-hidden="true"></div>
         </div>
     {% endif %}
 </div>

--- a/templates/partials/application/main-nav.html.twig
+++ b/templates/partials/application/main-nav.html.twig
@@ -229,7 +229,7 @@
                                 <li>
                                     <a href="{{ path('career/company', {slug: featuredPackage.getCompany.getSlugName}) }}"
                                        class="dropdown-item">
-                                        <span class="career-logo nav-menu-monogram" aria-hidden="true">
+                                        <span class="career-logo career-logo-monogram nav-menu-monogram" aria-hidden="true">
                                             {{ featuredPackage.getCompany.getName|slice(0, 1)|upper }}
                                         </span>
                                         <span class="nav-menu-label">{{ featuredPackage.getCompany.getName }}</span>

--- a/templates/partials/career/admin/company-tabs.html.twig
+++ b/templates/partials/career/admin/company-tabs.html.twig
@@ -11,7 +11,11 @@
 #}
 <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-3">
     <div class="d-flex align-items-center gap-3">
-        <span class="career-logo career-logo-sm" aria-hidden="true">{{ company.name|slice(0, 1)|upper }}</span>
+        {% include 'partials/career/logo.html.twig' with {
+            'logo': company.getSquareLogo,
+            'name': company.name,
+            'class': 'career-logo-sm',
+        } only %}
         <span>
             <h3 class="mb-0">{{ company.name }}</h3>
             <code class="small">{{ company.slugName }}</code>

--- a/templates/partials/career/company-form.html.twig
+++ b/templates/partials/career/company-form.html.twig
@@ -55,11 +55,17 @@
                         <h3>{{ 'Logo'|trans }}</h3>
                     </div>
                     <div class="panel-body">
-                        {% if form.currentRevision.vars.data is not null and form.currentRevision.vars.data.logo is not null %}
-                            <img class="career-logo-sm mb-3" style="object-fit: cover;"
-                                 src="{{ image_url(form.currentRevision.vars.data.logo, 'w320') }}" alt="">
+                        {% set revision = form.currentRevision.vars.data %}
+                        {% if revision is not null and revision.squareLogo is not null %}
+                            <img class="career-logo career-logo-lg mb-3"
+                                 src="{{ image_url(revision.squareLogo, 'w320') }}" alt="">
                         {% endif %}
-                        {{ form_row(form.currentRevision.logoFile) }}
+                        {{ form_row(form.currentRevision.squareLogoFile) }}
+                        {% if revision is not null and revision.bannerLogo is not null %}
+                            <img class="career-logo career-logo-plate mb-3"
+                                 src="{{ image_url(revision.bannerLogo, 'w640') }}" alt="">
+                        {% endif %}
+                        {{ form_row(form.currentRevision.bannerLogoFile) }}
                     </div>
                 </div>
             </div>

--- a/templates/partials/career/logo.html.twig
+++ b/templates/partials/career/logo.html.twig
@@ -1,0 +1,15 @@
+{#
+    A company's logo, or the monogram it falls back to without one:
+
+    {% include 'partials/career/logo.html.twig' with {'logo': company.getLogo, 'name': company.getName, 'class': 'career-logo-sm'} only %}
+
+    Pass `alt` where the logo is the only thing naming the company.
+#}
+{% if logo is not empty %}
+    <img class="career-logo {{ class }}"
+         loading="lazy"
+         alt="{{ alt|default('') }}"
+         src="{{ image_url(logo, 'w320') }}">
+{% else %}
+    <span class="career-logo career-logo-monogram {{ class }}" aria-hidden="true">{{ name|slice(0, 1)|upper }}</span>
+{% endif %}

--- a/templates/partials/career/vacancy-card.html.twig
+++ b/templates/partials/career/vacancy-card.html.twig
@@ -10,12 +10,11 @@
     <div class="card company-card h-100">
         <div class="card-body d-flex flex-column gap-2">
             <div class="d-flex align-items-center gap-2">
-                {% if company.getLogo %}
-                    <img class="career-logo-sm" style="object-fit: cover;" loading="lazy"
-                         src="{{ image_url(company.getLogo, 'w320') }}" alt="{{ company.getName }}">
-                {% else %}
-                    <span class="career-logo career-logo-sm">{{ company.getName|slice(0, 1)|upper }}</span>
-                {% endif %}
+                {% include 'partials/career/logo.html.twig' with {
+                    'logo': company.getSquareLogo,
+                    'name': company.getName,
+                    'class': 'career-logo-sm',
+                } only %}
                 <div>
                     <h6 class="card-title mb-0">
                         <a href="{{ vacancyUrl }}" class="stretched-link">{{ vacancy.getName|localise_text }}</a>

--- a/templates/partials/career/vacancy-card.html.twig
+++ b/templates/partials/career/vacancy-card.html.twig
@@ -1,4 +1,10 @@
+{#
+    A vacancy as a card. Pass `highlighted` to mark it as one a company has a running highlight package behind:
+
+    {% include 'partials/career/vacancy-card.html.twig' with {'vacancy': vacancy, 'highlighted': true} only %}
+#}
 {% set company = vacancy.getCompany %}
+{% set highlighted = highlighted|default(false) %}
 {% set vacancyUrl = path('career/vacancy', {
     companySlug: company.getSlugName,
     category: vacancy.getCategory.value,
@@ -7,8 +13,13 @@
 <div class="col">
     {# The title's stretched-link makes the whole card open the vacancy. The company link needs position-relative and
        z-2 to stay clickable on top of it. #}
-    <div class="card company-card h-100">
+    <div class="card company-card h-100{{ highlighted ? ' vacancy-card-highlighted' : '' }}">
         <div class="card-body d-flex flex-column gap-2">
+            {% if highlighted %}
+                <span class="page-header-eyebrow career-featured-kicker">
+                    <span class="fas fa-star" aria-hidden="true"></span> {{ 'Highlighted'|trans }}
+                </span>
+            {% endif %}
             <div class="d-flex align-items-center gap-2">
                 {% include 'partials/career/logo.html.twig' with {
                     'logo': company.getSquareLogo,

--- a/tests/Form/Career/CompanyTypeTest.php
+++ b/tests/Form/Career/CompanyTypeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Form\Career;
 
 use App\Entity\Career\Company;
+use App\Entity\Career\CompanyRevision;
 use App\Form\Application\LocalisedTextType;
 use App\Form\Career\CompanyRevisionType;
 use App\Form\Career\CompanyType;
@@ -14,6 +15,7 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Validation;
@@ -97,7 +99,7 @@ final class CompanyTypeTest extends TypeTestCase
         self::assertTrue($form->has('currentRevision'));
     }
 
-    public function testTheContentAndTheLogoUploadAreOfferedToBothAudiences(): void
+    public function testTheContentAndBothLogoUploadsAreOfferedToBothAudiences(): void
     {
         $revision = $this->factory->create(
             CompanyType::class,
@@ -113,7 +115,8 @@ final class CompanyTypeTest extends TypeTestCase
                 'contactEmail',
                 'contactPhone',
                 'contactAddress',
-                'logoFile',
+                'squareLogoFile',
+                'bannerLogoFile',
                 'languageDutch',
                 'languageEnglish',
             ] as $field
@@ -123,6 +126,60 @@ final class CompanyTypeTest extends TypeTestCase
                 $field,
             );
         }
+    }
+
+    public function testBothLogosAreDemandedUntilTheProfileCarriesThem(): void
+    {
+        $company = new Company();
+        $revision = new CompanyRevision();
+        $company->addRevision($revision);
+        $company->setCurrentRevision($revision);
+
+        foreach (
+            [
+                'squareLogoFile',
+                'bannerLogoFile',
+            ] as $field
+        ) {
+            self::assertTrue(
+                $this->logoField(
+                    $company,
+                    $field,
+                )->getConfig()->getRequired(),
+                $field,
+            );
+        }
+
+        $revision->setSquareLogo('career/1/images/square.png');
+        $revision->setBannerLogo('career/1/images/banner.png');
+
+        foreach (
+            [
+                'squareLogoFile',
+                'bannerLogoFile',
+            ] as $field
+        ) {
+            self::assertFalse(
+                $this->logoField(
+                    $company,
+                    $field,
+                )->getConfig()->getRequired(),
+                $field,
+            );
+        }
+    }
+
+    /**
+     * @return FormInterface<mixed>
+     */
+    private function logoField(
+        Company $company,
+        string $field,
+    ): FormInterface {
+        return $this->factory->create(
+            CompanyType::class,
+            $company,
+        )->get('currentRevision')->get($field);
     }
 
     /**

--- a/tests/Integration/LiveComponent/Application/PaginatedOverviewTest.php
+++ b/tests/Integration/LiveComponent/Application/PaginatedOverviewTest.php
@@ -11,6 +11,7 @@ use App\Twig\Components\Career\Admin\CompanyOverview;
 
 use function array_intersect;
 use function array_map;
+use function min;
 use function sprintf;
 
 /**
@@ -43,7 +44,11 @@ final class PaginatedOverviewTest extends DatabaseTestCase
         $this->seedCompanies(15);
         $overview = $this->overview();
         $firstPage = $this->names($overview);
-        $expected = $overview->getTotalCount() - 10;
+        $pageSize = CompanyOverview::PAGE_SIZES[0];
+        $expected = min(
+            $pageSize,
+            $overview->getTotalCount() - $pageSize,
+        );
 
         $overview->gotoPage(2);
 
@@ -83,7 +88,7 @@ final class PaginatedOverviewTest extends DatabaseTestCase
         $overview->pageSize = 7;
 
         self::assertCount(
-            10,
+            CompanyOverview::PAGE_SIZES[0],
             $overview->getRows(),
         );
     }

--- a/tests/Integration/Repository/Career/VacancyRepositoryTest.php
+++ b/tests/Integration/Repository/Career/VacancyRepositoryTest.php
@@ -84,8 +84,10 @@ final class VacancyRepositoryTest extends DatabaseTestCase
      */
     private function slugsOnTheOverview(): array
     {
+        $repository = $this->repository();
+
         $slugs = [];
-        foreach ($this->repository()->findForOverview() as $vacancy) {
+        foreach ($repository->findForOverviewByIds($repository->findActiveIdsForOverview()) as $vacancy) {
             $slugs[] = $vacancy->getSlugName();
         }
 

--- a/tests/Integration/Service/Application/RevisionDescriberRegistryTest.php
+++ b/tests/Integration/Service/Application/RevisionDescriberRegistryTest.php
@@ -42,7 +42,7 @@ final class RevisionDescriberRegistryTest extends DatabaseTestCase
         );
     }
 
-    public function testACompanyDescribesItselfIncludingTheLogoItsOwnScreenUsedToLeaveOut(): void
+    public function testACompanyDescribesItselfIncludingTheLogosItsOwnScreenUsedToLeaveOut(): void
     {
         $company = $this->entityManager->getRepository(Company::class)->findOneBy(['slugName' => 'nexunt']);
         self::assertInstanceOf(
@@ -56,12 +56,13 @@ final class RevisionDescriberRegistryTest extends DatabaseTestCase
             [
                 'Profile',
                 'Contact details',
-                'Logo',
+                'Logos',
             ],
             $this->headings($revision),
         );
         self::assertSame(
             [
+                RevisionFieldKind::Image,
                 RevisionFieldKind::Image,
             ],
             array_map(

--- a/tests/Integration/Service/FileReferenceProviderTest.php
+++ b/tests/Integration/Service/FileReferenceProviderTest.php
@@ -29,12 +29,14 @@ final class FileReferenceProviderTest extends DatabaseTestCase
             $revision,
             'The seed is expected to contain a company revision.',
         );
-        $revision->setLogo('career/1/images/reference-test.png');
+        $revision->setSquareLogo('career/1/images/reference-test.png');
+        $revision->setBannerLogo('career/1/images/banner-reference-test.png');
         $this->entityManager->flush();
 
         $provider = new CompanyLogoReferenceProvider($this->entityManager);
 
         self::assertTrue($provider->references('career/1/images/reference-test.png'));
+        self::assertTrue($provider->references('career/1/images/banner-reference-test.png'));
         self::assertFalse($provider->references('career/1/images/not-referenced.png'));
     }
 
@@ -109,7 +111,7 @@ final class FileReferenceProviderTest extends DatabaseTestCase
             CompanyRevision::class,
             $revision,
         );
-        $revision->setLogo('career/1/images/still-referenced.png');
+        $revision->setSquareLogo('career/1/images/still-referenced.png');
         $this->entityManager->flush();
 
         // The provider is auto-tagged, so FileStorage must refuse to unlink a file a revision still references.

--- a/tests/Service/Career/CompanyRevisionClonerTest.php
+++ b/tests/Service/Career/CompanyRevisionClonerTest.php
@@ -90,8 +90,12 @@ final class CompanyRevisionClonerTest extends TestCase
         );
 
         self::assertSame(
-            'logo.png',
-            $draft->getLogo(),
+            'square.png',
+            $draft->getSquareLogo(),
+        );
+        self::assertSame(
+            'banner.png',
+            $draft->getBannerLogo(),
         );
         self::assertSame(
             'Jane Doe',
@@ -153,7 +157,8 @@ final class CompanyRevisionClonerTest extends TestCase
             'https://example.com/en',
             'https://example.com/nl',
         ));
-        $source->setLogo('logo.png');
+        $source->setSquareLogo('square.png');
+        $source->setBannerLogo('banner.png');
         $source->setContactName('Jane Doe');
         $source->setContactAddress('Street 1');
         $source->setContactEmail('jane@example.com');

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -721,6 +721,10 @@
         <source>All subscribers</source>
         <target>All subscribers</target>
       </trans-unit>
+      <trans-unit id="gOiJzr7" resname="All vacancies">
+        <source>All vacancies</source>
+        <target state="translated">All vacancies</target>
+      </trans-unit>
       <trans-unit id="CdVO0Gm" resname="All years">
         <source>All years</source>
         <target state="translated">All years</target>
@@ -2472,6 +2476,14 @@
       <trans-unit id="Z_zbkeN" resname="Highlight">
         <source>Highlight</source>
         <target state="translated">Highlight</target>
+      </trans-unit>
+      <trans-unit id="RUMuLpj" resname="Highlighted">
+        <source>Highlighted</source>
+        <target state="translated">Highlighted</target>
+      </trans-unit>
+      <trans-unit id="XdAlCJ6" resname="Highlighted vacancies">
+        <source>Highlighted vacancies</source>
+        <target state="translated">Highlighted vacancies</target>
       </trans-unit>
       <trans-unit id="tSusVTR" resname="Highlights">
         <source>Highlights</source>
@@ -4592,6 +4604,10 @@
       <trans-unit id="8fyPK38" resname="Search by code or name">
         <source>Search by code or name</source>
         <target state="translated">Search by code or name</target>
+      </trans-unit>
+      <trans-unit id="XjL6auo" resname="Search by company name">
+        <source>Search by company name</source>
+        <target state="translated">Search by company name</target>
       </trans-unit>
       <trans-unit id="YWrWXBq" resname="Search by company, representative name, or email">
         <source>Search by company, representative name, or email</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -981,6 +981,10 @@
         <source>Banner</source>
         <target state="translated">Banner</target>
       </trans-unit>
+      <trans-unit id="rep8aq2" resname="Banner logo">
+        <source>Banner logo</source>
+        <target state="translated">Banner logo</target>
+      </trans-unit>
       <trans-unit id="LNfw4H_" resname="Banners">
         <source>Banners</source>
         <target state="translated">Banners</target>
@@ -2952,6 +2956,10 @@
       <trans-unit id="1TFZ._Z" resname="Logo, story and contact">
         <source>Logo, story and contact</source>
         <target state="translated">Logo, story and contact</target>
+      </trans-unit>
+      <trans-unit id="5CIt_FZ" resname="Logos">
+        <source>Logos</source>
+        <target state="translated">Logos</target>
       </trans-unit>
       <trans-unit id="4E407bE" resname="Logos and templates">
         <source>Logos and templates</source>
@@ -4981,6 +4989,10 @@
         <source>Sports</source>
         <target>Sports</target>
       </trans-unit>
+      <trans-unit id="vUUuIUT" resname="Square logo">
+        <source>Square logo</source>
+        <target state="translated">Square logo</target>
+      </trans-unit>
       <trans-unit id="oBphsD9" resname="Stale">
         <source>Stale</source>
         <target state="translated">Stale</target>
@@ -6660,6 +6672,14 @@
       <trans-unit id="C3pbkFh" resname="Your highlighted vacancies are saved.">
         <source>Your highlighted vacancies are saved.</source>
         <target state="translated">Your highlighted vacancies are saved.</target>
+      </trans-unit>
+      <trans-unit id="jpx_gla" resname="Your mark and name side by side, at least %width% pixels wide and wider than it is tall.">
+        <source>Your mark and name side by side, at least %width% pixels wide and wider than it is tall.</source>
+        <target state="translated">Your mark and name side by side, at least %width% pixels wide and wider than it is tall.</target>
+      </trans-unit>
+      <trans-unit id="SxjslXJ" resname="Your mark on its own, square, at least %size% by %size% pixels.">
+        <source>Your mark on its own, square, at least %size% by %size% pixels.</source>
+        <target state="translated">Your mark on its own, square, at least %size% by %size% pixels.</target>
       </trans-unit>
       <trans-unit id="Mnrixx." resname="Your message is being sent to %count% recipient(s).">
         <source>Your message is being sent to %count% recipient(s).</source>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -981,6 +981,10 @@
         <source>Banner</source>
         <target state="translated">Banner</target>
       </trans-unit>
+      <trans-unit id="rep8aq2" resname="Banner logo">
+        <source>Banner logo</source>
+        <target state="translated">Bannerlogo</target>
+      </trans-unit>
       <trans-unit id="LNfw4H_" resname="Banners">
         <source>Banners</source>
         <target state="translated">Banners</target>
@@ -2952,6 +2956,10 @@
       <trans-unit id="1TFZ._Z" resname="Logo, story and contact">
         <source>Logo, story and contact</source>
         <target state="translated">Logo, verhaal en contact</target>
+      </trans-unit>
+      <trans-unit id="5CIt_FZ" resname="Logos">
+        <source>Logos</source>
+        <target state="translated">Logo's</target>
       </trans-unit>
       <trans-unit id="4E407bE" resname="Logos and templates">
         <source>Logos and templates</source>
@@ -4981,6 +4989,10 @@
         <source>Sports</source>
         <target>Sport</target>
       </trans-unit>
+      <trans-unit id="vUUuIUT" resname="Square logo">
+        <source>Square logo</source>
+        <target state="translated">Vierkant logo</target>
+      </trans-unit>
       <trans-unit id="oBphsD9" resname="Stale">
         <source>Stale</source>
         <target state="translated">Verouderd</target>
@@ -6660,6 +6672,14 @@
       <trans-unit id="C3pbkFh" resname="Your highlighted vacancies are saved.">
         <source>Your highlighted vacancies are saved.</source>
         <target state="translated">Je uitgelichte vacatures zijn opgeslagen.</target>
+      </trans-unit>
+      <trans-unit id="jpx_gla" resname="Your mark and name side by side, at least %width% pixels wide and wider than it is tall.">
+        <source>Your mark and name side by side, at least %width% pixels wide and wider than it is tall.</source>
+        <target state="translated">Je beeldmerk en naam naast elkaar, minimaal %width% pixels breed en breder dan hoog.</target>
+      </trans-unit>
+      <trans-unit id="SxjslXJ" resname="Your mark on its own, square, at least %size% by %size% pixels.">
+        <source>Your mark on its own, square, at least %size% by %size% pixels.</source>
+        <target state="translated">Alleen je beeldmerk, vierkant, minimaal %size% bij %size% pixels.</target>
       </trans-unit>
       <trans-unit id="Mnrixx." resname="Your message is being sent to %count% recipient(s).">
         <source>Your message is being sent to %count% recipient(s).</source>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -721,6 +721,10 @@
         <source>All subscribers</source>
         <target>Alle inschrijvers</target>
       </trans-unit>
+      <trans-unit id="gOiJzr7" resname="All vacancies">
+        <source>All vacancies</source>
+        <target state="translated">Alle vacatures</target>
+      </trans-unit>
       <trans-unit id="CdVO0Gm" resname="All years">
         <source>All years</source>
         <target state="translated">Alle jaren</target>
@@ -2472,6 +2476,14 @@
       <trans-unit id="Z_zbkeN" resname="Highlight">
         <source>Highlight</source>
         <target state="translated">Uitlichting</target>
+      </trans-unit>
+      <trans-unit id="RUMuLpj" resname="Highlighted">
+        <source>Highlighted</source>
+        <target state="translated">Uitgelicht</target>
+      </trans-unit>
+      <trans-unit id="XdAlCJ6" resname="Highlighted vacancies">
+        <source>Highlighted vacancies</source>
+        <target state="translated">Uitgelichte vacatures</target>
       </trans-unit>
       <trans-unit id="tSusVTR" resname="Highlights">
         <source>Highlights</source>
@@ -4592,6 +4604,10 @@
       <trans-unit id="8fyPK38" resname="Search by code or name">
         <source>Search by code or name</source>
         <target state="translated">Zoek op code of naam</target>
+      </trans-unit>
+      <trans-unit id="XjL6auo" resname="Search by company name">
+        <source>Search by company name</source>
+        <target state="translated">Zoek op bedrijfsnaam</target>
       </trans-unit>
       <trans-unit id="YWrWXBq" resname="Search by company, representative name, or email">
         <source>Search by company, representative name, or email</source>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -235,7 +235,7 @@
       </trans-unit>
       <trans-unit id="Q5RHBE_" resname="Upload a JPEG, PNG or WebP image.">
         <source>Upload a JPEG, PNG or WebP image.</source>
-        <target state="translated">Upload a JPEG, PNG or WebP image.</target>
+        <target></target>
       </trans-unit>
       <trans-unit id="fcfNWQJ" resname="You can only highlight your own vacancies that are currently shown on the website.">
         <source>You can only highlight your own vacancies that are currently shown on the website.</source>

--- a/translations/validators.nl.xlf
+++ b/translations/validators.nl.xlf
@@ -235,7 +235,7 @@
       </trans-unit>
       <trans-unit id="Q5RHBE_" resname="Upload a JPEG, PNG or WebP image.">
         <source>Upload a JPEG, PNG or WebP image.</source>
-        <target state="translated">Upload een JPEG-, PNG- of WebP-afbeelding.</target>
+        <target></target>
       </trans-unit>
       <trans-unit id="fcfNWQJ" resname="You can only highlight your own vacancies that are currently shown on the website.">
         <source>You can only highlight your own vacancies that are currently shown on the website.</source>


### PR DESCRIPTION
# Description

A company handed over one logo, and that one file had to work in four places that want
very different shapes: cropped to a square beside a vacancy, stretched across the top of a
card, fitted into a tinted band on the landing page, or dropped for a monogram. Asking for
a size that suits all of them is not realistic, since a company only has whatever its brand
guide gave it. So a company now supplies two: a square mark, and a wider one carrying the
mark and the name together. Each is fitted whole into the box it belongs in, centred with
padding to sit in and a fixed height so a grid of companies keeps its rows aligned. One
includes renders of all of it, including the monogram fallback, so a list lines up whether or
not a company has uploaded anything yet.

The bounds on both uploads are deliberately loose. A mark exported a few pixels off square
is still the mark, and a long wordmark is still a banner, so the two ratios are only
separated far enough to keep them apart and to catch somebody uploading the wrong file into
the wrong slot. The minimum sizes are the smallest variant each is served at, so neither
image is ever asked to scale up. The migration renames the existing column, which means the
logo a company already handed over becomes its square one, and leaves the banner empty
until it uploads one.

While in there, the company overview and the vacancy overview both listed their items by
company name, which quietly rewarded whoever sits early in the alphabet. Both now draw a
random order once, when the page is first rendered, and carry it along as a seed. The order
stays steady while the reader filters and loads more, and a reload deals a new hand. Doing
that meant the company overview had to become a live component, so it also gained the free
text search it was missing, and both overviews now load a page at a time instead of
everything at once. The company strip on the landing page had the same bias, and now
shuffles and shows at most nine.

Highlighted vacancies were never actually shown anywhere, even though a company could
already buy a highlight package and pick which vacancy it covered. They now have a section
on the landing page and one above the vacancy overview, and they keep their place in the
overview grid with a marker on the card.

Finally, the career fixtures now generate and store real logo and banner artwork the way an
upload would, rather than pointing at paths nobody ever wrote a file to, so the career pages
can be looked at locally. A missing SCSS import that left the banner carousel unstyled is
fixed along with it.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
