### PR TITLE
fix(user): always add the sub claim to external app tokens

### DIFF
--- a/src/Service/User/ExternalAppService.php
+++ b/src/Service/User/ExternalAppService.php
@@ -56,11 +56,9 @@ class ExternalAppService
             'nonce' => $nonce ?? bin2hex(random_bytes(16)),
         ];
 
-        // Modern applications receive the standard `sub` subject claim; legacy shared-secret ones keep identifying the
-        // member through the opt-in `lidnr` claim.
-        if (!$app->getSignature()->usesSharedSecret()) {
-            $claims['sub'] = strval($member->getLidnr());
-        }
+        // The standard `sub` subject claim always identifies the member; the opt-in `lidnr` claim is deprecated and
+        // will be removed before the end of 2026.
+        $claims['sub'] = strval($member->getLidnr());
 
         foreach ($app->getClaims() as $claim) {
             $claims[$claim->value] = $claim->getValue($member);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The sub claim was added only for applications verifying via the JWKS endpoint, leaving shared-secret applications to identify the member using the deprecated lidnr claim. That claim will be removed before the end of 2026, so every application now receives sub regardless of its signature scheme.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Found while creating GEWIS/sudosos-backend#1022.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
